### PR TITLE
Add more coarse-grid solvers for GMG 

### DIFF
--- a/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator.prm
@@ -172,11 +172,11 @@ subsection linear solver
     set eig estimation verbosity       = quiet
 
     #coarse-grid solver
-    set mg coarse grid preconditioner     = ilu
-    set mg coarse grid max iterations     = 500
-    set mg coarse grid tolerance          = 1e-12
-    set mg coarse grid reduce             = 1e-12
-    set mg coarse grid max krylov vectors = 500
+    set mg gmres preconditioner     = ilu
+    set mg gmres max iterations     = 500
+    set mg gmres tolerance          = 1e-12
+    set mg gmres reduce             = 1e-12
+    set mg gmres max krylov vectors = 500
 
     #coarse-grid ILU preconditioner
     set ilu preconditioner fill               = 1

--- a/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_gcmg.prm
@@ -124,11 +124,11 @@ subsection linear solver
     set mg smoother relaxation = 0.5
 
     #coarse-grid solver
-    set mg coarse grid max iterations     = 2000
-    set mg coarse grid tolerance          = 1e-14
-    set mg coarse grid reduce             = 1e-4
-    set mg coarse grid max krylov vectors = 30
-    set mg coarse grid preconditioner     = amg
+    set mg gmres max iterations     = 2000
+    set mg gmres tolerance          = 1e-14
+    set mg gmres reduce             = 1e-4
+    set mg gmres max krylov vectors = 30
+    set mg gmres preconditioner     = amg
 
     #coarse-grid AMG preconditioner
     set amg aggregation threshold                 = 1e-14

--- a/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_lsmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_lsmg.prm
@@ -124,11 +124,11 @@ subsection linear solver
     set mg smoother relaxation = 0.5
 
     #coarse-grid solver
-    set mg coarse grid max iterations     = 2000
-    set mg coarse grid tolerance          = 1e-14
-    set mg coarse grid reduce             = 1e-4
-    set mg coarse grid max krylov vectors = 30
-    set mg coarse grid preconditioner     = amg
+    set mg gmres max iterations     = 2000
+    set mg gmres tolerance          = 1e-14
+    set mg gmres reduce             = 1e-4
+    set mg gmres max krylov vectors = 30
+    set mg gmres preconditioner     = amg
 
     #coarse-grid AMG preconditioner
     set amg aggregation threshold                 = 1e-14

--- a/applications_tests/lethe-fluid-matrix-free/taylor_couette_2d_local_ref.prm
+++ b/applications_tests/lethe-fluid-matrix-free/taylor_couette_2d_local_ref.prm
@@ -141,11 +141,11 @@ subsection linear solver
     set eig estimation verbosity       = quiet
 
     # Coarse-grid solver
-    set mg coarse grid max iterations         = 50
-    set mg coarse grid tolerance              = 1e-7
-    set mg coarse grid reduce                 = 1e-4
-    set mg coarse grid max krylov vectors     = 50
-    set mg coarse grid preconditioner         = ilu
+    set mg gmres max iterations         = 50
+    set mg gmres tolerance              = 1e-7
+    set mg gmres reduce                 = 1e-4
+    set mg gmres max krylov vectors     = 50
+    set mg gmres preconditioner         = ilu
     set ilu preconditioner fill               = 0
     set ilu preconditioner absolute tolerance = 1e-10
     set ilu preconditioner relative tolerance = 1.00

--- a/applications_tests/lethe-fluid-matrix-free/tgv_restart_bdf1.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_restart_bdf1.prm
@@ -172,11 +172,11 @@ subsection linear solver
     set eig estimation verbosity       = quiet
 
     #coarse-grid solver
-    set mg coarse grid max iterations     = 2000
-    set mg coarse grid tolerance          = 1e-7
-    set mg coarse grid reduce             = 1e-4
-    set mg coarse grid max krylov vectors = 30
-    set mg coarse grid preconditioner     = ilu
+    set mg gmres max iterations     = 2000
+    set mg gmres tolerance          = 1e-7
+    set mg gmres reduce             = 1e-4
+    set mg gmres max krylov vectors = 30
+    set mg gmres preconditioner     = ilu
 
     set ilu preconditioner fill               = 1
     set ilu preconditioner absolute tolerance = 1e-10

--- a/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
+++ b/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
@@ -247,11 +247,12 @@ The ``lethe-fluid-matrix-free`` has significantly more parameters for its linear
       set eig estimation verbosity       = verbose
 
       # Coarse-grid solver
-      set mg coarse grid max iterations         = 2000
-      set mg coarse grid tolerance              = 1e-7
-      set mg coarse grid reduce                 = 1e-4
-      set mg coarse grid max krylov vectors     = 30
-      set mg coarse grid preconditioner         = ilu
+      set mg coarse grid solver                 = gmres
+      set mg gmres max iterations               = 2000
+      set mg gmres tolerance                    = 1e-7
+      set mg gmres reduce                       = 1e-4
+      set mg gmres max krylov vectors           = 30
+      set mg gmres preconditioner               = ilu
       set ilu preconditioner fill               = 1
       set ilu preconditioner absolute tolerance = 1e-10
       set ilu preconditioner relative tolerance = 1.00

--- a/doc/source/parameters/cfd/linear_solver_control.rst
+++ b/doc/source/parameters/cfd/linear_solver_control.rst
@@ -184,7 +184,7 @@ AMG preconditioner
 LSMG and GCMG preconditioners
 ------------------------------
 
-Different parameters for the main components of the two geometric multigrid algorithms can be specified. The parameters can be general or can belong to either the smoother, the coarse-grid solver or the coarse-grid solver preconditioner. For the latter, one can choose between ``amg`` and ``ilu``.
+Different parameters for the main components of the two geometric multigrid algorithms can be specified. The parameters can be general or can belong to either the smoother or the coarse-grid solver. Lethe supports different coarse-grid solvers: ``gmres``, ``amg``, ``ilu`` and ``direct``. The ``gmres`` coarse-grid solver supports two preconditioners ``amg`` or ``ilu``. 
 
 .. code-block:: text
 
@@ -204,13 +204,17 @@ Different parameters for the main components of the two geometric multigrid algo
     set eig estimation verbosity       = quiet
 
     # Coarse-grid solver parameters
-    set mg coarse grid max iterations     = 2000
-    set mg coarse grid tolerance          = 1e-14
-    set mg coarse grid reduce             = 1e-4
-    set mg coarse grid max krylov vectors = 30
-    set mg coarse grid preconditioner     = amg
+    set mg coarse grid solver = gmres
+
+    # Parameters for GMRES as coarse grid solver
+    set mg gmres max iterations     = 2000
+    set mg gmres tolerance          = 1e-14
+    set mg gmres reduce             = 1e-4
+    set mg gmres max krylov vectors = 30
+    set mg gmres preconditioner     = amg
     
-    # Coarse-grid AMG preconditioner parameters
+    # Parameters for AMG as coarse-grid solver or GMRES preconditioner
+    set mg use amg default parameters             = false
     set amg preconditioner ilu fill               = 0
     set amg preconditioner ilu absolute tolerance = 1e-12
     set amg preconditioner ilu relative tolerance = 1.00
@@ -220,7 +224,7 @@ Different parameters for the main components of the two geometric multigrid algo
     set amg smoother sweeps                       = 2
     set amg smoother overlap                      = 1
 
-    # Coarse-grid ILU preconditioner parameters
+    # Parameters for ILU as coarse-grid solver or GMRES preconditioner
     set ilu preconditioner fill               = 1
     set ilu preconditioner absolute tolerance = 1e-12
     set ilu preconditioner relative tolerance = 1
@@ -229,4 +233,7 @@ Different parameters for the main components of the two geometric multigrid algo
   The default algorithms build and use ALL the multigrid levels. There are two ways to change the number of levels, either by setting the ``mg min level`` parameter OR the ``mg level min cells`` parameter. For ``lsmg`` the coarsest mesh should cover the whole domain, i.e., no hanging nodes are allowed.
 
 .. tip::
-  If ``mg verbosity`` is set to ``verbose``, the information about the levels (cells and degrees of freedom) and the number of iterations of the coarse grid solver are displayed. If this parameter is set to ``extra verbose``, apart from all the previous information, an additional table with the time it took to set up the different components of the multigrid preconditioners is also displayed. 
+  If ``mg verbosity`` is set to ``verbose``, the information about the levels (cells and degrees of freedom) and the number of iterations of the coarse grid solver are displayed. If this parameter is set to ``extra verbose``, apart from all the previous information, several additional tables with the times related to multigrid are also displayed. 
+
+.. tip::
+  If your coarse-grid level is small enough, it might be worth it for some problems to set ``mg use amg default parameters = true`` to use a direct solver.

--- a/doc/source/parameters/cfd/linear_solver_control.rst
+++ b/doc/source/parameters/cfd/linear_solver_control.rst
@@ -184,7 +184,7 @@ AMG preconditioner
 LSMG and GCMG preconditioners
 ------------------------------
 
-Different parameters for the main components of the two geometric multigrid algorithms can be specified. The parameters can be general or can belong to either the smoother or the coarse-grid solver. Lethe supports different coarse-grid solvers: ``gmres``, ``amg``, ``ilu`` and ``direct``. The ``gmres`` coarse-grid solver supports two preconditioners ``amg`` or ``ilu``. 
+Different parameters for the main components of the two geometric multigrid algorithms can be specified. The parameters can be general or can belong to either the smoother or the coarse-grid solver. Lethe supports different coarse-grid solvers: ``gmres``, ``amg``, ``ilu`` and ``direct``. The ``gmres`` coarse-grid solver supports two preconditioners ``amg`` and ``ilu``. 
 
 .. code-block:: text
 
@@ -214,7 +214,7 @@ Different parameters for the main components of the two geometric multigrid algo
     set mg gmres preconditioner     = amg
     
     # Parameters for AMG as coarse-grid solver or GMRES preconditioner
-    set mg use amg default parameters             = false
+    set mg amg use default parameters             = false
     set amg preconditioner ilu fill               = 0
     set amg preconditioner ilu absolute tolerance = 1e-12
     set amg preconditioner ilu relative tolerance = 1.00
@@ -236,4 +236,4 @@ Different parameters for the main components of the two geometric multigrid algo
   If ``mg verbosity`` is set to ``verbose``, the information about the levels (cells and degrees of freedom) and the number of iterations of the coarse grid solver are displayed. If this parameter is set to ``extra verbose``, apart from all the previous information, several additional tables with the times related to multigrid are also displayed. 
 
 .. tip::
-  If your coarse-grid level is small enough, it might be worth it for some problems to set ``mg use amg default parameters = true`` to use a direct solver.
+  If your coarse-grid level is small enough, it might be worth it for some problems to set ``mg amg use default parameters = true`` to use a direct solver.

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
@@ -143,11 +143,12 @@ subsection linear solver
     set eig estimation verbosity       = verbose
 
     # Coarse-grid solver
-    set mg coarse grid max iterations     = 2000
-    set mg coarse grid tolerance          = 1e-7
-    set mg coarse grid reduce             = 1e-4
-    set mg coarse grid max krylov vectors = 30
-    set mg coarse grid preconditioner     = ilu
+    set mg coarse grid solver       = gmres
+    set mg gmres max iterations     = 2000
+    set mg gmres tolerance          = 1e-7
+    set mg gmres reduce             = 1e-4
+    set mg gmres max krylov vectors = 30
+    set mg gmres preconditioner     = ilu
 
     set ilu preconditioner fill               = 1
     set ilu preconditioner absolute tolerance = 1e-10

--- a/examples/incompressible-flow/3d-turbulent-taylor-couette/tc-matrix-free.prm
+++ b/examples/incompressible-flow/3d-turbulent-taylor-couette/tc-matrix-free.prm
@@ -153,11 +153,12 @@ subsection linear solver
     set eig estimation verbosity       = verbose
 
     # Coarse-grid solver
-    set mg coarse grid max iterations         = 2000
-    set mg coarse grid tolerance              = 1e-7
-    set mg coarse grid reduce                 = 1e-4
-    set mg coarse grid max krylov vectors     = 30
-    set mg coarse grid preconditioner         = ilu
+    set mg coarse grid solver                 = gmres
+    set mg gmres max iterations               = 2000
+    set mg gmres tolerance                    = 1e-7
+    set mg gmres reduce                       = 1e-4
+    set mg gmres max krylov vectors           = 30
+    set mg gmres preconditioner               = ilu
     set ilu preconditioner fill               = 1
     set ilu preconditioner absolute tolerance = 1e-10
     set ilu preconditioner relative tolerance = 1.00

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1145,19 +1145,19 @@ namespace Parameters
     CoarseGridSolverType mg_coarse_grid_solver;
 
     // MG coarse-grid solver maximum number of iterations
-    int mg_coarse_grid_max_iterations;
+    int mg_gmres_max_iterations;
 
     // MG coarse-grid solver tolerance
-    double mg_coarse_grid_tolerance;
+    double mg_gmres_tolerance;
 
     // MG coarse-grid solver reduce
-    double mg_coarse_grid_reduce;
+    double mg_gmres_reduce;
 
     // MG coarse-grid solver maximum number of krylov vectors
-    int mg_coarse_grid_max_krylov_vectors;
+    int mg_gmres_max_krylov_vectors;
 
     // MG coarse-grid solver preconditioner
-    PreconditionerType mg_coarse_grid_preconditioner;
+    PreconditionerType mg_gmres_preconditioner;
 
     // MG use default parameters for AMG
     bool mg_use_amg_default_parameters;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1159,6 +1159,9 @@ namespace Parameters
     // MG coarse-grid solver preconditioner
     PreconditionerType mg_coarse_grid_preconditioner;
 
+    // MG use default parameters for AMG
+    bool mg_use_amg_default_parameters;
+
     // MG information about levels
     Verbosity mg_verbosity;
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1134,6 +1134,16 @@ namespace Parameters
     // MG print max, min, eigenvalues
     Verbosity eig_estimation_verbose;
 
+    // Type of coarse grid solver
+    enum class CoarseGridSolverType
+    {
+      gmres,
+      amg,
+      ilu,
+      direct
+    };
+    CoarseGridSolverType mg_coarse_grid_solver;
+
     // MG coarse-grid solver maximum number of iterations
     int mg_coarse_grid_max_iterations;
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1046,22 +1046,22 @@ namespace Parameters
 
     SolverType solver;
 
-    // Verbosity of linear solver
+    /// Verbosity of linear solver
     Verbosity verbosity;
 
-    // Relative residuals of the iterative solver
+    /// Relative residuals of the iterative solver
     double relative_residual;
 
-    // Minimum residual of the iterative solver
+    /// Minimum residual of the iterative solver
     double minimum_residual;
 
-    // Maximum number of iterations
+    /// Maximum number of iterations
     int max_iterations;
 
-    // Maximum number of krylov vectors
+    /// Maximum number of krylov vectors
     int max_krylov_vectors;
 
-    // Type of preconditioner
+    /// Type of preconditioner
     enum class PreconditionerType
     {
       ilu,
@@ -1071,70 +1071,70 @@ namespace Parameters
     };
     PreconditionerType preconditioner;
 
-    // ILU or ILUT fill
+    /// ILU or ILUT fill
     double ilu_precond_fill;
 
-    // ILU or ILUT absolute tolerance
+    /// ILU or ILUT absolute tolerance
     double ilu_precond_atol;
 
-    // ILU or ILUT relative tolerance
+    /// ILU or ILUT relative tolerance
     double ilu_precond_rtol;
 
-    // AMG parameters either as linear solver preconditioner or as
-    // preconditioner of a coarse-grid solver for LSMG or GCMG
+    /// AMG parameters either as linear solver preconditioner or as
+    /// preconditioner of a coarse-grid solver for LSMG or GCMG
 
-    // ILU or ILUT fill for smoother
+    /// ILU or ILUT fill for smoother
     double amg_precond_ilu_fill;
 
-    // ILU or ILUT absolute tolerance for smoother
+    /// ILU or ILUT absolute tolerance for smoother
     double amg_precond_ilu_atol;
 
-    // ILU or ILUT relative tolerance for smoother
+    /// ILU or ILUT relative tolerance for smoother
     double amg_precond_ilu_rtol;
 
-    // AMG aggregation threshold
+    /// AMG aggregation threshold
     double amg_aggregation_threshold;
 
-    // AMG number of cycles
+    /// AMG number of cycles
     unsigned int amg_n_cycles;
 
-    // AMG W_cycle
+    /// AMG W_cycle
     bool amg_w_cycles;
 
-    // AMG Smoother sweeps
+    /// AMG Smoother sweeps
     unsigned int amg_smoother_sweeps;
 
-    // AMG Smoother overalp
+    /// AMG Smoother overalp
     unsigned int amg_smoother_overlap;
 
-    // Block linear solver to throw error.
+    /// Block linear solver to throw error.
     bool force_linear_solver_continuation;
 
-    // MG min level
+    /// MG min level
     int mg_min_level;
 
-    // MG minimum number of cells per level
+    /// MG minimum number of cells per level
     int mg_level_min_cells;
 
-    // MG smoother number of iterations
+    /// MG smoother number of iterations
     int mg_smoother_iterations;
 
-    // MG smoother relaxation parameter
+    /// MG smoother relaxation parameter
     double mg_smoother_relaxation;
 
-    // MG eigenvalue estimation for smoother relaxation parameter
+    /// MG eigenvalue estimation for smoother relaxation parameter
     bool mg_smoother_eig_estimation;
 
-    // MG smoothing range to set range between eigenvalues
+    /// MG smoothing range to set range between eigenvalues
     int eig_estimation_smoothing_range;
 
-    // MG number of cg iterations to find eigenvalue
+    /// MG number of cg iterations to find eigenvalue
     int eig_estimation_cg_n_iterations;
 
-    // MG print max, min, eigenvalues
+    /// MG print max, min, eigenvalues
     Verbosity eig_estimation_verbose;
 
-    // Type of coarse grid solver
+    /// Type of coarse grid solver
     enum class CoarseGridSolverType
     {
       gmres,
@@ -1144,25 +1144,25 @@ namespace Parameters
     };
     CoarseGridSolverType mg_coarse_grid_solver;
 
-    // MG coarse-grid solver maximum number of iterations
+    /// MG coarse-grid solver maximum number of iterations
     int mg_gmres_max_iterations;
 
-    // MG coarse-grid solver tolerance
+    /// MG coarse-grid solver tolerance
     double mg_gmres_tolerance;
 
-    // MG coarse-grid solver reduce
+    /// MG coarse-grid solver reduce
     double mg_gmres_reduce;
 
-    // MG coarse-grid solver maximum number of krylov vectors
+    /// MG coarse-grid solver maximum number of krylov vectors
     int mg_gmres_max_krylov_vectors;
 
-    // MG coarse-grid solver preconditioner
+    /// MG coarse-grid solver preconditioner
     PreconditionerType mg_gmres_preconditioner;
 
-    // MG use default parameters for AMG
-    bool mg_use_amg_default_parameters;
+    /// MG use default parameters for AMG
+    bool mg_amg_use_default_parameters;
 
-    // MG information about levels
+    /// MG information about levels
     Verbosity mg_verbosity;
 
     static void

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -186,10 +186,13 @@ private:
   std::shared_ptr<TrilinosWrappers::PreconditionILU> precondition_ilu;
 
   /// Direct solver as coarse grid solver
-  TrilinosWrappers::SolverDirect precondition_direct;
+  std::shared_ptr<TrilinosWrappers::SolverDirect> precondition_direct;
 
   /// Solver control for the coarse grid solver
   std::shared_ptr<ReductionControl> coarse_grid_solver_control;
+
+  /// Solver control for the direct solver
+  std::shared_ptr<SolverControl> direct_solver_control;
 
   /// GMRES as coarse grid solver
   std::shared_ptr<SolverGMRES<VectorType>> coarse_grid_solver;

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -119,6 +119,22 @@ public:
   get_mg_operators() const;
 
 private:
+  /**
+   * @brief Set the up AMG object needed for coarse-grid solver or
+   * preconditioning.
+   *
+   */
+  void
+  setup_AMG();
+
+  /**
+   * @brief Set the up ILU object needed for coarse-grid solver or
+   * preconditioning.
+   *
+   */
+  void
+  setup_ILU();
+
   /// Min level of the multigrid hierarchy
   unsigned int minlevel;
 
@@ -136,7 +152,7 @@ private:
   MGLevelObject<MGTwoLevelTransfer<dim, VectorType>> transfers;
 
   /// Level operators for the geometric multigrid
-  MGLevelObject<std::shared_ptr<OperatorType>> mg_operators; // TODO: reuse
+  MGLevelObject<std::shared_ptr<OperatorType>> mg_operators;
 
   /// Multigrid level object storing all operators
   std::shared_ptr<mg::Matrix<VectorType>> mg_matrix;
@@ -158,16 +174,16 @@ private:
   MGConstrainedDoFs mg_constrained_dofs;
 
   /// Transfer operator for local smoothing
-  std::shared_ptr<LSTransferType> mg_transfer_ls; // TODO: reuse
+  std::shared_ptr<LSTransferType> mg_transfer_ls;
 
   /// Transfer operator for global coarsening
-  std::shared_ptr<GCTransferType> mg_transfer_gc; // TODO: reuse
+  std::shared_ptr<GCTransferType> mg_transfer_gc;
 
   /// Algebraic multigrid as coarse grid solver
-  TrilinosWrappers::PreconditionAMG precondition_amg;
+  std::shared_ptr<TrilinosWrappers::PreconditionAMG> precondition_amg;
 
   /// Incomplete LU as coarse grid solver
-  TrilinosWrappers::PreconditionILU precondition_ilu;
+  std::shared_ptr<TrilinosWrappers::PreconditionILU> precondition_ilu;
 
   /// Direct solver as coarse grid solver
   TrilinosWrappers::SolverDirect precondition_direct;

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -169,6 +169,9 @@ private:
   /// Incomplete LU as coarse grid solver
   TrilinosWrappers::PreconditionILU precondition_ilu;
 
+  /// Direct solver as coarse grid solver
+  TrilinosWrappers::SolverDirect precondition_direct;
+
   /// Solver control for the coarse grid solver
   std::shared_ptr<ReductionControl> coarse_grid_solver_control;
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2384,30 +2384,30 @@ namespace Parameters
                           "The coarse grid solver for lsmg or gcmg"
                           "Choices are <gmres|amg|ilu|direct>.");
 
-        prm.declare_entry("mg coarse grid max iterations",
+        prm.declare_entry("mg gmres max iterations",
                           "2000",
                           Patterns::Integer(),
-                          "mg coarse grid iterations for lsmg or gcmg");
+                          "mg gmres iterations for lsmg or gcmg");
 
-        prm.declare_entry("mg coarse grid tolerance",
+        prm.declare_entry("mg gmres tolerance",
                           "1e-14",
                           Patterns::Double(),
-                          "mg coarse grid tolerance n for lsmg or gcmg");
+                          "mg gmres tolerance n for lsmg or gcmg");
 
-        prm.declare_entry("mg coarse grid reduce",
+        prm.declare_entry("mg gmres reduce",
                           "1e-4",
                           Patterns::Double(),
-                          "mg coarse grid reduce for lsmg or gcmg");
+                          "mg gmres reduce for lsmg or gcmg");
 
-        prm.declare_entry("mg coarse grid max krylov vectors",
+        prm.declare_entry("mg gmres max krylov vectors",
                           "30",
                           Patterns::Integer(),
-                          "mg coarse grid max krylov vectors for lsmg or gcmg");
+                          "mg gmres max krylov vectors for lsmg or gcmg");
 
-        prm.declare_entry("mg coarse grid preconditioner",
+        prm.declare_entry("mg gmres preconditioner",
                           "amg",
                           Patterns::Selection("amg|ilu"),
-                          "The preconditioner for the mg coarse grid solver"
+                          "The preconditioner for the mg gmres solver"
                           "Choices are <amg|ilu>.");
 
         prm.declare_entry("mg use amg default parameters",
@@ -2528,21 +2528,20 @@ namespace Parameters
           throw std::logic_error(
             "Error, invalid coarse grid solver type. Choices are gmres, amg, ilu or direct.");
 
-        mg_coarse_grid_max_iterations =
-          prm.get_integer("mg coarse grid max iterations");
-        mg_coarse_grid_tolerance = prm.get_double("mg coarse grid tolerance");
-        mg_coarse_grid_reduce    = prm.get_double("mg coarse grid reduce");
-        mg_coarse_grid_max_krylov_vectors =
-          prm.get_integer("mg coarse grid max krylov vectors");
+        mg_gmres_max_iterations = prm.get_integer("mg gmres max iterations");
+        mg_gmres_tolerance      = prm.get_double("mg gmres tolerance");
+        mg_gmres_reduce         = prm.get_double("mg gmres reduce");
+        mg_gmres_max_krylov_vectors =
+          prm.get_integer("mg gmres max krylov vectors");
 
-        const std::string cg_precond = prm.get("mg coarse grid preconditioner");
+        const std::string cg_precond = prm.get("mg gmres preconditioner");
         if (cg_precond == "amg")
-          mg_coarse_grid_preconditioner = PreconditionerType::amg;
+          mg_gmres_preconditioner = PreconditionerType::amg;
         else if (cg_precond == "ilu")
-          mg_coarse_grid_preconditioner = PreconditionerType::ilu;
+          mg_gmres_preconditioner = PreconditionerType::ilu;
         else
           throw std::logic_error(
-            "Error, invalid preconditioner type for mg coarse grid solver. Choices are amg or ilu.");
+            "Error, invalid preconditioner type for mg gmres solver. Choices are amg or ilu.");
 
         mg_use_amg_default_parameters =
           prm.get_bool("mg use amg default parameters");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2410,6 +2410,11 @@ namespace Parameters
                           "The preconditioner for the mg coarse grid solver"
                           "Choices are <amg|ilu>.");
 
+        prm.declare_entry("mg use amg default parameters",
+                          "false",
+                          Patterns::Bool(),
+                          "Use default parameters for Trilinos AMG");
+
         prm.declare_entry(
           "mg verbosity",
           "verbose",
@@ -2538,6 +2543,9 @@ namespace Parameters
         else
           throw std::logic_error(
             "Error, invalid preconditioner type for mg coarse grid solver. Choices are amg or ilu.");
+
+        mg_use_amg_default_parameters =
+          prm.get_bool("mg use amg default parameters");
 
         const std::string mg_op = prm.get("mg verbosity");
         if (mg_op == "verbose")

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2479,8 +2479,8 @@ namespace Parameters
           prm.get_double("ilu preconditioner absolute tolerance");
         ilu_precond_rtol =
           prm.get_double("ilu preconditioner relative tolerance");
-        amg_precond_ilu_fill = prm.get_double("amg preconditioner ilu fill");
 
+        amg_precond_ilu_fill = prm.get_double("amg preconditioner ilu fill");
         amg_precond_ilu_atol =
           prm.get_double("amg preconditioner ilu absolute tolerance");
         amg_precond_ilu_rtol =

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2410,7 +2410,7 @@ namespace Parameters
                           "The preconditioner for the mg gmres solver"
                           "Choices are <amg|ilu>.");
 
-        prm.declare_entry("mg use amg default parameters",
+        prm.declare_entry("mg amg use default parameters",
                           "false",
                           Patterns::Bool(),
                           "Use default parameters for Trilinos AMG");
@@ -2543,8 +2543,8 @@ namespace Parameters
           throw std::logic_error(
             "Error, invalid preconditioner type for mg gmres solver. Choices are amg or ilu.");
 
-        mg_use_amg_default_parameters =
-          prm.get_bool("mg use amg default parameters");
+        mg_amg_use_default_parameters =
+          prm.get_bool("mg amg use default parameters");
 
         const std::string mg_op = prm.get("mg verbosity");
         if (mg_op == "verbose")

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2378,6 +2378,12 @@ namespace Parameters
                           "State whether MG should print max and min eigenvalue"
                           "Choices are <quiet|verbose>.");
 
+        prm.declare_entry("mg coarse grid solver",
+                          "gmres",
+                          Patterns::Selection("gmres|amg|ilu|direct"),
+                          "The coarse grid solver for lsmg or gcmg"
+                          "Choices are <gmres|amg|ilu|direct>.");
+
         prm.declare_entry("mg coarse grid max iterations",
                           "2000",
                           Patterns::Integer(),
@@ -2503,6 +2509,19 @@ namespace Parameters
         else
           throw(std::runtime_error(
             "Unknown verbosity mode for the eigenvalue estimation"));
+
+        const std::string cg_solver = prm.get("mg coarse grid solver");
+        if (cg_solver == "gmres")
+          mg_coarse_grid_solver = CoarseGridSolverType::gmres;
+        else if (cg_solver == "amg")
+          mg_coarse_grid_solver = CoarseGridSolverType::amg;
+        else if (cg_solver == "ilu")
+          mg_coarse_grid_solver = CoarseGridSolverType::ilu;
+        else if (cg_solver == "direct")
+          mg_coarse_grid_solver = CoarseGridSolverType::direct;
+        else
+          throw std::logic_error(
+            "Error, invalid coarse grid solver type. Choices are gmres, amg, ilu or direct.");
 
         mg_coarse_grid_max_iterations =
           prm.get_integer("mg coarse grid max iterations");

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -967,7 +967,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
 
           if (!this->simulation_parameters.linear_solver
                  .at(PhysicsID::fluid_dynamics)
-                 .mg_use_amg_default_parameters)
+                 .mg_amg_use_default_parameters)
             {
               amg_data.elliptic = false;
               if (this->dof_handler.get_fe().degree > 1)
@@ -1116,7 +1116,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
 
       if (!this->simulation_parameters.linear_solver
              .at(PhysicsID::fluid_dynamics)
-             .mg_use_amg_default_parameters)
+             .mg_amg_use_default_parameters)
         {
           amg_data.elliptic = false;
           if (this->dof_handler.get_fe().degree > 1)

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -937,26 +937,26 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
     {
       const int max_iterations =
         this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .mg_coarse_grid_max_iterations;
+          .mg_gmres_max_iterations;
       const double tolerance =
         this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .mg_coarse_grid_tolerance;
+          .mg_gmres_tolerance;
       const double reduce =
         this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .mg_coarse_grid_reduce;
+          .mg_gmres_reduce;
       this->coarse_grid_solver_control = std::make_shared<ReductionControl>(
         max_iterations, tolerance, reduce, false, false);
       SolverGMRES<VectorType>::AdditionalData solver_parameters;
       solver_parameters.max_n_tmp_vectors =
         this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .mg_coarse_grid_max_krylov_vectors;
+          .mg_gmres_max_krylov_vectors;
 
       this->coarse_grid_solver = std::make_shared<SolverGMRES<VectorType>>(
         *this->coarse_grid_solver_control, solver_parameters);
 
       if (this->simulation_parameters.linear_solver
             .at(PhysicsID::fluid_dynamics)
-            .mg_coarse_grid_preconditioner ==
+            .mg_gmres_preconditioner ==
           Parameters::LinearSolver::PreconditionerType::amg)
         {
           TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
@@ -1070,7 +1070,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
         }
       else if (this->simulation_parameters.linear_solver
                  .at(PhysicsID::fluid_dynamics)
-                 .mg_coarse_grid_preconditioner ==
+                 .mg_gmres_preconditioner ==
                Parameters::LinearSolver::PreconditionerType::ilu)
         {
           int current_preconditioner_fill_level =

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1016,6 +1016,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
              .mg_coarse_grid_solver ==
            Parameters::LinearSolver::CoarseGridSolverType::direct)
     {
+#if DEAL_II_VERSION_GTE(9, 6, 0)
       TrilinosWrappers::SolverDirect::AdditionalData data;
       this->direct_solver_control =
         std::make_shared<SolverControl>(100, 1.e-10);
@@ -1031,6 +1032,12 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
         MGCoarseGridApplyPreconditioner<VectorType,
                                         TrilinosWrappers::SolverDirect>>(
         *this->precondition_direct);
+#else
+      AssertThrow(
+        false,
+        ExcMessage(
+          "The usage of a direct solver as coarse grid solver requires a version of deal.II >= 9.6.0"));
+#endif
     }
   else
     AssertThrow(

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1016,13 +1016,21 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
              .mg_coarse_grid_solver ==
            Parameters::LinearSolver::CoarseGridSolverType::direct)
     {
-      this->precondition_direct.initialize(
+      TrilinosWrappers::SolverDirect::AdditionalData data;
+      this->direct_solver_control =
+        std::make_shared<SolverControl>(100, 1.e-10);
+
+      this->precondition_direct =
+        std::make_shared<TrilinosWrappers::SolverDirect>(
+          *this->direct_solver_control, data);
+
+      this->precondition_direct->initialize(
         this->mg_operators[this->minlevel]->get_system_matrix());
 
       this->mg_coarse = std::make_shared<
         MGCoarseGridApplyPreconditioner<VectorType,
                                         TrilinosWrappers::SolverDirect>>(
-        this->precondition_direct);
+        *this->precondition_direct);
     }
   else
     AssertThrow(

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1012,7 +1012,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
                   AssertThrow(
                     false,
                     ExcMessage(
-                      "the extraction of constant modes for the AMG coarse-grid solver requires a version od deal.II >= 9.6.0"));
+                      "The extraction of constant modes for the AMG coarse-grid solver requires a version of deal.II >= 9.6.0"));
 #endif
                 }
               else if (this->simulation_parameters.linear_solver
@@ -1159,7 +1159,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
               AssertThrow(
                 false,
                 ExcMessage(
-                  "the extraction of constant modes for the AMG coarse-grid solver requires a version od deal.II >= 9.6.0"));
+                  "The extraction of constant modes for the AMG coarse-grid solver requires a version of deal.II >= 9.6.0"));
 #endif
             }
           else if (this->simulation_parameters.linear_solver

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -44,6 +44,151 @@
 
 #include <deal.II/numerics/vector_tools.h>
 
+namespace dealii
+{
+  /**
+   * Coarse grid solver using a preconditioner only. This is a little wrapper,
+   * transforming a preconditioner into a coarse grid solver.
+   */
+  template <class VectorType, class PreconditionerType>
+  class MGCoarseGridApplyPreconditioner : public MGCoarseGridBase<VectorType>
+  {
+  public:
+    /**
+     * Default constructor.
+     */
+    MGCoarseGridApplyPreconditioner();
+
+    /**
+     * Constructor. Store a pointer to the preconditioner for later use.
+     */
+    MGCoarseGridApplyPreconditioner(const PreconditionerType &precondition);
+
+    /**
+     * Clear the pointer.
+     */
+    void
+    clear();
+
+    /**
+     * Initialize new data.
+     */
+    void
+    initialize(const PreconditionerType &precondition);
+
+    /**
+     * Implementation of the abstract function.
+     */
+    virtual void
+    operator()(const unsigned int level,
+               VectorType        &dst,
+               const VectorType  &src) const override;
+
+  private:
+    /**
+     * Reference to the preconditioner.
+     */
+    SmartPointer<
+      const PreconditionerType,
+      MGCoarseGridApplyPreconditioner<VectorType, PreconditionerType>>
+      preconditioner;
+  };
+
+
+
+  template <class VectorType, class PreconditionerType>
+  MGCoarseGridApplyPreconditioner<VectorType, PreconditionerType>::
+    MGCoarseGridApplyPreconditioner()
+    : preconditioner(0, typeid(*this).name())
+  {}
+
+
+
+  template <class VectorType, class PreconditionerType>
+  MGCoarseGridApplyPreconditioner<VectorType, PreconditionerType>::
+    MGCoarseGridApplyPreconditioner(const PreconditionerType &preconditioner)
+    : preconditioner(&preconditioner, typeid(*this).name())
+  {}
+
+
+
+  template <class VectorType, class PreconditionerType>
+  void
+  MGCoarseGridApplyPreconditioner<VectorType, PreconditionerType>::initialize(
+    const PreconditionerType &preconditioner_)
+  {
+    preconditioner = &preconditioner_;
+  }
+
+
+
+  template <class VectorType, class PreconditionerType>
+  void
+  MGCoarseGridApplyPreconditioner<VectorType, PreconditionerType>::clear()
+  {
+    preconditioner = 0;
+  }
+
+
+
+  namespace internal
+  {
+    namespace MGCoarseGridApplyPreconditioner
+    {
+      template <class VectorType,
+                class PreconditionerType,
+                typename std::enable_if<
+                  std::is_same<typename VectorType::value_type, double>::value,
+                  VectorType>::type * = nullptr>
+      void
+      solve(const PreconditionerType preconditioner,
+            VectorType              &dst,
+            const VectorType        &src)
+      {
+        // to allow the case that the preconditioner was only set up on a
+        // subset of processes
+        if (preconditioner != nullptr)
+          preconditioner->vmult(dst, src);
+      }
+
+      template <class VectorType,
+                class PreconditionerType,
+                typename std::enable_if<
+                  !std::is_same<typename VectorType::value_type, double>::value,
+                  VectorType>::type * = nullptr>
+      void
+      solve(const PreconditionerType preconditioner,
+            VectorType              &dst,
+            const VectorType        &src)
+      {
+        LinearAlgebra::distributed::Vector<double> src_;
+        LinearAlgebra::distributed::Vector<double> dst_;
+
+        src_ = src;
+        dst_ = dst;
+
+        // to allow the case that the preconditioner was only set up on a
+        // subset of processes
+        if (preconditioner != nullptr)
+          preconditioner->vmult(dst_, src_);
+
+        dst = dst_;
+      }
+    } // namespace MGCoarseGridApplyPreconditioner
+  }   // namespace internal
+
+
+  template <class VectorType, class PreconditionerType>
+  void
+  MGCoarseGridApplyPreconditioner<VectorType, PreconditionerType>::operator()(
+    const unsigned int /*level*/,
+    VectorType       &dst,
+    const VectorType &src) const
+  {
+    internal::MGCoarseGridApplyPreconditioner::solve(preconditioner, dst, src);
+  }
+} // namespace dealii
+
 template <int dim>
 MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
   const SimulationParameters<dim>         &simulation_parameters,
@@ -786,29 +931,168 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
   // Create coarse-grid GMRES solver and AMG preconditioner
   this->mg_setup_timer.enter_subsection("Create coarse-grid solver");
 
-  const int max_iterations =
-    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-      .mg_coarse_grid_max_iterations;
-  const double tolerance =
-    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-      .mg_coarse_grid_tolerance;
-  const double reduce =
-    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-      .mg_coarse_grid_reduce;
-  this->coarse_grid_solver_control = std::make_shared<ReductionControl>(
-    max_iterations, tolerance, reduce, false, false);
-  SolverGMRES<VectorType>::AdditionalData solver_parameters;
-  solver_parameters.max_n_tmp_vectors =
-    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-      .mg_coarse_grid_max_krylov_vectors;
-
-  this->coarse_grid_solver =
-    std::make_shared<SolverGMRES<VectorType>>(*this->coarse_grid_solver_control,
-                                              solver_parameters);
-
   if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-        .mg_coarse_grid_preconditioner ==
-      Parameters::LinearSolver::PreconditionerType::amg)
+        .mg_coarse_grid_solver ==
+      Parameters::LinearSolver::CoarseGridSolverType::gmres)
+    {
+      const int max_iterations =
+        this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .mg_coarse_grid_max_iterations;
+      const double tolerance =
+        this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .mg_coarse_grid_tolerance;
+      const double reduce =
+        this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .mg_coarse_grid_reduce;
+      this->coarse_grid_solver_control = std::make_shared<ReductionControl>(
+        max_iterations, tolerance, reduce, false, false);
+      SolverGMRES<VectorType>::AdditionalData solver_parameters;
+      solver_parameters.max_n_tmp_vectors =
+        this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+          .mg_coarse_grid_max_krylov_vectors;
+
+      this->coarse_grid_solver = std::make_shared<SolverGMRES<VectorType>>(
+        *this->coarse_grid_solver_control, solver_parameters);
+
+      if (this->simulation_parameters.linear_solver
+            .at(PhysicsID::fluid_dynamics)
+            .mg_coarse_grid_preconditioner ==
+          Parameters::LinearSolver::PreconditionerType::amg)
+        {
+          TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
+          amg_data.elliptic = false;
+          if (this->dof_handler.get_fe().degree > 1)
+            amg_data.higher_order_elements = true;
+          amg_data.n_cycles = this->simulation_parameters.linear_solver
+                                .at(PhysicsID::fluid_dynamics)
+                                .amg_n_cycles;
+          amg_data.w_cycle = this->simulation_parameters.linear_solver
+                               .at(PhysicsID::fluid_dynamics)
+                               .amg_w_cycles;
+          amg_data.aggregation_threshold =
+            this->simulation_parameters.linear_solver
+              .at(PhysicsID::fluid_dynamics)
+              .amg_aggregation_threshold;
+          amg_data.smoother_sweeps = this->simulation_parameters.linear_solver
+                                       .at(PhysicsID::fluid_dynamics)
+                                       .amg_smoother_sweeps;
+          amg_data.smoother_overlap = this->simulation_parameters.linear_solver
+                                        .at(PhysicsID::fluid_dynamics)
+                                        .amg_smoother_overlap;
+          amg_data.output_details = false;
+          amg_data.smoother_type  = "ILU";
+          amg_data.coarse_type    = "ILU";
+
+          std::vector<std::vector<bool>> constant_modes;
+          ComponentMask                  components(dim + 1, true);
+          if (this->simulation_parameters.linear_solver
+                .at(PhysicsID::fluid_dynamics)
+                .preconditioner ==
+              Parameters::LinearSolver::PreconditionerType::lsmg)
+
+            {
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+              // Constant modes for velocity and pressure
+              DoFTools::extract_level_constant_modes(this->minlevel,
+                                                     this->dof_handler,
+                                                     components,
+                                                     constant_modes);
+#else
+              AssertThrow(
+                false,
+                ExcMessage(
+                  "the extraction of constant modes for the AMG coarse-grid solver requires a version od deal.II >= 9.6.0"));
+#endif
+            }
+          else if (this->simulation_parameters.linear_solver
+                     .at(PhysicsID::fluid_dynamics)
+                     .preconditioner ==
+                   Parameters::LinearSolver::PreconditionerType::gcmg)
+            {
+              // Constant modes for velocity and pressure
+              DoFTools::extract_constant_modes(
+                this->dof_handlers[this->minlevel], components, constant_modes);
+            }
+
+          amg_data.constant_modes = constant_modes;
+
+          // Extract matrix of the minlevel to avoid building it twice
+          const TrilinosWrappers::SparseMatrix &min_level_matrix =
+            this->mg_operators[this->minlevel]->get_system_matrix();
+
+          Teuchos::ParameterList              parameter_ml;
+          std::unique_ptr<Epetra_MultiVector> distributed_constant_modes;
+          amg_data.set_parameters(parameter_ml,
+                                  distributed_constant_modes,
+                                  min_level_matrix);
+
+          const double ilu_fill = this->simulation_parameters.linear_solver
+                                    .at(PhysicsID::fluid_dynamics)
+                                    .ilu_precond_fill;
+          const double ilu_atol = this->simulation_parameters.linear_solver
+                                    .at(PhysicsID::fluid_dynamics)
+                                    .amg_precond_ilu_atol;
+          const double ilu_rtol = this->simulation_parameters.linear_solver
+                                    .at(PhysicsID::fluid_dynamics)
+                                    .amg_precond_ilu_rtol;
+          parameter_ml.set("smoother: ifpack level-of-fill", ilu_fill);
+          parameter_ml.set("smoother: ifpack absolute threshold", ilu_atol);
+          parameter_ml.set("smoother: ifpack relative threshold", ilu_rtol);
+
+          parameter_ml.set("coarse: ifpack level-of-fill", ilu_fill);
+          parameter_ml.set("coarse: ifpack absolute threshold", ilu_atol);
+          parameter_ml.set("coarse: ifpack relative threshold", ilu_rtol);
+
+          this->precondition_amg.initialize(min_level_matrix, parameter_ml);
+
+          this->mg_coarse = std::make_shared<
+            MGCoarseGridIterativeSolver<VectorType,
+                                        SolverGMRES<VectorType>,
+                                        OperatorType,
+                                        decltype(this->precondition_amg)>>(
+            *this->coarse_grid_solver,
+            *this->mg_operators[this->minlevel],
+            this->precondition_amg);
+        }
+      else if (this->simulation_parameters.linear_solver
+                 .at(PhysicsID::fluid_dynamics)
+                 .mg_coarse_grid_preconditioner ==
+               Parameters::LinearSolver::PreconditionerType::ilu)
+        {
+          int current_preconditioner_fill_level =
+            this->simulation_parameters.linear_solver
+              .at(PhysicsID::fluid_dynamics)
+              .ilu_precond_fill;
+          const double ilu_atol = this->simulation_parameters.linear_solver
+                                    .at(PhysicsID::fluid_dynamics)
+                                    .ilu_precond_atol;
+          const double ilu_rtol = this->simulation_parameters.linear_solver
+                                    .at(PhysicsID::fluid_dynamics)
+                                    .ilu_precond_rtol;
+          TrilinosWrappers::PreconditionILU::AdditionalData
+            preconditionerOptions(current_preconditioner_fill_level,
+                                  ilu_atol,
+                                  ilu_rtol,
+                                  0);
+
+          this->precondition_ilu.initialize(
+            this->mg_operators[this->minlevel]->get_system_matrix(),
+            preconditionerOptions);
+
+          this->mg_coarse = std::make_shared<
+            MGCoarseGridIterativeSolver<VectorType,
+                                        SolverGMRES<VectorType>,
+                                        OperatorType,
+                                        decltype(this->precondition_ilu)>>(
+            *this->coarse_grid_solver,
+            *this->mg_operators[this->minlevel],
+            this->precondition_ilu);
+        }
+    }
+  else if (this->simulation_parameters.linear_solver
+             .at(PhysicsID::fluid_dynamics)
+             .mg_coarse_grid_solver ==
+           Parameters::LinearSolver::CoarseGridSolverType::amg)
     {
       TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
       amg_data.elliptic = false;
@@ -897,18 +1181,14 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
       this->precondition_amg.initialize(min_level_matrix, parameter_ml);
 
       this->mg_coarse = std::make_shared<
-        MGCoarseGridIterativeSolver<VectorType,
-                                    SolverGMRES<VectorType>,
-                                    OperatorType,
-                                    decltype(this->precondition_amg)>>(
-        *this->coarse_grid_solver,
-        *this->mg_operators[this->minlevel],
+        MGCoarseGridApplyPreconditioner<VectorType,
+                                        TrilinosWrappers::PreconditionAMG>>(
         this->precondition_amg);
     }
   else if (this->simulation_parameters.linear_solver
              .at(PhysicsID::fluid_dynamics)
-             .mg_coarse_grid_preconditioner ==
-           Parameters::LinearSolver::PreconditionerType::ilu)
+             .mg_coarse_grid_solver ==
+           Parameters::LinearSolver::CoarseGridSolverType::ilu)
     {
       int current_preconditioner_fill_level =
         this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
@@ -927,14 +1207,40 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
         preconditionerOptions);
 
       this->mg_coarse = std::make_shared<
-        MGCoarseGridIterativeSolver<VectorType,
-                                    SolverGMRES<VectorType>,
-                                    OperatorType,
-                                    decltype(this->precondition_ilu)>>(
-        *this->coarse_grid_solver,
-        *this->mg_operators[this->minlevel],
+        MGCoarseGridApplyPreconditioner<VectorType,
+                                        TrilinosWrappers::PreconditionILU>>(
         this->precondition_ilu);
     }
+  else if (this->simulation_parameters.linear_solver
+             .at(PhysicsID::fluid_dynamics)
+             .mg_coarse_grid_solver ==
+           Parameters::LinearSolver::CoarseGridSolverType::direct)
+    {
+      this->precondition_direct.initialize(
+        this->mg_operators[this->minlevel]->get_system_matrix());
+
+      this->mg_coarse = std::make_shared<
+        MGCoarseGridApplyPreconditioner<VectorType,
+                                        TrilinosWrappers::SolverDirect>>(
+        this->precondition_direct);
+    }
+  else
+    AssertThrow(
+      this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+            .mg_coarse_grid_solver ==
+          Parameters::LinearSolver::CoarseGridSolverType::gmres ||
+        this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+            .mg_coarse_grid_solver ==
+          Parameters::LinearSolver::CoarseGridSolverType::amg ||
+        this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+            .mg_coarse_grid_solver ==
+          Parameters::LinearSolver::CoarseGridSolverType::ilu ||
+        this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+            .mg_coarse_grid_solver ==
+          Parameters::LinearSolver::CoarseGridSolverType::direct,
+      ExcMessage(
+        "This coarse-grid solver is not supported. Supported options are <gmres|amg|ilu|direct>."));
+
   this->mg_setup_timer.leave_subsection("Create coarse-grid solver");
 
   if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
@@ -1050,29 +1356,37 @@ MFNavierStokesPreconditionGMG<dim>::vmult(VectorType       &dst,
     AssertThrow(false, ExcNotImplemented());
 
   // Save number of coarse grid iterations needed in one vmult
-  this->coarse_grid_iterations.emplace_back(
-    this->coarse_grid_solver_control->last_step());
+  if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .mg_coarse_grid_solver ==
+      Parameters::LinearSolver::CoarseGridSolverType::gmres)
+    this->coarse_grid_iterations.emplace_back(
+      this->coarse_grid_solver_control->last_step());
 }
 
 template <int dim>
 void
 MFNavierStokesPreconditionGMG<dim>::print_relevant_info() const
 {
-  if (this->coarse_grid_iterations.empty())
-    this->pcout << "  -Coarse grid solver took: 0 iterations" << std::endl;
-  else
+  if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
+        .mg_coarse_grid_solver ==
+      Parameters::LinearSolver::CoarseGridSolverType::gmres)
     {
-      unsigned int total = this->coarse_grid_iterations[0];
-      this->pcout << "  -Coarse grid solver took: "
-                  << this->coarse_grid_iterations[0];
-      for (unsigned int i = 1; i < this->coarse_grid_iterations.size(); i++)
+      if (this->coarse_grid_iterations.empty())
+        this->pcout << "  -Coarse grid solver took: 0 iterations" << std::endl;
+      else
         {
-          this->pcout << " + " << this->coarse_grid_iterations[i];
-          total += this->coarse_grid_iterations[i];
-        }
-      this->pcout << " = " << total << " iterations" << std::endl;
+          unsigned int total = this->coarse_grid_iterations[0];
+          this->pcout << "  -Coarse grid solver took: "
+                      << this->coarse_grid_iterations[0];
+          for (unsigned int i = 1; i < this->coarse_grid_iterations.size(); i++)
+            {
+              this->pcout << " + " << this->coarse_grid_iterations[i];
+              total += this->coarse_grid_iterations[i];
+            }
+          this->pcout << " = " << total << " iterations" << std::endl;
 
-      this->coarse_grid_iterations.clear();
+          this->coarse_grid_iterations.clear();
+        }
     }
 }
 

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1037,7 +1037,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
 
               const double ilu_fill = this->simulation_parameters.linear_solver
                                         .at(PhysicsID::fluid_dynamics)
-                                        .ilu_precond_fill;
+                                        .amg_precond_ilu_fill;
               const double ilu_atol = this->simulation_parameters.linear_solver
                                         .at(PhysicsID::fluid_dynamics)
                                         .amg_precond_ilu_atol;
@@ -1182,7 +1182,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
 
           const double ilu_fill = this->simulation_parameters.linear_solver
                                     .at(PhysicsID::fluid_dynamics)
-                                    .ilu_precond_fill;
+                                    .amg_precond_ilu_fill;
           const double ilu_atol = this->simulation_parameters.linear_solver
                                     .at(PhysicsID::fluid_dynamics)
                                     .amg_precond_ilu_atol;

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -960,6 +960,164 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
           Parameters::LinearSolver::PreconditionerType::amg)
         {
           TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
+
+          // Extract matrix of the minlevel to avoid building it twice
+          const TrilinosWrappers::SparseMatrix &min_level_matrix =
+            this->mg_operators[this->minlevel]->get_system_matrix();
+
+          if (!this->simulation_parameters.linear_solver
+                 .at(PhysicsID::fluid_dynamics)
+                 .mg_use_amg_default_parameters)
+            {
+              amg_data.elliptic = false;
+              if (this->dof_handler.get_fe().degree > 1)
+                amg_data.higher_order_elements = true;
+              amg_data.n_cycles = this->simulation_parameters.linear_solver
+                                    .at(PhysicsID::fluid_dynamics)
+                                    .amg_n_cycles;
+              amg_data.w_cycle = this->simulation_parameters.linear_solver
+                                   .at(PhysicsID::fluid_dynamics)
+                                   .amg_w_cycles;
+              amg_data.aggregation_threshold =
+                this->simulation_parameters.linear_solver
+                  .at(PhysicsID::fluid_dynamics)
+                  .amg_aggregation_threshold;
+              amg_data.smoother_sweeps =
+                this->simulation_parameters.linear_solver
+                  .at(PhysicsID::fluid_dynamics)
+                  .amg_smoother_sweeps;
+              amg_data.smoother_overlap =
+                this->simulation_parameters.linear_solver
+                  .at(PhysicsID::fluid_dynamics)
+                  .amg_smoother_overlap;
+              amg_data.output_details = false;
+              amg_data.smoother_type  = "ILU";
+              amg_data.coarse_type    = "ILU";
+
+              std::vector<std::vector<bool>> constant_modes;
+              ComponentMask                  components(dim + 1, true);
+              if (this->simulation_parameters.linear_solver
+                    .at(PhysicsID::fluid_dynamics)
+                    .preconditioner ==
+                  Parameters::LinearSolver::PreconditionerType::lsmg)
+
+                {
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+                  // Constant modes for velocity and pressure
+                  DoFTools::extract_level_constant_modes(this->minlevel,
+                                                         this->dof_handler,
+                                                         components,
+                                                         constant_modes);
+#else
+                  AssertThrow(
+                    false,
+                    ExcMessage(
+                      "the extraction of constant modes for the AMG coarse-grid solver requires a version od deal.II >= 9.6.0"));
+#endif
+                }
+              else if (this->simulation_parameters.linear_solver
+                         .at(PhysicsID::fluid_dynamics)
+                         .preconditioner ==
+                       Parameters::LinearSolver::PreconditionerType::gcmg)
+                {
+                  // Constant modes for velocity and pressure
+                  DoFTools::extract_constant_modes(
+                    this->dof_handlers[this->minlevel],
+                    components,
+                    constant_modes);
+                }
+
+              amg_data.constant_modes = constant_modes;
+
+              Teuchos::ParameterList              parameter_ml;
+              std::unique_ptr<Epetra_MultiVector> distributed_constant_modes;
+              amg_data.set_parameters(parameter_ml,
+                                      distributed_constant_modes,
+                                      min_level_matrix);
+
+              const double ilu_fill = this->simulation_parameters.linear_solver
+                                        .at(PhysicsID::fluid_dynamics)
+                                        .ilu_precond_fill;
+              const double ilu_atol = this->simulation_parameters.linear_solver
+                                        .at(PhysicsID::fluid_dynamics)
+                                        .amg_precond_ilu_atol;
+              const double ilu_rtol = this->simulation_parameters.linear_solver
+                                        .at(PhysicsID::fluid_dynamics)
+                                        .amg_precond_ilu_rtol;
+              parameter_ml.set("smoother: ifpack level-of-fill", ilu_fill);
+              parameter_ml.set("smoother: ifpack absolute threshold", ilu_atol);
+              parameter_ml.set("smoother: ifpack relative threshold", ilu_rtol);
+
+              parameter_ml.set("coarse: ifpack level-of-fill", ilu_fill);
+              parameter_ml.set("coarse: ifpack absolute threshold", ilu_atol);
+              parameter_ml.set("coarse: ifpack relative threshold", ilu_rtol);
+
+              this->precondition_amg.initialize(min_level_matrix, parameter_ml);
+            }
+          else
+            {
+              this->precondition_amg.initialize(min_level_matrix, amg_data);
+            }
+
+          this->mg_coarse = std::make_shared<
+            MGCoarseGridIterativeSolver<VectorType,
+                                        SolverGMRES<VectorType>,
+                                        OperatorType,
+                                        decltype(this->precondition_amg)>>(
+            *this->coarse_grid_solver,
+            *this->mg_operators[this->minlevel],
+            this->precondition_amg);
+        }
+      else if (this->simulation_parameters.linear_solver
+                 .at(PhysicsID::fluid_dynamics)
+                 .mg_coarse_grid_preconditioner ==
+               Parameters::LinearSolver::PreconditionerType::ilu)
+        {
+          int current_preconditioner_fill_level =
+            this->simulation_parameters.linear_solver
+              .at(PhysicsID::fluid_dynamics)
+              .ilu_precond_fill;
+          const double ilu_atol = this->simulation_parameters.linear_solver
+                                    .at(PhysicsID::fluid_dynamics)
+                                    .ilu_precond_atol;
+          const double ilu_rtol = this->simulation_parameters.linear_solver
+                                    .at(PhysicsID::fluid_dynamics)
+                                    .ilu_precond_rtol;
+          TrilinosWrappers::PreconditionILU::AdditionalData
+            preconditionerOptions(current_preconditioner_fill_level,
+                                  ilu_atol,
+                                  ilu_rtol,
+                                  0);
+
+          this->precondition_ilu.initialize(
+            this->mg_operators[this->minlevel]->get_system_matrix(),
+            preconditionerOptions);
+
+          this->mg_coarse = std::make_shared<
+            MGCoarseGridIterativeSolver<VectorType,
+                                        SolverGMRES<VectorType>,
+                                        OperatorType,
+                                        decltype(this->precondition_ilu)>>(
+            *this->coarse_grid_solver,
+            *this->mg_operators[this->minlevel],
+            this->precondition_ilu);
+        }
+    }
+  else if (this->simulation_parameters.linear_solver
+             .at(PhysicsID::fluid_dynamics)
+             .mg_coarse_grid_solver ==
+           Parameters::LinearSolver::CoarseGridSolverType::amg)
+    {
+      TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
+
+      // Extract matrix of the minlevel to avoid building it twice
+      const TrilinosWrappers::SparseMatrix &min_level_matrix =
+        this->mg_operators[this->minlevel]->get_system_matrix();
+
+      if (!this->simulation_parameters.linear_solver
+             .at(PhysicsID::fluid_dynamics)
+             .mg_use_amg_default_parameters)
+        {
           amg_data.elliptic = false;
           if (this->dof_handler.get_fe().degree > 1)
             amg_data.higher_order_elements = true;
@@ -1016,10 +1174,6 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
 
           amg_data.constant_modes = constant_modes;
 
-          // Extract matrix of the minlevel to avoid building it twice
-          const TrilinosWrappers::SparseMatrix &min_level_matrix =
-            this->mg_operators[this->minlevel]->get_system_matrix();
-
           Teuchos::ParameterList              parameter_ml;
           std::unique_ptr<Epetra_MultiVector> distributed_constant_modes;
           amg_data.set_parameters(parameter_ml,
@@ -1044,141 +1198,12 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
           parameter_ml.set("coarse: ifpack relative threshold", ilu_rtol);
 
           this->precondition_amg.initialize(min_level_matrix, parameter_ml);
-
-          this->mg_coarse = std::make_shared<
-            MGCoarseGridIterativeSolver<VectorType,
-                                        SolverGMRES<VectorType>,
-                                        OperatorType,
-                                        decltype(this->precondition_amg)>>(
-            *this->coarse_grid_solver,
-            *this->mg_operators[this->minlevel],
-            this->precondition_amg);
         }
-      else if (this->simulation_parameters.linear_solver
-                 .at(PhysicsID::fluid_dynamics)
-                 .mg_coarse_grid_preconditioner ==
-               Parameters::LinearSolver::PreconditionerType::ilu)
+      else
         {
-          int current_preconditioner_fill_level =
-            this->simulation_parameters.linear_solver
-              .at(PhysicsID::fluid_dynamics)
-              .ilu_precond_fill;
-          const double ilu_atol = this->simulation_parameters.linear_solver
-                                    .at(PhysicsID::fluid_dynamics)
-                                    .ilu_precond_atol;
-          const double ilu_rtol = this->simulation_parameters.linear_solver
-                                    .at(PhysicsID::fluid_dynamics)
-                                    .ilu_precond_rtol;
-          TrilinosWrappers::PreconditionILU::AdditionalData
-            preconditionerOptions(current_preconditioner_fill_level,
-                                  ilu_atol,
-                                  ilu_rtol,
-                                  0);
-
-          this->precondition_ilu.initialize(
-            this->mg_operators[this->minlevel]->get_system_matrix(),
-            preconditionerOptions);
-
-          this->mg_coarse = std::make_shared<
-            MGCoarseGridIterativeSolver<VectorType,
-                                        SolverGMRES<VectorType>,
-                                        OperatorType,
-                                        decltype(this->precondition_ilu)>>(
-            *this->coarse_grid_solver,
-            *this->mg_operators[this->minlevel],
-            this->precondition_ilu);
-        }
-    }
-  else if (this->simulation_parameters.linear_solver
-             .at(PhysicsID::fluid_dynamics)
-             .mg_coarse_grid_solver ==
-           Parameters::LinearSolver::CoarseGridSolverType::amg)
-    {
-      TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
-      amg_data.elliptic = false;
-      if (this->dof_handler.get_fe().degree > 1)
-        amg_data.higher_order_elements = true;
-      amg_data.n_cycles =
-        this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .amg_n_cycles;
-      amg_data.w_cycle =
-        this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .amg_w_cycles;
-      amg_data.aggregation_threshold =
-        this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .amg_aggregation_threshold;
-      amg_data.smoother_sweeps =
-        this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .amg_smoother_sweeps;
-      amg_data.smoother_overlap =
-        this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .amg_smoother_overlap;
-      amg_data.output_details = false;
-      amg_data.smoother_type  = "ILU";
-      amg_data.coarse_type    = "ILU";
-
-      std::vector<std::vector<bool>> constant_modes;
-      ComponentMask                  components(dim + 1, true);
-      if (this->simulation_parameters.linear_solver
-            .at(PhysicsID::fluid_dynamics)
-            .preconditioner ==
-          Parameters::LinearSolver::PreconditionerType::lsmg)
-
-        {
-#if DEAL_II_VERSION_GTE(9, 6, 0)
-          // Constant modes for velocity and pressure
-          DoFTools::extract_level_constant_modes(this->minlevel,
-                                                 this->dof_handler,
-                                                 components,
-                                                 constant_modes);
-#else
-          AssertThrow(
-            false,
-            ExcMessage(
-              "the extraction of constant modes for the AMG coarse-grid solver requires a version od deal.II >= 9.6.0"));
-#endif
-        }
-      else if (this->simulation_parameters.linear_solver
-                 .at(PhysicsID::fluid_dynamics)
-                 .preconditioner ==
-               Parameters::LinearSolver::PreconditionerType::gcmg)
-        {
-          // Constant modes for velocity and pressure
-          DoFTools::extract_constant_modes(this->dof_handlers[this->minlevel],
-                                           components,
-                                           constant_modes);
+          this->precondition_amg.initialize(min_level_matrix, amg_data);
         }
 
-      amg_data.constant_modes = constant_modes;
-
-      // Extract matrix of the minlevel to avoid building it twice
-      const TrilinosWrappers::SparseMatrix &min_level_matrix =
-        this->mg_operators[this->minlevel]->get_system_matrix();
-
-      Teuchos::ParameterList              parameter_ml;
-      std::unique_ptr<Epetra_MultiVector> distributed_constant_modes;
-      amg_data.set_parameters(parameter_ml,
-                              distributed_constant_modes,
-                              min_level_matrix);
-
-      const double ilu_fill =
-        this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .ilu_precond_fill;
-      const double ilu_atol =
-        this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .amg_precond_ilu_atol;
-      const double ilu_rtol =
-        this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-          .amg_precond_ilu_rtol;
-      parameter_ml.set("smoother: ifpack level-of-fill", ilu_fill);
-      parameter_ml.set("smoother: ifpack absolute threshold", ilu_atol);
-      parameter_ml.set("smoother: ifpack relative threshold", ilu_rtol);
-
-      parameter_ml.set("coarse: ifpack level-of-fill", ilu_fill);
-      parameter_ml.set("coarse: ifpack absolute threshold", ilu_atol);
-      parameter_ml.set("coarse: ifpack relative threshold", ilu_rtol);
-
-      this->precondition_amg.initialize(min_level_matrix, parameter_ml);
 
       this->mg_coarse = std::make_shared<
         MGCoarseGridApplyPreconditioner<VectorType,


### PR DESCRIPTION
# Description of the problem

Until now the matrix-free solver was only supporting GMRES as coarse-grid solver preconditioned by ILU or AMG for the GMG preconditioner.

# Description of the solution

This PR adds also the possibility to choose AMG, ILU or a direct solver as coarse-grid solver in the GMG preconditioner.  It creates a new parameter that allows to choose the coarse-grid solver and renames the GMRES specific parameters to be able to differentiate them. 

# How Has This Been Tested?

All the tests use by default the GMRES coarse-grid solver and none of them was modified. Only the parameters were renamed according to the new definition of GMRES parameters in the prm file.

# Documentation

- [X] `doc/source/parameters/cfd/linear_solver_control.rst`: the parameters were updated in the linear solver section.
- [X] `doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst`: the name of the gmres parameters was updated.