### PR TITLE
Increase core count to 4 for CI

### DIFF
--- a/.github/workflows/main_parameter_files.yml
+++ b/.github/workflows/main_parameter_files.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
   
 env:
-  COMPILE_JOBS: 2
+  COMPILE_JOBS: 4
   MULTI_CORE_TESTS_REGEX: "mpirun=2"
 
 jobs:

--- a/.github/workflows/main_release.yml
+++ b/.github/workflows/main_release.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  COMPILE_JOBS: 2
+  COMPILE_JOBS: 4
   MULTI_CORE_TESTS_REGEX: "mpirun=2"
 
 jobs:

--- a/.github/workflows/main_warnings.yml
+++ b/.github/workflows/main_warnings.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  COMPILE_JOBS: 2
+  COMPILE_JOBS: 4
   MULTI_CORE_TESTS_REGEX: "mpirun=2"
 
 jobs:


### PR DESCRIPTION
# Description of the problem

- Public github actions now have 4 cores instead of 2 like in the past. They should be leveraged

# Description of the solution

- Increase the core count to 4 for serial jobs and compilation

# How Has This Been Tested?

- Will it work? we shall see

EDIT
It seems to remove 10-15 minutes from the CI. I like this

