### PR TITLE
Add instruction on how to compile on cluster with muparser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-05-23
+
+### Added
+
+- MINOR dependency on muParser. This requires to load an additional module "muparser/2.3.2" when compiling deal.II and Lethe on clusters. [#1143](https://github.com/chaos-polymtl/lethe/pull/1143) 
+
 ## [Master] - 2024-05-20
 
 ### Removed

--- a/doc/source/installation/digital_alliance.rst
+++ b/doc/source/installation/digital_alliance.rst
@@ -50,6 +50,7 @@ Load ``Trilinos``, ``Parmetis`` and ``P4est``, and their prerequisite modules:
   module load parmetis/4.0.3
   module load p4est/2.2
   module load opencascade/7.5.2
+  module load muparser/2.3.2
 
 Then, we can clone and compile ``dealii``. Although Lethe always supports the master branch of deal.II, we maintain an identical deal.II fork on the lethe repository. This fork is always tested to make sure it works with lethe. To clone the deal.II fork github repository, execute in ``$HOME/dealii`` directory:
 
@@ -170,6 +171,7 @@ In the nano terminal, copy-paste (with ``Ctrl+Shift+V``):
   module load parmetis/4.0.3
   module load p4est/2.2
   module load opencascade/7.5.2
+  module load muparser/2.3.2
 
   export DEAL_II_DIR=$HOME/dealii/inst/
   export PATH=$PATH:$HOME/lethe/inst/bin/


### PR DESCRIPTION
# Description of the problem

The new parsing class prevented compilation on the Digital Alliance clusters.

# Description of the solution

An instruction on which module to load to allow compilation is added.

# How Has This Been Tested?

Compilation of deal.II and Lethe on the cluster works, and all tests pass.

# Documentation

- [doc/source/installation/digital_alliance.rst] The required module is added.
