### PR TITLE
One way coupling MF and heat transfer

### DIFF
--- a/applications_tests/lethe-fluid-matrix-free/heat_transfer_high_pe_stab_gls.mpirun=2.output
+++ b/applications_tests/lethe-fluid-matrix-free/heat_transfer_high_pe_stab_gls.mpirun=2.output
@@ -1,0 +1,39 @@
+Running on 2 MPI rank(s)...
+   Number of active cells:       256
+   Number of degrees of freedom: 867
+   Volume of triangulation:      1
+   Number of thermal degrees of freedom: 289
+
+*****************************
+Steady iteration:        1/3
+*****************************
+L2 error velocity : 5.55112e-17
+L2 error temperature : 0.011498
+
+*****************************
+Steady iteration:        2/3
+*****************************
+   Number of active cells:       1024
+   Number of degrees of freedom: 3267
+   Volume of triangulation:      1
+   Number of thermal degrees of freedom: 1089
+L2 error velocity : 5.55112e-17
+L2 error temperature : 0.0020271
+
+*****************************
+Steady iteration:        3/3
+*****************************
+   Number of active cells:       4096
+   Number of degrees of freedom: 12675
+   Volume of triangulation:      1
+   Number of thermal degrees of freedom: 4225
+L2 error velocity : 5.55112e-17
+L2 error temperature : 0.000212391
+cells  error_velocity    error_pressure  
+  256 5.551115e-17    - 0.000000e+00   - 
+ 1024 5.551115e-17 0.00 0.000000e+00 nan 
+ 4096 5.551115e-17 0.00 0.000000e+00 nan 
+cells error_temperature 
+  256 1.149804e-02    - 
+ 1024 2.027103e-03 2.50 
+ 4096 2.123908e-04 3.25 

--- a/applications_tests/lethe-fluid-matrix-free/heat_transfer_high_pe_stab_gls.output
+++ b/applications_tests/lethe-fluid-matrix-free/heat_transfer_high_pe_stab_gls.output
@@ -1,0 +1,39 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       256
+   Number of degrees of freedom: 867
+   Volume of triangulation:      1
+   Number of thermal degrees of freedom: 289
+
+*****************************
+Steady iteration:        1/3
+*****************************
+L2 error velocity : 5.55112e-17
+L2 error temperature : 0.011498
+
+*****************************
+Steady iteration:        2/3
+*****************************
+   Number of active cells:       1024
+   Number of degrees of freedom: 3267
+   Volume of triangulation:      1
+   Number of thermal degrees of freedom: 1089
+L2 error velocity : 5.55112e-17
+L2 error temperature : 0.0020271
+
+*****************************
+Steady iteration:        3/3
+*****************************
+   Number of active cells:       4096
+   Number of degrees of freedom: 12675
+   Volume of triangulation:      1
+   Number of thermal degrees of freedom: 4225
+L2 error velocity : 5.55112e-17
+L2 error temperature : 0.000212391
+cells  error_velocity    error_pressure  
+  256 5.551115e-17    - 0.000000e+00   - 
+ 1024 5.551115e-17 0.00 0.000000e+00 nan 
+ 4096 5.551115e-17 0.00 0.000000e+00 nan 
+cells error_temperature 
+  256 1.149804e-02    - 
+ 1024 2.027103e-03 2.50 
+ 4096 2.123908e-04 3.25 

--- a/applications_tests/lethe-fluid-matrix-free/heat_transfer_high_pe_stab_gls.prm
+++ b/applications_tests/lethe-fluid-matrix-free/heat_transfer_high_pe_stab_gls.prm
@@ -1,0 +1,194 @@
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method            = steady
+  set number mesh adapt = 2
+  set output name       = stab_adv_diff
+  set output frequency  = 0
+  set subdivision       = 1
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+
+subsection FEM
+  set velocity order    = 1
+  set pressure order    = 1
+  set temperature order = 1
+end
+
+#---------------------------------------------------
+# Source term
+#---------------------------------------------------
+
+subsection source term
+  subsection fluid dynamics
+    set enable = false
+  end
+end
+
+#---------------------------------------------------
+# Timer
+#---------------------------------------------------
+
+subsection timer
+  set type = none # <none|iteration|end>
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+
+subsection initial conditions
+  set type = nodal
+  subsection uvwp
+    set Function expression = 1; 0; 0
+  end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  set number of fluids = 1
+  subsection fluid 0
+    set thermal conductivity = 0.01
+  end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = hyper_rectangle
+  set grid arguments     = 0, 0 : 1, 1.0 : true
+  set initial refinement = 4
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+
+subsection multiphysics
+  set heat transfer = true
+end
+
+#---------------------------------------------------
+# Mesh Adaptation Control
+#---------------------------------------------------
+
+subsection mesh adaptation
+  set type = uniform
+end
+
+#---------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+
+subsection analytical solution
+  set enable    = true
+  set verbosity = verbose
+  subsection uvwp
+    set Function expression = 1 ; 0 ; 0
+  end
+  subsection temperature
+    set Function constants  = Pe=100
+    set Function expression = (exp(Pe*x)-1)/(exp(Pe)-1)
+  end
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions
+  set number = 3
+  subsection bc 0
+    set id   = 0
+    set type = function
+    subsection u
+      set Function expression = 1
+    end
+  end
+  subsection bc 1
+    set id   = 2
+    set type = slip
+  end
+  subsection bc 2
+    set id   = 3
+    set type = slip
+  end
+end
+
+subsection boundary conditions heat transfer
+  set number = 2
+  subsection bc 0
+    set id    = 0
+    set type  = temperature
+    subsection value
+      set Function expression = 0
+    end
+  end
+  subsection bc 1
+    set id    = 1
+    set type  = temperature
+    subsection value
+      set Function expression = 1
+    end
+  end
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection heat transfer
+    set verbosity      = quiet
+    set tolerance      = 1e-10
+    set max iterations = 20
+  end
+  subsection fluid dynamics
+    set verbosity      = quiet
+    set tolerance      = 1e-10
+    set max iterations = 20
+  end
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+  subsection heat transfer
+    set verbosity                             = quiet
+    set method                                = gmres
+    set relative residual                     = 1e-13
+    set minimum residual                      = 1e-14
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-14
+    set ilu preconditioner relative tolerance = 1.00
+  end
+end

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -327,7 +327,6 @@ protected:
 
   /**
    * @brief  Update the average velocity field solution in the multiphyscics interface.
-   * Currently not implemented for this solver but required for compilation.
    */
   virtual void
   update_multiphysics_time_average_solution() override;
@@ -420,6 +419,13 @@ private:
   void
   print_mg_setup_times();
 
+
+  /**
+   * @brief  Provide relevant solutions to multiphysics interface.
+   */
+  void
+  update_solutions_for_multiphysics();
+
 protected:
   /**
    * @brief Matrix-free operator in used for all the matrix-vector multiplications calls (vmult).
@@ -453,7 +459,8 @@ protected:
   DoFHandler<dim> dof_handler_fe_q_iso_q1;
 
   /**
-   * @brief Trilinos vector storing the average velocities that is provided to other physics.
+   * @brief Trilinos vector storing the average velocities that are provided to other
+   * physics.
    *
    */
   TrilinosWrappers::MPI::Vector multiphysics_average_velocities;
@@ -465,7 +472,8 @@ protected:
   TrilinosWrappers::MPI::Vector multiphysics_present_solution;
 
   /**
-   * @brief Trilinos vector storing the previous solutions that are provided to other physics.
+   * @brief Vector storing trilinos vectors containing the previous solutions that are
+   * provided to other physics.
    *
    */
   std::vector<TrilinosWrappers::MPI::Vector> multiphysics_previous_solutions;

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -420,7 +420,9 @@ private:
   print_mg_setup_times();
 
   /**
-   * @brief  Provide relevant solutions to multiphysics interface.
+   * @brief  Provide present and previous flow solutions to the multiphysics
+   * interface. These solutions can be accessed through the multiphysics
+   * interface by the different physics.
    */
   void
   update_solutions_for_multiphysics();

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -451,6 +451,24 @@ protected:
    *
    */
   DoFHandler<dim> dof_handler_fe_q_iso_q1;
+
+  /**
+   * @brief Trilinos vector storing the average velocities that is provided to other physics.
+   *
+   */
+  TrilinosWrappers::MPI::Vector multiphysics_average_velocities;
+
+  /**
+   * @brief Trilinos vector storing the present solution that is provided to other physics.
+   *
+   */
+  TrilinosWrappers::MPI::Vector multiphysics_present_solution;
+
+  /**
+   * @brief Trilinos vector storing the previous solutions that are provided to other physics.
+   *
+   */
+  std::vector<TrilinosWrappers::MPI::Vector> multiphysics_previous_solutions;
 };
 
 #endif

--- a/include/solvers/mf_navier_stokes.h
+++ b/include/solvers/mf_navier_stokes.h
@@ -419,7 +419,6 @@ private:
   void
   print_mg_setup_times();
 
-
   /**
    * @brief  Provide relevant solutions to multiphysics interface.
    */

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1656,7 +1656,7 @@ MFNavierStokesSolver<dim>::setup_dofs_fd()
   // Pre-allocate memory for the previous solutions using the information
   // of the BDF schemes
   this->multiphysics_previous_solutions.resize(
-    maximum_number_of_previous_solutions());
+    this->simulation_control->get_number_of_previous_solution_in_assembly());
 
   for (auto &solution : this->multiphysics_previous_solutions)
     solution.reinit(this->locally_owned_dofs,
@@ -2096,9 +2096,12 @@ MFNavierStokesSolver<dim>::update_solutions_for_multiphysics()
 
   // Convert the previous solutions to multiphysics vector type and provide them
   // to the multiphysics interface
-  for (auto &trilinos_solution : this->multiphysics_previous_solutions)
-    for (auto &dealii_solution : this->previous_solutions)
-      convert_vector_dealii_to_trilinos(trilinos_solution, dealii_solution);
+  const unsigned int number_of_previous_solutions =
+    this->simulation_control->get_number_of_previous_solution_in_assembly();
+
+  for (unsigned int i = 0; i < number_of_previous_solutions; i++)
+    convert_vector_dealii_to_trilinos(this->multiphysics_previous_solutions[i],
+                                      this->previous_solutions[i]);
 
   this->multiphysics->set_previous_solutions(
     PhysicsID::fluid_dynamics, &this->multiphysics_previous_solutions);


### PR DESCRIPTION
# Description of the problem

The `lethe-fluid-matrix-free` application was not coupled to any other physics. 

# Description of the solution

This PR enables the one way coupling between fluid dynamics and heat transfer using the existent multiphysics interface.

# How Has This Been Tested?
One test was added to verify the coupling. It is the same one that is used in the matrix-based application:
- [X] `applications_tests/lethe-fluid-matrix-free/heat_transfer_high_pe_stab_gls.prm`

