### PR TITLE
Add timers for matrix-free operators

### DIFF
--- a/include/solvers/mf_navier_stokes_operators.h
+++ b/include/solvers/mf_navier_stokes_operators.h
@@ -22,6 +22,8 @@
 
 #include <solvers/simulation_parameters.h>
 
+#include <deal.II/base/timer.h>
+
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/sparsity_tools.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
@@ -478,6 +480,16 @@ protected:
    *
    */
   std::vector<bool> edge_constrained_cell;
+
+  /**
+   * @brief Conditional OStream for parallel output
+   *
+   */
+  ConditionalOStream pcout;
+
+public:
+  // Timer for internal operator calls
+  mutable TimerOutput timer;
 };
 
 /**

--- a/include/solvers/mf_navier_stokes_operators.h
+++ b/include/solvers/mf_navier_stokes_operators.h
@@ -482,13 +482,16 @@ protected:
   std::vector<bool> edge_constrained_cell;
 
   /**
-   * @brief Conditional OStream for parallel output
+   * @brief Conditional OStream for parallel output.
    *
    */
   ConditionalOStream pcout;
 
 public:
-  // Timer for internal operator calls
+  /**
+   * @brief Timer for internal operator calls.
+   *
+   */
   mutable TimerOutput timer;
 };
 

--- a/source/solvers/mf_navier_stokes_operators.cc
+++ b/source/solvers/mf_navier_stokes_operators.cc
@@ -69,6 +69,8 @@ evaluate_function(const Function<dim>                       &function,
 
 template <int dim, typename number>
 NavierStokesOperatorBase<dim, number>::NavierStokesOperatorBase()
+  : pcout(std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+  , timer(this->pcout, TimerOutput::never, TimerOutput::wall_times)
 {}
 
 template <int dim, typename number>
@@ -82,6 +84,8 @@ NavierStokesOperatorBase<dim, number>::NavierStokesOperatorBase(
   const StabilizationType            stabilization,
   const unsigned int                 mg_level,
   std::shared_ptr<SimulationControl> simulation_control)
+  : pcout(std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+  , timer(this->pcout, TimerOutput::never, TimerOutput::wall_times)
 {
   this->reinit(mapping,
                dof_handler,
@@ -291,6 +295,8 @@ void
 NavierStokesOperatorBase<dim, number>::vmult(VectorType       &dst,
                                              const VectorType &src) const
 {
+  this->timer.enter_subsection("operator::vmult");
+
   // save values for edge constrained dofs and set them to 0 in src vector
   for (unsigned int i = 0; i < edge_constrained_indices.size(); ++i)
     {
@@ -318,6 +324,8 @@ NavierStokesOperatorBase<dim, number>::vmult(VectorType       &dst,
       dst.local_element(edge_constrained_indices[i]) =
         edge_constrained_values[i];
     }
+
+  this->timer.leave_subsection("operator::vmult");
 }
 
 template <int dim, typename number>
@@ -349,6 +357,8 @@ NavierStokesOperatorBase<dim, number>::vmult_interface_up(
   VectorType       &dst,
   VectorType const &src) const
 {
+  this->timer.enter_subsection("operator::vmult_interface_up");
+
   if (has_edge_constrained_indices == false)
     {
       dst = number(0.);
@@ -372,6 +382,8 @@ NavierStokesOperatorBase<dim, number>::vmult_interface_up(
                               dst,
                               src_cpy,
                               false);
+
+  this->timer.leave_subsection("operator::vmult_interface_up");
 }
 
 
@@ -379,6 +391,8 @@ template <int dim, typename number>
 const TrilinosWrappers::SparseMatrix &
 NavierStokesOperatorBase<dim, number>::get_system_matrix() const
 {
+  this->timer.enter_subsection("operator::get_system_matrix");
+
   if (system_matrix.m() == 0 && system_matrix.n() == 0)
     {
       const auto &dof_handler = this->matrix_free.get_dof_handler();
@@ -436,6 +450,8 @@ NavierStokesOperatorBase<dim, number>::get_system_matrix() const
     &NavierStokesOperatorBase::do_cell_integral_local,
     this);
 
+  this->timer.leave_subsection("operator::get_system_matrix");
+
   return this->system_matrix;
 }
 
@@ -458,6 +474,8 @@ void
 NavierStokesOperatorBase<dim, number>::evaluate_non_linear_term(
   const VectorType &newton_step)
 {
+  this->timer.enter_subsection("operator::evaluate_non_linear_term");
+
   const unsigned int n_cells = matrix_free.n_cell_batches();
   FECellIntegrator   integrator(matrix_free);
 
@@ -480,6 +498,8 @@ NavierStokesOperatorBase<dim, number>::evaluate_non_linear_term(
             integrator.get_hessian_diagonal(q);
         }
     }
+
+  this->timer.leave_subsection("operator::evaluate_non_linear_term");
 }
 
 template <int dim, typename number>
@@ -488,6 +508,9 @@ NavierStokesOperatorBase<dim, number>::
   evaluate_time_derivative_previous_solutions(
     const VectorType &time_derivative_previous_solutions)
 {
+  this->timer.enter_subsection(
+    "operator::evaluate_time_derivative_previous_solutions");
+
   const unsigned int n_cells = matrix_free.n_cell_batches();
   FECellIntegrator   integrator(matrix_free);
 
@@ -501,6 +524,9 @@ NavierStokesOperatorBase<dim, number>::
       for (const auto q : integrator.quadrature_point_indices())
         time_derivatives_previous_solutions(cell, q) += integrator.get_value(q);
     }
+
+  this->timer.leave_subsection(
+    "operator::evaluate_time_derivative_previous_solutions");
 }
 
 template <int dim, typename number>
@@ -520,8 +546,12 @@ void
 NavierStokesOperatorBase<dim, number>::evaluate_residual(VectorType       &dst,
                                                          const VectorType &src)
 {
+  this->timer.enter_subsection("operator::evaluate_residual");
+
   this->matrix_free.cell_loop(
     &NavierStokesOperatorBase::local_evaluate_residual, this, dst, src, true);
+
+  this->timer.leave_subsection("operator::evaluate_residual");
 }
 
 template <int dim, typename number>
@@ -529,6 +559,8 @@ void
 NavierStokesOperatorBase<dim, number>::compute_inverse_diagonal(
   VectorType &diagonal) const
 {
+  this->timer.enter_subsection("operator::compute_inverse_diagonal");
+
   this->matrix_free.initialize_dof_vector(diagonal);
   MatrixFreeTools::compute_diagonal(
     matrix_free,
@@ -541,6 +573,8 @@ NavierStokesOperatorBase<dim, number>::compute_inverse_diagonal(
 
   for (auto &i : diagonal)
     i = (std::abs(i) > 1.0e-10) ? (1.0 / i) : 1.0;
+
+  this->timer.leave_subsection("operator::compute_inverse_diagonal");
 }
 
 template <int dim, typename number>


### PR DESCRIPTION
# Description of the problem

There were timers for the setup of the different components of multigrid, the application of the GMG preconditioner, but the operator timers were missing.

# Description of the solution

As a follow up of #1112 , this PR adds timers for each operator and prints relevant information if `set mg verbosity  = extra verbose` as follows:

```
----------------------
System operator times
----------------------
+------------------------------------------------+------------------+------------+------------------+
| Total wallclock time elapsed                   |     19.45s     3 |     19.47s |     19.48s     6 |
|                                                |                  |                               |
| Section                            | no. calls |   min time  rank |   avg time |   max time  rank |
+------------------------------------------------+------------------+------------+------------------+
| operator::evaluate_non_linear_term |         4 |   0.05946s     3 |   0.07027s |   0.07744s     0 |
| operator::evaluate_residual        |         5 |   0.08911s     0 |   0.09178s |   0.09308s     4 |
| operator::vmult                    |        53 |     1.004s     0 |     1.025s |     1.033s     6 |
+------------------------------------------------+------------------+------------+------------------+
-----------------------
Operator level 0 times
-----------------------

+------------------------------------------------+------------------+------------+------------------+
| Total wallclock time elapsed                   |      19.1s     1 |      19.1s |      19.1s     0 |
|                                                |                  |                               |
| Section                            | no. calls |   min time  rank |   avg time |   max time  rank |
+------------------------------------------------+------------------+------------+------------------+
| operator::compute_inverse_diagonal |         4 |   0.02723s     2 |   0.02774s |   0.02836s     7 |
| operator::evaluate_non_linear_term |         4 | 0.0003811s     3 | 0.0004285s | 0.0004796s     0 |
| operator::get_system_matrix        |         4 |   0.04298s     7 |   0.04391s |   0.04527s     0 |
| operator::vmult                    |       328 |   0.07959s     0 |   0.08443s |   0.08579s     6 |
+------------------------------------------------+------------------+------------+------------------+
```

# Comments

- Useful to better understand bottlenecks and fix them.
