### PR TITLE
Fix viscosity initial conditions for matrix-free

### DIFF
--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -116,8 +116,8 @@ public:
 
   /**
    * @brief Getter function for all level operators.
-   * 
-   * @return Multigrid object that contains all level operators. 
+   *
+   * @return Multigrid object that contains all level operators.
    */
   const MGLevelObject<std::shared_ptr<OperatorType>> &
   get_mg_operators() const;

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -114,6 +114,14 @@ public:
   void
   print_relevant_info() const;
 
+  /**
+   * @brief Getter function for all level operators.
+   * 
+   * @return Multigrid object that contains all level operators. 
+   */
+  const MGLevelObject<std::shared_ptr<OperatorType>> &
+  get_mg_operators() const;
+
 private:
   /// Min level of the multigrid hierarchy
   unsigned int minlevel;


### PR DESCRIPTION
# Description of the problem

After the changes in #1102  where the architecture of the Newton solver was changed to be able to reuse the preconditioner, the initial conditions related to viscosity were not working as expected in the matrix-free application when using multigrid preconditioners.

# Description of the solution

Now the kinematic viscosity of all the operators of the different multigrid levels is set to the temporary viscosity when needed to ensure the correct preconditioning.

# How Has This Been Tested?

The flow around a sphere benchmark, which uses the viscosity ramp as initial condition, obtains now the expected results.