### PR TITLE
Adding a custom parsed function

### DIFF
--- a/include/core/mu_parser_internal.h
+++ b/include/core/mu_parser_internal.h
@@ -26,7 +26,6 @@
 #include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
-#include <muParserFixes.h>
 #include <muParser.h>
 #include <muParserFixes.h>
 

--- a/include/core/mu_parser_internal.h
+++ b/include/core/mu_parser_internal.h
@@ -23,8 +23,18 @@
 #include <deal.II/base/mu_parser_internal.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/thread_local_storage.h>
+#include <deal.II/base/thread_management.h>
+#include <deal.II/base/utilities.h>
 
+#include <muParser.h>
+
+#include <cmath>
+#include <ctime>
+#include <limits>
+#include <map>
 #include <memory>
+#include <mutex>
+#include <random>
 #include <string>
 #include <vector>
 

--- a/include/core/mu_parser_internal.h
+++ b/include/core/mu_parser_internal.h
@@ -43,51 +43,136 @@ namespace internal
 {
   namespace FunctionParserCustom
   {
+    /**
+     * @brief Rounds the value to the nearest integer
+     * @param[in] val Value to round
+     * @return Rounded value
+     */
     int
     mu_round(double val);
 
+    /**
+     * @brief If-condition
+     * @param[in] condition Boolean expression
+     * @param[in] thenvalue Expression if true
+     * @param[in] elsevalue Expression if false
+     * @return Resulting value
+     */
     double
     mu_if(double condition, double thenvalue, double elsevalue);
 
+    /**
+     * @brief Logical or
+     * @param[in] left First parameter
+     * @param[in] right Second parameter
+     * @return 1 if either is true, 0 else
+     */
     double
     mu_or(double left, double right);
 
+    /**
+     * @brief Logical and
+     * @param[in] left First parameter
+     * @param[in] right Second parameter
+     * @return 1 if both are true, 0 else
+     */
     double
     mu_and(double left, double right);
 
+    /**
+     * Rounds the value to the nearest integer (same as round)
+     * @param[in] value Value to round
+     * @return Rounded value
+     */
     double
     mu_int(double value);
 
+    /**
+     * Rounds the value to the upper integer
+     * @param[in] value Value to round
+     * @return Rounded value
+     */
     double
     mu_ceil(double value);
 
+    /**
+     * @brief Rounds the value to the lower integer
+     * @param[in] value Value to round
+     * @return Rounded value
+     */
     double
     mu_floor(double value);
 
+    /**
+     * @brief Performs the cotangent operation
+     * @param[in] value Value to process
+     * @return Cotan(value)
+     */
     double
     mu_cot(double value);
 
+    /**
+     * @brief Performs the cosecant operation
+     * @param[in] value Value to process
+     * @return Cosec(value)
+     */
     double
     mu_csc(double value);
 
+    /**
+     * @brief Performs the secant operation
+     * @param[in] value Value to process
+     * @return Sec(value)
+     */
     double
     mu_sec(double value);
 
+    /**
+     * @brief Performs the natural-logarithm operation
+     * @param[in] value Value to process
+     * @return std::log(value)
+     */
     double
     mu_log(double value);
 
+    /**
+     * @brief Performs the a to the power b operation
+     * @param[in] a Base
+     * @param[in] b Exponent
+     * @return std::pow(a,b)
+     */
     double
     mu_pow(double a, double b);
 
+    /**
+     * @brief Performs the erf operation
+     * @param[in] value Value to process
+     * @return std::erf(value)
+     */
     double
     mu_erf(double value);
 
+    /**
+     * @brief Performs the erfc operation
+     * @param[in] value Value to process
+     * @return std::erfc(value)
+     */
     double
     mu_erfc(double value);
 
+    /**
+     * @brief Generate number in [0,1] with a specific seed
+     * @param[in] seed Number to be able to reproduce random behavior between
+     * runs
+     * @return Random number
+     */
     double
     mu_rand_seed(double seed);
 
+    /**
+     * @brief Generate number in [0,1]
+     * @return Random number
+     */
     double
     mu_rand();
 

--- a/include/core/mu_parser_internal.h
+++ b/include/core/mu_parser_internal.h
@@ -20,6 +20,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/array_view.h>
+#include <deal.II/base/mu_parser_internal.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/thread_local_storage.h>
 

--- a/include/core/mu_parser_internal.h
+++ b/include/core/mu_parser_internal.h
@@ -116,7 +116,7 @@ namespace internal
 
       virtual ~ParserImplementation() = default;
 
-      virtual void
+      void
       initialize(const std::string                   &vars,
                  const std::vector<std::string>      &expressions,
                  const std::map<std::string, double> &constants,

--- a/include/core/mu_parser_internal.h
+++ b/include/core/mu_parser_internal.h
@@ -1,0 +1,158 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+#ifndef lethe_mu_parser_internal_h
+#define lethe_mu_parser_internal_h
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/array_view.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/thread_local_storage.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace internal
+{
+  namespace FunctionParserCustom
+  {
+    int
+    mu_round(double val);
+
+    double
+    mu_if(double condition, double thenvalue, double elsevalue);
+
+    double
+    mu_or(double left, double right);
+
+    double
+    mu_and(double left, double right);
+
+    double
+    mu_int(double value);
+
+    double
+    mu_ceil(double value);
+
+    double
+    mu_floor(double value);
+
+    double
+    mu_cot(double value);
+
+    double
+    mu_csc(double value);
+
+    double
+    mu_sec(double value);
+
+    double
+    mu_log(double value);
+
+    double
+    mu_pow(double a, double b);
+
+    double
+    mu_erf(double value);
+
+    double
+    mu_erfc(double value);
+
+    double
+    mu_rand_seed(double seed);
+
+    double
+    mu_rand();
+
+
+    std::vector<std::string>
+    get_function_names();
+
+    DeclException2(ExcParseError,
+                   int,
+                   std::string,
+                   << "Parsing Error at Column " << arg1
+                   << ". The parser said: " << arg2);
+
+
+
+    class muParserBase
+    {
+    public:
+      virtual ~muParserBase() = default;
+    };
+
+    struct ParserData
+    {
+      ParserData() = default;
+
+      ParserData(const ParserData &) = delete;
+
+      std::vector<double> vars;
+
+      std::vector<std::unique_ptr<muParserBase>> parsers;
+    };
+
+    template <int n_components>
+    class ParserImplementation
+    {
+    public:
+      ParserImplementation();
+
+      virtual ~ParserImplementation() = default;
+
+      virtual void
+      initialize(const std::string                   &vars,
+                 const std::vector<std::string>      &expressions,
+                 const std::map<std::string, double> &constants,
+                 const bool                           time_dependent = false);
+
+      void
+      init_muparser() const;
+
+      double
+      do_value(const dealii::Tensor<1, n_components> &p,
+               const double                           time,
+               unsigned int                           component) const;
+
+      void
+      do_all_values(const dealii::Tensor<1, n_components> &p,
+                    const double                           time,
+                    dealii::ArrayView<double>             &values) const;
+
+      std::vector<std::string> expressions;
+
+    private:
+      mutable dealii::Threads::ThreadLocalStorage<
+        ::internal::FunctionParserCustom::ParserData>
+        parser_data;
+
+      std::map<std::string, double> constants;
+
+
+      std::vector<std::string> var_names;
+
+      bool initialized;
+
+      unsigned int n_vars;
+    };
+  } // namespace FunctionParserCustom
+} // namespace internal
+
+
+#endif // LETHE_MU_PARSER_INTERNAL_H

--- a/include/core/mu_parser_internal.h
+++ b/include/core/mu_parser_internal.h
@@ -93,6 +93,7 @@ namespace internal
 
     /**
      * @brief Get the array of all function names.
+     * @return Available implemented functions
      */
     std::vector<std::string>
     get_function_names();
@@ -103,12 +104,9 @@ namespace internal
                    << "Parsing Error at Column " << arg1
                    << ". The parser said: " << arg2);
 
+
     /**
-     * deal.II uses muParser as a purely internal dependency. To this end, we do
-     * not include any muParser headers in our own headers (and the bundled
-     * version of the dependency does not install its headers or compile a
-     * separate muparser library). Hence, to interface with muParser, we use the
-     * PIMPL idiom here to wrap a pointer to mu::Parser objects.
+     * @brief Base class used for thread safe instances of the parser.
      */
     class muParserBase
     {

--- a/include/core/mu_parser_internal.h
+++ b/include/core/mu_parser_internal.h
@@ -183,21 +183,21 @@ namespace internal
       std::vector<std::string> expressions;
 
     private:
-      // Thread safe object for using muParser
+      /// Thread safe object for using muParser
       mutable dealii::Threads::ThreadLocalStorage<
         ::internal::FunctionParserCustom::ParserData>
         parser_data;
 
-      // Constants
+      /// Constants
       std::map<std::string, double> constants;
 
-      // Variable name
+      /// Variable name
       std::vector<std::string> var_names;
 
-      // Keeps track if the muParser object is initialized
+      /// Keeps track if the muParser object is initialized
       bool initialized;
 
-      // Number of variables
+      /// Number of variables
       unsigned int n_vars;
     };
   } // namespace FunctionParserCustom

--- a/include/core/mu_parser_internal.h
+++ b/include/core/mu_parser_internal.h
@@ -27,6 +27,7 @@
 #include <deal.II/base/utilities.h>
 
 #include <muParser.h>
+#include <muParserFixes.h>
 
 #include <cmath>
 #include <ctime>
@@ -203,6 +204,5 @@ namespace internal
     };
   } // namespace FunctionParserCustom
 } // namespace internal
-
 
 #endif // lethe_mu_parser_internal_h

--- a/include/core/mu_parser_internal.h
+++ b/include/core/mu_parser_internal.h
@@ -39,253 +39,257 @@
 #include <string>
 #include <vector>
 
-namespace internal
+/**
+ * \defgroup Implementation of internal classes and functions to interface with
+ * muParser
+ * @brief Internal functionalities for using muParser
+ *
+ * \ingroup internalFunctionParserCustom
+ */
+namespace internalFunctionParserCustom
 {
-  namespace FunctionParserCustom
+  /**
+   * @brief Rounds the value to the nearest integer
+   * @param[in] val Value to round
+   * @return Rounded value
+   */
+  int
+  mu_round(double val);
+
+  /**
+   * @brief If-condition
+   * @param[in] condition Boolean expression
+   * @param[in] thenvalue Expression if true
+   * @param[in] elsevalue Expression if false
+   * @return Resulting value
+   */
+  double
+  mu_if(double condition, double thenvalue, double elsevalue);
+
+  /**
+   * @brief Logical or
+   * @param[in] left First parameter
+   * @param[in] right Second parameter
+   * @return 1 if either is true, 0 else
+   */
+  double
+  mu_or(double left, double right);
+
+  /**
+   * @brief Logical and
+   * @param[in] left First parameter
+   * @param[in] right Second parameter
+   * @return 1 if both are true, 0 else
+   */
+  double
+  mu_and(double left, double right);
+
+  /**
+   * Rounds the value to the nearest integer (same as round)
+   * @param[in] value Value to round
+   * @return Rounded value
+   */
+  double
+  mu_int(double value);
+
+  /**
+   * Rounds the value to the upper integer
+   * @param[in] value Value to round
+   * @return Rounded value
+   */
+  double
+  mu_ceil(double value);
+
+  /**
+   * @brief Rounds the value to the lower integer
+   * @param[in] value Value to round
+   * @return Rounded value
+   */
+  double
+  mu_floor(double value);
+
+  /**
+   * @brief Performs the cotangent operation
+   * @param[in] value Value to process
+   * @return Cotan(value)
+   */
+  double
+  mu_cot(double value);
+
+  /**
+   * @brief Performs the cosecant operation
+   * @param[in] value Value to process
+   * @return Cosec(value)
+   */
+  double
+  mu_csc(double value);
+
+  /**
+   * @brief Performs the secant operation
+   * @param[in] value Value to process
+   * @return Sec(value)
+   */
+  double
+  mu_sec(double value);
+
+  /**
+   * @brief Performs the natural-logarithm operation
+   * @param[in] value Value to process
+   * @return std::log(value)
+   */
+  double
+  mu_log(double value);
+
+  /**
+   * @brief Performs the a to the power b operation
+   * @param[in] a Base
+   * @param[in] b Exponent
+   * @return std::pow(a,b)
+   */
+  double
+  mu_pow(double a, double b);
+
+  /**
+   * @brief Performs the erf operation
+   * @param[in] value Value to process
+   * @return std::erf(value)
+   */
+  double
+  mu_erf(double value);
+
+  /**
+   * @brief Performs the erfc operation
+   * @param[in] value Value to process
+   * @return std::erfc(value)
+   */
+  double
+  mu_erfc(double value);
+
+  /**
+   * @brief Generate number in [0,1] with a specific seed
+   * @param[in] seed Number to be able to reproduce random behavior between
+   * runs
+   * @return Random number
+   */
+  double
+  mu_rand_seed(double seed);
+
+  /**
+   * @brief Generate number in [0,1]
+   * @return Random number
+   */
+  double
+  mu_rand();
+
+  /**
+   * @brief Get the array of all function names.
+   * @return Available implemented functions
+   */
+  std::vector<std::string>
+  get_function_names();
+
+  DeclException2(ExcParseError,
+                 int,
+                 std::string,
+                 << "Parsing Error at Column " << arg1
+                 << ". The parser said: " << arg2);
+
+
+  /**
+   * @brief Base class used for thread safe instances of the parser.
+   */
+  class muParserBase
   {
-    /**
-     * @brief Rounds the value to the nearest integer
-     * @param[in] val Value to round
-     * @return Rounded value
-     */
-    int
-    mu_round(double val);
+  public:
+    virtual ~muParserBase() = default;
+  };
+
+  struct ParserData
+  {
+    ParserData() = default;
+
+    ParserData(const ParserData &) = delete;
+
+    std::vector<double> vars;
+
+    std::vector<std::unique_ptr<muParserBase>> parsers;
+  };
+
+  /**
+   * @brief Class that interfaces with muParser
+   * @tparam n_components
+   */
+  template <int n_components>
+  class ParserImplementation
+  {
+  public:
+    ParserImplementation();
+
+    virtual ~ParserImplementation() = default;
 
     /**
-     * @brief If-condition
-     * @param[in] condition Boolean expression
-     * @param[in] thenvalue Expression if true
-     * @param[in] elsevalue Expression if false
-     * @return Resulting value
+     * @brief Treat the input and initialize the muParser object
+     * @param[in] vars Variable names
+     * @param[in] expressions Expressions
+     * @param[in] constants Constants
+     * @param[in] time_dependent Boolean to define if the function is time
+     * dependent
      */
-    double
-    mu_if(double condition, double thenvalue, double elsevalue);
+    void
+    initialize(const std::string                   &vars,
+               const std::vector<std::string>      &expressions,
+               const std::map<std::string, double> &constants,
+               const bool                           time_dependent = false);
 
     /**
-     * @brief Logical or
-     * @param[in] left First parameter
-     * @param[in] right Second parameter
-     * @return 1 if either is true, 0 else
+     * @brief Actual initialization of the muParser object
      */
-    double
-    mu_or(double left, double right);
+    void
+    init_muparser() const;
 
     /**
-     * @brief Logical and
-     * @param[in] left First parameter
-     * @param[in] right Second parameter
-     * @return 1 if both are true, 0 else
-     */
-    double
-    mu_and(double left, double right);
-
-    /**
-     * Rounds the value to the nearest integer (same as round)
-     * @param[in] value Value to round
-     * @return Rounded value
-     */
-    double
-    mu_int(double value);
-
-    /**
-     * Rounds the value to the upper integer
-     * @param[in] value Value to round
-     * @return Rounded value
-     */
-    double
-    mu_ceil(double value);
-
-    /**
-     * @brief Rounds the value to the lower integer
-     * @param[in] value Value to round
-     * @return Rounded value
+     * @brief Evaluation of the function at a specific point
+     * @param[in] p Evalution point
+     * @param[in] time Current time
+     * @param[in] component Component of interest
+     * @return Value
      */
     double
-    mu_floor(double value);
+    do_value(const dealii::Tensor<1, n_components> &p,
+             const double                           time,
+             unsigned int                           component) const;
 
     /**
-     * @brief Performs the cotangent operation
-     * @param[in] value Value to process
-     * @return Cotan(value)
+     * @brief Evaluation of the function at a specific point for all components
+     * @param[in] p Evaluation point
+     * @param[in] time Current time
+     * @param[out] values Output values
      */
-    double
-    mu_cot(double value);
+    void
+    do_all_values(const dealii::Tensor<1, n_components> &p,
+                  const double                           time,
+                  dealii::ArrayView<double>             &values) const;
 
-    /**
-     * @brief Performs the cosecant operation
-     * @param[in] value Value to process
-     * @return Cosec(value)
-     */
-    double
-    mu_csc(double value);
+    std::vector<std::string> expressions;
 
-    /**
-     * @brief Performs the secant operation
-     * @param[in] value Value to process
-     * @return Sec(value)
-     */
-    double
-    mu_sec(double value);
+  private:
+    /// Thread safe object for using muParser
+    mutable dealii::Threads::ThreadLocalStorage<
+      ::internalFunctionParserCustom::ParserData>
+      parser_data;
 
-    /**
-     * @brief Performs the natural-logarithm operation
-     * @param[in] value Value to process
-     * @return std::log(value)
-     */
-    double
-    mu_log(double value);
+    /// Constants
+    std::map<std::string, double> constants;
 
-    /**
-     * @brief Performs the a to the power b operation
-     * @param[in] a Base
-     * @param[in] b Exponent
-     * @return std::pow(a,b)
-     */
-    double
-    mu_pow(double a, double b);
+    /// Variable name
+    std::vector<std::string> var_names;
 
-    /**
-     * @brief Performs the erf operation
-     * @param[in] value Value to process
-     * @return std::erf(value)
-     */
-    double
-    mu_erf(double value);
+    /// Keeps track if the muParser object is initialized
+    bool initialized;
 
-    /**
-     * @brief Performs the erfc operation
-     * @param[in] value Value to process
-     * @return std::erfc(value)
-     */
-    double
-    mu_erfc(double value);
-
-    /**
-     * @brief Generate number in [0,1] with a specific seed
-     * @param[in] seed Number to be able to reproduce random behavior between
-     * runs
-     * @return Random number
-     */
-    double
-    mu_rand_seed(double seed);
-
-    /**
-     * @brief Generate number in [0,1]
-     * @return Random number
-     */
-    double
-    mu_rand();
-
-    /**
-     * @brief Get the array of all function names.
-     * @return Available implemented functions
-     */
-    std::vector<std::string>
-    get_function_names();
-
-    DeclException2(ExcParseError,
-                   int,
-                   std::string,
-                   << "Parsing Error at Column " << arg1
-                   << ". The parser said: " << arg2);
-
-
-    /**
-     * @brief Base class used for thread safe instances of the parser.
-     */
-    class muParserBase
-    {
-    public:
-      virtual ~muParserBase() = default;
-    };
-
-    struct ParserData
-    {
-      ParserData() = default;
-
-      ParserData(const ParserData &) = delete;
-
-      std::vector<double> vars;
-
-      std::vector<std::unique_ptr<muParserBase>> parsers;
-    };
-
-    /**
-     * @brief Class that interfaces with muParser
-     * @tparam n_components
-     */
-    template <int n_components>
-    class ParserImplementation
-    {
-    public:
-      ParserImplementation();
-
-      virtual ~ParserImplementation() = default;
-
-      /**
-       * @brief Treat the input and initialize the muParser object
-       * @param[in] vars Variable names
-       * @param[in] expressions Expressions
-       * @param[in] constants Constants
-       * @param[in] time_dependent Boolean to define if the function is time
-       * dependent
-       */
-      void
-      initialize(const std::string                   &vars,
-                 const std::vector<std::string>      &expressions,
-                 const std::map<std::string, double> &constants,
-                 const bool                           time_dependent = false);
-
-      /**
-       * @brief Actual initialization of the muParser object
-       */
-      void
-      init_muparser() const;
-
-      /**
-       * @brief Evaluation of the function at a specific point
-       * @param[in] p Evalution point
-       * @param[in] time Current time
-       * @param[in] component Component of interest
-       * @return Value
-       */
-      double
-      do_value(const dealii::Tensor<1, n_components> &p,
-               const double                           time,
-               unsigned int                           component) const;
-
-      /**
-       * @brief Evaluation of the function at a specific point for all components
-       * @param[in] p Evaluation point
-       * @param[in] time Current time
-       * @param[out] values Output values
-       */
-      void
-      do_all_values(const dealii::Tensor<1, n_components> &p,
-                    const double                           time,
-                    dealii::ArrayView<double>             &values) const;
-
-      std::vector<std::string> expressions;
-
-    private:
-      /// Thread safe object for using muParser
-      mutable dealii::Threads::ThreadLocalStorage<
-        ::internal::FunctionParserCustom::ParserData>
-        parser_data;
-
-      /// Constants
-      std::map<std::string, double> constants;
-
-      /// Variable name
-      std::vector<std::string> var_names;
-
-      /// Keeps track if the muParser object is initialized
-      bool initialized;
-
-      /// Number of variables
-      unsigned int n_vars;
-    };
-  } // namespace FunctionParserCustom
-} // namespace internal
+    /// Number of variables
+    unsigned int n_vars;
+  };
+} /* namespace internalFunctionParserCustom */
 
 #endif // lethe_mu_parser_internal_h

--- a/include/core/mu_parser_internal.h
+++ b/include/core/mu_parser_internal.h
@@ -26,6 +26,7 @@
 #include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
+#include <muParserFixes.h>
 #include <muParser.h>
 #include <muParserFixes.h>
 

--- a/include/core/parsed_function_custom.h
+++ b/include/core/parsed_function_custom.h
@@ -40,8 +40,7 @@
 template <int n_components>
 class ParsedFunctionCustom
   : public FunctionTime<double>,
-    protected ::internal::FunctionParserCustom::ParserImplementation<
-      n_components>
+    protected ::internalFunctionParserCustom::ParserImplementation<n_components>
 {
 public:
   /**

--- a/include/core/parsed_function_custom.h
+++ b/include/core/parsed_function_custom.h
@@ -46,15 +46,15 @@ public:
   declare_parameters(ParameterHandler &prm);
 
   void
+  initialize();
+
+  void
   parse_parameters(ParameterHandler &prm);
 
   void
   initialize(const std::string vnames,
              const std::string expression,
              const std::string constants_list);
-
-  void
-  initialize();
 
   void
   vector_value(const Tensor<1, n_components> &p,

--- a/include/core/parsed_function_custom.h
+++ b/include/core/parsed_function_custom.h
@@ -124,7 +124,6 @@ public:
 
   /**
    * @brief Set the time.
-   *
    * @param[in] newtime New time value
    */
   virtual void

--- a/include/core/parsed_function_custom.h
+++ b/include/core/parsed_function_custom.h
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2019 - 2020 by the Lethe authors
+ * Copyright (C) 2019 -  by the Lethe authors
  *
  * This file is part of the Lethe library
  *
@@ -131,17 +131,19 @@ public:
   set_time(const double newtime) override;
 
 private:
-  // Autoderivative behavior components
-  double                               h;
-  std::vector<Tensor<1, n_components>> ht;
+  /// Autoderivative behavior h step
+  double h;
+  /// Tensor for autoderivative behavior
+  Tensor<2, n_components> ht;
 
-  // muParser components: variable names, expressions (same number as
-  // variables), constants
+  /// muParser component: variable names
   std::string vnames;
+  /// muParser component:  expressions (same number as variables)
   std::string expression;
+  /// muParser component: constants
   std::string constants_list;
 
-  // Used to know if member variables for muParser have been initialized
+  /// Used to know if member variables for muParser have been initialized
   bool initialized;
 };
 

--- a/include/core/parsed_function_custom.h
+++ b/include/core/parsed_function_custom.h
@@ -40,37 +40,93 @@ class ParsedFunctionCustom
       n_components>
 {
 public:
+  /**
+   * @brief Basic constructor with only the finite difference step
+   * @param[in] h Step for finite difference
+   */
   ParsedFunctionCustom(const double h = 1e-8);
 
+  /**
+   * @brief Declaration of the parameters for the parameter file.
+   *
+   * @param[in,out] prm Parameter object for parameters parsing
+   */
   void
   declare_parameters(ParameterHandler &prm);
 
+  /**
+   * @brief Initialization of the muParser object using member strings.
+   *
+   * This functions exists to avoid code duplication.
+   */
   void
   initialize();
 
+  /**
+   * @brief Parse the parameters from the parameter file.
+   *
+   * @param[in,out] prm Parameter object for parameters parsing
+   */
   void
   parse_parameters(ParameterHandler &prm);
 
+  /**
+   * @brief Initialize the muParser object using the input strings.
+   *
+   * @param[in] vnames Name of all variables
+   * @param[in] expression Expressions for all source terms
+   * @param[in] constants_list Constants used by the expressions
+   */
   void
   initialize(const std::string vnames,
              const std::string expression,
              const std::string constants_list);
 
+  /**
+   * @brief Evaluate all components at the evaluation point
+   *
+   * @param[in] p Evaluation point
+   * @param[out] values Output values
+   */
   void
   vector_value(const Tensor<1, n_components> &p,
                Tensor<1, n_components>       &values) const;
 
+  /**
+   * @brief Evaluation the value at evaluation point for one component
+   *
+   * @param[in] p Evaluation point
+   * @param[in] component Component of interest
+   * @return Value
+   */
   double
   value(const Tensor<1, n_components> &p,
         const unsigned int             component = 0) const;
 
+  /**
+   * @brief Evaluate the gradient at evaluation point for one component
+   *
+   * @param[in] p Evaluation point
+   * @param[in] comp Component of interest
+   * @return Gradient
+   */
   Tensor<1, n_components>
   gradient(const Tensor<1, n_components> &p, unsigned int comp = 0) const;
 
+  /**
+   * @brief Evaluation the gradient at evaluation point for all components
+   * @param[in] p Evaluation point
+   * @param[out] gradients Gradients
+   */
   void
   vector_gradient(const Tensor<1, n_components> &p,
                   Tensor<2, n_components>       &gradients) const;
 
+  /**
+   * @brief Set the time.
+   *
+   * @param[in] newtime New time value
+   */
   virtual void
   set_time(const double newtime) override;
 
@@ -79,11 +135,13 @@ private:
   double                               h;
   std::vector<Tensor<1, n_components>> ht;
 
-  // muParser components
+  // muParser components: variable names, expressions (same number as
+  // variables), constants
   std::string vnames;
   std::string expression;
   std::string constants_list;
 
+  // Used to know if member variables for muParser have been initialized
   bool initialized;
 };
 

--- a/include/core/parsed_function_custom.h
+++ b/include/core/parsed_function_custom.h
@@ -1,0 +1,90 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 - 2020 by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+
+#ifndef lethe_parsed_function_custom_h
+#define lethe_parsed_function_custom_h
+
+
+#include <deal.II/base/config.h>
+
+#include <core/mu_parser_internal.h>
+#include <core/tensors_and_points_dimension_manipulation.h>
+#include <core/utilities.h>
+
+#include <deal.II/base/auto_derivative_function.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/function_parser.h>
+#include <deal.II/base/parameter_handler.h>
+
+#include <deal.II/grid/manifold.h>
+#include <deal.II/grid/manifold_lib.h>
+
+template <int n_components>
+class ParsedFunctionCustom
+  : public FunctionTime<double>,
+    protected ::internal::FunctionParserCustom::ParserImplementation<
+      n_components>
+{
+public:
+  ParsedFunctionCustom(const double h = 1e-8);
+
+  void
+  declare_parameters(ParameterHandler &prm);
+
+  void
+  parse_parameters(ParameterHandler &prm);
+
+  void
+  initialize(const std::string vnames,
+             const std::string expression,
+             const std::string constants_list);
+
+  void
+  initialize();
+
+  void
+  vector_value(const Tensor<1, n_components> &p,
+               Tensor<1, n_components>       &values) const;
+
+  double
+  value(const Tensor<1, n_components> &p,
+        const unsigned int             component = 0) const;
+
+  Tensor<1, n_components>
+  gradient(const Tensor<1, n_components> &p, unsigned int comp = 0) const;
+
+  void
+  vector_gradient(const Tensor<1, n_components> &p,
+                  Tensor<2, n_components>       &gradients) const;
+
+  virtual void
+  set_time(const double newtime) override;
+
+private:
+  // Autoderivative behavior components
+  double                               h;
+  std::vector<Tensor<1, n_components>> ht;
+
+  // muParser components
+  std::string vnames;
+  std::string expression;
+  std::string constants_list;
+
+  bool initialized;
+};
+
+#endif

--- a/include/core/parsed_function_custom.h
+++ b/include/core/parsed_function_custom.h
@@ -33,6 +33,10 @@
 #include <deal.II/grid/manifold.h>
 #include <deal.II/grid/manifold_lib.h>
 
+/**
+ * @brief Wrapper based on muParser to deal with arbitrary expressions
+ * @tparam n_components Number of variables (and expressions) parsed
+ */
 template <int n_components>
 class ParsedFunctionCustom
   : public FunctionTime<double>,

--- a/source/core/CMakeLists.txt
+++ b/source/core/CMakeLists.txt
@@ -13,9 +13,11 @@ add_library(lethe-core
   manifolds.cc
   mesh_controller.cc
   mobility_cahn_hilliard_model.cc
+  mu_parser_internal.cc
   parameters.cc
   parameters_lagrangian.cc
   parameters_multiphysics.cc
+  parsed_function_custom.cc
   pvd_handler.cc
   rheological_model.cc
   serial_solid.cc
@@ -51,12 +53,14 @@ add_library(lethe-core
   ../../include/core/manifolds.h
   ../../include/core/mesh_controller.h
   ../../include/core/mobility_cahn_hilliard_model.h
+  ../../include/core/mu_parser_internal.h
   ../../include/core/multiphysics.h
   ../../include/core/newton_non_linear_solver.h
   ../../include/core/non_linear_solver.h
   ../../include/core/parameters.h
   ../../include/core/parameters_lagrangian.h
   ../../include/core/parameters_multiphysics.h
+  ../../include/core/parsed_function_custom.h
   ../../include/core/periodic_hills_grid.h
   ../../include/core/phase_change.h
   ../../include/core/physical_property_model.h

--- a/source/core/mu_parser_internal.cc
+++ b/source/core/mu_parser_internal.cc
@@ -1,6 +1,5 @@
 #include <core/mu_parser_internal.h>
 
-#include <deal.II/base/mu_parser_internal.h>
 #include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
@@ -13,6 +12,8 @@
 #include <mutex>
 #include <random>
 #include <vector>
+
+using namespace dealii;
 
 namespace internal
 {
@@ -184,7 +185,7 @@ namespace internal
     /**
      * PIMPL for mu::Parser.
      */
-    class Parser : public internal::FunctionParserCustom::muParserBase
+    class Parser : public ::internal::FunctionParserCustom::muParserBase
     {
     public:
       operator dealii::mu::Parser &()
@@ -360,7 +361,7 @@ namespace internal
 
       // initialize the parser if that hasn't happened yet on the current
       // thread
-      internal::FunctionParserCustom::ParserData &data =
+      ::internal::FunctionParserCustom::ParserData &data =
         this->parser_data.get();
       if (data.vars.empty())
         init_muparser();
@@ -403,7 +404,7 @@ namespace internal
 
       // initialize the parser if that hasn't happened yet on the current
       // thread
-      internal::FunctionParserCustom::ParserData &data =
+      ::internal::FunctionParserCustom::ParserData &data =
         this->parser_data.get();
       if (data.vars.empty())
         init_muparser();

--- a/source/core/mu_parser_internal.cc
+++ b/source/core/mu_parser_internal.cc
@@ -216,9 +216,9 @@ namespace internal
       // Now we define how many variables we expect to read in. We distinguish
       // between two cases: Time dependent problems, and not time dependent
       // problems. In the first case the number of variables is given by the
-      // components plus one. In the other case, the number of variables is equal
-      // to the dimension. Once we parsed the variables string, if none of this
-      // is the case, then an exception is thrown.
+      // components plus one. In the other case, the number of variables is
+      // equal to the dimension. Once we parsed the variables string, if none of
+      // this is the case, then an exception is thrown.
       if (time_dependent)
         this->n_vars = n_components + 1;
       else

--- a/source/core/mu_parser_internal.cc
+++ b/source/core/mu_parser_internal.cc
@@ -181,7 +181,6 @@ namespace internal
               "rand_seed"};
     }
 
-#ifdef DEAL_II_WITH_MUPARSER
     /**
      * PIMPL for mu::Parser.
      */
@@ -201,7 +200,6 @@ namespace internal
     protected:
       dealii::mu::Parser parser;
     };
-#endif
 
     template <int n_components>
     ::internal::FunctionParserCustom::ParserImplementation<
@@ -252,12 +250,12 @@ namespace internal
     void
     ParserImplementation<n_components>::init_muparser() const
     {
-#ifdef DEAL_II_WITH_MUPARSER
       // check that we have not already initialized the parser on the
       // current thread, i.e., that the current function is only called
       // once per thread
       ParserData &data = this->parser_data.get();
-      Assert(data.parsers.empty() && data.vars.empty(), ExcInternalError());
+      Assert(data.parsers.empty() && data.vars.empty(),
+             dealii::StandardExceptions::ExcInternalError());
 
       // initialize the objects for the current thread
       data.parsers.reserve(n_components);
@@ -348,9 +346,6 @@ namespace internal
               AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
             }
         }
-#else
-      AssertThrow(false, ExcNeedsFunctionparser());
-#endif
     }
 
     template <int n_components>
@@ -360,8 +355,8 @@ namespace internal
       const double                           time,
       unsigned int                           component) const
     {
-#ifdef DEAL_II_WITH_MUPARSER
-      Assert(this->initialized == true, ExcNotInitialized());
+      Assert(this->initialized == true,
+             dealii::StandardExceptions::ExcNotInitialized());
 
       // initialize the parser if that hasn't happened yet on the current
       // thread
@@ -378,7 +373,7 @@ namespace internal
       try
         {
           Assert(dynamic_cast<Parser *>(data.parsers[component].get()),
-                 ExcInternalError());
+                 dealii::StandardExceptions::ExcInternalError());
           // NOLINTNEXTLINE don't warn about using static_cast once we check
           dealii::mu::Parser &parser =
             static_cast<Parser &>(*data.parsers[component]);
@@ -393,13 +388,6 @@ namespace internal
           std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
           AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
         } // catch
-
-#else
-      (void)p;
-      (void)time;
-      (void)component;
-      AssertThrow(false, ExcNeedsFunctionparser());
-#endif
       return std::numeric_limits<double>::signaling_NaN();
     }
 
@@ -410,8 +398,8 @@ namespace internal
       const double                           time,
       dealii::ArrayView<double>             &values) const
     {
-#ifdef DEAL_II_WITH_MUPARSER
-      Assert(this->initialized == true, ExcNotInitialized());
+      Assert(this->initialized == true,
+             dealii::StandardExceptions::ExcNotInitialized());
 
       // initialize the parser if that hasn't happened yet on the current
       // thread
@@ -432,7 +420,7 @@ namespace internal
                ++component)
             {
               Assert(dynamic_cast<Parser *>(data.parsers[component].get()),
-                     ExcInternalError());
+                     dealii::StandardExceptions::ExcInternalError());
               dealii::mu::Parser &parser =
                 // We just checked that the pointer is valid so suppress the
                 // clang-tidy check
@@ -449,12 +437,6 @@ namespace internal
           std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
           AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
         } // catch
-#else
-      (void)p;
-      (void)time;
-      (void)values;
-      AssertThrow(false, ExcNeedsFunctionparser());
-#endif
     }
 
     // explicit instantiations

--- a/source/core/mu_parser_internal.cc
+++ b/source/core/mu_parser_internal.cc
@@ -175,18 +175,18 @@ namespace internal
     class Parser : public ::internal::FunctionParserCustom::muParserBase
     {
     public:
-      operator dealii::mu::Parser &()
+      operator mu::Parser &()
       {
         return parser;
       }
 
-      operator const dealii::mu::Parser &() const
+      operator const mu::Parser &() const
       {
         return parser;
       }
 
     protected:
-      dealii::mu::Parser parser;
+      mu::Parser parser;
     };
 
     template <int n_components>
@@ -251,7 +251,7 @@ namespace internal
       for (unsigned int component = 0; component < n_components; ++component)
         {
           data.parsers.emplace_back(std::make_unique<Parser>());
-          dealii::mu::Parser &parser =
+          mu::Parser &parser =
             dynamic_cast<Parser &>(*data.parsers.back());
 
           for (const auto &constant : this->constants)
@@ -324,7 +324,7 @@ namespace internal
               // now use the transformed expression
               parser.SetExpr(transformed_expression);
             }
-          catch (dealii::mu::ParserError &e)
+          catch (mu::ParserError &e)
             {
               std::cerr << "Message:  <" << e.GetMsg() << ">\n";
               std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
@@ -363,11 +363,11 @@ namespace internal
           Assert(dynamic_cast<Parser *>(data.parsers[component].get()),
                  dealii::StandardExceptions::ExcInternalError());
           // NOLINTNEXTLINE don't warn about using static_cast once we check
-          dealii::mu::Parser &parser =
+          mu::Parser &parser =
             static_cast<Parser &>(*data.parsers[component]);
           return parser.Eval();
         } // try
-      catch (dealii::mu::ParserError &e)
+      catch (mu::ParserError &e)
         {
           std::cerr << "Message:  <" << e.GetMsg() << ">\n";
           std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
@@ -409,14 +409,14 @@ namespace internal
             {
               Assert(dynamic_cast<Parser *>(data.parsers[component].get()),
                      dealii::StandardExceptions::ExcInternalError());
-              dealii::mu::Parser &parser =
+              mu::Parser &parser =
                 // We just checked that the pointer is valid so suppress the
                 // clang-tidy check
                 static_cast<Parser &>(*data.parsers[component]); // NOLINT
               values[component] = parser.Eval();
             }
         } // try
-      catch (dealii::mu::ParserError &e)
+      catch (mu::ParserError &e)
         {
           std::cerr << "Message:  <" << e.GetMsg() << ">\n";
           std::cerr << "Formula:  <" << e.GetExpr() << ">\n";

--- a/source/core/mu_parser_internal.cc
+++ b/source/core/mu_parser_internal.cc
@@ -251,8 +251,7 @@ namespace internal
       for (unsigned int component = 0; component < n_components; ++component)
         {
           data.parsers.emplace_back(std::make_unique<Parser>());
-          mu::Parser &parser =
-            dynamic_cast<Parser &>(*data.parsers.back());
+          mu::Parser &parser = dynamic_cast<Parser &>(*data.parsers.back());
 
           for (const auto &constant : this->constants)
             parser.DefineConst(constant.first, constant.second);
@@ -363,8 +362,7 @@ namespace internal
           Assert(dynamic_cast<Parser *>(data.parsers[component].get()),
                  dealii::StandardExceptions::ExcInternalError());
           // NOLINTNEXTLINE don't warn about using static_cast once we check
-          mu::Parser &parser =
-            static_cast<Parser &>(*data.parsers[component]);
+          mu::Parser &parser = static_cast<Parser &>(*data.parsers[component]);
           return parser.Eval();
         } // try
       catch (mu::ParserError &e)

--- a/source/core/mu_parser_internal.cc
+++ b/source/core/mu_parser_internal.cc
@@ -1,0 +1,483 @@
+#include <core/mu_parser_internal.h>
+
+#include <deal.II/base/mu_parser_internal.h>
+#include <deal.II/base/thread_management.h>
+#include <deal.II/base/utilities.h>
+
+#include <muParser.h>
+
+#include <cmath>
+#include <ctime>
+#include <limits>
+#include <map>
+#include <mutex>
+#include <random>
+#include <vector>
+
+namespace internal
+{
+  namespace FunctionParserCustom
+  {
+    int
+    mu_round(const double val)
+    {
+      return static_cast<int>(val + ((val >= 0.0) ? 0.5 : -0.5));
+    }
+
+    double
+    mu_if(const double condition,
+          const double thenvalue,
+          const double elsevalue)
+    {
+      if (mu_round(condition) != 0)
+        return thenvalue;
+      else
+        return elsevalue;
+    }
+
+    double
+    mu_or(const double left, const double right)
+    {
+      return static_cast<double>((mu_round(left) != 0) ||
+                                 (mu_round(right) != 0));
+    }
+
+    double
+    mu_and(const double left, const double right)
+    {
+      return static_cast<double>((mu_round(left) != 0) &&
+                                 (mu_round(right) != 0));
+    }
+
+    double
+    mu_int(const double value)
+    {
+      return static_cast<double>(mu_round(value));
+    }
+
+    double
+    mu_ceil(const double value)
+    {
+      return std::ceil(value);
+    }
+
+    double
+    mu_floor(const double value)
+    {
+      return std::floor(value);
+    }
+
+    double
+    mu_cot(const double value)
+    {
+      return 1.0 / std::tan(value);
+    }
+
+    double
+    mu_csc(const double value)
+    {
+      return 1.0 / std::sin(value);
+    }
+
+    double
+    mu_sec(const double value)
+    {
+      return 1.0 / std::cos(value);
+    }
+
+    double
+    mu_log(const double value)
+    {
+      return std::log(value);
+    }
+
+    double
+    mu_pow(const double a, const double b)
+    {
+      return std::pow(a, b);
+    }
+
+    double
+    mu_erf(const double value)
+    {
+      return std::erf(value);
+    }
+
+    double
+    mu_erfc(const double value)
+    {
+      return std::erfc(value);
+    }
+
+    double
+    mu_rand_seed(const double seed)
+    {
+      static std::mutex           rand_mutex;
+      std::lock_guard<std::mutex> lock(rand_mutex);
+
+      std::uniform_real_distribution<> uniform_distribution(0., 1.);
+
+      static std::map<double, std::mt19937> rng_map;
+
+      if (rng_map.find(seed) == rng_map.end())
+        rng_map[seed] = std::mt19937(static_cast<unsigned int>(seed));
+
+      return uniform_distribution(rng_map[seed]);
+    }
+
+    double
+    mu_rand()
+    {
+      static std::mutex                rand_mutex;
+      std::lock_guard<std::mutex>      lock(rand_mutex);
+      std::uniform_real_distribution<> uniform_distribution(0., 1.);
+      const unsigned int  seed = static_cast<unsigned long>(std::time(nullptr));
+      static std::mt19937 rng(seed);
+      return uniform_distribution(rng);
+    }
+
+    std::vector<std::string>
+    get_function_names()
+    {
+      return {// functions predefined by muparser
+              "sin",
+              "cos",
+              "tan",
+              "asin",
+              "acos",
+              "atan",
+              "sinh",
+              "cosh",
+              "tanh",
+              "asinh",
+              "acosh",
+              "atanh",
+              "atan2",
+              "log2",
+              "log10",
+              "log",
+              "ln",
+              "exp",
+              "sqrt",
+              "sign",
+              "rint",
+              "abs",
+              "min",
+              "max",
+              "sum",
+              "avg",
+              // functions we define ourselves above
+              "if",
+              "int",
+              "ceil",
+              "cot",
+              "csc",
+              "floor",
+              "sec",
+              "pow",
+              "erf",
+              "erfc",
+              "rand",
+              "rand_seed"};
+    }
+
+#ifdef DEAL_II_WITH_MUPARSER
+    /**
+     * PIMPL for mu::Parser.
+     */
+    class Parser : public internal::FunctionParserCustom::muParserBase
+    {
+    public:
+      operator dealii::mu::Parser &()
+      {
+        return parser;
+      }
+
+      operator const dealii::mu::Parser &() const
+      {
+        return parser;
+      }
+
+    protected:
+      dealii::mu::Parser parser;
+    };
+#endif
+
+    template <int n_components>
+    ::internal::FunctionParserCustom::ParserImplementation<
+      n_components>::ParserImplementation()
+      : initialized(false)
+      , n_vars(0)
+    {}
+
+    template <int n_components>
+    void
+    ParserImplementation<n_components>::initialize(
+      const std::string                   &variables,
+      const std::vector<std::string>      &expressions,
+      const std::map<std::string, double> &constants,
+      const bool                           time_dependent)
+    {
+      this->parser_data.clear(); // this will reset all thread-local objects
+
+      this->constants   = constants;
+      this->var_names   = dealii::Utilities::split_string_list(variables, ',');
+      this->expressions = expressions;
+      AssertThrow(((time_dependent) ? n_components + 1 : n_components) ==
+                    this->var_names.size(),
+                  dealii::ExcMessage("Wrong number of variables"));
+
+      // Now we define how many variables we expect to read in. We distinguish
+      // between two cases: Time dependent problems, and not time dependent
+      // problems. In the first case the number of variables is given by the
+      // dimension plus one. In the other case, the number of variables is equal
+      // to the dimension. Once we parsed the variables string, if none of this
+      // is the case, then an exception is thrown.
+      if (time_dependent)
+        this->n_vars = n_components + 1;
+      else
+        this->n_vars = n_components;
+
+      // create a parser object for the current thread we can then query in
+      // value() and vector_value(). this is not strictly necessary because a
+      // user may never call these functions on the current thread, but it gets
+      // us error messages about wrong formulas right away
+      this->init_muparser();
+      this->initialized = true;
+    }
+
+
+
+    template <int n_components>
+    void
+    ParserImplementation<n_components>::init_muparser() const
+    {
+#ifdef DEAL_II_WITH_MUPARSER
+      // check that we have not already initialized the parser on the
+      // current thread, i.e., that the current function is only called
+      // once per thread
+      ParserData &data = this->parser_data.get();
+      Assert(data.parsers.empty() && data.vars.empty(), ExcInternalError());
+
+      // initialize the objects for the current thread
+      data.parsers.reserve(n_components);
+      data.vars.resize(this->var_names.size());
+      for (unsigned int component = 0; component < n_components; ++component)
+        {
+          data.parsers.emplace_back(std::make_unique<Parser>());
+          dealii::mu::Parser &parser =
+            dynamic_cast<Parser &>(*data.parsers.back());
+
+          for (const auto &constant : this->constants)
+            parser.DefineConst(constant.first, constant.second);
+
+          for (unsigned int iv = 0; iv < this->var_names.size(); ++iv)
+            parser.DefineVar(this->var_names[iv], &data.vars[iv]);
+
+          // define some compatibility functions:
+          parser.DefineFun("if", mu_if, true);
+          parser.DefineOprt("|", mu_or, 1);
+          parser.DefineOprt("&", mu_and, 2);
+          parser.DefineFun("int", mu_int, true);
+          parser.DefineFun("ceil", mu_ceil, true);
+          parser.DefineFun("cot", mu_cot, true);
+          parser.DefineFun("csc", mu_csc, true);
+          parser.DefineFun("floor", mu_floor, true);
+          parser.DefineFun("sec", mu_sec, true);
+          parser.DefineFun("log", mu_log, true);
+          parser.DefineFun("pow", mu_pow, true);
+          parser.DefineFun("erfc", mu_erfc, true);
+          // Disable optimizations (by passing false) that assume the functions
+          // will always return the same value:
+          parser.DefineFun("rand_seed", mu_rand_seed, false);
+          parser.DefineFun("rand", mu_rand, false);
+
+          try
+            {
+              // muparser expects that functions have no
+              // space between the name of the function and the opening
+              // parenthesis. this is awkward because it is not backward
+              // compatible to the library we used to use before muparser
+              // (the fparser library) but also makes no real sense.
+              // consequently, in the expressions we set, remove any space
+              // we may find after function names
+              std::string transformed_expression = this->expressions[component];
+
+              for (const auto &current_function_name : get_function_names())
+                {
+                  const unsigned int function_name_length =
+                    current_function_name.size();
+
+                  std::string::size_type pos = 0;
+                  while (true)
+                    {
+                      // try to find any occurrences of the function name
+                      pos =
+                        transformed_expression.find(current_function_name, pos);
+                      if (pos == std::string::npos)
+                        break;
+
+                      // replace whitespace until there no longer is any
+                      while (
+                        (pos + function_name_length <
+                         transformed_expression.size()) &&
+                        ((transformed_expression[pos + function_name_length] ==
+                          ' ') ||
+                         (transformed_expression[pos + function_name_length] ==
+                          '\t')))
+                        transformed_expression.erase(
+                          transformed_expression.begin() + pos +
+                          function_name_length);
+
+                      // move the current search position by the size of the
+                      // actual function name
+                      pos += function_name_length;
+                    }
+                }
+
+              // now use the transformed expression
+              parser.SetExpr(transformed_expression);
+            }
+          catch (dealii::mu::ParserError &e)
+            {
+              std::cerr << "Message:  <" << e.GetMsg() << ">\n";
+              std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
+              std::cerr << "Token:    <" << e.GetToken() << ">\n";
+              std::cerr << "Position: <" << e.GetPos() << ">\n";
+              std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
+              AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
+            }
+        }
+#else
+      AssertThrow(false, ExcNeedsFunctionparser());
+#endif
+    }
+
+    template <int n_components>
+    double
+    ParserImplementation<n_components>::do_value(
+      const dealii::Tensor<1, n_components> &p,
+      const double                           time,
+      unsigned int                           component) const
+    {
+#ifdef DEAL_II_WITH_MUPARSER
+      Assert(this->initialized == true, ExcNotInitialized());
+
+      // initialize the parser if that hasn't happened yet on the current
+      // thread
+      internal::FunctionParserCustom::ParserData &data =
+        this->parser_data.get();
+      if (data.vars.empty())
+        init_muparser();
+
+      for (unsigned int i = 0; i < n_components; ++i)
+        data.vars[i] = p[i];
+      if (n_components != this->n_vars)
+        data.vars[n_components] = time;
+
+      try
+        {
+          Assert(dynamic_cast<Parser *>(data.parsers[component].get()),
+                 ExcInternalError());
+          // NOLINTNEXTLINE don't warn about using static_cast once we check
+          dealii::mu::Parser &parser =
+            static_cast<Parser &>(*data.parsers[component]);
+          return parser.Eval();
+        } // try
+      catch (dealii::mu::ParserError &e)
+        {
+          std::cerr << "Message:  <" << e.GetMsg() << ">\n";
+          std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
+          std::cerr << "Token:    <" << e.GetToken() << ">\n";
+          std::cerr << "Position: <" << e.GetPos() << ">\n";
+          std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
+          AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
+        } // catch
+
+#else
+      (void)p;
+      (void)time;
+      (void)component;
+      AssertThrow(false, ExcNeedsFunctionparser());
+#endif
+      return std::numeric_limits<double>::signaling_NaN();
+    }
+
+    template <int n_components>
+    void
+    ParserImplementation<n_components>::do_all_values(
+      const dealii::Tensor<1, n_components> &p,
+      const double                           time,
+      dealii::ArrayView<double>             &values) const
+    {
+#ifdef DEAL_II_WITH_MUPARSER
+      Assert(this->initialized == true, ExcNotInitialized());
+
+      // initialize the parser if that hasn't happened yet on the current
+      // thread
+      internal::FunctionParserCustom::ParserData &data =
+        this->parser_data.get();
+      if (data.vars.empty())
+        init_muparser();
+
+      for (unsigned int i = 0; i < n_components; ++i)
+        data.vars[i] = p[i];
+      if (n_components != this->n_vars)
+        data.vars[n_components] = time;
+
+      AssertDimension(values.size(), data.parsers.size());
+      try
+        {
+          for (unsigned int component = 0; component < data.parsers.size();
+               ++component)
+            {
+              Assert(dynamic_cast<Parser *>(data.parsers[component].get()),
+                     ExcInternalError());
+              dealii::mu::Parser &parser =
+                // We just checked that the pointer is valid so suppress the
+                // clang-tidy check
+                static_cast<Parser &>(*data.parsers[component]); // NOLINT
+              values[component] = parser.Eval();
+            }
+        } // try
+      catch (dealii::mu::ParserError &e)
+        {
+          std::cerr << "Message:  <" << e.GetMsg() << ">\n";
+          std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
+          std::cerr << "Token:    <" << e.GetToken() << ">\n";
+          std::cerr << "Position: <" << e.GetPos() << ">\n";
+          std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
+          AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
+        } // catch
+#else
+      (void)p;
+      (void)time;
+      (void)values;
+      AssertThrow(false, ExcNeedsFunctionparser());
+#endif
+    }
+
+    // explicit instantiations
+    template class ::internal::FunctionParserCustom::ParserImplementation<1>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<2>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<3>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<4>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<5>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<6>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<7>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<8>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<9>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<10>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<11>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<12>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<13>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<14>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<15>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<16>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<17>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<18>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<19>;
+    template class ::internal::FunctionParserCustom::ParserImplementation<20>;
+
+  } // namespace FunctionParserCustom
+} // namespace internal

--- a/source/core/mu_parser_internal.cc
+++ b/source/core/mu_parser_internal.cc
@@ -2,450 +2,440 @@
 
 using namespace dealii;
 
-namespace internal
+namespace internalFunctionParserCustom
 {
-  namespace FunctionParserCustom
+  int
+  mu_round(const double val)
   {
-    int
-    mu_round(const double val)
+    return static_cast<int>(val + ((val >= 0.0) ? 0.5 : -0.5));
+  }
+
+  double
+  mu_if(const double condition, const double thenvalue, const double elsevalue)
+  {
+    if (mu_round(condition) != 0)
+      return thenvalue;
+    else
+      return elsevalue;
+  }
+
+  double
+  mu_or(const double left, const double right)
+  {
+    return static_cast<double>((mu_round(left) != 0) || (mu_round(right) != 0));
+  }
+
+  double
+  mu_and(const double left, const double right)
+  {
+    return static_cast<double>((mu_round(left) != 0) && (mu_round(right) != 0));
+  }
+
+  double
+  mu_int(const double value)
+  {
+    return static_cast<double>(mu_round(value));
+  }
+
+  double
+  mu_ceil(const double value)
+  {
+    return std::ceil(value);
+  }
+
+  double
+  mu_floor(const double value)
+  {
+    return std::floor(value);
+  }
+
+  double
+  mu_cot(const double value)
+  {
+    return 1.0 / std::tan(value);
+  }
+
+  double
+  mu_csc(const double value)
+  {
+    return 1.0 / std::sin(value);
+  }
+
+  double
+  mu_sec(const double value)
+  {
+    return 1.0 / std::cos(value);
+  }
+
+  double
+  mu_log(const double value)
+  {
+    return std::log(value);
+  }
+
+  double
+  mu_pow(const double a, const double b)
+  {
+    return std::pow(a, b);
+  }
+
+  double
+  mu_erf(const double value)
+  {
+    return std::erf(value);
+  }
+
+  double
+  mu_erfc(const double value)
+  {
+    return std::erfc(value);
+  }
+
+  double
+  mu_rand_seed(const double seed)
+  {
+    static std::mutex           rand_mutex;
+    std::lock_guard<std::mutex> lock(rand_mutex);
+
+    std::uniform_real_distribution<> uniform_distribution(0., 1.);
+
+    static std::map<double, std::mt19937> rng_map;
+
+    if (rng_map.find(seed) == rng_map.end())
+      rng_map[seed] = std::mt19937(static_cast<unsigned int>(seed));
+
+    return uniform_distribution(rng_map[seed]);
+  }
+
+  double
+  mu_rand()
+  {
+    static std::mutex                rand_mutex;
+    std::lock_guard<std::mutex>      lock(rand_mutex);
+    std::uniform_real_distribution<> uniform_distribution(0., 1.);
+    const unsigned int  seed = static_cast<unsigned long>(std::time(nullptr));
+    static std::mt19937 rng(seed);
+    return uniform_distribution(rng);
+  }
+
+  std::vector<std::string>
+  get_function_names()
+  {
+    return {// functions predefined by muparser
+            "sin",
+            "cos",
+            "tan",
+            "asin",
+            "acos",
+            "atan",
+            "sinh",
+            "cosh",
+            "tanh",
+            "asinh",
+            "acosh",
+            "atanh",
+            "atan2",
+            "log2",
+            "log10",
+            "log",
+            "ln",
+            "exp",
+            "sqrt",
+            "sign",
+            "rint",
+            "abs",
+            "min",
+            "max",
+            "sum",
+            "avg",
+            // functions we define ourselves above
+            "if",
+            "int",
+            "ceil",
+            "cot",
+            "csc",
+            "floor",
+            "sec",
+            "pow",
+            "erf",
+            "erfc",
+            "rand",
+            "rand_seed"};
+  }
+
+  /**
+   * PIMPL for mu::Parser.
+   */
+  class Parser : public ::internalFunctionParserCustom::muParserBase
+  {
+  public:
+    operator mu::Parser &()
     {
-      return static_cast<int>(val + ((val >= 0.0) ? 0.5 : -0.5));
+      return parser;
     }
 
-    double
-    mu_if(const double condition,
-          const double thenvalue,
-          const double elsevalue)
+    operator const mu::Parser &() const
     {
-      if (mu_round(condition) != 0)
-        return thenvalue;
-      else
-        return elsevalue;
+      return parser;
     }
 
-    double
-    mu_or(const double left, const double right)
-    {
-      return static_cast<double>((mu_round(left) != 0) ||
-                                 (mu_round(right) != 0));
-    }
+  protected:
+    mu::Parser parser;
+  };
 
-    double
-    mu_and(const double left, const double right)
-    {
-      return static_cast<double>((mu_round(left) != 0) &&
-                                 (mu_round(right) != 0));
-    }
+  template <int n_components>
+  ::internalFunctionParserCustom::ParserImplementation<
+    n_components>::ParserImplementation()
+    : initialized(false)
+    , n_vars(0)
+  {}
 
-    double
-    mu_int(const double value)
-    {
-      return static_cast<double>(mu_round(value));
-    }
+  template <int n_components>
+  void
+  ParserImplementation<n_components>::initialize(
+    const std::string                   &variables,
+    const std::vector<std::string>      &expressions,
+    const std::map<std::string, double> &constants,
+    const bool                           time_dependent)
+  {
+    this->parser_data.clear(); // this will reset all thread-local objects
 
-    double
-    mu_ceil(const double value)
-    {
-      return std::ceil(value);
-    }
+    this->constants   = constants;
+    this->var_names   = dealii::Utilities::split_string_list(variables, ',');
+    this->expressions = expressions;
+    AssertThrow(((time_dependent) ? n_components + 1 : n_components) ==
+                  this->var_names.size(),
+                dealii::ExcMessage("Wrong number of variables"));
 
-    double
-    mu_floor(const double value)
-    {
-      return std::floor(value);
-    }
+    // Now we define how many variables we expect to read in. We distinguish
+    // between two cases: Time dependent problems, and not time dependent
+    // problems. In the first case the number of variables is given by the
+    // components plus one. In the other case, the number of variables is
+    // equal to the dimension. Once we parsed the variables string, if none of
+    // this is the case, then an exception is thrown.
+    if (time_dependent)
+      this->n_vars = n_components + 1;
+    else
+      this->n_vars = n_components;
 
-    double
-    mu_cot(const double value)
-    {
-      return 1.0 / std::tan(value);
-    }
+    // Create a parser object for the current thread we can then query in
+    // value() and vector_value(). This is not strictly necessary because a
+    // user may never call these functions on the current thread, but it gets
+    // us error messages about wrong formulas right away
+    this->init_muparser();
+    this->initialized = true;
+  }
 
-    double
-    mu_csc(const double value)
-    {
-      return 1.0 / std::sin(value);
-    }
 
-    double
-    mu_sec(const double value)
-    {
-      return 1.0 / std::cos(value);
-    }
 
-    double
-    mu_log(const double value)
-    {
-      return std::log(value);
-    }
+  template <int n_components>
+  void
+  ParserImplementation<n_components>::init_muparser() const
+  {
+    // check that we have not already initialized the parser on the
+    // current thread, i.e., that the current function is only called
+    // once per thread
+    ParserData &data = this->parser_data.get();
+    Assert(data.parsers.empty() && data.vars.empty(),
+           dealii::StandardExceptions::ExcInternalError());
 
-    double
-    mu_pow(const double a, const double b)
-    {
-      return std::pow(a, b);
-    }
-
-    double
-    mu_erf(const double value)
-    {
-      return std::erf(value);
-    }
-
-    double
-    mu_erfc(const double value)
-    {
-      return std::erfc(value);
-    }
-
-    double
-    mu_rand_seed(const double seed)
-    {
-      static std::mutex           rand_mutex;
-      std::lock_guard<std::mutex> lock(rand_mutex);
-
-      std::uniform_real_distribution<> uniform_distribution(0., 1.);
-
-      static std::map<double, std::mt19937> rng_map;
-
-      if (rng_map.find(seed) == rng_map.end())
-        rng_map[seed] = std::mt19937(static_cast<unsigned int>(seed));
-
-      return uniform_distribution(rng_map[seed]);
-    }
-
-    double
-    mu_rand()
-    {
-      static std::mutex                rand_mutex;
-      std::lock_guard<std::mutex>      lock(rand_mutex);
-      std::uniform_real_distribution<> uniform_distribution(0., 1.);
-      const unsigned int  seed = static_cast<unsigned long>(std::time(nullptr));
-      static std::mt19937 rng(seed);
-      return uniform_distribution(rng);
-    }
-
-    std::vector<std::string>
-    get_function_names()
-    {
-      return {// functions predefined by muparser
-              "sin",
-              "cos",
-              "tan",
-              "asin",
-              "acos",
-              "atan",
-              "sinh",
-              "cosh",
-              "tanh",
-              "asinh",
-              "acosh",
-              "atanh",
-              "atan2",
-              "log2",
-              "log10",
-              "log",
-              "ln",
-              "exp",
-              "sqrt",
-              "sign",
-              "rint",
-              "abs",
-              "min",
-              "max",
-              "sum",
-              "avg",
-              // functions we define ourselves above
-              "if",
-              "int",
-              "ceil",
-              "cot",
-              "csc",
-              "floor",
-              "sec",
-              "pow",
-              "erf",
-              "erfc",
-              "rand",
-              "rand_seed"};
-    }
-
-    /**
-     * PIMPL for mu::Parser.
-     */
-    class Parser : public ::internal::FunctionParserCustom::muParserBase
-    {
-    public:
-      operator mu::Parser &()
+    // initialize the objects for the current thread
+    data.parsers.reserve(n_components);
+    data.vars.resize(this->var_names.size());
+    for (unsigned int component = 0; component < n_components; ++component)
       {
-        return parser;
-      }
+        data.parsers.emplace_back(std::make_unique<Parser>());
+        mu::Parser &parser = dynamic_cast<Parser &>(*data.parsers.back());
 
-      operator const mu::Parser &() const
+        for (const auto &constant : this->constants)
+          parser.DefineConst(constant.first, constant.second);
+
+        for (unsigned int iv = 0; iv < this->var_names.size(); ++iv)
+          parser.DefineVar(this->var_names[iv], &data.vars[iv]);
+
+        // define some compatibility functions:
+        parser.DefineFun("if", mu_if, true);
+        parser.DefineOprt("|", mu_or, 1);
+        parser.DefineOprt("&", mu_and, 2);
+        parser.DefineFun("int", mu_int, true);
+        parser.DefineFun("ceil", mu_ceil, true);
+        parser.DefineFun("cot", mu_cot, true);
+        parser.DefineFun("csc", mu_csc, true);
+        parser.DefineFun("floor", mu_floor, true);
+        parser.DefineFun("sec", mu_sec, true);
+        parser.DefineFun("log", mu_log, true);
+        parser.DefineFun("pow", mu_pow, true);
+        parser.DefineFun("erfc", mu_erfc, true);
+        // Disable optimizations (by passing false) that assume the functions
+        // will always return the same value:
+        parser.DefineFun("rand_seed", mu_rand_seed, false);
+        parser.DefineFun("rand", mu_rand, false);
+
+        try
+          {
+            // muparser expects that functions have no
+            // space between the name of the function and the opening
+            // parenthesis. this is awkward because it is not backward
+            // compatible to the library we used to use before muparser
+            // (the fparser library) but also makes no real sense.
+            // consequently, in the expressions we set, remove any space
+            // we may find after function names
+            std::string transformed_expression = this->expressions[component];
+
+            for (const auto &current_function_name : get_function_names())
+              {
+                const unsigned int function_name_length =
+                  current_function_name.size();
+
+                std::string::size_type pos = 0;
+                while (true)
+                  {
+                    // try to find any occurrences of the function name
+                    pos =
+                      transformed_expression.find(current_function_name, pos);
+                    if (pos == std::string::npos)
+                      break;
+
+                    // replace whitespace until there no longer is any
+                    while (
+                      (pos + function_name_length <
+                       transformed_expression.size()) &&
+                      ((transformed_expression[pos + function_name_length] ==
+                        ' ') ||
+                       (transformed_expression[pos + function_name_length] ==
+                        '\t')))
+                      transformed_expression.erase(
+                        transformed_expression.begin() + pos +
+                        function_name_length);
+
+                    // move the current search position by the size of the
+                    // actual function name
+                    pos += function_name_length;
+                  }
+              }
+
+            // now use the transformed expression
+            parser.SetExpr(transformed_expression);
+          }
+        catch (mu::ParserError &e)
+          {
+            std::cerr << "Message:  <" << e.GetMsg() << ">\n";
+            std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
+            std::cerr << "Token:    <" << e.GetToken() << ">\n";
+            std::cerr << "Position: <" << e.GetPos() << ">\n";
+            std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
+            AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
+          }
+      }
+  }
+
+  template <int n_components>
+  double
+  ParserImplementation<n_components>::do_value(
+    const dealii::Tensor<1, n_components> &p,
+    const double                           time,
+    unsigned int                           component) const
+  {
+    Assert(this->initialized == true,
+           dealii::StandardExceptions::ExcNotInitialized());
+
+    // initialize the parser if that hasn't happened yet on the current
+    // thread
+    ::internalFunctionParserCustom::ParserData &data = this->parser_data.get();
+    if (data.vars.empty())
+      init_muparser();
+
+    for (unsigned int i = 0; i < n_components; ++i)
+      data.vars[i] = p[i];
+    if (n_components != this->n_vars)
+      data.vars[n_components] = time;
+
+    try
       {
-        return parser;
+        Assert(dynamic_cast<Parser *>(data.parsers[component].get()),
+               dealii::StandardExceptions::ExcInternalError());
+        // NOLINTNEXTLINE don't warn about using static_cast once we check
+        mu::Parser &parser = static_cast<Parser &>(*data.parsers[component]);
+        return parser.Eval();
       }
+    catch (mu::ParserError &e)
+      {
+        std::cerr << "Message:  <" << e.GetMsg() << ">\n";
+        std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
+        std::cerr << "Token:    <" << e.GetToken() << ">\n";
+        std::cerr << "Position: <" << e.GetPos() << ">\n";
+        std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
+        AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
+      }
+    return std::numeric_limits<double>::signaling_NaN();
+  }
 
-    protected:
-      mu::Parser parser;
-    };
+  template <int n_components>
+  void
+  ParserImplementation<n_components>::do_all_values(
+    const dealii::Tensor<1, n_components> &p,
+    const double                           time,
+    dealii::ArrayView<double>             &values) const
+  {
+    Assert(this->initialized == true,
+           dealii::StandardExceptions::ExcNotInitialized());
 
-    template <int n_components>
-    ::internal::FunctionParserCustom::ParserImplementation<
-      n_components>::ParserImplementation()
-      : initialized(false)
-      , n_vars(0)
-    {}
+    // initialize the parser if that hasn't happened yet on the current
+    // thread
+    ::internalFunctionParserCustom::ParserData &data = this->parser_data.get();
+    if (data.vars.empty())
+      init_muparser();
 
-    template <int n_components>
-    void
-    ParserImplementation<n_components>::initialize(
-      const std::string                   &variables,
-      const std::vector<std::string>      &expressions,
-      const std::map<std::string, double> &constants,
-      const bool                           time_dependent)
-    {
-      this->parser_data.clear(); // this will reset all thread-local objects
+    for (unsigned int i = 0; i < n_components; ++i)
+      data.vars[i] = p[i];
+    if (n_components != this->n_vars)
+      data.vars[n_components] = time;
 
-      this->constants   = constants;
-      this->var_names   = dealii::Utilities::split_string_list(variables, ',');
-      this->expressions = expressions;
-      AssertThrow(((time_dependent) ? n_components + 1 : n_components) ==
-                    this->var_names.size(),
-                  dealii::ExcMessage("Wrong number of variables"));
+    AssertDimension(values.size(), data.parsers.size());
+    try
+      {
+        for (unsigned int component = 0; component < data.parsers.size();
+             ++component)
+          {
+            Assert(dynamic_cast<Parser *>(data.parsers[component].get()),
+                   dealii::StandardExceptions::ExcInternalError());
+            mu::Parser &parser =
+              // We just checked that the pointer is valid so suppress the
+              // clang-tidy check
+              static_cast<Parser &>(*data.parsers[component]); // NOLINT
+            values[component] = parser.Eval();
+          }
+      } // try
+    catch (mu::ParserError &e)
+      {
+        std::cerr << "Message:  <" << e.GetMsg() << ">\n";
+        std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
+        std::cerr << "Token:    <" << e.GetToken() << ">\n";
+        std::cerr << "Position: <" << e.GetPos() << ">\n";
+        std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
+        AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
+      } // catch
+  }
 
-      // Now we define how many variables we expect to read in. We distinguish
-      // between two cases: Time dependent problems, and not time dependent
-      // problems. In the first case the number of variables is given by the
-      // components plus one. In the other case, the number of variables is
-      // equal to the dimension. Once we parsed the variables string, if none of
-      // this is the case, then an exception is thrown.
-      if (time_dependent)
-        this->n_vars = n_components + 1;
-      else
-        this->n_vars = n_components;
-
-      // Create a parser object for the current thread we can then query in
-      // value() and vector_value(). This is not strictly necessary because a
-      // user may never call these functions on the current thread, but it gets
-      // us error messages about wrong formulas right away
-      this->init_muparser();
-      this->initialized = true;
-    }
-
-
-
-    template <int n_components>
-    void
-    ParserImplementation<n_components>::init_muparser() const
-    {
-      // check that we have not already initialized the parser on the
-      // current thread, i.e., that the current function is only called
-      // once per thread
-      ParserData &data = this->parser_data.get();
-      Assert(data.parsers.empty() && data.vars.empty(),
-             dealii::StandardExceptions::ExcInternalError());
-
-      // initialize the objects for the current thread
-      data.parsers.reserve(n_components);
-      data.vars.resize(this->var_names.size());
-      for (unsigned int component = 0; component < n_components; ++component)
-        {
-          data.parsers.emplace_back(std::make_unique<Parser>());
-          mu::Parser &parser = dynamic_cast<Parser &>(*data.parsers.back());
-
-          for (const auto &constant : this->constants)
-            parser.DefineConst(constant.first, constant.second);
-
-          for (unsigned int iv = 0; iv < this->var_names.size(); ++iv)
-            parser.DefineVar(this->var_names[iv], &data.vars[iv]);
-
-          // define some compatibility functions:
-          parser.DefineFun("if", mu_if, true);
-          parser.DefineOprt("|", mu_or, 1);
-          parser.DefineOprt("&", mu_and, 2);
-          parser.DefineFun("int", mu_int, true);
-          parser.DefineFun("ceil", mu_ceil, true);
-          parser.DefineFun("cot", mu_cot, true);
-          parser.DefineFun("csc", mu_csc, true);
-          parser.DefineFun("floor", mu_floor, true);
-          parser.DefineFun("sec", mu_sec, true);
-          parser.DefineFun("log", mu_log, true);
-          parser.DefineFun("pow", mu_pow, true);
-          parser.DefineFun("erfc", mu_erfc, true);
-          // Disable optimizations (by passing false) that assume the functions
-          // will always return the same value:
-          parser.DefineFun("rand_seed", mu_rand_seed, false);
-          parser.DefineFun("rand", mu_rand, false);
-
-          try
-            {
-              // muparser expects that functions have no
-              // space between the name of the function and the opening
-              // parenthesis. this is awkward because it is not backward
-              // compatible to the library we used to use before muparser
-              // (the fparser library) but also makes no real sense.
-              // consequently, in the expressions we set, remove any space
-              // we may find after function names
-              std::string transformed_expression = this->expressions[component];
-
-              for (const auto &current_function_name : get_function_names())
-                {
-                  const unsigned int function_name_length =
-                    current_function_name.size();
-
-                  std::string::size_type pos = 0;
-                  while (true)
-                    {
-                      // try to find any occurrences of the function name
-                      pos =
-                        transformed_expression.find(current_function_name, pos);
-                      if (pos == std::string::npos)
-                        break;
-
-                      // replace whitespace until there no longer is any
-                      while (
-                        (pos + function_name_length <
-                         transformed_expression.size()) &&
-                        ((transformed_expression[pos + function_name_length] ==
-                          ' ') ||
-                         (transformed_expression[pos + function_name_length] ==
-                          '\t')))
-                        transformed_expression.erase(
-                          transformed_expression.begin() + pos +
-                          function_name_length);
-
-                      // move the current search position by the size of the
-                      // actual function name
-                      pos += function_name_length;
-                    }
-                }
-
-              // now use the transformed expression
-              parser.SetExpr(transformed_expression);
-            }
-          catch (mu::ParserError &e)
-            {
-              std::cerr << "Message:  <" << e.GetMsg() << ">\n";
-              std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
-              std::cerr << "Token:    <" << e.GetToken() << ">\n";
-              std::cerr << "Position: <" << e.GetPos() << ">\n";
-              std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
-              AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
-            }
-        }
-    }
-
-    template <int n_components>
-    double
-    ParserImplementation<n_components>::do_value(
-      const dealii::Tensor<1, n_components> &p,
-      const double                           time,
-      unsigned int                           component) const
-    {
-      Assert(this->initialized == true,
-             dealii::StandardExceptions::ExcNotInitialized());
-
-      // initialize the parser if that hasn't happened yet on the current
-      // thread
-      ::internal::FunctionParserCustom::ParserData &data =
-        this->parser_data.get();
-      if (data.vars.empty())
-        init_muparser();
-
-      for (unsigned int i = 0; i < n_components; ++i)
-        data.vars[i] = p[i];
-      if (n_components != this->n_vars)
-        data.vars[n_components] = time;
-
-      try
-        {
-          Assert(dynamic_cast<Parser *>(data.parsers[component].get()),
-                 dealii::StandardExceptions::ExcInternalError());
-          // NOLINTNEXTLINE don't warn about using static_cast once we check
-          mu::Parser &parser = static_cast<Parser &>(*data.parsers[component]);
-          return parser.Eval();
-        }
-      catch (mu::ParserError &e)
-        {
-          std::cerr << "Message:  <" << e.GetMsg() << ">\n";
-          std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
-          std::cerr << "Token:    <" << e.GetToken() << ">\n";
-          std::cerr << "Position: <" << e.GetPos() << ">\n";
-          std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
-          AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
-        }
-      return std::numeric_limits<double>::signaling_NaN();
-    }
-
-    template <int n_components>
-    void
-    ParserImplementation<n_components>::do_all_values(
-      const dealii::Tensor<1, n_components> &p,
-      const double                           time,
-      dealii::ArrayView<double>             &values) const
-    {
-      Assert(this->initialized == true,
-             dealii::StandardExceptions::ExcNotInitialized());
-
-      // initialize the parser if that hasn't happened yet on the current
-      // thread
-      ::internal::FunctionParserCustom::ParserData &data =
-        this->parser_data.get();
-      if (data.vars.empty())
-        init_muparser();
-
-      for (unsigned int i = 0; i < n_components; ++i)
-        data.vars[i] = p[i];
-      if (n_components != this->n_vars)
-        data.vars[n_components] = time;
-
-      AssertDimension(values.size(), data.parsers.size());
-      try
-        {
-          for (unsigned int component = 0; component < data.parsers.size();
-               ++component)
-            {
-              Assert(dynamic_cast<Parser *>(data.parsers[component].get()),
-                     dealii::StandardExceptions::ExcInternalError());
-              mu::Parser &parser =
-                // We just checked that the pointer is valid so suppress the
-                // clang-tidy check
-                static_cast<Parser &>(*data.parsers[component]); // NOLINT
-              values[component] = parser.Eval();
-            }
-        } // try
-      catch (mu::ParserError &e)
-        {
-          std::cerr << "Message:  <" << e.GetMsg() << ">\n";
-          std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
-          std::cerr << "Token:    <" << e.GetToken() << ">\n";
-          std::cerr << "Position: <" << e.GetPos() << ">\n";
-          std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
-          AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
-        } // catch
-    }
-
-    // explicit instantiations
-    template class ::internal::FunctionParserCustom::ParserImplementation<1>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<2>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<3>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<4>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<5>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<6>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<7>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<8>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<9>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<10>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<11>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<12>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<13>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<14>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<15>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<16>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<17>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<18>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<19>;
-    template class ::internal::FunctionParserCustom::ParserImplementation<20>;
-
-  } // namespace FunctionParserCustom
-} // namespace internal
+  // explicit instantiations
+  template class ::internalFunctionParserCustom::ParserImplementation<1>;
+  template class ::internalFunctionParserCustom::ParserImplementation<2>;
+  template class ::internalFunctionParserCustom::ParserImplementation<3>;
+  template class ::internalFunctionParserCustom::ParserImplementation<4>;
+  template class ::internalFunctionParserCustom::ParserImplementation<5>;
+  template class ::internalFunctionParserCustom::ParserImplementation<6>;
+  template class ::internalFunctionParserCustom::ParserImplementation<7>;
+  template class ::internalFunctionParserCustom::ParserImplementation<8>;
+  template class ::internalFunctionParserCustom::ParserImplementation<9>;
+  template class ::internalFunctionParserCustom::ParserImplementation<10>;
+  template class ::internalFunctionParserCustom::ParserImplementation<11>;
+  template class ::internalFunctionParserCustom::ParserImplementation<12>;
+  template class ::internalFunctionParserCustom::ParserImplementation<13>;
+  template class ::internalFunctionParserCustom::ParserImplementation<14>;
+  template class ::internalFunctionParserCustom::ParserImplementation<15>;
+  template class ::internalFunctionParserCustom::ParserImplementation<16>;
+  template class ::internalFunctionParserCustom::ParserImplementation<17>;
+  template class ::internalFunctionParserCustom::ParserImplementation<18>;
+  template class ::internalFunctionParserCustom::ParserImplementation<19>;
+  template class ::internalFunctionParserCustom::ParserImplementation<20>;
+} // namespace internalFunctionParserCustom

--- a/source/core/mu_parser_internal.cc
+++ b/source/core/mu_parser_internal.cc
@@ -216,7 +216,7 @@ namespace internal
       // Now we define how many variables we expect to read in. We distinguish
       // between two cases: Time dependent problems, and not time dependent
       // problems. In the first case the number of variables is given by the
-      // dimension plus one. In the other case, the number of variables is equal
+      // components plus one. In the other case, the number of variables is equal
       // to the dimension. Once we parsed the variables string, if none of this
       // is the case, then an exception is thrown.
       if (time_dependent)
@@ -224,8 +224,8 @@ namespace internal
       else
         this->n_vars = n_components;
 
-      // create a parser object for the current thread we can then query in
-      // value() and vector_value(). this is not strictly necessary because a
+      // Create a parser object for the current thread we can then query in
+      // value() and vector_value(). This is not strictly necessary because a
       // user may never call these functions on the current thread, but it gets
       // us error messages about wrong formulas right away
       this->init_muparser();
@@ -364,7 +364,7 @@ namespace internal
           // NOLINTNEXTLINE don't warn about using static_cast once we check
           mu::Parser &parser = static_cast<Parser &>(*data.parsers[component]);
           return parser.Eval();
-        } // try
+        }
       catch (mu::ParserError &e)
         {
           std::cerr << "Message:  <" << e.GetMsg() << ">\n";
@@ -373,7 +373,7 @@ namespace internal
           std::cerr << "Position: <" << e.GetPos() << ">\n";
           std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
           AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
-        } // catch
+        }
       return std::numeric_limits<double>::signaling_NaN();
     }
 

--- a/source/core/mu_parser_internal.cc
+++ b/source/core/mu_parser_internal.cc
@@ -1,18 +1,5 @@
 #include <core/mu_parser_internal.h>
 
-#include <deal.II/base/thread_management.h>
-#include <deal.II/base/utilities.h>
-
-#include <muParser.h>
-
-#include <cmath>
-#include <ctime>
-#include <limits>
-#include <map>
-#include <mutex>
-#include <random>
-#include <vector>
-
 using namespace dealii;
 
 namespace internal

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -68,7 +68,6 @@ namespace Parameters
     return sizes;
   }
 
-
   void
   SimulationControl::declare_parameters(ParameterHandler &prm)
   {

--- a/source/core/parsed_function_custom.cc
+++ b/source/core/parsed_function_custom.cc
@@ -1,0 +1,253 @@
+
+#include <core/parsed_function_custom.h>
+
+
+template <int n_components>
+ParsedFunctionCustom<n_components>::ParsedFunctionCustom(const double h)
+  : h(h)
+  , ht(n_components)
+  , vnames("")
+  , expression("")
+  , constants_list("")
+  , initialized(false)
+{
+  for (unsigned int i = 0; i < n_components; ++i)
+    ht[i][i] = h;
+}
+
+template <int n_components>
+void
+ParsedFunctionCustom<n_components>::declare_parameters(ParameterHandler &prm)
+{
+  Assert(n_components > 0, ExcZero());
+
+  // The expression of the variables
+  vnames = "c_";
+  for (unsigned int i = 1; i < n_components; i++)
+    vnames = vnames + ",c_" + std::to_string(i);
+  std::cout << vnames << std::endl;
+  prm.declare_entry(
+    "Variable names",
+    vnames,
+    Patterns::Anything(),
+    "The names of the variables as they will be used in the "
+    "function, separated by commas. By default, the names of variables "
+    "with which the function will be evaluated are the `c_i' (i from 0 to "
+    "n_components-1 and `t' for time. You can then use these variable names "
+    "in your function expression and they will be "
+    "replaced by the values of these variables at which the function is "
+    "currently evaluated. However, you can also choose a different set "
+    "of names for the variables at which to evaluate your function "
+    "expression.");
+
+  // The expression of the function
+  std::string expr = "0";
+  for (unsigned int i = 1; i < n_components; ++i)
+    expr += "; 0";
+  prm.declare_entry(
+    "Function expression",
+    expr,
+    Patterns::Anything(),
+    "The formula that denotes the function you want to evaluate for "
+    "particular values of the variables. This expression "
+    "may contain any of the usual operations such as addition or "
+    "multiplication, as well as all of the common functions such as "
+    "`sin' or `cos'. In addition, it may contain expressions like "
+    "`if(x>0, 1, -1)' where the expression evaluates to the second "
+    "argument if the first argument is true, and to the third argument "
+    "otherwise. "
+    "If the function you are describing represents a vector-valued "
+    "function with multiple components, then separate the expressions "
+    "for individual components by a semicolon.");
+
+  prm.declare_entry(
+    "Function constants",
+    "",
+    Patterns::Anything(),
+    "Sometimes it is convenient to use symbolic constants in the "
+    "expression that describes the function, rather than having to "
+    "use its numeric value everywhere the constant appears. These "
+    "values can be defined using this parameter, in the form "
+    "`var1=value1, var2=value2, ...'."
+    "\n\n"
+    "A typical example would be to set this runtime parameter to "
+    "`pi=3.1415926536' and then use `pi' in the expression of the "
+    "actual formula. (That said, for convenience this class actually "
+    "defines both `pi' and `Pi' by default, but you get the idea.)");
+}
+
+template <int n_components>
+void
+ParsedFunctionCustom<n_components>::parse_parameters(ParameterHandler &prm)
+{
+  vnames         = prm.get("Variable names");
+  expression     = prm.get("Function expression");
+  constants_list = prm.get("Function constants");
+  initialized    = true;
+  initialize();
+}
+
+template <int n_components>
+void
+ParsedFunctionCustom<n_components>::initialize(const std::string vnames,
+                                               const std::string expression,
+                                               const std::string constants_list)
+{
+  this->vnames         = vnames;
+  this->expression     = expression;
+  this->constants_list = constants_list;
+  initialized          = true;
+  initialize();
+}
+
+template <int n_components>
+void
+ParsedFunctionCustom<n_components>::initialize()
+{
+  if (!initialized)
+    throw ExcMessage(
+      "The required fields for muParser are not initialized yet. "
+      "This function should be called only after that is done.");
+  std::vector<std::string> const_list =
+    Utilities::split_string_list(constants_list, ',');
+  std::map<std::string, double> constants;
+  for (const auto &constant : const_list)
+    {
+      std::vector<std::string> this_c =
+        Utilities::split_string_list(constant, '=');
+      AssertThrow(this_c.size() == 2,
+                  ExcMessage("The list of constants, <" + constants_list +
+                             ">, is not a comma-separated list of "
+                             "entries of the form 'name=value'."));
+      constants[this_c[0]] = Utilities::string_to_double(this_c[1]);
+    }
+  // set pi and Pi as synonyms for the corresponding value. note that
+  // this overrides any value a user may have given
+  constants["pi"] = numbers::PI;
+  constants["Pi"] = numbers::PI;
+
+  const unsigned int nn = (Utilities::split_string_list(vnames)).size();
+  switch (nn)
+    {
+      case n_components:
+        // Time independent function
+        this->::internal::FunctionParserCustom::ParserImplementation<
+          n_components>::initialize(vnames,
+                                    Utilities::split_string_list(expression,
+                                                                 ';'),
+                                    constants);
+        break;
+      case n_components + 1:
+        // Time dependent function
+        this->::internal::FunctionParserCustom::ParserImplementation<
+          n_components>::initialize(vnames,
+                                    Utilities::split_string_list(expression,
+                                                                 ';'),
+                                    constants,
+                                    true);
+        break;
+      default:
+        AssertThrow(false,
+                    ExcMessage(
+                      "The list of variables specified is <" + vnames +
+                      "> which is a list of length " +
+                      Utilities::int_to_string(nn) +
+                      " but it has to be a list of length equal to" +
+                      " either n_components (for a time-independent function)" +
+                      " or n_components+1 (for a time-dependent function)."));
+    }
+}
+
+template <int n_components>
+void
+ParsedFunctionCustom<n_components>::vector_value(
+  const Tensor<1, n_components> &p,
+  Tensor<1, n_components>       &values) const
+{
+  for (unsigned int i = 0; i < n_components; i++)
+    values[i] = this->do_value(p, this->get_time(), i);
+}
+
+template <int n_components>
+double
+ParsedFunctionCustom<n_components>::value(const Tensor<1, n_components> &p,
+                                          unsigned int comp) const
+{
+  return this->do_value(p, this->get_time(), comp);
+}
+
+template <int n_components>
+Tensor<1, n_components>
+ParsedFunctionCustom<n_components>::gradient(const Tensor<1, n_components> &p,
+                                             unsigned int comp) const
+{
+  Tensor<1, n_components> grad;
+  // FourthOrder:
+  Tensor<1, n_components> q1, q2, q3, q4;
+  for (unsigned int i = 0; i < n_components; ++i)
+    {
+      q2      = p + ht[i];
+      q1      = q2 + ht[i];
+      q3      = p - ht[i];
+      q4      = q3 - ht[i];
+      grad[i] = (-this->value(q1, comp) + 8 * this->value(q2, comp) -
+                 8 * this->value(q3, comp) + this->value(q4, comp)) /
+                (12 * h);
+    }
+  return grad;
+}
+
+template <int n_components>
+void
+ParsedFunctionCustom<n_components>::vector_gradient(
+  const Tensor<1, n_components> &p,
+  Tensor<2, n_components>       &gradients) const
+{
+  Point<n_components>     q1, q2, q3, q4;
+  Tensor<1, n_components> v1{}, v2{}, v3{}, v4{};
+  const double            h_inv_12 = 1. / (12 * h);
+  for (unsigned int i = 0; i < n_components; ++i)
+    {
+      q2 = p + ht[i];
+      q1 = q2 + ht[i];
+      q3 = p - ht[i];
+      q4 = q3 - ht[i];
+      this->vector_value(q1, v1);
+      this->vector_value(q2, v2);
+      this->vector_value(q3, v3);
+      this->vector_value(q4, v4);
+
+      for (unsigned int comp = 0; comp < n_components; ++comp)
+        gradients[comp][i] =
+          (-v1[comp] + 8 * v2[comp] - 8 * v3[comp] + v4[comp]) * h_inv_12;
+    }
+}
+
+template <int n_components>
+void
+ParsedFunctionCustom<n_components>::set_time(const double newtime)
+{
+  // this->FunctionTime::set_time(newtime);
+}
+
+// Explicit instantiations
+template class ParsedFunctionCustom<1>;
+template class ParsedFunctionCustom<2>;
+template class ParsedFunctionCustom<3>;
+template class ParsedFunctionCustom<4>;
+template class ParsedFunctionCustom<5>;
+template class ParsedFunctionCustom<6>;
+template class ParsedFunctionCustom<7>;
+template class ParsedFunctionCustom<8>;
+template class ParsedFunctionCustom<9>;
+template class ParsedFunctionCustom<10>;
+template class ParsedFunctionCustom<11>;
+template class ParsedFunctionCustom<12>;
+template class ParsedFunctionCustom<13>;
+template class ParsedFunctionCustom<14>;
+template class ParsedFunctionCustom<15>;
+template class ParsedFunctionCustom<16>;
+template class ParsedFunctionCustom<17>;
+template class ParsedFunctionCustom<18>;
+template class ParsedFunctionCustom<19>;
+template class ParsedFunctionCustom<20>;

--- a/source/core/parsed_function_custom.cc
+++ b/source/core/parsed_function_custom.cc
@@ -225,10 +225,8 @@ ParsedFunctionCustom<n_components>::vector_gradient(
 
 template <int n_components>
 void
-ParsedFunctionCustom<n_components>::set_time(const double newtime)
-{
-  // this->FunctionTime::set_time(newtime);
-}
+ParsedFunctionCustom<n_components>::set_time(const double /*newtime*/)
+{}
 
 // Explicit instantiations
 template class ParsedFunctionCustom<1>;

--- a/source/core/parsed_function_custom.cc
+++ b/source/core/parsed_function_custom.cc
@@ -108,7 +108,7 @@ ParsedFunctionCustom<n_components>::initialize()
     {
       case n_components:
         // Time independent function
-        this->::internal::FunctionParserCustom::ParserImplementation<
+        this->::internalFunctionParserCustom::ParserImplementation<
           n_components>::initialize(vnames,
                                     Utilities::split_string_list(expression,
                                                                  ';'),
@@ -116,7 +116,7 @@ ParsedFunctionCustom<n_components>::initialize()
         break;
       case n_components + 1:
         // Time dependent function
-        this->::internal::FunctionParserCustom::ParserImplementation<
+        this->::internalFunctionParserCustom::ParserImplementation<
           n_components>::initialize(vnames,
                                     Utilities::split_string_list(expression,
                                                                  ';'),

--- a/source/core/parsed_function_custom.cc
+++ b/source/core/parsed_function_custom.cc
@@ -5,7 +5,7 @@
 template <int n_components>
 ParsedFunctionCustom<n_components>::ParsedFunctionCustom(const double h)
   : h(h)
-  , ht(n_components)
+  , ht()
   , vnames("")
   , expression("")
   , constants_list("")

--- a/source/core/parsed_function_custom.cc
+++ b/source/core/parsed_function_custom.cc
@@ -33,7 +33,7 @@ ParsedFunctionCustom<n_components>::declare_parameters(ParameterHandler &prm)
     "The names of the variables as they will be used in the "
     "function, separated by commas. By default, the names of variables "
     "with which the function will be evaluated are the `c_i' (i from 0 to "
-    "n_components-1 and `t' for time. You can then use these variable names "
+    "n_components-1) and `t' for time. You can then use these variable names "
     "in your function expression and they will be "
     "replaced by the values of these variables at which the function is "
     "currently evaluated. However, you can also choose a different set "

--- a/source/core/parsed_function_custom.cc
+++ b/source/core/parsed_function_custom.cc
@@ -76,29 +76,6 @@ ParsedFunctionCustom<n_components>::declare_parameters(ParameterHandler &prm)
     "defines both `pi' and `Pi' by default, but you get the idea.)");
 }
 
-template <int n_components>
-void
-ParsedFunctionCustom<n_components>::parse_parameters(ParameterHandler &prm)
-{
-  vnames         = prm.get("Variable names");
-  expression     = prm.get("Function expression");
-  constants_list = prm.get("Function constants");
-  initialized    = true;
-  initialize();
-}
-
-template <int n_components>
-void
-ParsedFunctionCustom<n_components>::initialize(const std::string vnames,
-                                               const std::string expression,
-                                               const std::string constants_list)
-{
-  this->vnames         = vnames;
-  this->expression     = expression;
-  this->constants_list = constants_list;
-  initialized          = true;
-  initialize();
-}
 
 template <int n_components>
 void
@@ -156,6 +133,30 @@ ParsedFunctionCustom<n_components>::initialize()
                       " either n_components (for a time-independent function)" +
                       " or n_components+1 (for a time-dependent function)."));
     }
+}
+
+template <int n_components>
+void
+ParsedFunctionCustom<n_components>::parse_parameters(ParameterHandler &prm)
+{
+  vnames         = prm.get("Variable names");
+  expression     = prm.get("Function expression");
+  constants_list = prm.get("Function constants");
+  initialized    = true;
+  initialize();
+}
+
+template <int n_components>
+void
+ParsedFunctionCustom<n_components>::initialize(const std::string vnames,
+                                               const std::string expression,
+                                               const std::string constants_list)
+{
+  this->vnames         = vnames;
+  this->expression     = expression;
+  this->constants_list = constants_list;
+  initialized          = true;
+  initialize();
 }
 
 template <int n_components>

--- a/tests/core/custom_parsed_functions.cc
+++ b/tests/core/custom_parsed_functions.cc
@@ -46,7 +46,7 @@ test()
 
 
 
-  deallog << "Testing first set" << std::endl;
+  deallog << "Testing second set" << std::endl;
   // Kinetics for a 5 species system of
   // 2A+3B=>1.5C
   // 1C+1D=>2E

--- a/tests/core/custom_parsed_functions.cc
+++ b/tests/core/custom_parsed_functions.cc
@@ -1,0 +1,126 @@
+/**
+ * @brief Tests the custom parsed functions.
+ */
+
+// Lethe
+#include <core/parsed_function_custom.h>
+
+// Tests (with common definitions)
+#include <../tests/tests.h>
+
+void
+test()
+{
+  deallog << "Beginning" << std::endl;
+
+  deallog << "Testing first set" << std::endl;
+  // Kinetics for a 3 species system of 2A+3B=>1.5C
+  std::string variable_names = "A,B,C";
+  std::string constants      = "a=2,b=3,c=1.5";
+  std::string expression1    = "-a*(A^a*B^b)";
+  std::string expression2    = "-b*(A^a*B^b)";
+  std::string expression3    = "+c*(A^a*B^b)";
+  std::string expression = expression1 + ";" + expression2 + ";" + expression3;
+  std::shared_ptr<ParsedFunctionCustom<3>> test_function =
+    std::make_shared<ParsedFunctionCustom<3>>();
+  test_function->initialize(variable_names, expression, constants);
+
+  Tensor<1, 3> initial_concentrations{};
+  initial_concentrations[0] = 1;
+  initial_concentrations[1] = 2;
+  initial_concentrations[2] = 0;
+
+  Tensor<1, 3> source_term{};
+  test_function->vector_value(initial_concentrations, source_term);
+  deallog << " Source term = " << source_term << std::endl;
+  for (unsigned int i = 0; i < 3; i++)
+    deallog << " Source term [" + std::to_string(i) + "] = "
+            << test_function->value(initial_concentrations, i) << std::endl;
+
+  Tensor<2, 3> source_term_gradients{};
+  test_function->vector_gradient(initial_concentrations, source_term_gradients);
+  deallog << " Source term gradients = " << source_term_gradients << std::endl;
+  for (unsigned int i = 0; i < 3; i++)
+    deallog << " Source term gradient [" + std::to_string(i) + "] = "
+            << test_function->gradient(initial_concentrations, i) << std::endl;
+
+
+
+  deallog << "Testing first set" << std::endl;
+  // Kinetics for a 5 species system of
+  // 2A+3B=>1.5C
+  // 1C+1D=>2E
+  variable_names          = "A,B,C,D,E";
+  constants               = "a=2,b=3,c=1.5,d=1,e=2";
+  expression1             = "-a*(A^a*B^b)";
+  expression2             = "-b*(A^a*B^b)";
+  expression3             = "+c*(A^a*B^b)-c*(C^c*D^d)";
+  std::string expression4 = "-d*(C^c*D^d)";
+  std::string expression5 = "+e*(C^c*D^d)";
+  expression = expression1 + ";" + expression2 + ";" + expression3 + ";" +
+               expression4 + ";" + expression5;
+  std::shared_ptr<ParsedFunctionCustom<5>> test_function_2 =
+    std::make_shared<ParsedFunctionCustom<5>>();
+  test_function_2->initialize(variable_names, expression, constants);
+
+  Tensor<1, 5> initial_concentrations_2{};
+  initial_concentrations_2[0] = 1;
+  initial_concentrations_2[1] = 2;
+  initial_concentrations_2[2] = 0.1;
+  initial_concentrations_2[3] = 2;
+  initial_concentrations_2[4] = 0;
+
+  Tensor<1, 5> source_term_2{};
+  test_function_2->vector_value(initial_concentrations_2, source_term_2);
+  deallog << " Source term = " << source_term_2 << std::endl;
+  for (unsigned int i = 0; i < 5; i++)
+    deallog << " Source term [" + std::to_string(i) + "] = "
+            << test_function_2->value(initial_concentrations_2, i) << std::endl;
+
+  Tensor<2, 5> source_term_gradients_2{};
+  test_function_2->vector_gradient(initial_concentrations_2,
+                                   source_term_gradients_2);
+  deallog << " Source term gradients = " << source_term_gradients_2
+          << std::endl;
+  for (unsigned int i = 0; i < 5; i++)
+    deallog << " Source term gradient [" + std::to_string(i) + "] = "
+            << test_function_2->gradient(initial_concentrations_2, i)
+            << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+int
+main()
+{
+  try
+    {
+      initlog();
+      test();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+}

--- a/tests/core/custom_parsed_functions.output
+++ b/tests/core/custom_parsed_functions.output
@@ -9,7 +9,7 @@ DEAL:: Source term gradients = -32.0000 -24.0000 0.00000  -48.0000 -36.0000 0.00
 DEAL:: Source term gradient [0] = -32.0000 -24.0000 0.00000
 DEAL:: Source term gradient [1] = -48.0000 -36.0000 0.00000
 DEAL:: Source term gradient [2] = 24.0000 18.0000 0.00000
-DEAL::Testing first set
+DEAL::Testing second set
 DEAL:: Source term = -16.0000 -24.0000 11.9051 -0.0632456 0.126491
 DEAL:: Source term [0] = -16.0000
 DEAL:: Source term [1] = -24.0000

--- a/tests/core/custom_parsed_functions.output
+++ b/tests/core/custom_parsed_functions.output
@@ -1,0 +1,25 @@
+
+DEAL::Beginning
+DEAL::Testing first set
+DEAL:: Source term = -16.0000 -24.0000 12.0000
+DEAL:: Source term [0] = -16.0000
+DEAL:: Source term [1] = -24.0000
+DEAL:: Source term [2] = 12.0000
+DEAL:: Source term gradients = -32.0000 -24.0000 0.00000  -48.0000 -36.0000 0.00000  24.0000 18.0000 0.00000
+DEAL:: Source term gradient [0] = -32.0000 -24.0000 0.00000
+DEAL:: Source term gradient [1] = -48.0000 -36.0000 0.00000
+DEAL:: Source term gradient [2] = 24.0000 18.0000 0.00000
+DEAL::Testing first set
+DEAL:: Source term = -16.0000 -24.0000 11.9051 -0.0632456 0.126491
+DEAL:: Source term [0] = -16.0000
+DEAL:: Source term [1] = -24.0000
+DEAL:: Source term [2] = 11.9051
+DEAL:: Source term [3] = -0.0632456
+DEAL:: Source term [4] = 0.126491
+DEAL:: Source term gradients = -32.0000 -24.0000 0.00000 0.00000 0.00000  -48.0000 -36.0000 0.00000 0.00000 0.00000  24.0000 18.0000 -1.42302 -0.0474341 1.48030e-08  1.15648e-10 1.15648e-10 -0.948683 -0.0316228 1.15648e-10  -2.31296e-10 -2.31296e-10 1.89737 0.0632456 -2.31296e-10
+DEAL:: Source term gradient [0] = -32.0000 -24.0000 0.00000 0.00000 0.00000
+DEAL:: Source term gradient [1] = -48.0000 -36.0000 0.00000 0.00000 0.00000
+DEAL:: Source term gradient [2] = 24.0000 18.0000 -1.42302 -0.0474341 1.48030e-08
+DEAL:: Source term gradient [3] = 1.15648e-10 1.15648e-10 -0.948683 -0.0316228 1.15648e-10
+DEAL:: Source term gradient [4] = -2.31296e-10 -2.31296e-10 1.89737 0.0632456 -2.31296e-10
+DEAL::OK


### PR DESCRIPTION
# Description of the problem

- In the idea of adding a reactive physics, a way to parse functions based on any variables needed to be added. For example, when a species A reacts at a rate of -dA/dt = k*A, the source term for A depends on A itself. 
- Parsed functions in deal.II didn't allow to parse functions unless they depended only on x,y,z,t.  

# Description of the solution

- A new custom class based on the deal.II implementation of parsed functions (using muParser) is added to Lethe.
- This class has the template parameter `n_component`. It requires that classes are instantiated with `n_component` expressions as well.
- Physics that will use this class will have the responsibility of interfacing between their variables of interest and the class ParsedFunctionCustom itself.
- When a different number of variables/expressions will be needed by a solver, this solver will have the responsibility of introducing dummy variables or expressions. This solution might change if required.

# How Has This Been Tested?

- [core/custom_parsed_functions] Unit test of value and gradient functions.

# Documentation

- Not at the moment, except for doxygen.

# Future changes

- A reactive auxiliary physics will be implemented using this class.