### PR TITLE
Sort operation in DCDD implementation in VOF and Tracer

### DIFF
--- a/include/solvers/tracer_assemblers.h
+++ b/include/solvers/tracer_assemblers.h
@@ -101,8 +101,6 @@ public:
   assemble_rhs(TracerScratchData<dim>    &scratch_data,
                StabilizedMethodsCopyData &copy_data) override;
 
-  const bool DCDD = true;
-
   std::shared_ptr<SimulationControl> simulation_control;
 };
 

--- a/include/solvers/vof_assemblers.h
+++ b/include/solvers/vof_assemblers.h
@@ -107,9 +107,6 @@ public:
   assemble_rhs(VOFScratchData<dim>       &scratch_data,
                StabilizedMethodsCopyData &copy_data) override;
 
-  // enable/disable DCDD shock capturing model, for debugging purposes
-  const bool DCDD = true;
-
   std::shared_ptr<SimulationControl> simulation_control;
   const Parameters::FEM              fem_parameters;
   const Parameters::VOF              vof_parameters;

--- a/source/solvers/tracer_assemblers.cc
+++ b/source/solvers/tracer_assemblers.cc
@@ -115,8 +115,7 @@ TracerAssemblerCore<dim>::assemble_matrix(TracerScratchData<dim> &scratch_data,
                 JxW;
             }
         }
-    }
-} // end loop on quadrature points
+    } // end loop on quadrature points
 }
 
 

--- a/source/solvers/tracer_assemblers.cc
+++ b/source/solvers/tracer_assemblers.cc
@@ -85,9 +85,6 @@ TracerAssemblerCore<dim>::assemble_matrix(TracerScratchData<dim> &scratch_data,
           const double laplacian_phi_T_j    = scratch_data.laplacian_phi[q][j];
           strong_jacobian_vec[q][j] +=
             velocity * grad_phi_T_j - diffusivity * laplacian_phi_T_j;
-
-          if (DCDD)
-            strong_jacobian_vec[q][j] += -vdcdd * laplacian_phi_T_j;
         }
 
       for (unsigned int i = 0; i < n_dofs; ++i)
@@ -109,15 +106,7 @@ TracerAssemblerCore<dim>::assemble_matrix(TracerScratchData<dim> &scratch_data,
               local_matrix(i, j) += tau * strong_jacobian_vec[q][j] *
                                     (grad_phi_T_i * velocity) * JxW;
 
-              if (DCDD)
-                {
-                  local_matrix(i, j) +=
-                    (vdcdd * scalar_product(grad_phi_T_j,
-                                            dcdd_factor * grad_phi_T_i) +
-                     d_vdcdd * grad_phi_T_j.norm() *
-                       scalar_product(tracer_gradient,
-                                      dcdd_factor * grad_phi_T_i)) *
-                    JxW;
+              local_matrix(i, j) += (vdcdd * scalar_product(grad_phi_T_i, dcdd_factor * grad_phi_T_j) + d_vdcdd * grad_phi_T_j.norm() * scalar_product(grad_phi_T_i, dcdd_factor * tracer_gradient)) * JxW;
                 }
             }
         }
@@ -197,9 +186,6 @@ TracerAssemblerCore<dim>::assemble_rhs(TracerScratchData<dim>    &scratch_data,
       strong_residual_vec[q] +=
         velocity * tracer_gradient - diffusivity * tracer_laplacian;
 
-      if (DCDD)
-        strong_residual_vec[q] += -vdcdd * tracer_laplacian;
-
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
           const auto phi_T_i      = scratch_data.phi[q][i];
@@ -214,13 +200,7 @@ TracerAssemblerCore<dim>::assemble_rhs(TracerScratchData<dim>    &scratch_data,
           local_rhs(i) -=
             tau * (strong_residual_vec[q] * (grad_phi_T_i * velocity)) * JxW;
 
-          if (DCDD)
-            {
-              local_rhs(i) +=
-                -vdcdd *
-                scalar_product(tracer_gradient, dcdd_factor * grad_phi_T_i) *
-                JxW;
-            }
+          local_rhs(i) -= vdcdd * scalar_product(grad_phi_T_i, dcdd_factor * tracer_gradient) * JxW;
         }
     } // end loop on quadrature points
 }

--- a/source/solvers/tracer_assemblers.cc
+++ b/source/solvers/tracer_assemblers.cc
@@ -106,11 +106,17 @@ TracerAssemblerCore<dim>::assemble_matrix(TracerScratchData<dim> &scratch_data,
               local_matrix(i, j) += tau * strong_jacobian_vec[q][j] *
                                     (grad_phi_T_i * velocity) * JxW;
 
-              local_matrix(i, j) += (vdcdd * scalar_product(grad_phi_T_i, dcdd_factor * grad_phi_T_j) + d_vdcdd * grad_phi_T_j.norm() * scalar_product(grad_phi_T_i, dcdd_factor * tracer_gradient)) * JxW;
-                }
+              local_matrix(i, j) +=
+                (vdcdd *
+                   scalar_product(grad_phi_T_i, dcdd_factor * grad_phi_T_j) +
+                 d_vdcdd * grad_phi_T_j.norm() *
+                   scalar_product(grad_phi_T_i,
+                                  dcdd_factor * tracer_gradient)) *
+                JxW;
             }
         }
-    } // end loop on quadrature points
+    }
+} // end loop on quadrature points
 }
 
 
@@ -200,7 +206,9 @@ TracerAssemblerCore<dim>::assemble_rhs(TracerScratchData<dim>    &scratch_data,
           local_rhs(i) -=
             tau * (strong_residual_vec[q] * (grad_phi_T_i * velocity)) * JxW;
 
-          local_rhs(i) -= vdcdd * scalar_product(grad_phi_T_i, dcdd_factor * tracer_gradient) * JxW;
+          local_rhs(i) -=
+            vdcdd *
+            scalar_product(grad_phi_T_i, dcdd_factor * tracer_gradient) * JxW;
         }
     } // end loop on quadrature points
 }

--- a/source/solvers/vof_assemblers.cc
+++ b/source/solvers/vof_assemblers.cc
@@ -271,7 +271,10 @@ VOFAssemblerCore<dim>::assemble_rhs(VOFScratchData<dim>       &scratch_data,
             JxW;
 
           // DCDD shock capturing
-          local_rhs(i) -= vdcdd * scalar_product(grad_phi_phase_i, dcdd_factor * phase_gradient) * JxW;
+          local_rhs(i) -=
+            vdcdd *
+            scalar_product(grad_phi_phase_i, dcdd_factor * phase_gradient) *
+            JxW;
         }
     }
 }

--- a/source/solvers/vof_assemblers.cc
+++ b/source/solvers/vof_assemblers.cc
@@ -145,18 +145,11 @@ VOFAssemblerCore<dim>::assemble_matrix(VOFScratchData<dim>       &scratch_data,
                                     (grad_phi_phase_i * velocity) * JxW;
 
               // DCDD shock capturing
-              if (DCDD)
-                {
-                  local_matrix(i, j) +=
-                    (vdcdd * scalar_product(grad_phi_phase_j,
-                                            dcdd_factor * grad_phi_phase_i)) *
-                    JxW;
-                }
+              local_matrix(i, j) += (vdcdd * scalar_product(grad_phi_phase_i, dcdd_factor * grad_phi_phase_j) * JxW;
             }
         }
     } // end loop on quadrature points
 }
-
 
 
 template <int dim>
@@ -278,13 +271,7 @@ VOFAssemblerCore<dim>::assemble_rhs(VOFScratchData<dim>       &scratch_data,
             JxW;
 
           // DCDD shock capturing
-          if (DCDD)
-            {
-              local_rhs(i) +=
-                -vdcdd *
-                scalar_product(phase_gradient, dcdd_factor * grad_phi_phase_i) *
-                JxW;
-            }
+          local_rhs(i) -= vdcdd * scalar_product(grad_phi_phase_i, dcdd_factor * phase_gradient) * JxW;
         }
     }
 }

--- a/source/solvers/vof_assemblers.cc
+++ b/source/solvers/vof_assemblers.cc
@@ -145,7 +145,10 @@ VOFAssemblerCore<dim>::assemble_matrix(VOFScratchData<dim>       &scratch_data,
                                     (grad_phi_phase_i * velocity) * JxW;
 
               // DCDD shock capturing
-              local_matrix(i, j) += (vdcdd * scalar_product(grad_phi_phase_i, dcdd_factor * grad_phi_phase_j) * JxW;
+              local_matrix(i, j) +=
+                (vdcdd * scalar_product(grad_phi_phase_i,
+                                        dcdd_factor * grad_phi_phase_j)) *
+                JxW;
             }
         }
     } // end loop on quadrature points


### PR DESCRIPTION
# Description of the problem

- DCDD calculation was done using test function multiplied by the right and function multiplied by the left in VOF and Tracer applications

# Description of the solution

- Fixed the indices
- Plus, the boolean attribute that activated DCDD (previously used for tests) was deprecated

# How Has This Been Tested?

- All tests pass

# Documentation

- No need

# Future changes

- This one solves the issue for DCDD

# Comments

- Maybe this operation can be inverted in other places in the code. I will try to keep an eye on it and change as I go.
