### PR TITLE
Add timers for GMG vmult

### DIFF
--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -204,6 +204,9 @@ private:
 
   /// Vector holding number of coarse grid iterations
   mutable std::vector<unsigned int> coarse_grid_iterations;
+
+  /// Internal timer for vmult timings
+  mutable TimerOutput timer;
 };
 
 

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -66,7 +66,6 @@ public:
    * @param[in] forcing_function Function specified in parameter file as source
    * term.
    * @param[in] simulation_control Required to get the time stepping method.
-   * @param[in] mg_computing_timer Timer for specific MG components.
    * @param[in] fe Describes the FE system for the vector-valued problem.
    */
   MFNavierStokesPreconditionGMG(
@@ -76,14 +75,12 @@ public:
     const std::shared_ptr<Quadrature<dim>>  &cell_quadrature,
     const std::shared_ptr<Function<dim>>     forcing_function,
     const std::shared_ptr<SimulationControl> simulation_control,
-    TimerOutput                             &mg_computing_timer,
     const std::shared_ptr<FESystem<dim>>     fe);
 
   /**
    * @brief Initialize smoother, coarse grid solver and multigrid object
    * needed for the geometric multigrid preconditioner.
    *
-   * @param[in] mg_computing_timer Timer for specific MG components.
    * @param[in] simulation_control Required to get the time stepping method.
    * @param[in] flow_control Required for dynamic flow control.
    * @param[in] present_solution Previous solution needed to evaluate the non
@@ -92,8 +89,7 @@ public:
    * derivatives of previous solutions.
    */
   void
-  initialize(TimerOutput                             &mg_computing_timer,
-             const std::shared_ptr<SimulationControl> simulation_control,
+  initialize(const std::shared_ptr<SimulationControl> simulation_control,
              FlowControl<dim>                        &flow_control,
              const VectorType                        &present_solution,
              const VectorType &time_derivative_previous_solutions);
@@ -205,8 +201,12 @@ private:
   /// Vector holding number of coarse grid iterations
   mutable std::vector<unsigned int> coarse_grid_iterations;
 
+public:
+  /// Timer for specific geometric multigrid components.
+  mutable TimerOutput mg_setup_timer;
+
   /// Internal timer for vmult timings
-  mutable TimerOutput timer;
+  mutable TimerOutput mg_vmult_timer;
 };
 
 
@@ -417,12 +417,6 @@ protected:
    *
    */
   VectorType time_derivative_previous_solutions;
-
-  /**
-   * @brief Timer for specific geometric multigrid components.
-   *
-   */
-  TimerOutput mg_computing_timer;
 };
 
 #endif

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1660,7 +1660,6 @@ MFNavierStokesSolver<dim>::set_initial_condition_fd(
                 this->cell_quadrature,
                 this->forcing_function,
                 this->simulation_control,
-                this->mg_computing_timer,
                 this->fe);
 
           auto mg_operators = this->gmg_preconditioner->get_mg_operators();
@@ -1774,7 +1773,6 @@ MFNavierStokesSolver<dim>::set_initial_condition_fd(
                     this->cell_quadrature,
                     this->forcing_function,
                     this->simulation_control,
-                    this->mg_computing_timer,
                     this->fe);
 
               auto mg_operators = this->gmg_preconditioner->get_mg_operators();

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -57,6 +57,10 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
   : pcout(std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
   , simulation_parameters(simulation_parameters)
   , dof_handler(dof_handler)
+  , timer(MPI_COMM_WORLD,
+          this->pcout,
+          TimerOutput::never,
+          TimerOutput::wall_times)
 {
   if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
         .preconditioner == Parameters::LinearSolver::PreconditionerType::lsmg)
@@ -1225,6 +1229,52 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
       this->gc_multigrid_preconditioner =
         std::make_shared<PreconditionMG<dim, VectorType, GCTransferType>>(
           this->dof_handler, *this->mg, *this->mg_transfer_gc);
+
+      // Print detailed timings of MG steps.
+      const auto create_mg_timer_function = [&](const std::string &label) {
+        return [label, this](const bool flag, const unsigned int level) {
+          const std::string label_full =
+            (label == "") ?
+              ("gmg::vmult::level_" + std::to_string(level)) :
+              ("gmg::vmult::level_" + std::to_string(level) + "::" + label);
+
+          if (flag)
+            this->timer.enter_subsection(label_full);
+          else
+            this->timer.leave_subsection(label_full);
+        };
+      };
+
+      this->mg->connect_pre_smoother_step(
+        create_mg_timer_function("0_pre_smoother_step"));
+      this->mg->connect_residual_step(
+        create_mg_timer_function("1_residual_step"));
+      this->mg->connect_restriction(create_mg_timer_function("2_restriction"));
+      this->mg->connect_coarse_solve(create_mg_timer_function(""));
+      this->mg->connect_prolongation(
+        create_mg_timer_function("3_prolongation"));
+      this->mg->connect_edge_prolongation(
+        create_mg_timer_function("4_edge_prolongation"));
+      this->mg->connect_post_smoother_step(
+        create_mg_timer_function("5_post_smoother_step"));
+
+
+      const auto create_mg_precon_timer_function =
+        [&](const std::string &label) {
+          return [label, this](const bool flag) {
+            const std::string label_full = "gmg::vmult::" + label;
+
+            if (flag)
+              this->timer.enter_subsection(label_full);
+            else
+              this->timer.leave_subsection(label_full);
+          };
+        };
+
+      this->gc_multigrid_preconditioner->connect_transfer_to_mg(
+        create_mg_precon_timer_function("transfer_to_mg"));
+      this->gc_multigrid_preconditioner->connect_transfer_to_global(
+        create_mg_precon_timer_function("transfer_to_global"));
     }
   else
     AssertThrow(false, ExcNotImplemented());


### PR DESCRIPTION
# Description of the problem

There were only timers for the setup of the different components of multigrid but not for the actual application of the MG preconditioner.

# Description of the solution

Now an additional table with specific times is printed when `set mg verbosity  = extra verbose` with all the information: 

```
+-------------------------------------------------------+------------+------------+
| Total wallclock time elapsed since start              |      23.3s |            |
|                                                       |            |            |
| Section                                   | no. calls |  wall time | % of total |
+-------------------------------------------+-----------+------------+------------+
| gmg::vmult::level_0                       |       174 |      1.89s |       8.1% |
| gmg::vmult::level_1::0_pre_smoother_step  |       174 |      6.11s |        26% |
| gmg::vmult::level_1::1_residual_step      |       174 |     0.673s |       2.9% |
| gmg::vmult::level_1::2_restriction        |       174 |    0.0134s |         0% |
| gmg::vmult::level_1::3_prolongation       |       174 |    0.0156s |         0% |
| gmg::vmult::level_1::4_edge_prolongation  |       174 |  0.000208s |         0% |
| gmg::vmult::level_1::5_post_smoother_step |       174 |      6.83s |        29% |
| gmg::vmult::transfer_to_global            |       174 |   0.00177s |         0% |
| gmg::vmult::transfer_to_mg                |       174 |   0.00202s |         0% |
+-------------------------------------------+-----------+------------+------------+
```
It can be printed for each iteration or at the end as with the other tables reporting times in Lethe. The existent timer for the MG setup times was renamed and now both timers belong to the `MFNavierStokesPreconditionGMG` class.
