### PR TITLE
Deploy DEBUG CI on self-hosted runner

### DIFF
--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -1,6 +1,7 @@
 name: CI-Debug
 
-on:
+on: 
+# Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
   push:
     # Runs on every push on master branch
     branches:
@@ -8,20 +9,22 @@ on:
   pull_request:
     paths-ignore:
       - 'doc/**'
-
+    
 # Cancels running instances when a pull request is updated by a commit
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
+
 env:
-  COMPILE_JOBS: 2
-  MULTI_CORE_TESTS_REGEX: "mpirun=2"
+  COMPILE_JOBS: 8
+  TEST_JOBS: 4 
+
 
 jobs:
   build:
     name: Build (deal.ii:${{ matrix.dealii_version }})
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     strategy:
       fail-fast: false
@@ -54,8 +57,8 @@ jobs:
       #
       - name: Compile Lethe (Debug-deal.ii:${{ matrix.dealii_version }})
         run: |
-          mkdir build-Debug
-          cd build-Debug
+          mkdir build-debug
+          cd build-debug
           cmake ../ -DCMAKE_BUILD_TYPE=Debug
           make -j${{ env.COMPILE_JOBS }}
 
@@ -65,20 +68,8 @@ jobs:
           #Allow OMPI to run as root
           export OMPI_ALLOW_RUN_AS_ROOT=1
           export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-          cd build-Debug
-          # Print the tests to be executed
-          ctest -N --exclude-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
+          cd build-debug
+          ctest -N
+
           # Run in parallel
-          ctest --output-on-failure -j${{ env.COMPILE_JOBS }} --exclude-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
-      
-      # These tests require two cores each so we will run them sequencially
-      - name: Run multi-core Lethe tests (Debug-deal.ii:${{ matrix.dealii_version }})
-        run: |
-          #Allow OMPI to run as root
-          export OMPI_ALLOW_RUN_AS_ROOT=1
-          export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-          cd build-Debug
-          # Print the tests to be executed
-          ctest -N --tests-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
-          # Run sequencially
-          ctest --output-on-failure --tests-regex ${{ env.MULTI_CORE_TESTS_REGEX }}
+          ctest --output-on-failure -j${{ env.TEST_JOBS }} 

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   COMPILE_JOBS: 18
-  TEST_JOBS: 18
+  TEST_JOBS: 12
 
 
 jobs:

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     paths-ignore:
       - 'doc/**'
+      - 'contrib/**'
+      - 'examples/**'
     
 # Cancels running instances when a pull request is updated by a commit
 concurrency:

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   COMPILE_JOBS: 8
-  TEST_JOBS: 3 
+  TEST_JOBS: 8
 
 
 jobs:

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -17,8 +17,8 @@ concurrency:
 
 
 env:
-  COMPILE_JOBS: 8
-  TEST_JOBS: 8
+  COMPILE_JOBS: 12
+  TEST_JOBS: 12
 
 
 jobs:

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   COMPILE_JOBS: 8
-  TEST_JOBS: 4 
+  TEST_JOBS: 3 
 
 
 jobs:

--- a/.github/workflows/main_debug.yml
+++ b/.github/workflows/main_debug.yml
@@ -17,8 +17,8 @@ concurrency:
 
 
 env:
-  COMPILE_JOBS: 12
-  TEST_JOBS: 12
+  COMPILE_JOBS: 18
+  TEST_JOBS: 18
 
 
 jobs:

--- a/.github/workflows/main_parameter_files.yml
+++ b/.github/workflows/main_parameter_files.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths-ignore:
       - 'doc/**'
+      - 'contrib/**'
 
 # Cancels running instances when a pull request is updated by a commit
 concurrency:

--- a/.github/workflows/main_release.yml
+++ b/.github/workflows/main_release.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     paths-ignore:
       - 'doc/**'
+      - 'contrib/**'
+      - 'examples/**'
 
 # Cancels running instances when a pull request is updated by a commit
 concurrency:

--- a/.github/workflows/main_warnings.yml
+++ b/.github/workflows/main_warnings.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     paths-ignore:
       - 'doc/**'
+      - 'contrib/**'
+      - 'examples/**'
 
 # Cancels running instances when a pull request is updated by a commit
 concurrency:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,8 +141,8 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   if(BUILD_TESTING)
     set(DEAL_II_WITH_DEALII ON)
     set(DEAL_II_DEALII_VERSION ${DEAL_II_VERSION})
-    add_subdirectory(tests)
     add_subdirectory(applications_tests)
+    add_subdirectory(tests)
 
     if(TXR_EXECUTABLE)
       add_custom_target(update-golden

--- a/applications_tests/lethe-fluid/CMakeLists.txt
+++ b/applications_tests/lethe-fluid/CMakeLists.txt
@@ -60,7 +60,7 @@ file(COPY poiseuille_restart_files/poiseuille_restart-output.0005.0000.vtu DESTI
 file(COPY poiseuille_restart_files/poiseuille_restart-output.0010.0000.vtu DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/poiseuille_restart.${_build_type}/mpirun=1/")
 file(COPY poiseuille_restart_files/poiseuille_restart-output.0015.0000.vtu DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/poiseuille_restart.${_build_type}/mpirun=1/")
 
-sdeal_ii_pickup_tests()
+deal_ii_pickup_tests()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set_tests_properties(lethe-fluid/mms3d_isothermal_compressible_ns_gls.debug PROPERTIES TIMEOUT 2000)

--- a/applications_tests/lethe-fluid/CMakeLists.txt
+++ b/applications_tests/lethe-fluid/CMakeLists.txt
@@ -60,5 +60,8 @@ file(COPY poiseuille_restart_files/poiseuille_restart-output.0005.0000.vtu DESTI
 file(COPY poiseuille_restart_files/poiseuille_restart-output.0010.0000.vtu DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/poiseuille_restart.${_build_type}/mpirun=1/")
 file(COPY poiseuille_restart_files/poiseuille_restart-output.0015.0000.vtu DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/poiseuille_restart.${_build_type}/mpirun=1/")
 
+sdeal_ii_pickup_tests()
 
-deal_ii_pickup_tests()
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set_tests_properties(lethe-fluid/mms3d_isothermal_compressible_ns_gls.debug PROPERTIES TIMEOUT 2000)
+endif()


### PR DESCRIPTION
# Description of the problem

- The DEBUG CI is too slow on github actions

# Description of the solution

- Deploy it locally on our machines


# Comments

- This is work in progress until the real CI machine is also built
