### PR TITLE
Fix nitsche restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-04-30
+
+### Fixed
+
+- MINOR The lethe-fluid-nitsche solver was unable to restart when the immersed triangulation was made of simplices. This has been fixed, however, mesh adaptation crashes when it is done after the restart process. I (problembär) have an idea why (the previous particle_handler of the previous checkpoint is still registered somehow in the triangulation), but I will need more time to come up with an adequate solution. [#1106](https://github.com/chaos-polymtl/lethe/pull/1106)
+
 ## [Master] - 2024-04-24
 
 ### Added

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -297,11 +297,12 @@ SolidBase<dim, spacedim>::load_triangulation(const std::string filename_tria)
   try
     {
       // if (auto solid_tria =
-      //       dynamic_cast<parallel::distributed::Triangulation<dim, spacedim> *>(
+      //       dynamic_cast<parallel::distributed::Triangulation<dim, spacedim>
+      //       *>(
       //         get_solid_triangulation().get()))
       //   {
-          solid_tria->load(filename_tria.c_str());
-        // }
+      solid_tria->load(filename_tria.c_str());
+      // }
     }
   catch (...)
     {
@@ -760,16 +761,18 @@ template <int dim, int spacedim>
 void
 SolidBase<dim, spacedim>::read_checkpoint(std::string prefix)
 {
-  // Setup an un-refined triangulation before loading if we have a fully distributed triangulation.
-  // If we have a fully distributed triangulation, nothing should be done to setup the triangulation
-  // since it will be fully generated during the restart process.
-  if (!param->solid_mesh.simplex)  setup_triangulation(true);
+  // Setup an un-refined triangulation before loading if we have a fully
+  // distributed triangulation. If we have a fully distributed triangulation,
+  // nothing should be done to setup the triangulation since it will be fully
+  // generated during the restart process.
+  if (!param->solid_mesh.simplex)
+    setup_triangulation(true);
 
   // Read the triangulation from the checkpoint
   const std::string filename = prefix + ".triangulation";
   try
     {
-           this->solid_tria->load(filename.c_str());
+      this->solid_tria->load(filename.c_str());
     }
   catch (...)
     {
@@ -798,9 +801,11 @@ SolidBase<dim, spacedim>::read_checkpoint(std::string prefix)
   system_trans_vectors.deserialize(x_system);
   displacement_relevant = displacement;
 
-  // Reset triangulation position using displacement vector if is not a simplex triangulation
-  // fullydistributed::triangulation store their displacement when they are saved wheras distributed::triangulation do not.
-  if (!param->solid_mesh.simplex) move_solid_triangulation_with_displacement();
+  // Reset triangulation position using displacement vector if is not a simplex
+  // triangulation fullydistributed::triangulation store their displacement when
+  // they are saved wheras distributed::triangulation do not.
+  if (!param->solid_mesh.simplex)
+    move_solid_triangulation_with_displacement();
 
   // We did not checkpoint particles, we re-create them from scratch
   setup_particles();

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -282,27 +282,11 @@ void
 SolidBase<dim, spacedim>::load_triangulation(const std::string filename_tria)
 {
   // Load solid triangulation from given file
-  // TODO not functional for now, as not all information as passed with the load
-  // function (see dealii documentation for classTriangulation) => change the
-  // way the load works, or change the way the solid triangulation is handled
-  // std::ifstream in_folder(filename_tria.c_str());
-  // if (!in_folder)
-  //   AssertThrow(false,
-  //               ExcMessage(
-  //                 std::string(
-  //                   "You are trying to restart a previous computation, "
-  //                   "but the restart file <") +
-  //                 filename_tria + "> does not appear to exist!"));
-
+  // Currently we only load the triangulation without loading the particles,
+  // this is an issue that needs to be addressed in a near future.
   try
     {
-      // if (auto solid_tria =
-      //       dynamic_cast<parallel::distributed::Triangulation<dim, spacedim>
-      //       *>(
-      //         get_solid_triangulation().get()))
-      //   {
       solid_tria->load(filename_tria.c_str());
-      // }
     }
   catch (...)
     {

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -285,23 +285,23 @@ SolidBase<dim, spacedim>::load_triangulation(const std::string filename_tria)
   // TODO not functional for now, as not all information as passed with the load
   // function (see dealii documentation for classTriangulation) => change the
   // way the load works, or change the way the solid triangulation is handled
-  std::ifstream in_folder(filename_tria.c_str());
-  if (!in_folder)
-    AssertThrow(false,
-                ExcMessage(
-                  std::string(
-                    "You are trying to restart a previous computation, "
-                    "but the restart file <") +
-                  filename_tria + "> does not appear to exist!"));
+  // std::ifstream in_folder(filename_tria.c_str());
+  // if (!in_folder)
+  //   AssertThrow(false,
+  //               ExcMessage(
+  //                 std::string(
+  //                   "You are trying to restart a previous computation, "
+  //                   "but the restart file <") +
+  //                 filename_tria + "> does not appear to exist!"));
 
   try
     {
-      if (auto solid_tria =
-            dynamic_cast<parallel::distributed::Triangulation<dim, spacedim> *>(
-              get_solid_triangulation().get()))
-        {
+      // if (auto solid_tria =
+      //       dynamic_cast<parallel::distributed::Triangulation<dim, spacedim> *>(
+      //         get_solid_triangulation().get()))
+      //   {
           solid_tria->load(filename_tria.c_str());
-        }
+        // }
     }
   catch (...)
     {
@@ -752,12 +752,12 @@ SolidBase<dim, spacedim>::write_checkpoint(std::string prefix)
 
   system_trans_vectors.prepare_for_serialization(sol_set_transfer);
 
-  if (auto tria = dynamic_cast<parallel::distributed::Triangulation<dim> *>(
-        this->solid_tria.get()))
-    {
+  // if (auto tria = dynamic_cast<parallel::distributed::Triangulation<dim> *>(
+  //       this->solid_tria.get()))
+  //   {
       std::string triangulationName = prefix + ".triangulation";
-      tria->save(prefix + ".triangulation");
-    }
+      this->solid_tria.get()->save(prefix + ".triangulation");
+    // }
 }
 
 template <int dim, int spacedim>
@@ -769,19 +769,19 @@ SolidBase<dim, spacedim>::read_checkpoint(std::string prefix)
 
   // Read the triangulation from the checkpoint
   const std::string filename = prefix + ".triangulation";
-  std::ifstream     in(filename.c_str());
-  if (!in)
-    AssertThrow(false,
-                ExcMessage(
-                  std::string("You are trying to read a solid triangulation, "
-                              "but the restart file <") +
-                  filename + "> does not appear to exist!"));
+  // std::ifstream     in(filename.c_str());
+  // if (!in)
+  //   AssertThrow(false,
+  //               ExcMessage(
+  //                 std::string("You are trying to read a solid triangulation, "
+  //                             "but the restart file <") +
+  //                 filename + "> does not appear to exist!"));
 
   try
     {
-      if (auto tria = dynamic_cast<parallel::distributed::Triangulation<dim> *>(
-            this->solid_tria.get()))
-        tria->load(filename.c_str());
+      // if (auto tria = dynamic_cast<parallel::distributed::Triangulation<dim> *>(
+      //       this->solid_tria.get()))
+        this->solid_tria.get()->load(filename.c_str());
     }
   catch (...)
     {


### PR DESCRIPTION
# Description of the problem

- Nitsche does not restart when the mesh was generated with simplices. See #275 

# Description of the solution

- Fixes the issue by restarting the fully distributed triangulation for the solid correctly.

# How Has This Been Tested?

- Still pending a unit test, WIP


# Comments

- While running this test case I managed to find another bug, which is that the Nitsche model is unable of mesh adaptation once it has been restarted. This bug was there all the time. I will try to figure out something, in the meantime I will try to m erge this PR anyway.
