### PR TITLE
Allow to use FE_Q_iso_Q1 elements for the MG coarse level

### DIFF
--- a/doc/source/parameters/cfd/linear_solver_control.rst
+++ b/doc/source/parameters/cfd/linear_solver_control.rst
@@ -204,7 +204,8 @@ Different parameters for the main components of the two geometric multigrid algo
     set eig estimation verbosity       = quiet
 
     # Coarse-grid solver parameters
-    set mg coarse grid solver = gmres
+    set mg coarse grid solver          = gmres
+    set mg coarse grid use fe q iso q1 = false
 
     # Parameters for GMRES as coarse grid solver
     set mg gmres max iterations     = 2000
@@ -236,4 +237,4 @@ Different parameters for the main components of the two geometric multigrid algo
   If ``mg verbosity`` is set to ``verbose``, the information about the levels (cells and degrees of freedom) and the number of iterations of the coarse grid solver are displayed. If this parameter is set to ``extra verbose``, apart from all the previous information, several additional tables with the times related to multigrid are also displayed. 
 
 .. tip::
-  If your coarse-grid level is small enough, it might be worth it for some problems to set ``mg amg use default parameters = true`` to use a direct solver.
+  If your coarse-grid level is small enough, it might be worth it for some problems to set ``mg amg use default parameters = true`` to use a direct solver. On the other hand, if high order elements are used, it might be useful to set ``set mg coarse grid use fe q iso q1 = true`` to solve the coarse grid problem using `FE_Q_iso_Q1 elements <https://www.dealii.org/developer/doxygen/deal.II/classFE__Q__iso__Q1.html>`_.

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1119,9 +1119,6 @@ namespace Parameters
     /// MG minimum number of cells per level
     int mg_level_min_cells;
 
-    /// MG use elements with linear interpolation for coarse grid
-    bool mg_use_fe_q_iso_q1;
-
     /// MG smoother number of iterations
     int mg_smoother_iterations;
 
@@ -1149,6 +1146,9 @@ namespace Parameters
       direct
     };
     CoarseGridSolverType mg_coarse_grid_solver;
+
+    /// MG use FE_Q_iso_Q1 elements for coarse grid
+    bool mg_use_fe_q_iso_q1;
 
     /// MG coarse-grid solver maximum number of iterations
     int mg_gmres_max_iterations;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1119,6 +1119,9 @@ namespace Parameters
     /// MG minimum number of cells per level
     int mg_level_min_cells;
 
+    /// MG use elements with linear interpolation for coarse grid
+    bool mg_use_fe_q_iso_q1;
+
     /// MG smoother number of iterations
     int mg_smoother_iterations;
 

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -61,6 +61,8 @@ public:
    * @param[in] simulation_parameters Object containing all parameters specified
    * in input file.
    * @param[in] dof_handler Describes the layout of DoFs and the type of FE.
+   * @param[in] dof_handler_fe_q_iso_q1 Describes the layout of DoFs for
+   * FE_Q_iso_Q1 elements.
    * @param[in] mapping Describes the transformations from unit to real cell.
    * @param[in] cell_quadrature Required for local operations on cells.
    * @param[in] forcing_function Function specified in parameter file as source
@@ -71,7 +73,7 @@ public:
   MFNavierStokesPreconditionGMG(
     const SimulationParameters<dim>         &simulation_parameters,
     const DoFHandler<dim>                   &dof_handler,
-    const DoFHandler<dim>                   &dof_handler_q_iso_q1,
+    const DoFHandler<dim>                   &dof_handler_fe_q_iso_q1,
     const std::shared_ptr<Mapping<dim>>     &mapping,
     const std::shared_ptr<Quadrature<dim>>  &cell_quadrature,
     const std::shared_ptr<Function<dim>>     forcing_function,
@@ -222,7 +224,7 @@ private:
   const DoFHandler<dim> &dof_handler;
 
   /// Describes the layout of DoFs for FE_Q_iso_Q1 elements.
-  const DoFHandler<dim> &dof_handler_q_iso_q1;
+  const DoFHandler<dim> &dof_handler_fe_q_iso_q1;
 
   /// Vector holding number of coarse grid iterations
   mutable std::vector<unsigned int> coarse_grid_iterations;
@@ -448,7 +450,7 @@ protected:
    * @brief Describes the layout of DoFs for FE_Q_iso_Q1 elements.
    *
    */
-  DoFHandler<dim> dof_handler_q_iso_q1;
+  DoFHandler<dim> dof_handler_fe_q_iso_q1;
 };
 
 #endif

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -71,6 +71,7 @@ public:
   MFNavierStokesPreconditionGMG(
     const SimulationParameters<dim>         &simulation_parameters,
     const DoFHandler<dim>                   &dof_handler,
+    const DoFHandler<dim>                   &dof_handler_q_iso_q1,
     const std::shared_ptr<Mapping<dim>>     &mapping,
     const std::shared_ptr<Quadrature<dim>>  &cell_quadrature,
     const std::shared_ptr<Function<dim>>     forcing_function,
@@ -217,8 +218,11 @@ private:
   /// Simulation parameters
   SimulationParameters<dim> simulation_parameters;
 
-  /// DoF Handler
+  /// Describes the layout of DoFs and the type of FE.
   const DoFHandler<dim> &dof_handler;
+
+  /// Describes the layout of DoFs for FE Q iso Q1 elements.
+  const DoFHandler<dim> &dof_handler_q_iso_q1;
 
   /// Vector holding number of coarse grid iterations
   mutable std::vector<unsigned int> coarse_grid_iterations;
@@ -439,6 +443,12 @@ protected:
    *
    */
   VectorType time_derivative_previous_solutions;
+
+  /**
+   * @brief Describes the layout of DoFs for FE Q iso Q1 elements.
+   *
+   */
+  DoFHandler<dim> dof_handler_q_iso_q1;
 };
 
 #endif

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -221,7 +221,7 @@ private:
   /// Describes the layout of DoFs and the type of FE.
   const DoFHandler<dim> &dof_handler;
 
-  /// Describes the layout of DoFs for FE Q iso Q1 elements.
+  /// Describes the layout of DoFs for FE_Q_iso_Q1 elements.
   const DoFHandler<dim> &dof_handler_q_iso_q1;
 
   /// Vector holding number of coarse grid iterations
@@ -445,7 +445,7 @@ protected:
   VectorType time_derivative_previous_solutions;
 
   /**
-   * @brief Describes the layout of DoFs for FE Q iso Q1 elements.
+   * @brief Describes the layout of DoFs for FE_Q_iso_Q1 elements.
    *
    */
   DoFHandler<dim> dof_handler_q_iso_q1;

--- a/include/solvers/mf_navier_stokes_operators.h
+++ b/include/solvers/mf_navier_stokes_operators.h
@@ -496,7 +496,8 @@ protected:
   std::vector<bool> edge_constrained_cell;
 
   /**
-   * @brief
+   * @brief DoF mask object needed for the sparsity pattern and computation of the system
+   * matrix of the coarse level in case FE_Q_iso_Q1 elements are used.
    *
    */
   Table<2, bool> bool_dof_mask;

--- a/include/solvers/mf_navier_stokes_operators.h
+++ b/include/solvers/mf_navier_stokes_operators.h
@@ -496,6 +496,12 @@ protected:
   std::vector<bool> edge_constrained_cell;
 
   /**
+   * @brief
+   *
+   */
+  const Table<2, bool> bool_dof_mask;
+
+  /**
    * @brief Conditional OStream for parallel output.
    *
    */

--- a/include/solvers/mf_navier_stokes_operators.h
+++ b/include/solvers/mf_navier_stokes_operators.h
@@ -499,7 +499,7 @@ protected:
    * @brief
    *
    */
-  const Table<2, bool> bool_dof_mask;
+  Table<2, bool> bool_dof_mask;
 
   /**
    * @brief Conditional OStream for parallel output.

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2354,6 +2354,12 @@ namespace Parameters
                           Patterns::Integer(),
                           "mg minimum number of cells for coarse level");
 
+        prm.declare_entry(
+          "mg use linear interpolation coarse grid",
+          "false",
+          Patterns::Bool(),
+          "use elements with linear interpolation for coarse grid");
+
         prm.declare_entry("mg smoother iterations",
                           "10",
                           Patterns::Integer(),
@@ -2503,6 +2509,8 @@ namespace Parameters
 
         mg_min_level       = prm.get_integer("mg min level");
         mg_level_min_cells = prm.get_integer("mg level min cells");
+        mg_use_fe_q_iso_q1 =
+          prm.get_bool("mg use linear interpolation coarse grid");
 
         mg_smoother_iterations     = prm.get_integer("mg smoother iterations");
         mg_smoother_relaxation     = prm.get_double("mg smoother relaxation");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2354,12 +2354,6 @@ namespace Parameters
                           Patterns::Integer(),
                           "mg minimum number of cells for coarse level");
 
-        prm.declare_entry(
-          "mg use linear interpolation coarse grid",
-          "false",
-          Patterns::Bool(),
-          "use elements with linear interpolation for coarse grid");
-
         prm.declare_entry("mg smoother iterations",
                           "10",
                           Patterns::Integer(),
@@ -2396,6 +2390,12 @@ namespace Parameters
                           Patterns::Selection("gmres|amg|ilu|direct"),
                           "The coarse grid solver for lsmg or gcmg"
                           "Choices are <gmres|amg|ilu|direct>.");
+
+        prm.declare_entry(
+          "mg coarse grid use fe q iso q1",
+          "false",
+          Patterns::Bool(),
+          "use elements with linear interpolation for coarse grid");
 
         prm.declare_entry("mg gmres max iterations",
                           "2000",
@@ -2509,8 +2509,6 @@ namespace Parameters
 
         mg_min_level       = prm.get_integer("mg min level");
         mg_level_min_cells = prm.get_integer("mg level min cells");
-        mg_use_fe_q_iso_q1 =
-          prm.get_bool("mg use linear interpolation coarse grid");
 
         mg_smoother_iterations     = prm.get_integer("mg smoother iterations");
         mg_smoother_relaxation     = prm.get_double("mg smoother relaxation");
@@ -2542,6 +2540,8 @@ namespace Parameters
         else
           throw std::logic_error(
             "Error, invalid coarse grid solver type. Choices are gmres, amg, ilu or direct.");
+
+        mg_use_fe_q_iso_q1 = prm.get_bool("mg coarse grid use fe q iso q1");
 
         mg_gmres_max_iterations = prm.get_integer("mg gmres max iterations");
         mg_gmres_tolerance      = prm.get_double("mg gmres tolerance");

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -453,11 +453,8 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
               level == this->minlevel)
             {
               const auto points =
-                true ? QGaussLobatto<1>(this->dof_handler.get_fe().degree + 1)
-                         .get_points() :
-                       QIterated<1>(QGaussLobatto<1>(2),
-                                    this->dof_handler.get_fe().degree)
-                         .get_points();
+                QGaussLobatto<1>(this->dof_handler.get_fe().degree + 1)
+                  .get_points();
 
               quadrature_mg = QIterated<dim>(QGauss<1>(2), points);
             }
@@ -603,11 +600,8 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
               l == this->minlevel)
             {
               const auto points =
-                true ? QGaussLobatto<1>(this->dof_handler.get_fe().degree + 1)
-                         .get_points() :
-                       QIterated<1>(QGaussLobatto<1>(2),
-                                    this->dof_handler.get_fe().degree)
-                         .get_points();
+                QGaussLobatto<1>(this->dof_handler.get_fe().degree + 1)
+                  .get_points();
 
               this->dof_handlers[l].distribute_dofs(
                 FESystem<dim>(FE_Q_iso_Q1<dim>(points), dim + 1));
@@ -769,11 +763,8 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
               level == this->minlevel)
             {
               const auto points =
-                true ? QGaussLobatto<1>(this->dof_handler.get_fe().degree + 1)
-                         .get_points() :
-                       QIterated<1>(QGaussLobatto<1>(2),
-                                    this->dof_handler.get_fe().degree)
-                         .get_points();
+                QGaussLobatto<1>(this->dof_handler.get_fe().degree + 1)
+                  .get_points();
 
               quadrature_mg = QIterated<dim>(QGauss<1>(2), points);
             }
@@ -1535,11 +1526,8 @@ MFNavierStokesSolver<dim>::setup_dofs_fd()
           this->dof_handler_q_iso_q1.reinit(*this->triangulation);
 
           const auto points =
-            true ? QGaussLobatto<1>(this->dof_handler.get_fe().degree + 1)
-                     .get_points() :
-                   QIterated<1>(QGaussLobatto<1>(2),
-                                this->dof_handler.get_fe().degree)
-                     .get_points();
+            QGaussLobatto<1>(this->dof_handler.get_fe().degree + 1)
+              .get_points();
 
           this->dof_handler_q_iso_q1.distribute_dofs(
             FESystem<dim>(FE_Q_iso_Q1<dim>(points), dim + 1));

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -615,7 +615,7 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
           else
             this->dof_handlers[l].distribute_dofs(this->dof_handler.get_fe());
         }
-        
+
       this->mg_setup_timer.leave_subsection(
         "Create DoFHandlers and distribute DoFs");
 

--- a/source/solvers/mf_navier_stokes_operators.cc
+++ b/source/solvers/mf_navier_stokes_operators.cc
@@ -15,6 +15,65 @@
 
 #include "solvers/mf_navier_stokes_operators.h"
 
+#include <deal.II/grid/grid_generator.h>
+/**
+ * @brief Create a bool dof mask object
+ *
+ * @tparam dim
+ * @tparam spacedim
+ * @param fe
+ * @param quadrature
+ * @return Table<2, bool>
+ */
+template <int dim, int spacedim>
+Table<2, bool>
+create_bool_dof_mask(const FiniteElement<dim, spacedim> &fe,
+                     const Quadrature<dim>              &quadrature)
+{
+  const auto compute_scalar_bool_dof_mask = [&quadrature](const auto &fe) {
+    Table<2, bool>           bool_dof_mask(fe.dofs_per_cell, fe.dofs_per_cell);
+    MappingQ1<dim, spacedim> mapping;
+    FEValues<dim>            fe_values(mapping, fe, quadrature, update_values);
+
+    Triangulation<dim, spacedim> tria;
+    GridGenerator::hyper_cube(tria);
+
+    fe_values.reinit(tria.begin());
+    for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+      for (unsigned int j = 0; j < fe.dofs_per_cell; ++j)
+        {
+          double sum = 0;
+          for (unsigned int q = 0; q < quadrature.size(); ++q)
+            sum += fe_values.shape_value(i, q) * fe_values.shape_value(j, q);
+          if (sum != 0)
+            bool_dof_mask(i, j) = true;
+        }
+
+    return bool_dof_mask;
+  };
+
+  Table<2, bool> bool_dof_mask(fe.dofs_per_cell, fe.dofs_per_cell);
+
+  if (fe.n_components() == 1)
+    {
+      bool_dof_mask = compute_scalar_bool_dof_mask(fe);
+    }
+  else
+    {
+      const auto scalar_bool_dof_mask =
+        compute_scalar_bool_dof_mask(fe.base_element(0));
+
+      for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
+        for (unsigned int j = 0; j < fe.n_dofs_per_cell(); ++j)
+          if (scalar_bool_dof_mask[fe.system_to_component_index(i).second]
+                                  [fe.system_to_component_index(j).second])
+            bool_dof_mask[i][j] = true;
+    }
+
+
+  return bool_dof_mask;
+}
+
 /**
  * @brief Matrix free helper function
  *
@@ -84,7 +143,8 @@ NavierStokesOperatorBase<dim, number>::NavierStokesOperatorBase(
   const StabilizationType            stabilization,
   const unsigned int                 mg_level,
   std::shared_ptr<SimulationControl> simulation_control)
-  : pcout(std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+  : bool_dof_mask(create_bool_dof_mask(dof_handler.get_fe(), quadrature))
+  , pcout(std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
   , timer(this->pcout, TimerOutput::never, TimerOutput::wall_times)
 {
   this->reinit(mapping,
@@ -397,15 +457,17 @@ NavierStokesOperatorBase<dim, number>::get_system_matrix() const
     {
       const auto &dof_handler = this->matrix_free.get_dof_handler();
 
+      const unsigned int mg_level = this->matrix_free.get_mg_level();
+
       IndexSet locally_relevant_dofs;
       IndexSet locally_owned_dofs;
 
-      if (this->matrix_free.get_mg_level() != numbers::invalid_unsigned_int)
+      if (mg_level != numbers::invalid_unsigned_int)
         {
-          locally_relevant_dofs = DoFTools::extract_locally_relevant_level_dofs(
-            dof_handler, this->matrix_free.get_mg_level());
-          locally_owned_dofs =
-            dof_handler.locally_owned_mg_dofs(this->matrix_free.get_mg_level());
+          locally_relevant_dofs =
+            DoFTools::extract_locally_relevant_level_dofs(dof_handler,
+                                                          mg_level);
+          locally_owned_dofs = dof_handler.locally_owned_mg_dofs(mg_level);
         }
       else
         {
@@ -416,18 +478,59 @@ NavierStokesOperatorBase<dim, number>::get_system_matrix() const
 
       DynamicSparsityPattern dsp(locally_relevant_dofs);
 
-      if (this->matrix_free.get_mg_level() != numbers::invalid_unsigned_int)
-        MGTools::make_sparsity_pattern(dof_handler,
-                                       dsp,
-                                       this->matrix_free.get_mg_level(),
-                                       this->constraints,
-                                       false);
-      else
-        DoFTools::make_sparsity_pattern(dof_handler,
-                                        dsp,
-                                        this->constraints,
-                                        false);
+      if (mg_level != numbers::invalid_unsigned_int)
+        {
+          // MGTools::make_sparsity_pattern(dof_handler,
+          //                                dsp,
+          //                                mg_level,
+          //                                this->constraints,
+          //                                false);
 
+          // the following code does the same as
+          // MGTools::make_sparsity_pattern() but also
+          // consideres bool_dof_mask for FE_Q_iso_Q1
+          std::vector<types::global_dof_index> dofs_on_this_cell;
+
+          for (const auto &cell : dof_handler.cell_iterators_on_level(mg_level))
+            if (cell->is_locally_owned_on_level())
+              {
+                const unsigned int dofs_per_cell =
+                  dof_handler.get_fe().n_dofs_per_cell();
+                dofs_on_this_cell.resize(dofs_per_cell);
+                cell->get_mg_dof_indices(dofs_on_this_cell);
+
+                constraints.add_entries_local_to_global(dofs_on_this_cell,
+                                                        dsp,
+                                                        false,
+                                                        bool_dof_mask);
+              }
+        }
+      else
+        {
+          // DoFTools::make_sparsity_pattern(dof_handler,
+          //                                 dsp,
+          //                                 this->constraints,
+          //                                 false);
+
+          // the following code does the same as
+          // DoFTools::make_sparsity_pattern() but also
+          // consideres bool_dof_mask for FE_Q_iso_Q1
+          std::vector<types::global_dof_index> dofs_on_this_cell;
+
+          for (const auto &cell : dof_handler.active_cell_iterators())
+            if (cell->is_locally_owned())
+              {
+                const unsigned int dofs_per_cell =
+                  cell->get_fe().n_dofs_per_cell();
+                dofs_on_this_cell.resize(dofs_per_cell);
+                cell->get_dof_indices(dofs_on_this_cell);
+
+                constraints.add_entries_local_to_global(dofs_on_this_cell,
+                                                        dsp,
+                                                        false,
+                                                        bool_dof_mask);
+              }
+        }
 
       SparsityTools::distribute_sparsity_pattern(
         dsp,
@@ -449,6 +552,32 @@ NavierStokesOperatorBase<dim, number>::get_system_matrix() const
     system_matrix,
     &NavierStokesOperatorBase::do_cell_integral_local,
     this);
+
+  // const auto &lexicographic_numbering =
+  //   matrix_free.get_shape_info().lexicographic_numbering;
+
+  // unsigned int cell   = numbers::invalid_unsigned_int;
+  // unsigned int column = numbers::invalid_unsigned_int;
+
+  // MatrixFreeTools::
+  //   compute_matrix<dim, -1, 0, dim + 1, number, VectorizedArray<number>>(
+  //     matrix_free, constraints, system_matrix, [&](auto &integrator) {
+  //       if (cell != integrator.get_current_cell_index())
+  //         {
+  //           cell   = integrator.get_current_cell_index();
+  //           column = 0;
+  //         }
+
+  //       this->do_cell_integral_local(integrator);
+
+  //       // remove spurious entries for FE_Q_iso_Q1
+  //       for (unsigned int i = 0; i < lexicographic_numbering.size(); ++i)
+  //         if (!bool_dof_mask[lexicographic_numbering[i]]
+  //                           [lexicographic_numbering[column]])
+  //           integrator.begin_dof_values()[i] = 0.0;
+
+  //       column++;
+  //     });
 
   this->timer.leave_subsection("operator::get_system_matrix");
 


### PR DESCRIPTION
# Description 

Adds a new feature for the GMG preconditioners of the matrix-free application. It allows to use FE_Q_iso_Q1 elements for the coarsest level if the new parameter `set mg coarse grid use fe q iso q1 = true`. This might be useful for certain problems when high order elements are used.

# How Has This Been Tested?

The flow around a sphere case was tested and everything seems to work as it should.  We will test it more in the following weeks with different benchmarks.

# Documentation

- The new parameter was added to the description of the MG linear solver parameters.
