### PR TITLE
Fix dynamic sparsity pattern multiphysics

### DIFF
--- a/source/solvers/cahn_hilliard.cc
+++ b/source/solvers/cahn_hilliard.cc
@@ -1105,7 +1105,7 @@ CahnHilliard<dim>::setup_dofs()
   zero_constraints.close();
 
   // Sparse matrices initialization
-  DynamicSparsityPattern dsp(this->dof_handler.n_dofs());
+  DynamicSparsityPattern dsp(locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(this->dof_handler,
                                   dsp,
                                   nonzero_constraints,

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -1218,7 +1218,7 @@ HeatTransfer<dim>::setup_dofs()
   zero_constraints.close();
 
   // Sparse matrices initialization
-  DynamicSparsityPattern dsp(this->dof_handler.n_dofs());
+  DynamicSparsityPattern dsp(locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(this->dof_handler,
                                   dsp,
                                   nonzero_constraints,

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -736,7 +736,7 @@ Tracer<dim>::setup_dofs()
   zero_constraints.close();
 
   // Sparse matrices initialization
-  DynamicSparsityPattern dsp(this->dof_handler.n_dofs());
+  DynamicSparsityPattern dsp(locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(this->dof_handler,
                                   dsp,
                                   nonzero_constraints,

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -2281,7 +2281,7 @@ VolumeOfFluid<dim>::setup_dofs()
   define_zero_constraints();
 
   // Sparse matrices initialization
-  DynamicSparsityPattern dsp(this->dof_handler.n_dofs());
+  DynamicSparsityPattern dsp(this->locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(this->dof_handler,
                                   dsp,
                                   this->nonzero_constraints,


### PR DESCRIPTION
# Description of the problem

Several tests were crashing due to a new assert introduced in deal.II recently #https://github.com/dealii/dealii/pull/17033. The dynamic sparsity pattern in most of the multiphysics was being initialized with the number of dofs. 

# Description of the solution

The dynamic sparsity pattern is now initialized using the locally relevant dofs as it should have been done since the beginning. The CI is not broken anymore.

# How Has This Been Tested?

 All test pass. 
