### PR TITLE
Add functionality to disable hessians in matrix-free

### DIFF
--- a/doc/source/parameters/cfd/linear_solver_control.rst
+++ b/doc/source/parameters/cfd/linear_solver_control.rst
@@ -117,6 +117,16 @@ When set to ``extra verbose``, the residual at each iteration of the linear solv
 .. caution:: 
 		Be aware that the setup of the ``amg`` preconditioner is very expensive and does not scale linearly with the size of the matrix. As such, it is generally preferable to minimize the number of assembly of such preconditioner. This can be achieved by using the ``inexact newton`` for the nonlinear solver (see :doc:`non-linear_solver_control`).
 
+* There are two additional parameters that can be used in this subsection that only work for the ``lethe-fluid-matrix-free`` application at the moment. They allow to turn on or off the hessian terms present in the Jacobian and the residual (or right-hand side) of the Navier-Stokes problem:
+
+.. code-block:: text
+
+    set enable hessians in jacobian = true
+    set enable hessians in rhs      = true
+
+.. caution::
+   This is useful for performance reasons, however, it highly depends on the problem being solver and must be used carefully.
+
 In addition to the method parameters, one can also set specific parameters for each of the preconditioners by adding specific lines inside of the specific physics subsection:
 
 -------------------
@@ -189,9 +199,11 @@ Different parameters for the main components of the two geometric multigrid algo
 .. code-block:: text
 
     # General MG parameters
-    set mg verbosity       = quiet
-    set mg min level       = -1
-    set mg level min cells = -1
+    set mg verbosity                   = quiet
+    set mg min level                   = -1
+    set mg level min cells             = -1
+    set mg enable hessians in jacobian = true
+    set mg enable hessians in rhs      = true
 
     # Relaxation smoother parameters
     set mg smoother iterations     = 10
@@ -238,3 +250,6 @@ Different parameters for the main components of the two geometric multigrid algo
 
 .. tip::
   If your coarse-grid level is small enough, it might be worth it for some problems to set ``mg amg use default parameters = true`` to use a direct solver. On the other hand, if high order elements are used, it might be useful to set ``set mg coarse grid use fe q iso q1 = true`` to solve the coarse grid problem using `FE_Q_iso_Q1 elements <https://www.dealii.org/developer/doxygen/deal.II/classFE__Q__iso__Q1.html>`_.
+
+.. tip::
+  Evaluating terms involving the hessian is expensive. Therefore, one can turn on or off those terms in the mg level operators to improve performance by setting ``mg enable hessians in jacobian`` and ``mg enable hessians in rhs`` equal to ``false``. This is useful for certain problems and must be used carefully.

--- a/doc/source/parameters/cfd/linear_solver_control.rst
+++ b/doc/source/parameters/cfd/linear_solver_control.rst
@@ -203,7 +203,6 @@ Different parameters for the main components of the two geometric multigrid algo
     set mg min level                   = -1
     set mg level min cells             = -1
     set mg enable hessians in jacobian = true
-    set mg enable hessians in residual = true
 
     # Relaxation smoother parameters
     set mg smoother iterations     = 10
@@ -252,4 +251,4 @@ Different parameters for the main components of the two geometric multigrid algo
   If your coarse-grid level is small enough, it might be worth it for some problems to set ``mg amg use default parameters = true`` to use a direct solver. On the other hand, if high order elements are used, it might be useful to set ``set mg coarse grid use fe q iso q1 = true`` to solve the coarse grid problem using `FE_Q_iso_Q1 elements <https://www.dealii.org/developer/doxygen/deal.II/classFE__Q__iso__Q1.html>`_.
 
 .. tip::
-  Evaluating terms involving the hessian is expensive. Therefore, one can turn on or off those terms in the mg level operators to improve performance by setting ``mg enable hessians in jacobian`` and ``mg enable hessians in residual`` equal to ``false``. This is useful for certain problems and must be used carefully.
+  Evaluating terms involving the hessian is expensive. Therefore, one can turn on or off those terms in the mg level operators to improve performance by setting ``mg enable hessians in jacobian`` to ``false``. This is useful for certain problems and must be used carefully.

--- a/doc/source/parameters/cfd/linear_solver_control.rst
+++ b/doc/source/parameters/cfd/linear_solver_control.rst
@@ -122,7 +122,7 @@ When set to ``extra verbose``, the residual at each iteration of the linear solv
 .. code-block:: text
 
     set enable hessians in jacobian = true
-    set enable hessians in rhs      = true
+    set enable hessians in residual = true
 
 .. caution::
    This is useful for performance reasons, however, it highly depends on the problem being solver and must be used carefully.
@@ -203,7 +203,7 @@ Different parameters for the main components of the two geometric multigrid algo
     set mg min level                   = -1
     set mg level min cells             = -1
     set mg enable hessians in jacobian = true
-    set mg enable hessians in rhs      = true
+    set mg enable hessians in residual = true
 
     # Relaxation smoother parameters
     set mg smoother iterations     = 10
@@ -252,4 +252,4 @@ Different parameters for the main components of the two geometric multigrid algo
   If your coarse-grid level is small enough, it might be worth it for some problems to set ``mg amg use default parameters = true`` to use a direct solver. On the other hand, if high order elements are used, it might be useful to set ``set mg coarse grid use fe q iso q1 = true`` to solve the coarse grid problem using `FE_Q_iso_Q1 elements <https://www.dealii.org/developer/doxygen/deal.II/classFE__Q__iso__Q1.html>`_.
 
 .. tip::
-  Evaluating terms involving the hessian is expensive. Therefore, one can turn on or off those terms in the mg level operators to improve performance by setting ``mg enable hessians in jacobian`` and ``mg enable hessians in rhs`` equal to ``false``. This is useful for certain problems and must be used carefully.
+  Evaluating terms involving the hessian is expensive. Therefore, one can turn on or off those terms in the mg level operators to improve performance by setting ``mg enable hessians in jacobian`` and ``mg enable hessians in residual`` equal to ``false``. This is useful for certain problems and must be used carefully.

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1127,9 +1127,6 @@ namespace Parameters
     /// MG enable hessians in jacobian
     bool mg_enable_hessians_jacobian;
 
-    /// MG enable hessians in residual
-    bool mg_enable_hessians_residual;
-
     /// MG smoother number of iterations
     int mg_smoother_iterations;
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1025,12 +1025,6 @@ namespace Parameters
     // Abort solver if non-linear solution has not reached tolerance
     bool abort_at_convergence_failure;
 
-    // Enable hessians in jacobian
-    bool enable_hessians_jacobian;
-
-    // Enable hessians in rhs
-    bool enable_hessians_rhs;
-
     static void
     declare_parameters(ParameterHandler &prm, const std::string &physics_name);
     void
@@ -1069,10 +1063,10 @@ namespace Parameters
     /// Maximum number of krylov vectors
     int max_krylov_vectors;
 
-    // Enable hessians in jacobian
+    /// Enable hessians in jacobian
     bool enable_hessians_jacobian;
 
-    // Enable hessians in rhs
+    /// Enable hessians in rhs
     bool enable_hessians_rhs;
 
     /// Type of preconditioner
@@ -1129,6 +1123,12 @@ namespace Parameters
 
     /// MG minimum number of cells per level
     int mg_level_min_cells;
+
+    /// Enable hessians in jacobian
+    bool mg_enable_hessians_jacobian;
+
+    /// Enable hessians in rhs
+    bool mg_enable_hessians_rhs;
 
     /// MG smoother number of iterations
     int mg_smoother_iterations;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1025,6 +1025,11 @@ namespace Parameters
     // Abort solver if non-linear solution has not reached tolerance
     bool abort_at_convergence_failure;
 
+    // Enable hessians in jacobian
+    bool enable_hessians_jacobian;
+
+    // Enable hessians in rhs
+    bool enable_hessians_rhs;
 
     static void
     declare_parameters(ParameterHandler &prm, const std::string &physics_name);
@@ -1063,6 +1068,12 @@ namespace Parameters
 
     /// Maximum number of krylov vectors
     int max_krylov_vectors;
+
+    // Enable hessians in jacobian
+    bool enable_hessians_jacobian;
+
+    // Enable hessians in rhs
+    bool enable_hessians_rhs;
 
     /// Type of preconditioner
     enum class PreconditionerType

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1066,8 +1066,8 @@ namespace Parameters
     /// Enable hessians in jacobian
     bool enable_hessians_jacobian;
 
-    /// Enable hessians in rhs
-    bool enable_hessians_rhs;
+    /// Enable hessians in residual
+    bool enable_hessians_residual;
 
     /// Type of preconditioner
     enum class PreconditionerType
@@ -1124,11 +1124,11 @@ namespace Parameters
     /// MG minimum number of cells per level
     int mg_level_min_cells;
 
-    /// Enable hessians in jacobian
+    /// MG enable hessians in jacobian
     bool mg_enable_hessians_jacobian;
 
-    /// Enable hessians in rhs
-    bool mg_enable_hessians_rhs;
+    /// MG enable hessians in residual
+    bool mg_enable_hessians_residual;
 
     /// MG smoother number of iterations
     int mg_smoother_iterations;

--- a/include/solvers/mf_navier_stokes_operators.h
+++ b/include/solvers/mf_navier_stokes_operators.h
@@ -79,17 +79,17 @@ public:
    * residual on or off.
    */
   NavierStokesOperatorBase(
-    const Mapping<dim>                &mapping,
-    const DoFHandler<dim>             &dof_handler,
-    const AffineConstraints<number>   &constraints,
-    const Quadrature<dim>             &quadrature,
-  const std::shared_ptr<Function<dim>> forcing_function,
-    const double                       kinematic_viscosity,
-    const StabilizationType            stabilization,
-    const unsigned int                 mg_level,
-    std::shared_ptr<SimulationControl> simulation_control,
-    const bool                        &enable_hessians_jacobian,
-    const bool                        &enable_hessians_residual);
+    const Mapping<dim>                  &mapping,
+    const DoFHandler<dim>               &dof_handler,
+    const AffineConstraints<number>     &constraints,
+    const Quadrature<dim>               &quadrature,
+    const std::shared_ptr<Function<dim>> forcing_function,
+    const double                         kinematic_viscosity,
+    const StabilizationType              stabilization,
+    const unsigned int                   mg_level,
+    std::shared_ptr<SimulationControl>   simulation_control,
+    const bool                          &enable_hessians_jacobian,
+    const bool                          &enable_hessians_residual);
 
   /**
    * @brief Initialize the main matrix free object that contains all data and is
@@ -113,17 +113,17 @@ public:
    * residual on or off.
    */
   void
-  reinit(const Mapping<dim>                &mapping,
-         const DoFHandler<dim>             &dof_handler,
-         const AffineConstraints<number>   &constraints,
-         const Quadrature<dim>             &quadrature,
-  const std::shared_ptr<Function<dim>> forcing_function,
-         const double                       kinematic_viscosity,
-         const StabilizationType            stabilization,
-         const unsigned int                 mg_level,
-         std::shared_ptr<SimulationControl> simulation_control,
-         const bool                        &enable_hessians_jacobian,
-         const bool                        &enable_hessians_residual);
+  reinit(const Mapping<dim>                  &mapping,
+         const DoFHandler<dim>               &dof_handler,
+         const AffineConstraints<number>     &constraints,
+         const Quadrature<dim>               &quadrature,
+         const std::shared_ptr<Function<dim>> forcing_function,
+         const double                         kinematic_viscosity,
+         const StabilizationType              stabilization,
+         const unsigned int                   mg_level,
+         std::shared_ptr<SimulationControl>   simulation_control,
+         const bool                          &enable_hessians_jacobian,
+         const bool                          &enable_hessians_residual);
 
   /**
    * @brief Compute the element size h of the cells required to calculate

--- a/include/solvers/mf_navier_stokes_operators.h
+++ b/include/solvers/mf_navier_stokes_operators.h
@@ -75,21 +75,21 @@ public:
    * @param[in] simulation_control Required to get the time stepping method.
    * @param[in] enable_hessians_jacobian Flag to turn hessian terms from
    * jacobian on or off.
-   * @param[in] enable_hessians_rhs Flag to turn hessian terms from residual on
-   * or off.
+   * @param[in] enable_hessians_residual Flag to turn hessian terms from
+   * residual on or off.
    */
   NavierStokesOperatorBase(
-    const Mapping<dim>                  &mapping,
-    const DoFHandler<dim>               &dof_handler,
-    const AffineConstraints<number>     &constraints,
-    const Quadrature<dim>               &quadrature,
-    const std::shared_ptr<Function<dim>> forcing_function,
-    const double                         kinematic_viscosity,
-    const StabilizationType              stabilization,
-    const unsigned int                   mg_level,
-    std::shared_ptr<SimulationControl>   simulation_control,
-    const bool                          &enable_hessians_jacobian,
-    const bool                          &enable_hessians_rhs);
+    const Mapping<dim>                &mapping,
+    const DoFHandler<dim>             &dof_handler,
+    const AffineConstraints<number>   &constraints,
+    const Quadrature<dim>             &quadrature,
+  const std::shared_ptr<Function<dim>> forcing_function,
+    const double                       kinematic_viscosity,
+    const StabilizationType            stabilization,
+    const unsigned int                 mg_level,
+    std::shared_ptr<SimulationControl> simulation_control,
+    const bool                        &enable_hessians_jacobian,
+    const bool                        &enable_hessians_residual);
 
   /**
    * @brief Initialize the main matrix free object that contains all data and is
@@ -109,21 +109,21 @@ public:
    * @param[in] simulation_control Required to get the time stepping method.
    * @param[in] enable_hessians_jacobian Flag to turn hessian terms from
    * jacobian on or off.
-   * @param[in] enable_hessians_rhs Flag to turn hessian terms from residual on
-   * or off.
+   * @param[in] enable_hessians_residual Flag to turn hessian terms from
+   * residual on or off.
    */
   void
-  reinit(const Mapping<dim>                  &mapping,
-         const DoFHandler<dim>               &dof_handler,
-         const AffineConstraints<number>     &constraints,
-         const Quadrature<dim>               &quadrature,
-         const std::shared_ptr<Function<dim>> forcing_function,
-         const double                         kinematic_viscosity,
-         const StabilizationType              stabilization,
-         const unsigned int                   mg_level,
-         std::shared_ptr<SimulationControl>   simulation_control,
-         const bool                          &enable_hessians_jacobian,
-         const bool                          &enable_hessians_rhs);
+  reinit(const Mapping<dim>                &mapping,
+         const DoFHandler<dim>             &dof_handler,
+         const AffineConstraints<number>   &constraints,
+         const Quadrature<dim>             &quadrature,
+  const std::shared_ptr<Function<dim>> forcing_function,
+         const double                       kinematic_viscosity,
+         const StabilizationType            stabilization,
+         const unsigned int                 mg_level,
+         std::shared_ptr<SimulationControl> simulation_control,
+         const bool                        &enable_hessians_jacobian,
+         const bool                        &enable_hessians_residual);
 
   /**
    * @brief Compute the element size h of the cells required to calculate
@@ -432,7 +432,7 @@ protected:
    * @brief Flag to turn hessian terms from residual on or off.
    *
    */
-  bool enable_hessians_rhs;
+  bool enable_hessians_residual;
 
   /**
    * @brief Table with correct alignment for vectorization to store the values

--- a/include/solvers/mf_navier_stokes_operators.h
+++ b/include/solvers/mf_navier_stokes_operators.h
@@ -73,6 +73,10 @@ public:
    * @param[in] stabilization Stabilization type specified in parameter file.
    * @param[in] mg_level Level of the operator in case of MG methods.
    * @param[in] simulation_control Required to get the time stepping method.
+   * @param[in] enable_hessians_jacobian Flag to turn hessian terms from
+   * jacobian on or off.
+   * @param[in] enable_hessians_rhs Flag to turn hessian terms from residual on
+   * or off.
    */
   NavierStokesOperatorBase(
     const Mapping<dim>                  &mapping,
@@ -83,7 +87,9 @@ public:
     const double                         kinematic_viscosity,
     const StabilizationType              stabilization,
     const unsigned int                   mg_level,
-    std::shared_ptr<SimulationControl>   simulation_control);
+    std::shared_ptr<SimulationControl>   simulation_control,
+    const bool                          &enable_hessians_jacobian,
+    const bool                          &enable_hessians_rhs);
 
   /**
    * @brief Initialize the main matrix free object that contains all data and is
@@ -100,6 +106,11 @@ public:
    * @param[in] kinematic_viscosity Kinematic viscosity.
    * @param[in] stabilization Stabilization type specified in parameter file.
    * @param[in] mg_level Level of the operator in case of MG methods.
+   * @param[in] simulation_control Required to get the time stepping method.
+   * @param[in] enable_hessians_jacobian Flag to turn hessian terms from
+   * jacobian on or off.
+   * @param[in] enable_hessians_rhs Flag to turn hessian terms from residual on
+   * or off.
    */
   void
   reinit(const Mapping<dim>                  &mapping,
@@ -110,7 +121,9 @@ public:
          const double                         kinematic_viscosity,
          const StabilizationType              stabilization,
          const unsigned int                   mg_level,
-         std::shared_ptr<SimulationControl>   simulation_control);
+         std::shared_ptr<SimulationControl>   simulation_control,
+         const bool                          &enable_hessians_jacobian,
+         const bool                          &enable_hessians_rhs);
 
   /**
    * @brief Compute the element size h of the cells required to calculate
@@ -408,6 +421,18 @@ protected:
    *
    */
   std::shared_ptr<SimulationControl> simulation_control;
+
+  /**
+   * @brief Flag to turn hessian terms from jacobian on or off.
+   *
+   */
+  bool enable_hessians_jacobian;
+
+  /**
+   * @brief Flag to turn hessian terms from residual on or off.
+   *
+   */
+  bool enable_hessians_rhs;
 
   /**
    * @brief Table with correct alignment for vectorization to store the values

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2012,7 +2012,7 @@ namespace Parameters
 
         prm.declare_entry(
           "enable hessians in rhs",
-          "false",
+          "true",
           Patterns::Bool(),
           "Turns off the terms involving the hessian in the rhs");
       }
@@ -2307,7 +2307,7 @@ namespace Parameters
 
         prm.declare_entry(
           "enable hessians in rhs",
-          "false",
+          "true",
           Patterns::Bool(),
           "Turns off the terms involving the hessian in the rhs");
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2003,6 +2003,18 @@ namespace Parameters
           "false",
           Patterns::Bool(),
           "Aborts Lethe by throwing an exception if non-linear solver convergence has failed");
+
+        prm.declare_entry(
+          "enable hessians in jacobian",
+          "true",
+          Patterns::Bool(),
+          "Turns off the terms involving the hessian in the Jacobian");
+
+        prm.declare_entry(
+          "enable hessians in rhs",
+          "false",
+          Patterns::Bool(),
+          "Turns off the terms involving the hessian in the rhs");
       }
       prm.leave_subsection();
     }
@@ -2046,16 +2058,16 @@ namespace Parameters
           throw(std::runtime_error(
             "Invalid strategy for kinsol non-linear solver "));
 
-        tolerance             = prm.get_double("tolerance");
-        step_tolerance        = prm.get_double("step tolerance");
-        matrix_tolerance      = prm.get_double("matrix tolerance");
-        max_iterations        = prm.get_integer("max iterations");
-        display_precision     = prm.get_integer("residual precision");
-        force_rhs_calculation = prm.get_bool("force rhs calculation");
-        reuse_matrix          = prm.get_bool("reuse matrix");
-        reuse_preconditioner  = prm.get_bool("reuse preconditioner");
-        abort_at_convergence_failure =
-          prm.get_bool("abort at convergence failure");
+        tolerance                = prm.get_double("tolerance");
+        step_tolerance           = prm.get_double("step tolerance");
+        matrix_tolerance         = prm.get_double("matrix tolerance");
+        max_iterations           = prm.get_integer("max iterations");
+        display_precision        = prm.get_integer("residual precision");
+        force_rhs_calculation    = prm.get_bool("force rhs calculation");
+        reuse_matrix             = prm.get_bool("reuse matrix");
+        reuse_preconditioner     = prm.get_bool("reuse preconditioner");
+        enable_hessians_jacobian = prm.get_bool("enable hessians in jacobian");
+        enable_hessians_rhs      = prm.get_bool("enable hessians in rhs");
       }
       prm.leave_subsection();
     }
@@ -2287,6 +2299,18 @@ namespace Parameters
                           "The preconditioner for the linear solver."
                           "Choices are <amg|ilu|lsmg|gcmg>.");
 
+        prm.declare_entry(
+          "enable hessians in jacobian",
+          "true",
+          Patterns::Bool(),
+          "Turns off the terms involving the hessian in the Jacobian");
+
+        prm.declare_entry(
+          "enable hessians in rhs",
+          "false",
+          Patterns::Bool(),
+          "Turns off the terms involving the hessian in the rhs");
+
         prm.declare_entry("ilu preconditioner fill",
                           "0",
                           Patterns::Double(),
@@ -2486,6 +2510,9 @@ namespace Parameters
         else
           throw std::logic_error(
             "Error, invalid preconditioner type. Choices are amg, ilu, lsmg or gcmg.");
+
+        enable_hessians_jacobian = prm.get_bool("enable hessians in jacobian");
+        enable_hessians_rhs      = prm.get_bool("enable hessians in rhs");
 
         ilu_precond_fill = prm.get_double("ilu preconditioner fill");
         ilu_precond_atol =

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2373,12 +2373,6 @@ namespace Parameters
           Patterns::Bool(),
           "Turns off the terms involving the hessian in the Jacobian of mg operators");
 
-        prm.declare_entry(
-          "mg enable hessians in residual",
-          "true",
-          Patterns::Bool(),
-          "Turns off the terms involving the hessian in the rhs of mg operators");
-
         prm.declare_entry("mg smoother iterations",
                           "10",
                           Patterns::Integer(),
@@ -2539,8 +2533,6 @@ namespace Parameters
         mg_level_min_cells = prm.get_integer("mg level min cells");
         mg_enable_hessians_jacobian =
           prm.get_bool("mg enable hessians in jacobian");
-        mg_enable_hessians_residual =
-          prm.get_bool("mg enable hessians in residual");
 
         mg_smoother_iterations     = prm.get_integer("mg smoother iterations");
         mg_smoother_relaxation     = prm.get_double("mg smoother relaxation");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2058,14 +2058,16 @@ namespace Parameters
           throw(std::runtime_error(
             "Invalid strategy for kinsol non-linear solver "));
 
-        tolerance                = prm.get_double("tolerance");
-        step_tolerance           = prm.get_double("step tolerance");
-        matrix_tolerance         = prm.get_double("matrix tolerance");
-        max_iterations           = prm.get_integer("max iterations");
-        display_precision        = prm.get_integer("residual precision");
-        force_rhs_calculation    = prm.get_bool("force rhs calculation");
-        reuse_matrix             = prm.get_bool("reuse matrix");
-        reuse_preconditioner     = prm.get_bool("reuse preconditioner");
+        tolerance             = prm.get_double("tolerance");
+        step_tolerance        = prm.get_double("step tolerance");
+        matrix_tolerance      = prm.get_double("matrix tolerance");
+        max_iterations        = prm.get_integer("max iterations");
+        display_precision     = prm.get_integer("residual precision");
+        force_rhs_calculation = prm.get_bool("force rhs calculation");
+        reuse_matrix          = prm.get_bool("reuse matrix");
+        reuse_preconditioner  = prm.get_bool("reuse preconditioner");
+        abort_at_convergence_failure =
+          prm.get_bool("abort at convergence failure");
         enable_hessians_jacobian = prm.get_bool("enable hessians in jacobian");
         enable_hessians_rhs      = prm.get_bool("enable hessians in rhs");
       }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2003,18 +2003,6 @@ namespace Parameters
           "false",
           Patterns::Bool(),
           "Aborts Lethe by throwing an exception if non-linear solver convergence has failed");
-
-        prm.declare_entry(
-          "enable hessians in jacobian",
-          "true",
-          Patterns::Bool(),
-          "Turns off the terms involving the hessian in the Jacobian");
-
-        prm.declare_entry(
-          "enable hessians in rhs",
-          "true",
-          Patterns::Bool(),
-          "Turns off the terms involving the hessian in the rhs");
       }
       prm.leave_subsection();
     }
@@ -2068,8 +2056,6 @@ namespace Parameters
         reuse_preconditioner  = prm.get_bool("reuse preconditioner");
         abort_at_convergence_failure =
           prm.get_bool("abort at convergence failure");
-        enable_hessians_jacobian = prm.get_bool("enable hessians in jacobian");
-        enable_hessians_rhs      = prm.get_bool("enable hessians in rhs");
       }
       prm.leave_subsection();
     }
@@ -2295,12 +2281,6 @@ namespace Parameters
                           Patterns::Integer(),
                           "Maximum number of krylov vectors for GMRES");
 
-        prm.declare_entry("preconditioner",
-                          "ilu",
-                          Patterns::Selection("amg|ilu|lsmg|gcmg"),
-                          "The preconditioner for the linear solver."
-                          "Choices are <amg|ilu|lsmg|gcmg>.");
-
         prm.declare_entry(
           "enable hessians in jacobian",
           "true",
@@ -2312,6 +2292,13 @@ namespace Parameters
           "true",
           Patterns::Bool(),
           "Turns off the terms involving the hessian in the rhs");
+
+        prm.declare_entry("preconditioner",
+                          "ilu",
+                          Patterns::Selection("amg|ilu|lsmg|gcmg"),
+                          "The preconditioner for the linear solver."
+                          "Choices are <amg|ilu|lsmg|gcmg>.");
+
 
         prm.declare_entry("ilu preconditioner fill",
                           "0",
@@ -2379,6 +2366,18 @@ namespace Parameters
                           "-1",
                           Patterns::Integer(),
                           "mg minimum number of cells for coarse level");
+
+        prm.declare_entry(
+          "mg enable hessians in jacobian",
+          "true",
+          Patterns::Bool(),
+          "Turns off the terms involving the hessian in the Jacobian of mg operators");
+
+        prm.declare_entry(
+          "mg enable hessians in rhs",
+          "true",
+          Patterns::Bool(),
+          "Turns off the terms involving the hessian in the rhs of mg operators");
 
         prm.declare_entry("mg smoother iterations",
                           "10",
@@ -2495,10 +2494,12 @@ namespace Parameters
           throw(
             std::runtime_error("Unknown verbosity mode for the linear solver"));
 
-        relative_residual  = prm.get_double("relative residual");
-        minimum_residual   = prm.get_double("minimum residual");
-        max_iterations     = prm.get_integer("max iters");
-        max_krylov_vectors = prm.get_integer("max krylov vectors");
+        relative_residual        = prm.get_double("relative residual");
+        minimum_residual         = prm.get_double("minimum residual");
+        max_iterations           = prm.get_integer("max iters");
+        max_krylov_vectors       = prm.get_integer("max krylov vectors");
+        enable_hessians_jacobian = prm.get_bool("enable hessians in jacobian");
+        enable_hessians_rhs      = prm.get_bool("enable hessians in rhs");
 
         const std::string precond = prm.get("preconditioner");
         if (precond == "amg")
@@ -2513,8 +2514,6 @@ namespace Parameters
           throw std::logic_error(
             "Error, invalid preconditioner type. Choices are amg, ilu, lsmg or gcmg.");
 
-        enable_hessians_jacobian = prm.get_bool("enable hessians in jacobian");
-        enable_hessians_rhs      = prm.get_bool("enable hessians in rhs");
 
         ilu_precond_fill = prm.get_double("ilu preconditioner fill");
         ilu_precond_atol =
@@ -2538,6 +2537,9 @@ namespace Parameters
 
         mg_min_level       = prm.get_integer("mg min level");
         mg_level_min_cells = prm.get_integer("mg level min cells");
+        mg_enable_hessians_jacobian =
+          prm.get_bool("mg enable hessians in jacobian");
+        mg_enable_hessians_rhs = prm.get_bool("mg enable hessians in rhs");
 
         mg_smoother_iterations     = prm.get_integer("mg smoother iterations");
         mg_smoother_relaxation     = prm.get_double("mg smoother relaxation");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2494,6 +2494,8 @@ namespace Parameters
         max_krylov_vectors       = prm.get_integer("max krylov vectors");
         enable_hessians_jacobian = prm.get_bool("enable hessians in jacobian");
         enable_hessians_residual = prm.get_bool("enable hessians in residual");
+        
+        Assert(enable_hessians_residual || !enable_hessians_jacobian);
 
         const std::string precond = prm.get("preconditioner");
         if (precond == "amg")
@@ -2533,6 +2535,7 @@ namespace Parameters
         mg_level_min_cells = prm.get_integer("mg level min cells");
         mg_enable_hessians_jacobian =
           prm.get_bool("mg enable hessians in jacobian");
+        Assert(enable_hessians_jacobian || !mg_enable_hessians_jacobian);
 
         mg_smoother_iterations     = prm.get_integer("mg smoother iterations");
         mg_smoother_relaxation     = prm.get_double("mg smoother relaxation");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2288,7 +2288,7 @@ namespace Parameters
           "Turns off the terms involving the hessian in the Jacobian");
 
         prm.declare_entry(
-          "enable hessians in rhs",
+          "enable hessians in residual",
           "true",
           Patterns::Bool(),
           "Turns off the terms involving the hessian in the rhs");
@@ -2374,7 +2374,7 @@ namespace Parameters
           "Turns off the terms involving the hessian in the Jacobian of mg operators");
 
         prm.declare_entry(
-          "mg enable hessians in rhs",
+          "mg enable hessians in residual",
           "true",
           Patterns::Bool(),
           "Turns off the terms involving the hessian in the rhs of mg operators");
@@ -2499,7 +2499,7 @@ namespace Parameters
         max_iterations           = prm.get_integer("max iters");
         max_krylov_vectors       = prm.get_integer("max krylov vectors");
         enable_hessians_jacobian = prm.get_bool("enable hessians in jacobian");
-        enable_hessians_rhs      = prm.get_bool("enable hessians in rhs");
+        enable_hessians_residual = prm.get_bool("enable hessians in residual");
 
         const std::string precond = prm.get("preconditioner");
         if (precond == "amg")
@@ -2539,7 +2539,8 @@ namespace Parameters
         mg_level_min_cells = prm.get_integer("mg level min cells");
         mg_enable_hessians_jacobian =
           prm.get_bool("mg enable hessians in jacobian");
-        mg_enable_hessians_rhs = prm.get_bool("mg enable hessians in rhs");
+        mg_enable_hessians_residual =
+          prm.get_bool("mg enable hessians in residual");
 
         mg_smoother_iterations     = prm.get_integer("mg smoother iterations");
         mg_smoother_relaxation     = prm.get_double("mg smoother relaxation");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2494,8 +2494,9 @@ namespace Parameters
         max_krylov_vectors       = prm.get_integer("max krylov vectors");
         enable_hessians_jacobian = prm.get_bool("enable hessians in jacobian");
         enable_hessians_residual = prm.get_bool("enable hessians in residual");
-        
-        Assert(enable_hessians_residual || !enable_hessians_jacobian);
+
+        Assert(enable_hessians_residual || !enable_hessians_jacobian,
+               ExcNotImplemented());
 
         const std::string precond = prm.get("preconditioner");
         if (precond == "amg")
@@ -2535,7 +2536,8 @@ namespace Parameters
         mg_level_min_cells = prm.get_integer("mg level min cells");
         mg_enable_hessians_jacobian =
           prm.get_bool("mg enable hessians in jacobian");
-        Assert(enable_hessians_jacobian || !mg_enable_hessians_jacobian);
+        Assert(enable_hessians_jacobian || !mg_enable_hessians_jacobian,
+               ExcNotImplemented());
 
         mg_smoother_iterations     = prm.get_integer("mg smoother iterations");
         mg_smoother_relaxation     = prm.get_double("mg smoother relaxation");

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -481,9 +481,7 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
             this->simulation_parameters.linear_solver
               .at(PhysicsID::fluid_dynamics)
               .mg_enable_hessians_jacobian,
-            this->simulation_parameters.linear_solver
-              .at(PhysicsID::fluid_dynamics)
-              .mg_enable_hessians_residual);
+            true);
 
           this->ls_mg_operators[level].initialize(*(this->mg_operators)[level]);
           this->ls_mg_interface_in[level].initialize(
@@ -792,9 +790,7 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
             this->simulation_parameters.linear_solver
               .at(PhysicsID::fluid_dynamics)
               .mg_enable_hessians_jacobian,
-            this->simulation_parameters.linear_solver
-              .at(PhysicsID::fluid_dynamics)
-              .mg_enable_hessians_residual);
+            true);
 
           this->mg_setup_timer.leave_subsection("Set up operators");
         }

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -480,10 +480,10 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
             simulation_control,
             this->simulation_parameters.linear_solver
               .at(PhysicsID::fluid_dynamics)
-              .enable_hessians_jacobian,
+              .mg_enable_hessians_jacobian,
             this->simulation_parameters.linear_solver
               .at(PhysicsID::fluid_dynamics)
-              .enable_hessians_rhs);
+              .mg_enable_hessians_rhs);
 
           this->ls_mg_operators[level].initialize(*(this->mg_operators)[level]);
           this->ls_mg_interface_in[level].initialize(
@@ -791,10 +791,10 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
             simulation_control,
             this->simulation_parameters.linear_solver
               .at(PhysicsID::fluid_dynamics)
-              .enable_hessians_jacobian,
+              .mg_enable_hessians_jacobian,
             this->simulation_parameters.linear_solver
               .at(PhysicsID::fluid_dynamics)
-              .enable_hessians_rhs);
+              .mg_enable_hessians_rhs);
 
           this->mg_setup_timer.leave_subsection("Set up operators");
         }
@@ -1576,9 +1576,9 @@ MFNavierStokesSolver<dim>::setup_dofs_fd()
     this->simulation_parameters.stabilization.stabilization,
     mg_level,
     this->simulation_control,
-    this->simulation_parameters.non_linear_solver.at(PhysicsID::fluid_dynamics)
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
       .enable_hessians_jacobian,
-    this->simulation_parameters.non_linear_solver.at(PhysicsID::fluid_dynamics)
+    this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
       .enable_hessians_rhs);
 
 

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -483,7 +483,7 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
               .mg_enable_hessians_jacobian,
             this->simulation_parameters.linear_solver
               .at(PhysicsID::fluid_dynamics)
-              .mg_enable_hessians_rhs);
+              .mg_enable_hessians_residual);
 
           this->ls_mg_operators[level].initialize(*(this->mg_operators)[level]);
           this->ls_mg_interface_in[level].initialize(
@@ -794,7 +794,7 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
               .mg_enable_hessians_jacobian,
             this->simulation_parameters.linear_solver
               .at(PhysicsID::fluid_dynamics)
-              .mg_enable_hessians_rhs);
+              .mg_enable_hessians_residual);
 
           this->mg_setup_timer.leave_subsection("Set up operators");
         }
@@ -1579,7 +1579,7 @@ MFNavierStokesSolver<dim>::setup_dofs_fd()
     this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
       .enable_hessians_jacobian,
     this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
-      .enable_hessians_rhs);
+      .enable_hessians_residual);
 
 
   // Initialize vectors using operator

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -477,7 +477,13 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
               .get_kinematic_viscosity_scale(),
             this->simulation_parameters.stabilization.stabilization,
             level,
-            simulation_control);
+            simulation_control,
+            this->simulation_parameters.linear_solver
+              .at(PhysicsID::fluid_dynamics)
+              .enable_hessians_jacobian,
+            this->simulation_parameters.linear_solver
+              .at(PhysicsID::fluid_dynamics)
+              .enable_hessians_rhs);
 
           this->ls_mg_operators[level].initialize(*(this->mg_operators)[level]);
           this->ls_mg_interface_in[level].initialize(
@@ -782,7 +788,13 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
               .get_kinematic_viscosity_scale(),
             this->simulation_parameters.stabilization.stabilization,
             numbers::invalid_unsigned_int,
-            simulation_control);
+            simulation_control,
+            this->simulation_parameters.linear_solver
+              .at(PhysicsID::fluid_dynamics)
+              .enable_hessians_jacobian,
+            this->simulation_parameters.linear_solver
+              .at(PhysicsID::fluid_dynamics)
+              .enable_hessians_rhs);
 
           this->mg_setup_timer.leave_subsection("Set up operators");
         }
@@ -1563,7 +1575,11 @@ MFNavierStokesSolver<dim>::setup_dofs_fd()
       .get_kinematic_viscosity_scale(),
     this->simulation_parameters.stabilization.stabilization,
     mg_level,
-    this->simulation_control);
+    this->simulation_control,
+    this->simulation_parameters.non_linear_solver.at(PhysicsID::fluid_dynamics)
+      .enable_hessians_jacobian,
+    this->simulation_parameters.non_linear_solver.at(PhysicsID::fluid_dynamics)
+      .enable_hessians_rhs);
 
 
   // Initialize vectors using operator

--- a/source/solvers/mf_navier_stokes_operators.cc
+++ b/source/solvers/mf_navier_stokes_operators.cc
@@ -136,17 +136,17 @@ NavierStokesOperatorBase<dim, number>::NavierStokesOperatorBase()
 
 template <int dim, typename number>
 NavierStokesOperatorBase<dim, number>::NavierStokesOperatorBase(
-  const Mapping<dim>                &mapping,
-  const DoFHandler<dim>             &dof_handler,
-  const AffineConstraints<number>   &constraints,
-  const Quadrature<dim>             &quadrature,
+  const Mapping<dim>                  &mapping,
+  const DoFHandler<dim>               &dof_handler,
+  const AffineConstraints<number>     &constraints,
+  const Quadrature<dim>               &quadrature,
   const std::shared_ptr<Function<dim>> forcing_function,
-  const double                       kinematic_viscosity,
-  const StabilizationType            stabilization,
-  const unsigned int                 mg_level,
-  std::shared_ptr<SimulationControl> simulation_control,
-  const bool                        &enable_hessians_jacobian,
-  const bool                        &enable_hessians_residual)
+  const double                         kinematic_viscosity,
+  const StabilizationType              stabilization,
+  const unsigned int                   mg_level,
+  std::shared_ptr<SimulationControl>   simulation_control,
+  const bool                          &enable_hessians_jacobian,
+  const bool                          &enable_hessians_residual)
   : pcout(std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
   , timer(this->pcout, TimerOutput::never, TimerOutput::wall_times)
 {
@@ -166,17 +166,17 @@ NavierStokesOperatorBase<dim, number>::NavierStokesOperatorBase(
 template <int dim, typename number>
 void
 NavierStokesOperatorBase<dim, number>::reinit(
-  const Mapping<dim>                &mapping,
-  const DoFHandler<dim>             &dof_handler,
-  const AffineConstraints<number>   &constraints,
-  const Quadrature<dim>             &quadrature,
+  const Mapping<dim>                  &mapping,
+  const DoFHandler<dim>               &dof_handler,
+  const AffineConstraints<number>     &constraints,
+  const Quadrature<dim>               &quadrature,
   const std::shared_ptr<Function<dim>> forcing_function,
-  const double                       kinematic_viscosity,
-  const StabilizationType            stabilization,
-  const unsigned int                 mg_level,
-  std::shared_ptr<SimulationControl> simulation_control,
-  const bool                        &enable_hessians_jacobian,
-  const bool                        &enable_hessians_residual)
+  const double                         kinematic_viscosity,
+  const StabilizationType              stabilization,
+  const unsigned int                   mg_level,
+  std::shared_ptr<SimulationControl>   simulation_control,
+  const bool                          &enable_hessians_jacobian,
+  const bool                          &enable_hessians_residual)
 {
   this->system_matrix.clear();
   this->constraints.copy_from(constraints);

--- a/source/solvers/mf_navier_stokes_operators.cc
+++ b/source/solvers/mf_navier_stokes_operators.cc
@@ -144,7 +144,9 @@ NavierStokesOperatorBase<dim, number>::NavierStokesOperatorBase(
   const double                         kinematic_viscosity,
   const StabilizationType              stabilization,
   const unsigned int                   mg_level,
-  std::shared_ptr<SimulationControl>   simulation_control)
+  std::shared_ptr<SimulationControl>   simulation_control,
+  const bool                          &enable_hessians_jacobian,
+  const bool                          &enable_hessians_rhs)
   : pcout(std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
   , timer(this->pcout, TimerOutput::never, TimerOutput::wall_times)
 {
@@ -156,7 +158,9 @@ NavierStokesOperatorBase<dim, number>::NavierStokesOperatorBase(
                kinematic_viscosity,
                stabilization,
                mg_level,
-               simulation_control);
+               simulation_control,
+               enable_hessians_jacobian,
+               enable_hessians_rhs);
 }
 
 template <int dim, typename number>
@@ -170,7 +174,9 @@ NavierStokesOperatorBase<dim, number>::reinit(
   const double                         kinematic_viscosity,
   const StabilizationType              stabilization,
   const unsigned int                   mg_level,
-  std::shared_ptr<SimulationControl>   simulation_control)
+  std::shared_ptr<SimulationControl>   simulation_control,
+  const bool                          &enable_hessians_jacobian,
+  const bool                          &enable_hessians_rhs)
 {
   this->system_matrix.clear();
   this->constraints.copy_from(constraints);
@@ -202,6 +208,10 @@ NavierStokesOperatorBase<dim, number>::reinit(
       "Only SUPG/PSPG and GLS stabilization is supported at the moment.");
 
   this->simulation_control = simulation_control;
+
+  this->enable_hessians_jacobian = enable_hessians_jacobian;
+
+  this->enable_hessians_rhs = enable_hessians_rhs;
 
   this->compute_element_size();
 
@@ -622,8 +632,14 @@ NavierStokesOperatorBase<dim, number>::
     {
       integrator.reinit(cell);
       integrator.read_dof_values_plain(newton_step);
-      integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
-                          EvaluationFlags::hessians);
+
+      if (this->enable_hessians_jacobian)
+        integrator.evaluate(EvaluationFlags::values |
+                            EvaluationFlags::gradients |
+                            EvaluationFlags::hessians);
+      else
+        integrator.evaluate(EvaluationFlags::values |
+                            EvaluationFlags::gradients);
 
       // Get previously calculated element size needed for tau
       const auto h = integrator.read_cell_data(this->get_element_size());
@@ -632,8 +648,10 @@ NavierStokesOperatorBase<dim, number>::
         {
           nonlinear_previous_values(cell, q)   = integrator.get_value(q);
           nonlinear_previous_gradient(cell, q) = integrator.get_gradient(q);
-          nonlinear_previous_hessian_diagonal(cell, q) =
-            integrator.get_hessian_diagonal(q);
+
+          if (this->enable_hessians_jacobian)
+            nonlinear_previous_hessian_diagonal(cell, q) =
+              integrator.get_hessian_diagonal(q);
 
           // Calculate tau
           VectorizedArray<number> u_mag_squared = 1e-12;
@@ -797,8 +815,11 @@ void
 NavierStokesStabilizedOperator<dim, number>::do_cell_integral_local(
   FECellIntegrator &integrator) const
 {
-  integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
-                      EvaluationFlags::hessians);
+  if (this->enable_hessians_jacobian)
+    integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
+                        EvaluationFlags::hessians);
+  else
+    integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
   const unsigned int cell = integrator.get_current_cell_index();
 
@@ -832,8 +853,10 @@ NavierStokesStabilizedOperator<dim, number>::do_cell_integral_local(
       typename FECellIntegrator::value_type    value = integrator.get_value(q);
       typename FECellIntegrator::gradient_type gradient =
         integrator.get_gradient(q);
-      typename FECellIntegrator::gradient_type hessian_diagonal =
-        integrator.get_hessian_diagonal(q);
+      typename FECellIntegrator::gradient_type hessian_diagonal;
+
+      if (this->enable_hessians_jacobian)
+        hessian_diagonal = integrator.get_hessian_diagonal(q);
 
       // Result value/gradient we will use
       typename FECellIntegrator::value_type    value_result;
@@ -949,26 +972,29 @@ NavierStokesStabilizedOperator<dim, number>::do_cell_integral_local(
             {
               for (unsigned int k = 0; k < dim; ++k)
                 {
-                  for (unsigned int l = 0; l < dim; ++l)
+                  if (this->enable_hessians_jacobian)
                     {
-                      // +((u·∇)δu + (δu·∇)u - ν∆δu)τ(−ν∆v)
+                      for (unsigned int l = 0; l < dim; ++l)
+                        {
+                          // +((u·∇)δu + (δu·∇)u - ν∆δu)τ(−ν∆v)
+                          hessian_result[i][k][k] +=
+                            tau * -this->kinematic_viscosity *
+                            (gradient[i][l] * previous_values[l] +
+                             previous_gradient[i][l] * value[l] -
+                             this->kinematic_viscosity *
+                               hessian_diagonal[i][l]);
+                        }
+
+                      // +(∇δp)τ(−ν∆v)
                       hessian_result[i][k][k] +=
-                        tau * -this->kinematic_viscosity *
-                        (gradient[i][l] * previous_values[l] +
-                         previous_gradient[i][l] * value[l] -
-                         this->kinematic_viscosity * hessian_diagonal[i][l]);
+                        tau * -this->kinematic_viscosity * (gradient[dim][i]);
+
+                      // +(∂t δu)τ(−ν∆v)
+                      if (transient)
+                        hessian_result[i][k][k] += tau *
+                                                   -this->kinematic_viscosity *
+                                                   ((*bdf_coefs)[0] * value[i]);
                     }
-
-                  // +(∇δp)τ(−ν∆v)
-                  hessian_result[i][k][k] +=
-                    tau * -this->kinematic_viscosity * (gradient[dim][i]);
-
-                  // +(∂t δu)τ(−ν∆v)
-                  if (transient)
-                    hessian_result[i][k][k] += tau *
-                                               -this->kinematic_viscosity *
-                                               ((*bdf_coefs)[0] * value[i]);
-
 
                   // LSIC term
                   // (∇·δu)τ'(∇·v)
@@ -979,11 +1005,16 @@ NavierStokesStabilizedOperator<dim, number>::do_cell_integral_local(
 
       integrator.submit_gradient(gradient_result, q);
       integrator.submit_value(value_result, q);
-      integrator.submit_hessian(hessian_result, q);
+
+      if (this->enable_hessians_jacobian)
+        integrator.submit_hessian(hessian_result, q);
     }
 
-  integrator.integrate(EvaluationFlags::values | EvaluationFlags::gradients |
-                       EvaluationFlags::hessians);
+  if (this->enable_hessians_jacobian)
+    integrator.integrate(EvaluationFlags::values | EvaluationFlags::gradients |
+                         EvaluationFlags::hessians);
+  else
+    integrator.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
 }
 
 /**
@@ -1010,8 +1041,14 @@ NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
     {
       integrator.reinit(cell);
       integrator.read_dof_values_plain(src);
-      integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
-                          EvaluationFlags::hessians);
+
+      if (this->enable_hessians_rhs)
+        integrator.evaluate(EvaluationFlags::values |
+                            EvaluationFlags::gradients |
+                            EvaluationFlags::hessians);
+      else
+        integrator.evaluate(EvaluationFlags::values |
+                            EvaluationFlags::gradients);
 
       // To identify whether the problem is transient or steady
       bool transient =
@@ -1045,8 +1082,10 @@ NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
           typename FECellIntegrator::value_type value = integrator.get_value(q);
           typename FECellIntegrator::gradient_type gradient =
             integrator.get_gradient(q);
-          typename FECellIntegrator::gradient_type hessian_diagonal =
-            integrator.get_hessian_diagonal(q);
+          typename FECellIntegrator::gradient_type hessian_diagonal;
+
+          if (this->enable_hessians_rhs)
+            hessian_diagonal = integrator.get_hessian_diagonal(q);
 
           // Time derivatives of previous solutions
           Tensor<1, dim + 1, VectorizedArray<number>> previous_time_derivatives;
@@ -1146,27 +1185,29 @@ NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
                 {
                   for (unsigned int k = 0; k < dim; ++k)
                     {
-                      for (unsigned int l = 0; l < dim; ++l)
+                      if (this->enable_hessians_rhs)
                         {
-                          // (-ν∆u + (u·∇)u)τ(−ν∆v)
+                          for (unsigned int l = 0; l < dim; ++l)
+                            {
+                              // (-ν∆u + (u·∇)u)τ(−ν∆v)
+                              hessian_result[i][k][k] +=
+                                tau * -this->kinematic_viscosity *
+                                (-this->kinematic_viscosity *
+                                   hessian_diagonal[i][l] +
+                                 gradient[i][l] * value[l]);
+                            }
+                          // + (∇p - f)τ(−ν∆v)
                           hessian_result[i][k][k] +=
                             tau * -this->kinematic_viscosity *
-                            (-this->kinematic_viscosity *
-                               hessian_diagonal[i][l] +
-                             gradient[i][l] * value[l]);
+                            (gradient[dim][i] - source_value[i]);
+
+                          // + (∂t u)τ(−ν∆v)
+                          if (transient)
+                            hessian_result[i][k][k] +=
+                              tau * -this->kinematic_viscosity *
+                              ((*bdf_coefs)[0] * value[i] +
+                               previous_time_derivatives[i]);
                         }
-                      // + (∇p - f)τ(−ν∆v)
-                      hessian_result[i][k][k] +=
-                        tau * -this->kinematic_viscosity *
-                        (gradient[dim][i] - source_value[i]);
-
-                      // + (∂t u)τ(−ν∆v)
-                      if (transient)
-                        hessian_result[i][k][k] +=
-                          tau * -this->kinematic_viscosity *
-                          ((*bdf_coefs)[0] * value[i] +
-                           previous_time_derivatives[i]);
-
 
                       // LSIC term
                       // (∇·u)τ'(∇·v)
@@ -1177,13 +1218,19 @@ NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
 
           integrator.submit_gradient(gradient_result, q);
           integrator.submit_value(value_result, q);
-          integrator.submit_hessian(hessian_result, q);
+          if (this->enable_hessians_rhs)
+            integrator.submit_hessian(hessian_result, q);
         }
 
-      integrator.integrate_scatter(EvaluationFlags::values |
-                                     EvaluationFlags::gradients |
-                                     EvaluationFlags::hessians,
-                                   dst);
+      if (this->enable_hessians_rhs)
+        integrator.integrate_scatter(EvaluationFlags::values |
+                                       EvaluationFlags::gradients |
+                                       EvaluationFlags::hessians,
+                                     dst);
+      else
+        integrator.integrate_scatter(EvaluationFlags::values |
+                                       EvaluationFlags::gradients,
+                                     dst);
     }
 }
 


### PR DESCRIPTION
# Description of the problem

Evaluating terms involving the hessian is expensive. In the matrix-free application this is done way more times than in the matrix-based application, and is affecting performance significantly. 

# Description of the solution

In this PR we include 3 new parameters that allow to enable or disable all the terms involving the hessian. The first two allow to do so for the jacobian and the residual of the linear system. The other one, allows to do the same for the jacobian of the multigrid preconditioner operators.

# How Has This Been Tested?

- By default all terms are enabled, so all existent test pass.
- I have tested two problems in my machine and this seems promising in terms of performance. Further testing will be done in the following days.

# Documentation

- The three new parameters and a brief description have been added to the linear solver parameters documentation: `lethe/doc/source/parameters/cfd/linear_solver_control.rst`. It is emphasized that these parameters only work for `lethe-fluid-matrix-free` at the moment.