### PR TITLE
Correct minor typos in documentation

### DIFF
--- a/doc/source/parameters/cfd/boundary_conditions_cfd.rst
+++ b/doc/source/parameters/cfd/boundary_conditions_cfd.rst
@@ -30,9 +30,9 @@ where `beta` is a constant and  :math:`(\mathbf{u}\cdot n)_{-}` is :math:`min (0
 .. code-block:: text
 
   subsection boundary conditions
-    set number         = 2
-    set time dependent = false
-    set fix pressure constant = false;
+    set number                = 2
+    set time dependent        = false
+    set fix pressure constant = false
     subsection bc 0
       set id                 = 0
       set type               = function

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -51,7 +51,7 @@ This subsection controls the post-processing other than the forces and torque on
     set calculate tracer statistics      = false
     set tracer statistics name           = tracer_statistics
 
-    # Thermal postprocesses
+    # Thermal postprocessing
     set postprocessed fluid              = both
     set calculate temperature statistics = false
     set temperature statistics name      = temperature_statistics


### PR DESCRIPTION
There were two typos in the documentation and they have been fixed.