### PR TITLE
Think it is fixed, test are still passing, need to make a new test

### DIFF
--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -378,7 +378,10 @@ namespace Parameters
         translational,
         rotational,
         periodic
-      } BC_type;
+      };
+
+      // Vector of each boundary types
+      std::vector<BoundaryType> bc_types;
 
       // Outlet boundary IDs
       std::vector<unsigned int> outlet_boundaries;
@@ -421,7 +424,8 @@ namespace Parameters
         std::unordered_map<unsigned int, Tensor<1, 3>>
                                                    &boundary_rotational_vector,
         std::unordered_map<unsigned int, Point<3>> &point_on_rotation_axis,
-        std::vector<unsigned int>                  &outlet_boundaries);
+        std::vector<unsigned int>                  &outlet_boundaries,
+        std::vector<BoundaryType>                  &bc_types);
     };
 
     template <int dim>

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -1118,12 +1118,12 @@ namespace Parameters
 
       if (boundary_type == "outlet")
         {
-          BC_type = BoundaryType::outlet;
+          bc_types.push_back(BoundaryType::outlet);
           this->outlet_boundaries.push_back(boundary_id);
         }
       else if (boundary_type == "translational")
         {
-          BC_type = BoundaryType::translational;
+          bc_types.push_back(BoundaryType::translational);
           Tensor<1, 3> translational_velocity;
           translational_velocity[0] = prm.get_double("speed x");
           translational_velocity[1] = prm.get_double("speed y");
@@ -1134,7 +1134,7 @@ namespace Parameters
         }
       else if (boundary_type == "rotational")
         {
-          BC_type                 = BoundaryType::rotational;
+          bc_types.push_back(BoundaryType::rotational);
           double rotational_speed = prm.get_double("rotational speed");
 
           // Read the rotational vector from a list of doubles
@@ -1157,11 +1157,11 @@ namespace Parameters
         }
       else if (boundary_type == "fixed_wall")
         {
-          BC_type = BoundaryType::fixed_wall;
+          bc_types.push_back(BoundaryType::fixed_wall);
         }
       else if (boundary_type == "periodic")
         {
-          BC_type                   = BoundaryType::periodic;
+          bc_types.push_back(BoundaryType::periodic);
           this->periodic_boundary_0 = prm.get_integer("periodic id 0");
           this->periodic_boundary_1 = prm.get_integer("periodic id 1");
           this->periodic_direction  = prm.get_integer("periodic direction");
@@ -1206,7 +1206,8 @@ namespace Parameters
                             boundary_rotational_speed,
                             boundary_rotational_vector,
                             point_on_rotation_axis,
-                            outlet_boundaries);
+                            outlet_boundaries,
+                            bc_types);
 
       for (unsigned int counter = 0; counter < DEM_BC_number; ++counter)
         {
@@ -1228,7 +1229,8 @@ namespace Parameters
       std::unordered_map<unsigned int, Tensor<1, 3>>
                                                  &boundary_rotational_vector,
       std::unordered_map<unsigned int, Point<3>> &point_on_rotation_axis,
-      std::vector<unsigned int>                  &outlet_boundaries)
+      std::vector<unsigned int>                  &outlet_boundaries,
+      std::vector<BoundaryType>                  &bc_types)
     {
       Tensor<1, 3> zero_tensor({0.0, 0.0, 0.0});
 
@@ -1240,7 +1242,9 @@ namespace Parameters
           point_on_rotation_axis.insert({counter, Point<3>(zero_tensor)});
         }
 
+      // NOTE This first vector should not be initialized this big.
       outlet_boundaries.reserve(DEM_BC_number);
+      bc_types.reserve(DEM_BC_number);
     }
 
     template <int dim>

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -232,10 +232,16 @@ DEMSolver<dim>::DEMSolver(DEMSolverParameters<dim> dem_parameters)
     }
 
   // Check if there's periodic boundaries
-  if (parameters.boundary_conditions.BC_type ==
-      Parameters::Lagrangian::BCDEM::BoundaryType::periodic)
+  for (unsigned int i_bc = 0;
+       i_bc < parameters.boundary_conditions.bc_types.size();
+       ++i_bc)
     {
-      has_periodic_boundaries = true;
+      if (parameters.boundary_conditions.bc_types[i_bc] ==
+          Parameters::Lagrangian::BCDEM::BoundaryType::periodic)
+        {
+          has_periodic_boundaries = true;
+          break;
+        }
     }
 
   // Assign gravity/acceleration

--- a/source/dem/read_mesh.cc
+++ b/source/dem/read_mesh.cc
@@ -15,10 +15,12 @@ read_mesh(const Parameters::Mesh   &mesh_parameters,
 
   attach_grid_to_triangulation(triangulation, mesh_parameters);
 
-  if (bc_params.BC_type ==
-      Parameters::Lagrangian::BCDEM::BoundaryType::periodic)
+  // Check if there's periodic boundaries
+  for (unsigned int i_bc = 0; i_bc < bc_params.bc_types.size(); ++i_bc)
     {
-      match_periodic_boundaries(triangulation, bc_params);
+      if (bc_params.bc_types[i_bc] ==
+          Parameters::Lagrangian::BCDEM::BoundaryType::periodic)
+        match_periodic_boundaries(triangulation, bc_params);
     }
 
   if (!restart)

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -1470,10 +1470,16 @@ CFDDEMSolver<dim>::dem_setup_contact_parameters()
   load_balance_step      = false;
 
   // Check if there's periodic boundaries
-  if (dem_parameters.boundary_conditions.BC_type ==
-      Parameters::Lagrangian::BCDEM::BoundaryType::periodic)
+  for (unsigned int i_bc = 0;
+       i_bc < dem_parameters.boundary_conditions.bc_types.size();
+       ++i_bc)
     {
-      has_periodic_boundaries = true;
+      if (dem_parameters.boundary_conditions.bc_types[i_bc] ==
+          Parameters::Lagrangian::BCDEM::BoundaryType::periodic)
+        {
+          has_periodic_boundaries = true;
+          break;
+        }
     }
 }
 


### PR DESCRIPTION
# Description of the problem

- Periodic boundary conditions were not working when they were not declare as the last BC in the parameter file.
- BC_type was changing value at every BC being parsed. "BC_type" was being checked later in the code (in dem.cc) to set "has_periodic_boundaries" to true or false.  If the periodic BC was being declared before the an other BC, "BC_type" was not set to "BoundaryType::periodic", thus "has_periodic_boundaries = false".

# Description of the solution

- We store every BC type in a vector (BC_types). 
- We check each component of that vector, if it's equal to "BoundaryType::periodic", then "has_periodic_boundaries = true"

# How Has This Been Tested?

- Every test is passing.
- I can modify one of our current test to add a dummy BC at the end of a parameter file, so that it check for this kind of problem.

# Comments

- Not gonna lie, it was not hard a bug spot in the code... wish I had spot this mistake earlier in my results.... 
