### PR TITLE
Allow to disable Navier-Stokes source term in MF

### DIFF
--- a/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator.prm
@@ -115,6 +115,16 @@ subsection boundary conditions
 end
 
 #---------------------------------------------------
+# Source term
+#---------------------------------------------------
+
+subsection source term
+  subsection xyz
+    set enable = false
+  end
+end
+
+#---------------------------------------------------
 # Mesh Adaptation Control
 #---------------------------------------------------
 

--- a/applications_tests/lethe-fluid-matrix-free/poiseuille3d_flow_control.prm
+++ b/applications_tests/lethe-fluid-matrix-free/poiseuille3d_flow_control.prm
@@ -54,6 +54,16 @@ subsection boundary conditions
 end
 
 #---------------------------------------------------
+# Source term
+#---------------------------------------------------
+
+subsection source term
+  subsection xyz
+    set enable = false
+  end
+end
+
+#---------------------------------------------------
 # Flow control
 #---------------------------------------------------
 

--- a/applications_tests/lethe-fluid-matrix-free/taylor_couette_2d_local_ref.prm
+++ b/applications_tests/lethe-fluid-matrix-free/taylor_couette_2d_local_ref.prm
@@ -80,6 +80,16 @@ subsection boundary conditions
 end
 
 #---------------------------------------------------
+# Source term
+#---------------------------------------------------
+
+subsection source term
+  subsection xyz
+    set enable = false
+  end
+end
+
+#---------------------------------------------------
 # Mesh Adaptation Control
 #---------------------------------------------------
 

--- a/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu.prm
@@ -118,6 +118,16 @@ subsection boundary conditions
 end
 
 #---------------------------------------------------
+# Source term
+#---------------------------------------------------
+
+subsection source term
+  subsection xyz
+    set enable = false
+  end
+end
+
+#---------------------------------------------------
 # Non-Linear Solver Control
 #---------------------------------------------------
 

--- a/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu_gls.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu_gls.prm
@@ -118,6 +118,16 @@ subsection boundary conditions
 end
 
 #---------------------------------------------------
+# Source term
+#---------------------------------------------------
+
+subsection source term
+  subsection xyz
+    set enable = false
+  end
+end
+
+#---------------------------------------------------
 # Non-Linear Solver Control
 #---------------------------------------------------
 

--- a/applications_tests/lethe-fluid-matrix-free/tgv_restart_bdf1.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_restart_bdf1.prm
@@ -133,6 +133,16 @@ subsection boundary conditions
 end
 
 #---------------------------------------------------
+# Source term
+#---------------------------------------------------
+
+subsection source term
+  subsection xyz
+    set enable = false
+  end
+end
+
+#---------------------------------------------------
 # Non-Linear Solver Control
 #---------------------------------------------------
 

--- a/doc/source/parameters/cfd/source_term.rst
+++ b/doc/source/parameters/cfd/source_term.rst
@@ -8,9 +8,9 @@ If the problem being simulated has a source, it can be added in this section. Th
 
   subsection source term
     subsection xyz
-      # Default values in 2D
-      set Function expression = 0; 0; 0
-      # in 3D: set Function expression = 0; 0; 0; 0
+      set Function expression = 0; 0; 0 #In 2D
+      set Function expression = 0; 0; 0; 0 #In 3D
+      set enable              = true
     end
 
     subsection heat transfer
@@ -44,6 +44,10 @@ If the problem being simulated has a source, it can be added in this section. Th
   .. tip::
 
 	For ``subsection xyz``, each term can depend on both space (``x``, ``y`` and, if 3D, ``z``) and time (``t``). See :ref:`ex function`.
+
+  .. tip::
+
+	If you are using the ``lethe-fluid-matrix-free`` application the usage of a source term significantly affects performance. If you are not using it, we advice you to disable it explicitly by setting ``enable = false``.
 
 * ``subsection heat transfer``: defines the parameters for a heat source term. This source term is defined by a ``Function expression`` and can depend on both space (``x``, ``y`` and, if 3D, ``z``) and time (``t``). See :ref:`ex function`.
 

--- a/include/solvers/mf_navier_stokes_operators.h
+++ b/include/solvers/mf_navier_stokes_operators.h
@@ -75,15 +75,15 @@ public:
    * @param[in] simulation_control Required to get the time stepping method.
    */
   NavierStokesOperatorBase(
-    const Mapping<dim>                &mapping,
-    const DoFHandler<dim>             &dof_handler,
-    const AffineConstraints<number>   &constraints,
-    const Quadrature<dim>             &quadrature,
-    const Function<dim>               *forcing_function,
-    const double                       kinematic_viscosity,
-    const StabilizationType            stabilization,
-    const unsigned int                 mg_level,
-    std::shared_ptr<SimulationControl> simulation_control);
+    const Mapping<dim>                  &mapping,
+    const DoFHandler<dim>               &dof_handler,
+    const AffineConstraints<number>     &constraints,
+    const Quadrature<dim>               &quadrature,
+    const std::shared_ptr<Function<dim>> forcing_function,
+    const double                         kinematic_viscosity,
+    const StabilizationType              stabilization,
+    const unsigned int                   mg_level,
+    std::shared_ptr<SimulationControl>   simulation_control);
 
   /**
    * @brief Initialize the main matrix free object that contains all data and is
@@ -102,15 +102,15 @@ public:
    * @param[in] mg_level Level of the operator in case of MG methods.
    */
   void
-  reinit(const Mapping<dim>                &mapping,
-         const DoFHandler<dim>             &dof_handler,
-         const AffineConstraints<number>   &constraints,
-         const Quadrature<dim>             &quadrature,
-         const Function<dim>               *forcing_function,
-         const double                       kinematic_viscosity,
-         const StabilizationType            stabilization,
-         const unsigned int                 mg_level,
-         std::shared_ptr<SimulationControl> simulation_control);
+  reinit(const Mapping<dim>                  &mapping,
+         const DoFHandler<dim>               &dof_handler,
+         const AffineConstraints<number>     &constraints,
+         const Quadrature<dim>               &quadrature,
+         const std::shared_ptr<Function<dim>> forcing_function,
+         const double                         kinematic_viscosity,
+         const StabilizationType              stabilization,
+         const unsigned int                   mg_level,
+         std::shared_ptr<SimulationControl>   simulation_control);
 
   /**
    * @brief Compute the element size h of the cells required to calculate
@@ -379,11 +379,22 @@ protected:
   unsigned int fe_degree;
 
   /**
+   * @brief Flag to activate or not a source term for the operator.
+   *
+   */
+  bool enable_source_term;
+
+  /**
    * @brief Force function or source function for the Navier-Stokes equations.
    *
    */
   const Function<dim> *forcing_function;
 
+  /**
+   * @brief Flag to activate or not the dyanimc flow control for the operator.
+   *
+   */
+  bool enable_beta_force;
 
   /**
    * @brief Additional source term in the case of dynamic flow control.

--- a/include/solvers/mf_navier_stokes_operators.h
+++ b/include/solvers/mf_navier_stokes_operators.h
@@ -379,22 +379,10 @@ protected:
   unsigned int fe_degree;
 
   /**
-   * @brief Flag to activate or not a source term for the operator.
-   *
-   */
-  bool enable_source_term;
-
-  /**
    * @brief Force function or source function for the Navier-Stokes equations.
    *
    */
-  const Function<dim> *forcing_function;
-
-  /**
-   * @brief Flag to activate or not the dyanimc flow control for the operator.
-   *
-   */
-  bool enable_beta_force;
+  std::shared_ptr<Function<dim>> forcing_function;
 
   /**
    * @brief Additional source term in the case of dynamic flow control.

--- a/include/solvers/source_terms.h
+++ b/include/solvers/source_terms.h
@@ -64,16 +64,19 @@ namespace SourceTerms
     virtual void
     parse_parameters(ParameterHandler &prm);
 
-    // Velocity-pressure components
+    /// Enable the Navier-Stokes source term
+    bool enable;
+
+    /// Velocity-pressure components
     std::shared_ptr<Functions::ParsedFunction<dim>> navier_stokes_source;
 
-    // Heat transfer source
+    /// Heat transfer source
     std::shared_ptr<Functions::ParsedFunction<dim>> heat_transfer_source;
 
-    // Tracer source
+    /// Tracer source
     std::shared_ptr<Functions::ParsedFunction<dim>> tracer_source;
 
-    // Cahn-Hilliard source
+    /// Cahn-Hilliard source
     std::shared_ptr<Functions::ParsedFunction<dim>> cahn_hilliard_source;
   };
 
@@ -84,6 +87,10 @@ namespace SourceTerms
     prm.enter_subsection("source term");
 
     prm.enter_subsection("xyz");
+    prm.declare_entry("enable",
+                      "true",
+                      Patterns::Bool(),
+                      "Enable the usage of a source term for the fluid solver");
     navier_stokes_source->declare_parameters(prm, dim + 1);
     prm.leave_subsection();
 
@@ -109,6 +116,7 @@ namespace SourceTerms
     prm.enter_subsection("source term");
 
     prm.enter_subsection("xyz");
+    enable = prm.get_bool("enable");
     navier_stokes_source->parse_parameters(prm);
     prm.leave_subsection();
 

--- a/source/solvers/mf_navier_stokes_operators.cc
+++ b/source/solvers/mf_navier_stokes_operators.cc
@@ -1070,7 +1070,6 @@ NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
               gradient_result[i] = this->kinematic_viscosity * gradient[i];
               // -(∇·v,p)
               gradient_result[i][i] += -value[dim];
-
               // +(v,-f)
               value_result[i] = -source_value[i];
 


### PR DESCRIPTION
# Description of the problem

The evaluation of the source term function, even if it was zero, was affecting the performance of the matrix-free application, as the evaluation needed to be executed every time we performed a vmult using the matrix-free operators.

# Description of the solution

This PR adds a new `enable` parameter that allows to disable the source term explicitly in the matrix free application. It allows to reset the pointer of the forcing function in `mf_navier_stokes.cc` and consequently to check within the matrix-free operators if the pointer exists or not, to evaluate the source term function. 

# How Has This Been Tested?

- All the tests pass and the` enable = false` parameter was added to all the matrix-free tests that do not require a source term. 

# Documentation

- The parameter was added to the source term page in the documentation with a tip that specifies when it is useful to explicitly disable the source term. 

# Future changes

- The Navier-Stokes source term parameter subsection needs to be renamed from `xyz` to `navier stokes`. Since this changes more than 100 files (tests, examples, documentation), I will do this in the next PR. 
