### PR TITLE
Add instruction on installing muparser (dependency)

### DIFF
--- a/doc/source/installation/apple_arm.rst
+++ b/doc/source/installation/apple_arm.rst
@@ -17,7 +17,12 @@ The easiest way to install deal.II and its dependencies under Mac OS is through 
 Installing deal.II Using Candi (Step #1)
 -----------------------------------------
 
-To install the dependencies (mpi, p4est, trilinos and METIS) all together using Candi, the following `procedure <https://github.com/dealii/dealii/wiki/Apple-ARM-M1-OSX>`_ on the deal.II wiki can be followed.
+To install the dependencies (mpi, p4est, trilinos and METIS) all together using Candi, the following `procedure <https://github.com/dealii/dealii/wiki/Apple-ARM-M1-OSX>`_ on the deal.II wiki can be followed. You also need to ensure that muParser is installed:
+
+.. code-block:: text
+  :class: copy-button
+
+  sudo apt-get install libmuparser-dev
 
 Clone the candi git repository in a folder of your choice  (e.g. ``$HOME/sofware/``). You can edit the ``candi.cfg`` file if you want to force the installation of the deal.II master version instead of the current stable version by setting the ``STABLE_BUILD=false``. Under Apple ARM, we only recommend the installation of the required libraries, namely parmetis, trilinos and p4est.
 

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -19,7 +19,7 @@ Lethe requires a modern version of the `deal.II library <https://www.dealii.org/
   
 1. :ref:`install-deal.II-apt` (recommended for users)
 2. :ref:`install-deal.II-candi` (recommended for developers) 
-3. :ref:`install-deal.II-manually` (recommended for exerimented developers) 
+3. :ref:`install-deal.II-manually` (recommended for experimented developers)
 
 
 .. _install-deal.II-apt:
@@ -36,6 +36,13 @@ In case you are using Ubuntu, you will need to `update the backports <https://la
 
   sudo add-apt-repository ppa:ginggs/deal.ii-9.5.1-backports
   sudo apt update
+
+A dependency required by Lethe, and that deal.II needs to be compiled with, is muParser:
+
+.. code-block:: text
+  :class: copy-button
+
+  sudo apt-get install libmuparser-dev
 
 To install deal.II, run:
 
@@ -78,6 +85,13 @@ The following packages (which are specified after line 57) should be installed:
     PACKAGES="${PACKAGES} once:p4est"
     PACKAGES="${PACKAGES} once:trilinos"
     PACKAGES="${PACKAGES} dealii"
+
+A dependency required by Lethe, and that deal.II needs to be compiled with, is muParser:
+
+.. code-block:: text
+  :class: copy-button
+
+  sudo apt-get install libmuparser-dev
 
 Other packages can be disabled by simply commenting out the lines (adding an ``#`` at the beggining of the lines)
 
@@ -203,7 +217,7 @@ Configure deal.II in a build folder at the same level as the source code
   mkdir build
   cd build
 
-Depending on how you have installed p4est, Trilinos and METIS, you may need to specify the installation folder of the three libraries
+Depending on how you have installed p4est, Trilinos and METIS, you may need to specify the installation folder of the three libraries. You also need to ensure that muParser is installed.
 
 .. code-block:: text
   :class: copy-button

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -19,7 +19,7 @@ Lethe requires a modern version of the `deal.II library <https://www.dealii.org/
   
 1. :ref:`install-deal.II-apt` (recommended for users)
 2. :ref:`install-deal.II-candi` (recommended for developers) 
-3. :ref:`install-deal.II-manually` (recommended for experimented developers)
+3. :ref:`install-deal.II-manually` (recommended for experienced developers)
 
 
 .. _install-deal.II-apt:

--- a/doc/source/installation/windows_wsl.rst
+++ b/doc/source/installation/windows_wsl.rst
@@ -105,7 +105,14 @@ This is done following `this procedure <https://www.dealii.org/download.html#:~:
   sudo add-apt-repository ppa:ginggs/deal.ii-9.5.1-backports
   sudo apt update
 
-2. |linux_shell| To install deal.II, run:
+2. |linux_shell| A dependency required by Lethe, and that deal.II needs to be compiled with, is muParser:
+
+.. code-block:: text
+  :class: copy-button
+
+  sudo apt-get install libmuparser-dev
+
+3. |linux_shell| To install deal.II, run:
 
 .. code-block:: text
   :class: copy-button
@@ -142,7 +149,8 @@ Installing deal.II using Candi (Step #1)
   bc libgmp-dev build-essential autoconf automake cmake \
   libtool gfortran libboost-all-dev zlib1g-dev openmpi-bin \
   openmpi-common libopenmpi-dev libblas3 libblas-dev \
-  liblapack3 liblapack-dev libsuitesparse-dev
+  liblapack3 liblapack-dev libsuitesparse-dev libmuparser-dev
+
 
 .. tip::
   The symbols ``\`` indicate that this a single command written on multiple lines.


### PR DESCRIPTION
# Description of the problem

- Some computers are missing the muParser dependency.

# Description of the solution

- Lines explaining that it is required and how to install it easily are added to the documentation.

# Documentation

- This PR is only documentation.
