### PR TITLE
Improve Scratch data for CFD-DEM simulations

### DIFF
--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -740,19 +740,9 @@ public:
           cell_void_fraction[j] = cell_void_fraction_bulk;
       }
 
-    // Resize arrays to be of the right size
-    fluid_velocity_laplacian_at_particle_location.resize(number_of_particles);
-    fluid_velocity_curls_at_particle_location_2d.resize(number_of_particles);
-    fluid_velocity_curls_at_particle_location_3d.resize(number_of_particles);
-    fluid_pressure_gradients_at_particle_location.resize(number_of_particles);
-    fluid_velocity_at_particle_location.resize(number_of_particles);
-
     if (number_of_particles == 0)
       return;
 
-
-    // If particles are in the cell, gather the rest of the
-    // information
 
     // Create local vector that will be used to spawn an in-situ quadrature to
     // interpolate at the location of the particles
@@ -770,7 +760,6 @@ public:
 
     // Create a quadrature for the Navier-Stokes equations that is based on the
     // particle reference location
-
     Quadrature<dim> q_local(particle_reference_location, particle_weights);
     FEValues<dim>   fe_values_local_particles(this->fe_values.get_fe(),
                                             q_local,

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -1930,8 +1930,6 @@ GLSVansAssemblerFPI<dim>::assemble_matrix(
             beta_drag * (velocity - average_particles_velocity);
         }
 
-      // We loop over the column first to prevent recalculation
-      // of the strong jacobian in the inner loop
       for (unsigned int j = 0; j < n_dofs; ++j)
         {
           const auto &phi_u_j = scratch_data.phi_u[q][j];
@@ -1939,7 +1937,6 @@ GLSVansAssemblerFPI<dim>::assemble_matrix(
             // Drag Force
             beta_drag * phi_u_j;
         }
-
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -324,7 +324,8 @@ NavierStokesScratchData<dim>::enable_particle_fluid_interactions(
   max_number_of_particles_per_cell = n_global_max_particles_per_cell;
   interpolated_void_fraction       = enable_void_fraction_interpolation;
 
-  // Velocities
+  // Reinitialize vectors used to store flow information at the particle
+  // location
   particle_velocity =
     std::vector<Tensor<1, dim>>(n_global_max_particles_per_cell);
   fluid_velocity_at_particle_location =
@@ -333,6 +334,15 @@ NavierStokesScratchData<dim>::enable_particle_fluid_interactions(
   fluid_particle_relative_velocity_at_particle_location =
     std::vector<Tensor<1, dim>>(n_global_max_particles_per_cell);
   Re_particle = std::vector<double>(n_global_max_particles_per_cell);
+
+  fluid_velocity_laplacian_at_particle_location =
+    std::vector<Tensor<1, dim>>(n_global_max_particles_per_cell);
+  fluid_velocity_curls_at_particle_location_2d =
+    std::vector<Tensor<1, 1>>(n_global_max_particles_per_cell);
+  fluid_velocity_curls_at_particle_location_3d =
+    std::vector<Tensor<1, 3>>(n_global_max_particles_per_cell);
+  fluid_pressure_gradients_at_particle_location =
+    std::vector<Tensor<1, dim>>(n_global_max_particles_per_cell);
 }
 
 


### PR DESCRIPTION
# Description of the problem

- The scratch data for CFD-DEM simulation was very much all over the place. Memory was being reallocated and interpolation was sometimes done manually whereas some other times it was done using a quadrature defined on the fly

# Description of the solution

- Unify interpolation
- Prevent memory reallocation

# How Has This Been Tested?

- All tests pass with no changed results (as expected)


# Comments

- This does not lead to a large speed boost (like 3-4% on what I tested), but it really makes the code more readable and more uniform. Next PR will be on improving the assemblers. Since this was really limited to the scratch data I feel this PR can stand on its own.

