### PR TITLE
Fix memory copy of vectors in CFD-DEM simulations

### DIFF
--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -675,9 +675,9 @@ public:
   void
   reinit_particle_fluid_interactions(
     const typename DoFHandler<dim>::active_cell_iterator & /*cell*/,
-    const VectorType /*current_solution*/,
-    const VectorType                       previous_solution,
-    const VectorType                       void_fraction_solution,
+    const VectorType & /*current_solution*/,
+    const VectorType                      &previous_solution,
+    const VectorType                      &void_fraction_solution,
     const Particles::ParticleHandler<dim> &particle_handler,
     DoFHandler<dim>                       &dof_handler,
     DoFHandler<dim>                       &void_fraction_dof_handler)


### PR DESCRIPTION
# Description of the problem

- Vector were being copied when gathering information for particle-fluid interaction

# Description of the solution

- Pass by reference instead of by copy


# Comments

- This was soooo dumb 
