### PR TITLE
Correct smoothing range MG parameter

### DIFF
--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1137,7 +1137,7 @@ namespace Parameters
     bool mg_smoother_eig_estimation;
 
     /// MG smoothing range to set range between eigenvalues
-    int eig_estimation_smoothing_range;
+    double eig_estimation_smoothing_range;
 
     /// MG number of cg iterations to find eigenvalue
     int eig_estimation_cg_n_iterations;

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2390,7 +2390,7 @@ namespace Parameters
 
         prm.declare_entry("eig estimation smoothing range",
                           "10",
-                          Patterns::Integer(),
+                          Patterns::Double(),
                           "sets range between largest and smallest eig");
 
         prm.declare_entry("eig estimation cg n iterations",
@@ -2543,7 +2543,7 @@ namespace Parameters
         mg_smoother_relaxation     = prm.get_double("mg smoother relaxation");
         mg_smoother_eig_estimation = prm.get_bool("mg smoother eig estimation");
         eig_estimation_smoothing_range =
-          prm.get_integer("eig estimation smoothing range");
+          prm.get_double("eig estimation smoothing range");
         eig_estimation_cg_n_iterations =
           prm.get_integer("eig estimation cg n iterations");
 


### PR DESCRIPTION
The smoothing range parameter used for the eigenvalue estimation was defined as integer while it should be a double. 
