### PR TITLE
Post processing pressure power and viscous dissipation

### DIFF
--- a/applications_tests/lethe-fluid/taylorcouette-unstructured_gls.mpirun=1.output
+++ b/applications_tests/lethe-fluid/taylorcouette-unstructured_gls.mpirun=1.output
@@ -2,10 +2,12 @@ Running on 1 MPI rank(s)...
    Number of active cells:       100
    Number of degrees of freedom: 1320
    Volume of triangulation:      2.94539
+Viscous dissipation : 0.660346
 
 *****************************
 Steady iteration:        1/3
 *****************************
+Viscous dissipation : 0.284746
 
 *****************************
 Steady iteration:        2/3
@@ -13,6 +15,7 @@ Steady iteration:        2/3
    Number of active cells:       400
    Number of degrees of freedom: 5040
    Volume of triangulation:      2.94525
+Viscous dissipation : 0.28448
 
 *****************************
 Steady iteration:        3/3
@@ -20,6 +23,7 @@ Steady iteration:        3/3
    Number of active cells:       1600
    Number of degrees of freedom: 19680
    Volume of triangulation:      2.94524
+Viscous dissipation : 0.284447
 cells  error_velocity    error_pressure   
   100 6.681014e-04    - 1.075422e-02    - 
   400 1.131927e-04 2.56 3.175952e-03 1.76 

--- a/applications_tests/lethe-fluid/taylorcouette-unstructured_gls.prm
+++ b/applications_tests/lethe-fluid/taylorcouette-unstructured_gls.prm
@@ -84,6 +84,15 @@ subsection boundary conditions
 end
 
 #---------------------------------------------------
+# Post-processing
+#---------------------------------------------------
+
+subsection post-processing
+  set verbosity = verbose
+  set calculate viscous dissipation = true
+end
+
+#---------------------------------------------------
 # Manifolds
 #---------------------------------------------------
 

--- a/applications_tests/lethe-fluid/taylorcouette-unstructured_gls.prm
+++ b/applications_tests/lethe-fluid/taylorcouette-unstructured_gls.prm
@@ -88,7 +88,7 @@ end
 #---------------------------------------------------
 
 subsection post-processing
-  set verbosity = verbose
+  set verbosity                     = verbose
   set calculate viscous dissipation = true
 end
 

--- a/applications_tests/lethe-fluid/taylorcouette_gls.mpirun=2.output
+++ b/applications_tests/lethe-fluid/taylorcouette_gls.mpirun=2.output
@@ -2,10 +2,12 @@ Running on 2 MPI rank(s)...
    Number of active cells:       64
    Number of degrees of freedom: 864
    Volume of triangulation:      2.95
+Viscous dissipation : 0.627
 
 *****************************
 Steady iteration:        1/3
 *****************************
+Viscous dissipation : 0.285
 
 +------------------------------------------+
 |  Torque summary                          |
@@ -20,6 +22,7 @@ Steady iteration:        2/3
    Number of active cells:       256
    Number of degrees of freedom: 3264
    Volume of triangulation:      2.95
+Viscous dissipation : 0.284
 
 +------------------------------------------+
 |  Torque summary                          |
@@ -34,6 +37,7 @@ Steady iteration:        3/3
    Number of active cells:       1024
    Number of degrees of freedom: 12672
    Volume of triangulation:      2.95
+Viscous dissipation : 0.284
 
 +------------------------------------------+
 |  Torque summary                          |

--- a/applications_tests/lethe-fluid/taylorcouette_gls.output
+++ b/applications_tests/lethe-fluid/taylorcouette_gls.output
@@ -2,10 +2,12 @@ Running on 1 MPI rank(s)...
    Number of active cells:       64
    Number of degrees of freedom: 864
    Volume of triangulation:      2.95
+Viscous dissipation : 0.627
 
 *****************************
 Steady iteration:        1/3
 *****************************
+Viscous dissipation : 0.285
 
 +------------------------------------------+
 |  Torque summary                          |
@@ -20,6 +22,7 @@ Steady iteration:        2/3
    Number of active cells:       256
    Number of degrees of freedom: 3264
    Volume of triangulation:      2.95
+Viscous dissipation : 0.284
 
 +------------------------------------------+
 |  Torque summary                          |
@@ -34,6 +37,7 @@ Steady iteration:        3/3
    Number of active cells:       1024
    Number of degrees of freedom: 12672
    Volume of triangulation:      2.95
+Viscous dissipation : 0.284
 
 +------------------------------------------+
 |  Torque summary                          |

--- a/applications_tests/lethe-fluid/taylorcouette_gls.prm
+++ b/applications_tests/lethe-fluid/taylorcouette_gls.prm
@@ -103,7 +103,7 @@ end
 #---------------------------------------------------
 
 subsection post-processing
-  set verbosity = verbose
+  set verbosity                     = verbose
   set calculate viscous dissipation = true
 end
 

--- a/applications_tests/lethe-fluid/taylorcouette_gls.prm
+++ b/applications_tests/lethe-fluid/taylorcouette_gls.prm
@@ -99,6 +99,15 @@ subsection boundary conditions
 end
 
 #---------------------------------------------------
+# Post-processing
+#---------------------------------------------------
+
+subsection post-processing
+  set verbosity = verbose
+  set calculate viscous dissipation = true
+end
+
+#---------------------------------------------------
 # Mesh Adaptation Control
 #---------------------------------------------------
 

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -140,7 +140,7 @@ This subsection controls the post-processing other than the forces and torque on
     * The pressure power is calculated as
 
     .. math::
-       \frac{1}{\Omega} \int_{\Omega}  \nabla p \cdot \mathbf{\u} \mathrm{d} \Omega
+       \frac{1}{\Omega} \int_{\Omega}  \nabla p \cdot \mathbf{u} \mathrm{d} \Omega
 
     with :math:`\Omega` representing the volume of the domain, :math:`\mathbf{u}` the velocity  and :math:`p` the pressure.
 

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -35,6 +35,14 @@ This subsection controls the post-processing other than the forces and torque on
     set calculate enstrophy              = false
     set enstrophy name                   = enstrophy
 
+    # Viscous dissipation
+    set calculate viscous dissipation    = false
+    set viscous dissipation name         = viscous_dissipation
+
+    # Pressure power
+    set calculate pressure power         = false
+    set pressure power name              = pressure_power
+
     # Others
     set smoothed output fields           = false
 
@@ -92,15 +100,15 @@ This subsection controls the post-processing other than the forces and torque on
 * ``calculate pressure drop``: controls if calculation of the pressure drop from the inlet boundary to the outlet boundary is enabled.
     * ``inlet boundary id`` and ``outlet boundary id``: define the IDs for inlet and outlet boundaries, respectively. 
     * ``pressure drop name``: output filename for pressure drop calculations.
-    * The pressure drop :math:`\Delta P` and total pressure drop :math:`\Delta P_\text{total}` are calculated as:
+    * The pressure drop :math:`\Delta p` and total pressure drop :math:`\Delta p_\text{total}` are calculated as:
 
     .. math::
-      \Delta P =  \frac{ \int_{\Gamma_\text{inlet}} P \mathrm{d} \Gamma}{\int_{\Gamma_\text{inlet}} 1 \mathrm{d} \Gamma} - \frac{ \int_{\Gamma_\text{outlet}} P \mathrm{d} \Gamma}{\int_{\Gamma_\text{outlet}} 1 \mathrm{d} \Gamma}
+      \Delta p =  \frac{ \int_{\Gamma_\text{inlet}} p \mathrm{d} \Gamma}{\int_{\Gamma_\text{inlet}} 1 \mathrm{d} \Gamma} - \frac{ \int_{\Gamma_\text{outlet}} p \mathrm{d} \Gamma}{\int_{\Gamma_\text{outlet}} 1 \mathrm{d} \Gamma}
 
     .. math::
-      \Delta P_\text{total} =  \frac{ \int_{\Gamma_\text{inlet}} (P + \frac{1}{2} \mathbf{u} \cdot \mathbf{u}) \mathrm{d} \Gamma}{\int_{\Gamma_\text{inlet}} \mathrm{d} \Gamma} - \frac{ \int_{\Gamma_\text{outlet}} (P + \frac{1}{2} \mathbf{u} \cdot \mathbf{u}) \mathrm{d} \Gamma}{\int_{\Gamma_\text{outlet}} \mathrm{d} \Gamma}
+      \Delta p_\text{total} =  \frac{ \int_{\Gamma_\text{inlet}} (p + \frac{1}{2} \mathbf{u} \cdot \mathbf{u}) \mathrm{d} \Gamma}{\int_{\Gamma_\text{inlet}} \mathrm{d} \Gamma} - \frac{ \int_{\Gamma_\text{outlet}} (p + \frac{1}{2} \mathbf{u} \cdot \mathbf{u}) \mathrm{d} \Gamma}{\int_{\Gamma_\text{outlet}} \mathrm{d} \Gamma}
 
-    with :math:`\Gamma` representing the boundary, :math:`\mathbf{u}` the velocity  and :math:`P` the pressure.
+    with :math:`\Gamma` representing the boundary, :math:`\mathbf{u}` the velocity  and :math:`p` the pressure.
 
 * ``calculate flow rate``: controls if calculation of the volumetric flow rates at every boundary is enabled.
     * ``flow rate name``: output filename for flow rate calculations.
@@ -117,6 +125,24 @@ This subsection controls the post-processing other than the forces and torque on
       \mathcal{E} =  \frac{1}{2 \Omega} \int_{\Omega} \mathbf{\omega} \cdot \mathbf{\omega} \mathrm{d} \Omega
 
     with :math:`\Omega` representing the volume of the domain and :math:`\mathbf{\omega}` the vorticity.
+
+* ``calculate viscous dissipation``: controls if the viscous dissipation is calculated
+    * ``viscous dissipation name``: output filename for the viscous dissipation calculations.
+    * The viscous dissipation is calculated as 
+
+    .. math::
+       \frac{1}{\Omega} \int_{\Omega} \mathbf{\tau} : \nabla\mathbf{\u} \mathrm{d} \Omega
+
+    with :math:`\Omega` representing the volume of the domain and :math:`\mathbf{\tau}` the deviatoric stress tensor.
+
+* ``calculate pressure power``: controls if the pressure power is calculated.
+    * ``pressure power name``: output filename for the pressure power calculations.
+    * The pressure power is calculated as
+
+    .. math::
+       \frac{1}{\Omega} \int_{\Omega}  \nabla p \cdot \mathbf{\u} \mathrm{d} \Omega
+
+    with :math:`\Omega` representing the volume of the domain, :math:`\mathbf{u}` the velocity  and :math:`p` the pressure.
 
 * ``smoothed output fields``: controls if the Qcriterion field will be smoothed using an L2-projection over the nodes. The same will shortly be applied to the Vorticity. 
 

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -131,7 +131,7 @@ This subsection controls the post-processing other than the forces and torque on
     * The viscous dissipation is calculated as 
 
     .. math::
-       \frac{1}{\Omega} \int_{\Omega} \mathbf{\tau} : \nabla\mathbf{\u} \mathrm{d} \Omega
+       \frac{1}{\Omega} \int_{\Omega} \mathbf{\tau} : \nabla\mathbf{u} \mathrm{d} \Omega
 
     with :math:`\Omega` representing the volume of the domain and :math:`\mathbf{\tau}` the deviatoric stress tensor.
 

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -126,7 +126,7 @@ This subsection controls the post-processing other than the forces and torque on
 
     with :math:`\Omega` representing the volume of the domain and :math:`\mathbf{\omega}` the vorticity.
 
-* ``calculate viscous dissipation``: controls if the viscous dissipation is calculated
+* ``calculate viscous dissipation``: controls if the viscous dissipation is calculated.
     * ``viscous dissipation name``: output filename for the viscous dissipation calculations.
     * The viscous dissipation is calculated as 
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -813,95 +813,101 @@ namespace Parameters
   {
     Verbosity verbosity;
 
-    // Enable total kinetic energy post-processing
+    /// Enable total kinetic energy post-processing
     bool calculate_kinetic_energy;
 
-    // Enable total enstrophy post-processing
+    /// Enable total enstrophy post-processing
     bool calculate_enstrophy;
 
-    // Enable calculating apparent viscosity
+    /// Enable pressure work post-processing
+    bool calculate_pressure_work;
+
+    /// Enable calculating apparent viscosity
     bool calculate_apparent_viscosity;
 
-    // Enable velocity post-processing
+    /// Enable velocity post-processing
     bool calculate_average_velocities;
 
-    // Enable pressure drop post-processing
+    /// Enable pressure drop post-processing
     bool calculate_pressure_drop;
 
-    // The outlet boundary ID for pressure drop calculation
+    /// The inlet boundary ID for pressure drop calculation
     unsigned int inlet_boundary_id;
 
-    // The outlet boundary ID for pressure drop calculation
+    /// The outlet boundary ID for pressure drop calculation
     unsigned int outlet_boundary_id;
 
-    // Enable flow rate post-processing
+    /// Enable flow rate post-processing
     bool calculate_flow_rate;
 
-    // Set initial time to start calculations for velocities
+    /// Set initial time to start calculations for velocities
     double initial_time;
 
-    // Frequency of the calculation of the post-processed quantity
+    /// Frequency of the calculation of the post-processed quantity
     unsigned int calculation_frequency;
 
-    // Frequency of the output
+    /// Frequency of the output
     unsigned int output_frequency;
 
-    // Prefix for kinetic energy output
+    /// Prefix for kinetic energy output
     std::string kinetic_energy_output_name;
 
-    // Prefix for pressure drop output
+    /// Prefix for pressure drop output
     std::string pressure_drop_output_name;
 
-    // Prefix for flow rate output
+    /// Prefix for flow rate output
     std::string flow_rate_output_name;
 
-    // Prefix for the enstrophy output
+    /// Prefix for the enstrophy output
     std::string enstrophy_output_name;
 
-    // Prefix for the apparent viscosity output
+    /// Prefix for the pressure work output
+    std::string pressure_work_output_name;
+
+    /// Prefix for the apparent viscosity output
     std::string apparent_viscosity_output_name;
 
-    // Enable tracer statistics
+    /// Enable tracer statistics
     bool calculate_tracer_statistics;
 
-    // Prefix for the tracer output
+    /// Prefix for the tracer output
     std::string tracer_output_name;
 
-    // Enable temperature statistics
+    /// Enable temperature statistics
     bool calculate_temperature_statistics;
 
-    // Prefix for the temperature output
+    /// Prefix for the temperature output
     std::string temperature_output_name;
 
-    // Enable calculation of liquid fraction in phase change problems
+    /// Enable calculation of liquid fraction in phase change problems
     bool calculate_liquid_fraction;
 
-    // Prefix for the temperature output
+    /// Prefix for the temperature output
     std::string liquid_fraction_output_name;
 
-    // Enable heat flux calculation
+    /// Enable heat flux calculation
     bool calculate_heat_flux;
 
-    // Prefix for the total heat flux output
+    /// Prefix for the total heat flux output
     std::string heat_flux_output_name;
 
-    // Fluid domain, used when post-processing a multiphase simulation
+    /// Fluid domain, used when post-processing a multiphase simulation
     Parameters::FluidIndicator postprocessed_fluid;
 
-    // Enable barycenter calculation for fluid 1 in VOF and Cahn-Hilliard
-    // simulations
+    /// Enable barycenter calculation for fluid 1 in VOF and Cahn-Hilliard
+    /// simulations
     bool calculate_barycenter;
 
-    // Prefix for the VOF and Cahn-Hilliard barycenter output
+    /// Prefix for the VOF and Cahn-Hilliard barycenter output
     std::string barycenter_output_name;
 
-    // Enable smoothing postprocessed vectors and scalars
+    /// Enable smoothing postprocessed vectors and scalars
     bool smoothed_output_fields;
 
-    // Enable phase statistics
+    /// Enable phase statistics
     bool calculate_phase_statistics;
 
-    // Prefix for the phase output
+    /// Prefix for the phase output
     std::string phase_output_name;
 
     /// Enable mass conservation calculation for both fluids in VOF simulations

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -819,7 +819,7 @@ namespace Parameters
     /// Enable total enstrophy post-processing
     bool calculate_enstrophy;
 
-    /// Enable pressure work post-processing
+    /// Enable pressure power post-processing
     bool calculate_pressure_power;
 
     /// Enable viscous dissipation post-processing
@@ -864,7 +864,7 @@ namespace Parameters
     /// Prefix for the enstrophy output
     std::string enstrophy_output_name;
 
-    /// Prefix for the pressure work output
+    /// Prefix for the pressure power output
     std::string pressure_power_output_name;
 
     /// Prefix for the viscous dissipation output

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -822,6 +822,9 @@ namespace Parameters
     /// Enable pressure work post-processing
     bool calculate_pressure_work;
 
+    /// Enable viscous dissipation post-processing
+    bool calculate_viscous_dissipation;
+
     /// Enable calculating apparent viscosity
     bool calculate_apparent_viscosity;
 
@@ -863,6 +866,9 @@ namespace Parameters
 
     /// Prefix for the pressure work output
     std::string pressure_work_output_name;
+
+    /// Prefix for the viscous dissipation output
+    std::string viscous_dissipation_output_name;
 
     /// Prefix for the apparent viscosity output
     std::string apparent_viscosity_output_name;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -820,7 +820,7 @@ namespace Parameters
     bool calculate_enstrophy;
 
     /// Enable pressure work post-processing
-    bool calculate_pressure_work;
+    bool calculate_pressure_power;
 
     /// Enable viscous dissipation post-processing
     bool calculate_viscous_dissipation;
@@ -865,7 +865,7 @@ namespace Parameters
     std::string enstrophy_output_name;
 
     /// Prefix for the pressure work output
-    std::string pressure_work_output_name;
+    std::string pressure_power_output_name;
 
     /// Prefix for the viscous dissipation output
     std::string viscous_dissipation_output_name;

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -854,6 +854,7 @@ protected:
 
   // Post-processing variables
   TableHandler enstrophy_table;
+  TableHandler pressure_work_table;
   TableHandler kinetic_energy_table;
   TableHandler apparent_viscosity_table;
   TableHandler pressure_drop_table;

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -855,6 +855,7 @@ protected:
   // Post-processing variables
   TableHandler enstrophy_table;
   TableHandler pressure_work_table;
+  TableHandler viscous_dissipation_table;
   TableHandler kinetic_energy_table;
   TableHandler apparent_viscosity_table;
   TableHandler pressure_drop_table;

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -854,7 +854,7 @@ protected:
 
   // Post-processing variables
   TableHandler enstrophy_table;
-  TableHandler pressure_work_table;
+  TableHandler pressure_power_table;
   TableHandler viscous_dissipation_table;
   TableHandler kinetic_energy_table;
   TableHandler apparent_viscosity_table;

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -137,11 +137,10 @@ calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
                          const Mapping<dim>    &mapping);
 
 /**
- * @brief Calculate the average work done by pressure in the simulation domain
+ * @brief Calculate the average power done by pressure in the simulation
+ * domain. The average power is defined as ∫u.∇pdΩ/∫1dΩ
  * @return Average power done by pressure in the simulation domain
  * Post-processing function
- * This function calculates the average power done by pressure in the simulation
- * domain. This average power is defined as P_p = ∫u.∇pdΩ/∫1dΩ
  *
  * @param[in] dof_handler The dof_handler used for the calculation
  *
@@ -159,11 +158,10 @@ calculate_pressure_power(const DoFHandler<dim> &dof_handler,
                          const Mapping<dim>    &mapping);
 
 /**
- * @brief Calculate the viscous dissipation of kinetic energy
+ * @brief Calculate the viscous dissipation of kinetic energy which is defined as
+ *  ∫∇u.τdΩ/∫1dΩ
  * @return Viscous dissipation of kinetic energy
  * Post-processing function
- * This function calculates the viscous energy dissipation which is defined as
- *  W_p = ∫∇u.τdΩ/∫1dΩ
  *
  * @param[in] dof_handler The dof_handler used for the calculation
  *

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -153,10 +153,10 @@ calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
  */
 template <int dim, typename VectorType>
 double
-calculate_pressure_work(const DoFHandler<dim> &dof_handler,
-                        const VectorType      &evaluation_point,
-                        const Quadrature<dim> &quadrature_formula,
-                        const Mapping<dim>    &mapping);
+calculate_pressure_power(const DoFHandler<dim> &dof_handler,
+                         const VectorType      &evaluation_point,
+                         const Quadrature<dim> &quadrature_formula,
+                         const Mapping<dim>    &mapping);
 
 /**
  * @brief Calculate the viscous dissipation of kinetic energy

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -138,10 +138,10 @@ calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
 
 /**
  * @brief Calculate the average work done by pressure in the simulation domain
- * @return average work done by pressure in the simulation domain
+ * @return Average power done by pressure in the simulation domain
  * Post-processing function
- * This function calculates the average work done by pressure in the simulation
- * domain. This average work is defined as the W_p = ∫u.∇pdΩ/∫1dΩ
+ * This function calculates the average power done by pressure in the simulation
+ * domain. This average power is defined as P_p = ∫u.∇pdΩ/∫1dΩ
  *
  * @param[in] dof_handler The dof_handler used for the calculation
  *
@@ -162,8 +162,8 @@ calculate_pressure_power(const DoFHandler<dim> &dof_handler,
  * @brief Calculate the viscous dissipation of kinetic energy
  * @return Viscous dissipation of kinetic energy
  * Post-processing function
- * This function calculates the viscous energy dissipation  which is defined as
- * the W_p = ∫∇u.τdΩ/∫1dΩ
+ * This function calculates the viscous energy dissipation which is defined as
+ *  W_p = ∫∇u.τdΩ/∫1dΩ
  *
  * @param[in] dof_handler The dof_handler used for the calculation
  *

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -140,8 +140,8 @@ calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
  * @brief Calculate the average work done by pressure in the simulation domain
  * @return average work done by pressure in the simulation domain
  * Post-processing function
- * This function calculates the average work done by pressure in the simulation domain. This average
- * work is defined as the W_p = ∫u.∇pdΩ/∫1dΩ
+ * This function calculates the average work done by pressure in the simulation
+ * domain. This average work is defined as the W_p = ∫u.∇pdΩ/∫1dΩ
  *
  * @param[in] dof_handler The dof_handler used for the calculation
  *
@@ -154,9 +154,31 @@ calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
 template <int dim, typename VectorType>
 double
 calculate_pressure_work(const DoFHandler<dim> &dof_handler,
-                         const VectorType      &evaluation_point,
-                         const Quadrature<dim> &quadrature_formula,
-                         const Mapping<dim>    &mapping);
+                        const VectorType      &evaluation_point,
+                        const Quadrature<dim> &quadrature_formula,
+                        const Mapping<dim>    &mapping);
+
+/**
+ * @brief Calculate the viscous dissipation of kinetic energy
+ * @return Viscous dissipation of kinetic energy
+ * Post-processing function
+ * This function calculates the viscous energy dissipation  which is defined as
+ * the W_p = ∫∇u.τdΩ/∫1dΩ
+ *
+ * @param[in] dof_handler The dof_handler used for the calculation
+ *
+ * @param[in] evaluation_point The solution for the calculation
+ *
+ * @param[in] quadrature_formula The quadrature formula for the calculation
+ *
+ * @param[in] mapping The mapping of the simulation
+ */
+template <int dim, typename VectorType>
+double
+calculate_viscous_dissipation(const DoFHandler<dim> &dof_handler,
+                              const VectorType      &evaluation_point,
+                              const Quadrature<dim> &quadrature_formula,
+                              const Mapping<dim>    &mapping);
 
 /**
  * @brief Calculates the apparent viscosity of the fluid for non Newtonian flows.

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -121,17 +121,39 @@ calculate_enstrophy(const DoFHandler<dim> &dof_handler,
  * Post-processing function
  * This function calculates the average kinetic energy in the simulation domain
  *
- * @param dof_handler The dof_handler used for the calculation
+ * @param[in] dof_handler The dof_handler used for the calculation
  *
- * @param evaluation_point The solution at which the force is calculated
+ * @param[in] evaluation_point The solution for the calculation
  *
- * @param quadrature_formula The quadrature formula for the calculation
+ * @param[in] quadrature_formula The quadrature formula for the calculation
  *
- * @param mapping The mapping of the simulation
+ * @param[in] mapping The mapping of the simulation
  */
 template <int dim, typename VectorType>
 double
 calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
+                         const VectorType      &evaluation_point,
+                         const Quadrature<dim> &quadrature_formula,
+                         const Mapping<dim>    &mapping);
+
+/**
+ * @brief Calculate the average work done by pressure in the simulation domain
+ * @return average work done by pressure in the simulation domain
+ * Post-processing function
+ * This function calculates the average work done by pressure in the simulation domain. This average
+ * work is defined as the W_p = ∫u.∇pdΩ/∫1dΩ
+ *
+ * @param[in] dof_handler The dof_handler used for the calculation
+ *
+ * @param[in] evaluation_point The solution for the calculation
+ *
+ * @param[in] quadrature_formula The quadrature formula for the calculation
+ *
+ * @param[in] mapping The mapping of the simulation
+ */
+template <int dim, typename VectorType>
+double
+calculate_pressure_work(const DoFHandler<dim> &dof_handler,
                          const VectorType      &evaluation_point,
                          const Quadrature<dim> &quadrature_formula,
                          const Mapping<dim>    &mapping);

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -64,13 +64,13 @@
  */
 template <int dim, typename VectorType>
 std::pair<double, double>
-calculate_pressure_drop(const DoFHandler<dim>        &dof_handler,
-                        std::shared_ptr<Mapping<dim>> mapping,
-                        const VectorType             &evaluation_point,
-                        const Quadrature<dim>        &cell_quadrature_formula,
-                        const Quadrature<dim - 1>    &face_quadrature_formula,
-                        const unsigned int            inlet_boundary_id,
-                        const unsigned int            outlet_boundary_id);
+calculate_pressure_drop(const DoFHandler<dim>     &dof_handler,
+                        const Mapping<dim>        &mapping,
+                        const VectorType          &evaluation_point,
+                        const Quadrature<dim>     &cell_quadrature_formula,
+                        const Quadrature<dim - 1> &face_quadrature_formula,
+                        const unsigned int         inlet_boundary_id,
+                        const unsigned int         outlet_boundary_id);
 
 /**
  * @brief Calculate the CFL condition on the simulation domain

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -172,13 +172,18 @@ calculate_pressure_power(const DoFHandler<dim> &dof_handler,
  * @param[in] quadrature_formula The quadrature formula for the calculation
  *
  * @param[in] mapping The mapping of the simulation
+ *
+ * @param[in] properties_manager Manager for the physical properties used to
+ * calculate the kinematic viscosity
  */
 template <int dim, typename VectorType>
 double
-calculate_viscous_dissipation(const DoFHandler<dim> &dof_handler,
-                              const VectorType      &evaluation_point,
-                              const Quadrature<dim> &quadrature_formula,
-                              const Mapping<dim>    &mapping);
+calculate_viscous_dissipation(
+  const DoFHandler<dim>           &dof_handler,
+  const VectorType                &evaluation_point,
+  const Quadrature<dim>           &quadrature_formula,
+  const Mapping<dim>              &mapping,
+  const PhysicalPropertiesManager &properties_manager);
 
 /**
  * @brief Calculates the apparent viscosity of the fluid for non Newtonian flows.
@@ -197,11 +202,12 @@ calculate_viscous_dissipation(const DoFHandler<dim> &dof_handler,
  */
 template <int dim, typename VectorType>
 double
-calculate_apparent_viscosity(const DoFHandler<dim>     &dof_handler,
-                             const VectorType          &evaluation_point,
-                             const Quadrature<dim>     &quadrature_formula,
-                             const Mapping<dim>        &mapping,
-                             PhysicalPropertiesManager &properties_manager);
+calculate_apparent_viscosity(
+  const DoFHandler<dim>           &dof_handler,
+  const VectorType                &evaluation_point,
+  const Quadrature<dim>           &quadrature_formula,
+  const Mapping<dim>              &mapping,
+  const PhysicalPropertiesManager &properties_manager);
 
 /**
  * @brief Calculates the force due to the fluid motion on every boundary conditions
@@ -228,7 +234,7 @@ std::vector<std::vector<Tensor<1, dim>>>
 calculate_forces(
   const DoFHandler<dim>                               &dof_handler,
   const VectorType                                    &evaluation_point,
-  PhysicalPropertiesManager                           &properties_manager,
+  const PhysicalPropertiesManager                     &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions,
   const Quadrature<dim - 1>                           &face_quadrature_formula,
   const Mapping<dim>                                  &mapping);
@@ -259,7 +265,7 @@ std::vector<Tensor<1, 3>>
 calculate_torques(
   const DoFHandler<dim>                               &dof_handler,
   const VectorType                                    &evaluation_point,
-  PhysicalPropertiesManager                           &properties_manager,
+  const PhysicalPropertiesManager                     &properties_manager,
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions,
   const Quadrature<dim - 1>                           &face_quadrature_formula,
   const Mapping<dim>                                  &mapping);

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1677,6 +1677,12 @@ namespace Parameters
         "Enable calculation of the pressure work. The pressure work "
         "is calculated from the volumetric integral of u.grad(p) over the domain.");
 
+      prm.declare_entry(
+        "calculate viscous dissipation",
+        "false",
+        Patterns::Bool(),
+        "Enable calculation of the viscous dissipation. The viscous dissipation "
+        "is calculated from the volumetric integral of grad(u).tau over the domain.");
 
       prm.declare_entry("calculate apparent viscosity",
                         "false",
@@ -1739,6 +1745,11 @@ namespace Parameters
                         "pressure_work",
                         Patterns::FileName(),
                         "File output pressure work");
+
+      prm.declare_entry("viscous dissipation name",
+                        "viscous_dissipation",
+                        Patterns::FileName(),
+                        "File output viscous dissipation");
 
       prm.declare_entry("apparent viscosity name",
                         "apparent_viscosity",
@@ -1877,22 +1888,25 @@ namespace Parameters
       calculate_kinetic_energy = prm.get_bool("calculate kinetic energy");
       calculate_enstrophy      = prm.get_bool("calculate enstrophy");
       calculate_pressure_work  = prm.get_bool("calculate pressure work");
+      calculate_viscous_dissipation =
+        prm.get_bool("calculate viscous dissipation");
       calculate_apparent_viscosity =
         prm.get_bool("calculate apparent viscosity");
       calculate_average_velocities =
         prm.get_bool("calculate average velocities");
-      calculate_pressure_drop        = prm.get_bool("calculate pressure drop");
-      inlet_boundary_id              = prm.get_integer("inlet boundary id");
-      outlet_boundary_id             = prm.get_integer("outlet boundary id");
-      calculate_flow_rate            = prm.get_bool("calculate flow rate");
-      initial_time                   = prm.get_double("initial time");
-      kinetic_energy_output_name     = prm.get("kinetic energy name");
-      pressure_drop_output_name      = prm.get("pressure drop name");
-      flow_rate_output_name          = prm.get("flow rate name");
-      enstrophy_output_name          = prm.get("enstrophy name");
-      pressure_work_output_name      = prm.get("pressure work name");
-      apparent_viscosity_output_name = prm.get("apparent viscosity name");
-      output_frequency               = prm.get_integer("output frequency");
+      calculate_pressure_drop         = prm.get_bool("calculate pressure drop");
+      inlet_boundary_id               = prm.get_integer("inlet boundary id");
+      outlet_boundary_id              = prm.get_integer("outlet boundary id");
+      calculate_flow_rate             = prm.get_bool("calculate flow rate");
+      initial_time                    = prm.get_double("initial time");
+      kinetic_energy_output_name      = prm.get("kinetic energy name");
+      pressure_drop_output_name       = prm.get("pressure drop name");
+      flow_rate_output_name           = prm.get("flow rate name");
+      enstrophy_output_name           = prm.get("enstrophy name");
+      pressure_work_output_name       = prm.get("pressure work name");
+      viscous_dissipation_output_name = prm.get("viscous dissipation name");
+      apparent_viscosity_output_name  = prm.get("apparent viscosity name");
+      output_frequency                = prm.get_integer("output frequency");
       calculate_tracer_statistics = prm.get_bool("calculate tracer statistics");
       tracer_output_name          = prm.get("tracer statistics name");
       calculate_phase_statistics  = prm.get_bool("calculate phase statistics");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1744,7 +1744,7 @@ namespace Parameters
       prm.declare_entry("pressure power name",
                         "pressure_power",
                         Patterns::FileName(),
-                        "File output pressure work");
+                        "File output pressure power");
 
       prm.declare_entry("viscous dissipation name",
                         "viscous_dissipation",

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1670,6 +1670,14 @@ namespace Parameters
         "Enable calculation of total enstrophy. The total enstrophy "
         "is calculated from the volumetric integral of the enstrophy over the domain.");
 
+      prm.declare_entry(
+        "calculate pressure work",
+        "false",
+        Patterns::Bool(),
+        "Enable calculation of the pressure work. The pressure work "
+        "is calculated from the volumetric integral of u.grad(p) over the domain.");
+
+
       prm.declare_entry("calculate apparent viscosity",
                         "false",
                         Patterns::Bool(),
@@ -1726,6 +1734,11 @@ namespace Parameters
                         "enstrophy",
                         Patterns::FileName(),
                         "File output enstrophy");
+
+      prm.declare_entry("pressure work name",
+                        "pressure_work",
+                        Patterns::FileName(),
+                        "File output pressure work");
 
       prm.declare_entry("apparent viscosity name",
                         "apparent_viscosity",
@@ -1863,6 +1876,7 @@ namespace Parameters
 
       calculate_kinetic_energy = prm.get_bool("calculate kinetic energy");
       calculate_enstrophy      = prm.get_bool("calculate enstrophy");
+      calculate_pressure_work  = prm.get_bool("calculate pressure work");
       calculate_apparent_viscosity =
         prm.get_bool("calculate apparent viscosity");
       calculate_average_velocities =
@@ -1876,6 +1890,7 @@ namespace Parameters
       pressure_drop_output_name      = prm.get("pressure drop name");
       flow_rate_output_name          = prm.get("flow rate name");
       enstrophy_output_name          = prm.get("enstrophy name");
+      pressure_work_output_name      = prm.get("pressure work name");
       apparent_viscosity_output_name = prm.get("apparent viscosity name");
       output_frequency               = prm.get_integer("output frequency");
       calculate_tracer_statistics = prm.get_bool("calculate tracer statistics");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1671,10 +1671,10 @@ namespace Parameters
         "is calculated from the volumetric integral of the enstrophy over the domain.");
 
       prm.declare_entry(
-        "calculate pressure work",
+        "calculate pressure power",
         "false",
         Patterns::Bool(),
-        "Enable calculation of the pressure work. The pressure work "
+        "Enable calculation of the pressure power. The pressure power "
         "is calculated from the volumetric integral of u.grad(p) over the domain.");
 
       prm.declare_entry(
@@ -1742,7 +1742,7 @@ namespace Parameters
                         "File output enstrophy");
 
       prm.declare_entry("pressure work name",
-                        "pressure_work",
+                        "pressure_power",
                         Patterns::FileName(),
                         "File output pressure work");
 
@@ -1887,7 +1887,7 @@ namespace Parameters
 
       calculate_kinetic_energy = prm.get_bool("calculate kinetic energy");
       calculate_enstrophy      = prm.get_bool("calculate enstrophy");
-      calculate_pressure_work  = prm.get_bool("calculate pressure work");
+      calculate_pressure_power = prm.get_bool("calculate pressure power");
       calculate_viscous_dissipation =
         prm.get_bool("calculate viscous dissipation");
       calculate_apparent_viscosity =
@@ -1903,7 +1903,7 @@ namespace Parameters
       pressure_drop_output_name       = prm.get("pressure drop name");
       flow_rate_output_name           = prm.get("flow rate name");
       enstrophy_output_name           = prm.get("enstrophy name");
-      pressure_work_output_name       = prm.get("pressure work name");
+      pressure_power_output_name      = prm.get("pressure power name");
       viscous_dissipation_output_name = prm.get("viscous dissipation name");
       apparent_viscosity_output_name  = prm.get("apparent viscosity name");
       output_frequency                = prm.get_integer("output frequency");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1741,7 +1741,7 @@ namespace Parameters
                         Patterns::FileName(),
                         "File output enstrophy");
 
-      prm.declare_entry("pressure work name",
+      prm.declare_entry("pressure power name",
                         "pressure_power",
                         Patterns::FileName(),
                         "File output pressure work");

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1238,16 +1238,16 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
     }
 
   // Pressure work
-  if (this->simulation_parameters.post_processing.calculate_pressure_work)
+  if (this->simulation_parameters.post_processing.calculate_pressure_power)
     {
-      double pressure_work = calculate_pressure_work(this->dof_handler,
-                                                     present_solution,
-                                                     *this->cell_quadrature,
-                                                     *this->mapping);
+      double pressure_work = calculate_pressure_power(this->dof_handler,
+                                                      present_solution,
+                                                      *this->cell_quadrature,
+                                                      *this->mapping);
 
-      this->pressure_work_table.add_value(
+      this->pressure_power_table.add_value(
         "time", simulation_control->get_current_time());
-      this->pressure_work_table.add_value("pressure_work", pressure_work);
+      this->pressure_power_table.add_value("pressure_work", pressure_work);
 
       // Display pressure work to screen if verbosity is enabled
       if (this->simulation_parameters.post_processing.verbosity ==
@@ -1264,12 +1264,12 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
         {
           std::string filename =
             simulation_parameters.simulation_control.output_folder +
-            simulation_parameters.post_processing.pressure_work_output_name +
+            simulation_parameters.post_processing.pressure_power_output_name +
             ".dat";
           std::ofstream output(filename.c_str());
-          pressure_work_table.set_precision("time", 12);
-          pressure_work_table.set_precision("pressure_work", 12);
-          this->pressure_work_table.write_text(output);
+          pressure_power_table.set_precision("time", 12);
+          pressure_power_table.set_precision("pressure_work", 12);
+          this->pressure_power_table.write_text(output);
         }
     }
 
@@ -1782,9 +1782,14 @@ NavierStokesBase<dim, VectorType, DofsType>::read_checkpoint()
       deserialize_table(this->enstrophy_table,
                         prefix + post_processing.enstrophy_output_name +
                           suffix);
-    if (post_processing.calculate_pressure_work)
-      deserialize_table(this->pressure_work_table,
-                        prefix + post_processing.pressure_work_output_name +
+    if (post_processing.calculate_pressure_power)
+      deserialize_table(this->pressure_power_table,
+                        prefix + post_processing.pressure_power_output_name +
+                          suffix);
+    if (post_processing.calculate_viscous_dissipation)
+      deserialize_table(this->viscous_dissipation_table,
+                        prefix +
+                          post_processing.viscous_dissipation_output_name +
                           suffix);
     if (post_processing.calculate_kinetic_energy)
       deserialize_table(this->kinetic_energy_table,
@@ -2486,6 +2491,14 @@ NavierStokesBase<dim, VectorType, DofsType>::write_checkpoint()
     if (post_processing.calculate_kinetic_energy)
       serialize_table(this->kinetic_energy_table,
                       prefix + post_processing.kinetic_energy_output_name +
+                        suffix);
+    if (post_processing.calculate_pressure_power)
+      serialize_table(this->pressure_power_table,
+                      prefix + post_processing.pressure_power_output_name +
+                        suffix);
+    if (post_processing.calculate_viscous_dissipation)
+      serialize_table(this->viscous_dissipation_table,
+                      prefix + post_processing.viscous_dissipation_output_name +
                         suffix);
     if (post_processing.calculate_apparent_viscosity)
       serialize_table(this->apparent_viscosity_table,

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1415,7 +1415,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
       double             pressure_drop, total_pressure_drop;
       std::tie(pressure_drop, total_pressure_drop) = calculate_pressure_drop(
         this->dof_handler,
-        this->mapping,
+        *this->mapping,
         this->evaluation_point,
         *this->cell_quadrature,
         *this->face_quadrature,

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1248,7 +1248,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
 
       this->pressure_power_table.add_value(
         "time", simulation_control->get_current_time());
-      this->pressure_power_table.add_value("pressure_work", pressure_power);
+      this->pressure_power_table.add_value("pressure_power", pressure_power);
 
       // Display pressure power to screen if verbosity is enabled
       if (this->simulation_parameters.post_processing.verbosity ==

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1237,7 +1237,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
         }
     }
 
-  // Pressure work
+  // Pressure power
   if (this->simulation_parameters.post_processing.calculate_pressure_power)
     {
       double pressure_work = calculate_pressure_power(this->dof_handler,
@@ -1249,14 +1249,14 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
         "time", simulation_control->get_current_time());
       this->pressure_power_table.add_value("pressure_work", pressure_work);
 
-      // Display pressure work to screen if verbosity is enabled
+      // Display pressure power to screen if verbosity is enabled
       if (this->simulation_parameters.post_processing.verbosity ==
           Parameters::Verbosity::verbose)
         {
-          this->pcout << "Pressure work  : " << pressure_work << std::endl;
+          this->pcout << "Pressure power : " << pressure_work << std::endl;
         }
 
-      // Output pressure work to a text file from processor 0
+      // Output pressure power to a text file from processor 0
       if (simulation_control->get_step_number() %
               this->simulation_parameters.post_processing.output_frequency ==
             0 &&
@@ -1289,7 +1289,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
       this->viscous_dissipation_table.add_value("viscous_dissipation",
                                                 viscous_dissipation);
 
-      // Display pressure work to screen if verbosity is enabled
+      // Display pressure power to screen if verbosity is enabled
       if (this->simulation_parameters.post_processing.verbosity ==
           Parameters::Verbosity::verbose)
         {
@@ -1297,7 +1297,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
                       << std::endl;
         }
 
-      // Output pressure work to a text file from processor 0
+      // Output pressure power to a text file from processor 0
       if (simulation_control->get_step_number() %
               this->simulation_parameters.post_processing.output_frequency ==
             0 &&

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1277,11 +1277,12 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
   // Viscous dissipation
   if (this->simulation_parameters.post_processing.calculate_viscous_dissipation)
     {
-      double viscous_dissipation =
-        calculate_viscous_dissipation(this->dof_handler,
-                                      present_solution,
-                                      *this->cell_quadrature,
-                                      *this->mapping);
+      double viscous_dissipation = calculate_viscous_dissipation(
+        this->dof_handler,
+        present_solution,
+        *this->cell_quadrature,
+        *this->mapping,
+        simulation_parameters.physical_properties_manager);
 
       this->viscous_dissipation_table.add_value(
         "time", simulation_control->get_current_time());

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1240,20 +1240,21 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
   // Pressure power
   if (this->simulation_parameters.post_processing.calculate_pressure_power)
     {
-      double pressure_work = calculate_pressure_power(this->dof_handler,
-                                                      present_solution,
-                                                      *this->cell_quadrature,
-                                                      *this->mapping);
+      const double pressure_power =
+        calculate_pressure_power(this->dof_handler,
+                                 present_solution,
+                                 *this->cell_quadrature,
+                                 *this->mapping);
 
       this->pressure_power_table.add_value(
         "time", simulation_control->get_current_time());
-      this->pressure_power_table.add_value("pressure_work", pressure_work);
+      this->pressure_power_table.add_value("pressure_work", pressure_power);
 
       // Display pressure power to screen if verbosity is enabled
       if (this->simulation_parameters.post_processing.verbosity ==
           Parameters::Verbosity::verbose)
         {
-          this->pcout << "Pressure power : " << pressure_work << std::endl;
+          this->pcout << "Pressure power : " << pressure_power << std::endl;
         }
 
       // Output pressure power to a text file from processor 0
@@ -1268,7 +1269,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
             ".dat";
           std::ofstream output(filename.c_str());
           pressure_power_table.set_precision("time", 12);
-          pressure_power_table.set_precision("pressure_work", 12);
+          pressure_power_table.set_precision("pressure_power", 12);
           this->pressure_power_table.write_text(output);
         }
     }
@@ -1277,7 +1278,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
   // Viscous dissipation
   if (this->simulation_parameters.post_processing.calculate_viscous_dissipation)
     {
-      double viscous_dissipation = calculate_viscous_dissipation(
+      const double viscous_dissipation = calculate_viscous_dissipation(
         this->dof_handler,
         present_solution,
         *this->cell_quadrature,

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -440,6 +440,101 @@ calculate_enstrophy<3, LinearAlgebra::distributed::Vector<double>>(
 
 template <int dim, typename VectorType>
 double
+calculate_pressure_work(const DoFHandler<dim> &dof_handler,
+                    const VectorType      &evaluation_point,
+                    const Quadrature<dim> &quadrature_formula,
+                    const Mapping<dim>    &mapping)
+{
+  const FESystem<dim, dim> fe = dof_handler.get_fe();
+  FEValues<dim>            fe_values(mapping,
+                          fe,
+                          quadrature_formula,
+                          update_values | update_gradients |
+                            update_quadrature_points | update_JxW_values);
+
+  const FEValuesExtractors::Vector velocities(0);
+  const FEValuesExtractors::Scalar pressure(dim);
+
+  const unsigned int n_q_points = quadrature_formula.size();
+
+  std::vector<Tensor<1, dim>> velocity(n_q_points);
+  std::vector<Tensor<1, dim>> pressure_gradients(n_q_points);
+
+  double                      pressure_work = 0.0;
+  double                      domain_volume =
+    GridTools::volume(dof_handler.get_triangulation(), mapping);
+
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->is_locally_owned())
+        {
+          fe_values.reinit(cell);
+
+          fe_values[pressure].get_function_gradients(
+            evaluation_point, pressure_gradients);
+
+          fe_values[velocities].get_function_values(
+            evaluation_point, velocity);
+
+          for (unsigned int q = 0; q < n_q_points; q++)
+            {
+                  pressure_work += velocity[q]*pressure_gradients[q] * fe_values.JxW(q) /
+                        domain_volume;
+            }
+        }
+    }
+  const MPI_Comm mpi_communicator = dof_handler.get_communicator();
+  pressure_work                              = Utilities::MPI::sum(pressure_work, mpi_communicator);
+  return (pressure_work);
+}
+
+template double
+calculate_pressure_work<2, GlobalVectorType>(
+  const DoFHandler<2>    &dof_handler,
+  const GlobalVectorType &evaluation_point,
+  const Quadrature<2>    &quadrature_formula,
+  const Mapping<2>       &mapping);
+
+template double
+calculate_pressure_work<3, GlobalVectorType>(
+  const DoFHandler<3>    &dof_handler,
+  const GlobalVectorType &evaluation_point,
+  const Quadrature<3>    &quadrature_formula,
+  const Mapping<3>       &mapping);
+
+template double
+calculate_pressure_work<2, GlobalBlockVectorType>(
+  const DoFHandler<2>         &dof_handler,
+  const GlobalBlockVectorType &evaluation_point,
+  const Quadrature<2>         &quadrature_formula,
+  const Mapping<2>            &mapping);
+
+template double
+calculate_pressure_work<3, GlobalBlockVectorType>(
+  const DoFHandler<3>         &dof_handler,
+  const GlobalBlockVectorType &evaluation_point,
+  const Quadrature<3>         &quadrature_formula,
+  const Mapping<3>            &mapping);
+
+#ifndef LETHE_USE_LDV
+template double
+calculate_pressure_work<2, LinearAlgebra::distributed::Vector<double>>(
+  const DoFHandler<2>                              &dof_handler,
+  const LinearAlgebra::distributed::Vector<double> &evaluation_point,
+  const Quadrature<2>                              &quadrature_formula,
+  const Mapping<2>                                 &mapping);
+
+template double
+calculate_pressure_work<3, LinearAlgebra::distributed::Vector<double>>(
+  const DoFHandler<3>                              &dof_handler,
+  const LinearAlgebra::distributed::Vector<double> &evaluation_point,
+  const Quadrature<3>                              &quadrature_formula,
+  const Mapping<3>                                 &mapping);
+#endif
+
+
+template <int dim, typename VectorType>
+double
 calculate_kinetic_energy(const DoFHandler<dim> &dof_handler,
                          const VectorType      &evaluation_point,
                          const Quadrature<dim> &quadrature_formula,

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -548,7 +548,6 @@ calculate_viscous_dissipation(
                           update_gradients | update_JxW_values);
 
   const FEValuesExtractors::Vector velocity(0);
-  const FEValuesExtractors::Scalar pressure(dim);
 
   const unsigned int n_q_points = quadrature_formula.size();
 

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -35,16 +35,16 @@ using namespace dealii;
 
 template <int dim, typename VectorType>
 std::pair<double, double>
-calculate_pressure_drop(const DoFHandler<dim>        &dof_handler,
-                        std::shared_ptr<Mapping<dim>> mapping,
-                        const VectorType             &evaluation_point,
-                        const Quadrature<dim>        &cell_quadrature_formula,
-                        const Quadrature<dim - 1>    &face_quadrature_formula,
-                        const unsigned int            inlet_boundary_id,
-                        const unsigned int            outlet_boundary_id)
+calculate_pressure_drop(const DoFHandler<dim>     &dof_handler,
+                        const Mapping<dim>        &mapping,
+                        const VectorType          &evaluation_point,
+                        const Quadrature<dim>     &cell_quadrature_formula,
+                        const Quadrature<dim - 1> &face_quadrature_formula,
+                        const unsigned int         inlet_boundary_id,
+                        const unsigned int         outlet_boundary_id)
 {
   FESystem<dim, dim> fe = dof_handler.get_fe();
-  FEValues<dim>      fe_values(*mapping,
+  FEValues<dim>      fe_values(mapping,
                           fe,
                           cell_quadrature_formula,
                           update_values | update_quadrature_points |
@@ -166,28 +166,28 @@ calculate_pressure_drop(const DoFHandler<dim>        &dof_handler,
 
 template std::pair<double, double>
 calculate_pressure_drop<2, GlobalVectorType>(
-  const DoFHandler<2>        &dof_handler,
-  std::shared_ptr<Mapping<2>> mapping,
-  const GlobalVectorType     &evaluation_point,
-  const Quadrature<2>        &cell_quadrature_formula,
-  const Quadrature<1>        &face_quadrature_formula,
-  const unsigned int          inlet_boundary_id,
-  const unsigned int          outlet_boundary_id);
+  const DoFHandler<2>    &dof_handler,
+  const Mapping<2>       &mapping,
+  const GlobalVectorType &evaluation_point,
+  const Quadrature<2>    &cell_quadrature_formula,
+  const Quadrature<1>    &face_quadrature_formula,
+  const unsigned int      inlet_boundary_id,
+  const unsigned int      outlet_boundary_id);
 
 template std::pair<double, double>
 calculate_pressure_drop<3, GlobalVectorType>(
-  const DoFHandler<3>        &dof_handler,
-  std::shared_ptr<Mapping<3>> mapping,
-  const GlobalVectorType     &evaluation_point,
-  const Quadrature<3>        &cell_quadrature_formula,
-  const Quadrature<2>        &face_quadrature_formula,
-  const unsigned int          inlet_boundary_id,
-  const unsigned int          outlet_boundary_id);
+  const DoFHandler<3>    &dof_handler,
+  const Mapping<3>       &mapping,
+  const GlobalVectorType &evaluation_point,
+  const Quadrature<3>    &cell_quadrature_formula,
+  const Quadrature<2>    &face_quadrature_formula,
+  const unsigned int      inlet_boundary_id,
+  const unsigned int      outlet_boundary_id);
 
 template std::pair<double, double>
 calculate_pressure_drop<2, GlobalBlockVectorType>(
   const DoFHandler<2>         &dof_handler,
-  std::shared_ptr<Mapping<2>>  mapping,
+  const Mapping<2>            &mapping,
   const GlobalBlockVectorType &evaluation_point,
   const Quadrature<2>         &cell_quadrature_formula,
   const Quadrature<1>         &face_quadrature_formula,
@@ -197,7 +197,7 @@ calculate_pressure_drop<2, GlobalBlockVectorType>(
 template std::pair<double, double>
 calculate_pressure_drop<3, GlobalBlockVectorType>(
   const DoFHandler<3>         &dof_handler,
-  std::shared_ptr<Mapping<3>>  mapping,
+  const Mapping<3>            &mapping,
   const GlobalBlockVectorType &evaluation_point,
   const Quadrature<3>         &cell_quadrature_formula,
   const Quadrature<2>         &face_quadrature_formula,
@@ -208,7 +208,7 @@ calculate_pressure_drop<3, GlobalBlockVectorType>(
 template std::pair<double, double>
 calculate_pressure_drop<2, LinearAlgebra::distributed::Vector<double>>(
   const DoFHandler<2>                              &dof_handler,
-  std::shared_ptr<Mapping<2>>                       mapping,
+  const Mapping<2>                                 &mapping,
   const LinearAlgebra::distributed::Vector<double> &evaluation_point,
   const Quadrature<2>                              &cell_quadrature_formula,
   const Quadrature<1>                              &face_quadrature_formula,
@@ -218,7 +218,7 @@ calculate_pressure_drop<2, LinearAlgebra::distributed::Vector<double>>(
 template std::pair<double, double>
 calculate_pressure_drop<3, LinearAlgebra::distributed::Vector<double>>(
   const DoFHandler<3>                              &dof_handler,
-  std::shared_ptr<Mapping<3>>                       mapping,
+  const Mapping<3>                                 &mapping,
   const LinearAlgebra::distributed::Vector<double> &evaluation_point,
   const Quadrature<3>                              &cell_quadrature_formula,
   const Quadrature<2>                              &face_quadrature_formula,


### PR DESCRIPTION
# Description of the problem

- For the analysis of the turbulent taylor-couette problem we need to be able to postprocess the power of the pressure (\nabla p \cdot u) and the viscous dissipation (\tau \cdot \nabla u) in order to do the full kinetic energy balance

# Description of the solution

- Added both features as well as their tables and serialization
- Modified the application test for taylor couette to include the viscous dissipation. If you multiply the viscous dissipation by the volume of the triangulation you get exactly the torque * the angular velocity, which is exactly what we expect
- Added the documentation of the features.

# Comments

- I took the opportunity to make some more things const that should have been const
