### PR TITLE
Fix viscous initial condition for transient problems in MF

### DIFF
--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1671,11 +1671,6 @@ MFNavierStokesSolver<dim>::set_initial_condition_fd(
     }
   else if (initial_condition_type == Parameters::InitialConditionType::viscous)
     {
-      AssertThrow(
-        this->simulation_control->is_steady(),
-        dealii::ExcMessage(
-          "The lethe-fluid-matrix-free solver does not support viscous initial conditions for transient simulations."));
-
       // Set the nodal values to have an initial condition that is adequate
       this->set_nodal_values();
       this->present_solution.update_ghost_values();
@@ -1733,6 +1728,8 @@ MFNavierStokesSolver<dim>::set_initial_condition_fd(
         }
 
       // Solve the problem with the temporary viscosity
+      this->simulation_control->set_assembly_method(
+        Parameters::SimulationControl::TimeSteppingMethod::steady);
       PhysicsSolver<LinearAlgebra::distributed::Vector<double>>::
         solve_non_linear_system(false);
       this->finish_time_step();


### PR DESCRIPTION
# Description of the problem
The viscous initial condition was already implemented but we were not able to use it for transient simulations.

# Description of the solution
This was fixed by setting the assembly method to steady before solving the non linear system with the specified viscosity. This was already done for the ramp viscous initial condition. 

# How Has This Been Tested?
Run a test on my machine and works just as expected. 