### PR TITLE
Solid objects did not trigger a contact detection step when they were moved 

### DIFF
--- a/applications_tests/lethe-particles/moving_float.mpirun=1.output
+++ b/applications_tests/lethe-particles/moving_float.mpirun=1.output
@@ -16,7 +16,7 @@ This feature is useful in geometries with concave boundaries.
 Transient iteration: 10000    Time: 0.5      Time step: 5e-05   
 *****************************************************************
 | Variable                     | Min        | Max         | Average    | Total      | 
-| Contact list generation      | 0.0000e+00 | 2.7000e+01  | 2.7000e+01 | 2.7000e+01 | 
+| Contact list generation      | 0.0000e+00 | 2.8000e+01  | 2.8000e+01 | 2.8000e+01 | 
 | Velocity magnitude           | 9.7972e-02 | 1.0221e-01  | 9.9564e-02 | 4.9782e-01 | 
 | Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
 | Translational kinetic energy | 5.1464e-05 | 5.6016e-05  | 5.3162e-05 | 2.6581e-04 | 
@@ -26,7 +26,7 @@ Transient iteration: 10000    Time: 0.5      Time step: 5e-05
 Transient iteration: 20000    Time: 1        Time step: 5e-05   
 *****************************************************************
 | Variable                     | Min        | Max         | Average    | Total      | 
-| Contact list generation      | 0.0000e+00 | 2.7000e+01  | 2.3000e+01 | 4.6000e+01 | 
+| Contact list generation      | 0.0000e+00 | 2.8000e+01  | 2.4500e+01 | 4.9000e+01 | 
 | Velocity magnitude           | 1.0000e-01 | 1.0000e-01  | 1.0000e-01 | 5.0000e-01 | 
 | Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
 | Translational kinetic energy | 5.3617e-05 | 5.3617e-05  | 5.3617e-05 | 2.6808e-04 | 

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -1319,6 +1319,28 @@ DEMSolver<dim>::solve()
       // Check to see if it is contact search step
       contact_detection_step = contact_detection_iteration_check_function();
 
+      bool floating_mesh_map_step = false;
+      // Check to see if floating meshes need to be mapped in background mesh
+      if (has_floating_mesh)
+        {
+          floating_mesh_map_step = find_floating_mesh_mapping_step(
+            smallest_floating_mesh_mapping_criterion, this->solids);
+
+          if (floating_mesh_map_step)
+            {
+
+              // Update floating mesh information in the container manager
+              for (unsigned int i_solid = 0; i_solid < solids.size(); ++i_solid)
+                {
+                  floating_mesh_info[i_solid] =
+                    solids[i_solid]->map_solid_in_background_triangulation(
+                      triangulation);
+                }
+            }
+        }
+
+      contact_detection_step = contact_detection_step || floating_mesh_map_step;
+
       // Sort particles in cells
       if (particles_insertion_step || load_balance_step ||
           contact_detection_step || checkpoint_step)
@@ -1354,23 +1376,7 @@ DEMSolver<dim>::solve()
           particle_handler.update_ghost_particles();
         }
 
-      // Check to see if floating meshes need to be mapped in background mesh
-      if (has_floating_mesh)
-        {
-          bool floating_mesh_map_step = find_floating_mesh_mapping_step(
-            smallest_floating_mesh_mapping_criterion, this->solids);
 
-          if (floating_mesh_map_step)
-            {
-              // Update floating mesh information in the container manager
-              for (unsigned int i_solid = 0; i_solid < solids.size(); ++i_solid)
-                {
-                  floating_mesh_info[i_solid] =
-                    solids[i_solid]->map_solid_in_background_triangulation(
-                      triangulation);
-                }
-            }
-        }
 
       // Modify particles contact containers by search sequence
       if (particles_insertion_step || load_balance_step ||

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -1328,7 +1328,6 @@ DEMSolver<dim>::solve()
 
           if (floating_mesh_map_step)
             {
-
               // Update floating mesh information in the container manager
               for (unsigned int i_solid = 0; i_solid < solids.size(); ++i_solid)
                 {

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -1369,18 +1369,7 @@ DEMSolver<dim>::solve()
           update_moment_of_inertia(particle_handler, MOI);
 
           particle_handler.exchange_ghost_particles(true);
-        }
-      else
-        {
-          particle_handler.update_ghost_particles();
-        }
 
-
-
-      // Modify particles contact containers by search sequence
-      if (particles_insertion_step || load_balance_step ||
-          contact_detection_step || checkpoint_step)
-        {
           // Reset checkpoint step
           checkpoint_step = false;
 
@@ -1444,6 +1433,10 @@ DEMSolver<dim>::solve()
             simulation_control->get_current_time(),
             neighborhood_threshold_squared,
             has_floating_mesh);
+        }
+      else
+        {
+          particle_handler.update_ghost_particles();
         }
 
       // Particle-particle contact force

--- a/source/dem/dem_contact_manager.cc
+++ b/source/dem/dem_contact_manager.cc
@@ -294,6 +294,7 @@ DEMContactManager<dim>::execute_particle_wall_broad_search(
   // Particle-floating mesh broad search
   if (has_floating_mesh)
     {
+      std::cout << " Floating mesh broad search" << std::endl;
       particle_wall_broad_search_object.particle_floating_mesh_contact_search(
         floating_mesh_info,
         particle_handler,

--- a/source/dem/dem_contact_manager.cc
+++ b/source/dem/dem_contact_manager.cc
@@ -294,7 +294,6 @@ DEMContactManager<dim>::execute_particle_wall_broad_search(
   // Particle-floating mesh broad search
   if (has_floating_mesh)
     {
-      std::cout << " Floating mesh broad search" << std::endl;
       particle_wall_broad_search_object.particle_floating_mesh_contact_search(
         floating_mesh_info,
         particle_handler,


### PR DESCRIPTION
# Description of the problem

- Moving solid objects did not trigger a contaction step when they moved. This was problematic since if the particles were static, the solid objects could waltz through them if no contact detection were triggered on the particle side.

# Description of the solution

- Trigger a contact detection step when the solid object is mapped again.

# How Has This Been Tested?

- Bunny example without load balancing works fine now.


# Comments

- This may have a small negative impact on performance. This will improve when we refactor the contact detection mechanism in the code to make it cleaner and more logical.

Should close issue #1132 
