### PR TITLE
Migrate include after ifdefs in core and solver h

### DIFF
--- a/include/core/auxiliary_math_functions.h
+++ b/include/core/auxiliary_math_functions.h
@@ -35,4 +35,4 @@ harmonic_mean(const double &value_one, const double &value_two)
           (value_one + value_two + std::numeric_limits<double>::min()));
 }
 
-#endif // lethe_auxiliary_math_functions_h
+#endif

--- a/include/core/auxiliary_math_functions.h
+++ b/include/core/auxiliary_math_functions.h
@@ -13,12 +13,12 @@
  *
  * ---------------------------------------------------------------------
  */
-#include "core/parameters.h"
 
-#include <cfloat>
 
-#ifndef LETHE_AUXILIARY_MATH_FUNCTIONS_H
-#  define LETHE_AUXILIARY_MATH_FUNCTIONS_H
+#ifndef lethe_auxiliary_math_functions_h
+#define lethe_auxiliary_math_functions_h
+
+#include <limits>
 
 /**
  * Carries out the calculation of the harmonic mean of two values.
@@ -31,7 +31,8 @@
 inline double
 harmonic_mean(const double &value_one, const double &value_two)
 {
-  return (2 * value_one * value_two / (value_one + value_two + DBL_MIN));
+  return (2 * value_one * value_two /
+          (value_one + value_two + std::numeric_limits<double>::min()));
 }
 
-#endif // LETHE_AUXILIARY_MATH_FUNCTIONS_H
+#endif // lethe_auxiliary_math_functions_h

--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -12,9 +12,6 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Bruno Blais, Polytechnique Montreal, 2019 -
  */
 
 #ifndef lethe_boundary_conditions_h

--- a/include/core/dem_properties.h
+++ b/include/core/dem_properties.h
@@ -12,18 +12,15 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Bruno Blais, Polytechnique Montreal, 2020-
  */
 
-#include <iostream>
-#include <string>
-#include <tuple>
-#include <vector>
 
-#ifndef Lethe_DEM_properties_h
-#  define Lethe_DEM_properties_h
+
+#ifndef lethe_dem_properties_h
+#define lethe_dem_properties_h
+
+#include <string>
+#include <vector>
 
 namespace DEM
 {

--- a/include/core/dem_properties.h
+++ b/include/core/dem_properties.h
@@ -24,7 +24,7 @@
 
 namespace DEM
 {
-  /* This enum class is reponsible for the handling the specific indexes of the
+  /* This enum class is responsible for the handling the specific indexes of the
    * particles properties within the property pool and also to generate
    * the associative names for the properties
    * This is the only part where we should use a classical enum because it is

--- a/include/core/evaporation_model.h
+++ b/include/core/evaporation_model.h
@@ -13,6 +13,7 @@
  *
  * ---------------------------------------------------------------------
  */
+
 #ifndef lethe_evaporation_model_h
 #define lethe_evaporation_model_h
 

--- a/include/core/grids.h
+++ b/include/core/grids.h
@@ -12,9 +12,6 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Bruno Blais, Polytechnique Montreal, 2020 -
  */
 
 #ifndef lethe_grids_h

--- a/include/core/ib_particle.h
+++ b/include/core/ib_particle.h
@@ -15,10 +15,14 @@
  *
  */
 
+
+
+#ifndef lethe_ib_particle_h
+#define lethe_ib_particle_h
+
 #include <core/dem_properties.h>
 #include <core/shape.h>
 
-#include <deal.II/base/auto_derivative_function.h>
 #include <deal.II/base/function_signed_distance.h>
 #include <deal.II/base/parsed_function.h>
 #include <deal.II/base/point.h>
@@ -26,9 +30,6 @@
 #include <deal.II/physics/transformations.h>
 
 #include <vector>
-
-#ifndef lethe_ib_particle_h
-#  define lethe_ib_particle_h
 
 using namespace dealii;
 

--- a/include/core/ib_stencil.h
+++ b/include/core/ib_stencil.h
@@ -12,8 +12,6 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
- *
- * Author: Lucka Barbeau, Bruno Blais, Polytechnique Montreal, 2019 -
  */
 
 #ifndef lethe_ib_stencil_h

--- a/include/core/inexact_newton_non_linear_solver.h
+++ b/include/core/inexact_newton_non_linear_solver.h
@@ -14,8 +14,8 @@
  * ---------------------------------------------------------------------
  */
 
-#ifndef lethe_inexact_newton_iteration_non_linear_solver_h
-#define lethe_inexact_newton_iteration_non_linear_solver_h
+#ifndef lethe_inexact_newton_non_linear_solver_h
+#define lethe_inexact_newton_non_linear_solver_h
 
 #include <core/non_linear_solver.h>
 

--- a/include/core/kinsol_newton_non_linear_solver.h
+++ b/include/core/kinsol_newton_non_linear_solver.h
@@ -14,8 +14,8 @@
  * ---------------------------------------------------------------------
  */
 
-#ifndef kinsol_non_linear_solver_h
-#define kinsol_non_linear_solver_h
+#ifndef lethe_kinsol_non_linear_solver_h
+#define lethe_kinsol_non_linear_solver_h
 
 #include <core/non_linear_solver.h>
 #include <core/parameters.h>

--- a/include/core/lethe_grid_tools.h
+++ b/include/core/lethe_grid_tools.h
@@ -13,8 +13,8 @@
  *
  * -------------------------------------------------------------------*/
 
-#ifndef lethe_lethegridtools_h
-#define lethe_lethegridtools_h
+#ifndef lethe_lethe_grid_tools_h
+#define lethe_lethe_grid_tools_h
 
 #include <core/serial_solid.h>
 

--- a/include/core/lethe_grid_tools.h
+++ b/include/core/lethe_grid_tools.h
@@ -18,7 +18,6 @@
 
 #include <core/serial_solid.h>
 
-#include <deal.II/base/table_handler.h>
 #include <deal.II/base/tensor.h>
 
 #include <deal.II/dofs/dof_handler.h>

--- a/include/core/manifolds.h
+++ b/include/core/manifolds.h
@@ -12,9 +12,6 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Bruno Blais, Polytechnique Montreal, 2019 -
  */
 
 #ifndef lethe_manifolds_h

--- a/include/core/mesh_controller.h
+++ b/include/core/mesh_controller.h
@@ -14,8 +14,8 @@
  * ---------------------------------------------------------------------*/
 
 
-#ifndef lethe_mesh_controler_h
-#define lethe_mesh_controler_h
+#ifndef lethe_mesh_controller_h
+#define lethe_mesh_controller_h
 
 /**
  * @Class Controller that target a given number of elements in the mesh. This

--- a/include/core/mesh_controller.h
+++ b/include/core/mesh_controller.h
@@ -17,9 +17,6 @@
 #ifndef lethe_mesh_controler_h
 #define lethe_mesh_controler_h
 
-#include <iostream>
-
-
 /**
  * @Class Controller that target a given number of elements in the mesh. This
  * controller is used to define the coarsening factor.

--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -12,9 +12,6 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Bruno Blais, Polytechnique Montreal, 2019-
  */
 
 /*

--- a/include/core/periodic_hills_grid.h
+++ b/include/core/periodic_hills_grid.h
@@ -12,9 +12,6 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Audrey Collard-Daigneault, Polytechnique Montreal, 2020 -
  */
 
 #ifndef lethe_per_hills_grid_h
@@ -23,7 +20,6 @@
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/manifold_lib.h>
 #include <deal.II/grid/tria.h>

--- a/include/core/phase_change.h
+++ b/include/core/phase_change.h
@@ -14,8 +14,8 @@
  * ---------------------------------------------------------------------
  */
 
-#ifndef phase_change_h
-#define phase_change_h
+#ifndef lethe_phase_change_h
+#define lethe_phase_change_h
 
 #include <core/physical_property_model.h>
 

--- a/include/core/physics_solver.h
+++ b/include/core/physics_solver.h
@@ -13,8 +13,8 @@
  *
  * ---------------------------------------------------------------------*/
 
-#ifndef LETHE_PHYSICSSOLVER
-#define LETHE_PHYSICSSOLVER
+#ifndef lethe_physics_solver_h
+#define lethe_physics_solver_h
 
 #include <core/inexact_newton_non_linear_solver.h>
 #include <core/kinsol_newton_non_linear_solver.h>

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -12,9 +12,6 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Bruno Blais, Polytechnique Montreal, 2020 -
  */
 
 #ifndef lethe_simulation_control_h

--- a/include/core/solid_base.h
+++ b/include/core/solid_base.h
@@ -12,10 +12,6 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Authors: Carole-Anne Daunais, Valérie Bibeau, Polytechnique Montreal, 2020
- * Jeanne Joachim, Polytechnique Montreal, 2020-
  */
 
 #ifndef lethe_solid_base_h

--- a/include/core/solid_objects_parameters.h
+++ b/include/core/solid_objects_parameters.h
@@ -15,8 +15,8 @@
  */
 
 
-#ifndef solid_objects_parameters_h
-#define solid_objects_parameters_h
+#ifndef lethe_solid_objects_parameters_h
+#define lethe_solid_objects_parameters_h
 
 #include <core/parameters.h>
 

--- a/include/core/solid_objects_parameters.h
+++ b/include/core/solid_objects_parameters.h
@@ -12,14 +12,11 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Carole-Anne Daunais, Polytechnique Montreal, 2020 -
  */
 
 
-#ifndef nitsche_h
-#define nitsche_h
+#ifndef solid_objects_parameters_h
+#define solid_objects_parameters_h
 
 #include <core/parameters.h>
 

--- a/include/core/solutions_output.h
+++ b/include/core/solutions_output.h
@@ -12,9 +12,6 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Bruno Blais, Polytechnique Montreal, 2020 -
  */
 
 #ifndef lethe_solutions_output_h

--- a/include/core/tensors_and_points_dimension_manipulation.h
+++ b/include/core/tensors_and_points_dimension_manipulation.h
@@ -12,18 +12,15 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Shahab Golshan, Polytechnique Montreal, 2019
  */
+
+#ifndef tensors_and_points_dimension_manipulation_h
+#define tensors_and_points_dimension_manipulation_h
 
 #include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
 
 using namespace dealii;
-
-#ifndef tensors_and_points_dimension_manipulation_h
-#  define tensors_and_points_dimension_manipulation_h
 
 /**
  * Copies a two-dimensional tensor in a three-dimensional tensor. The third

--- a/include/core/tensors_and_points_dimension_manipulation.h
+++ b/include/core/tensors_and_points_dimension_manipulation.h
@@ -14,8 +14,8 @@
  * ---------------------------------------------------------------------
  */
 
-#ifndef tensors_and_points_dimension_manipulation_h
-#define tensors_and_points_dimension_manipulation_h
+#ifndef lethe_tensors_and_points_dimension_manipulation_h
+#define lethe_tensors_and_points_dimension_manipulation_h
 
 #include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -12,9 +12,6 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Bruno Blais, Polytechnique Montreal, 2020 -
  */
 
 #ifndef lethe_utilities_h

--- a/include/solvers/cahn_hilliard.h
+++ b/include/solvers/cahn_hilliard.h
@@ -26,8 +26,8 @@
  * phase field parameter and the chemical potential.
  */
 
-#ifndef cahn_hilliard_h
-#define cahn_hilliard_h
+#ifndef lethe_cahn_hilliard_h
+#define lethe_cahn_hilliard_h
 
 #include <core/bdf.h>
 #include <core/simulation_control.h>

--- a/include/solvers/cahn_hilliard_assemblers.h
+++ b/include/solvers/cahn_hilliard_assemblers.h
@@ -13,16 +13,14 @@
  *
  * ---------------------------------------------------------------------*/
 
+#ifndef lethe_cahn_hilliard_assemblers_h
+#define lethe_cahn_hilliard_assemblers_h
 
 #include <core/simulation_control.h>
 
 #include <solvers/cahn_hilliard_scratch_data.h>
 #include <solvers/copy_data.h>
 #include <solvers/multiphysics_interface.h>
-
-
-#ifndef lethe_cahn_hilliard_assemblers_h
-#  define lethe_cahn_hilliard_assemblers_h
 
 /**
  * @brief A pure virtual class that serves as an interface for all

--- a/include/solvers/cahn_hilliard_filter.h
+++ b/include/solvers/cahn_hilliard_filter.h
@@ -17,7 +17,6 @@
 #ifndef lethe_cahn_hilliard_filter_h
 #define lethe_cahn_hilliard_filter_h
 
-
 #include <core/parameters_multiphysics.h>
 
 /**

--- a/include/solvers/cahn_hilliard_scratch_data.h
+++ b/include/solvers/cahn_hilliard_scratch_data.h
@@ -16,6 +16,10 @@
  * Scratch data for the CahnHilliard auxiliary physics
  */
 
+
+#ifndef lethe_cahn_hilliard_scratch_data_h
+#define lethe_cahn_hilliard_scratch_data_h
+
 #include <core/multiphysics.h>
 
 #include <solvers/multiphysics_interface.h>
@@ -32,9 +36,6 @@
 
 #include <deal.II/numerics/vector_tools.h>
 
-
-#ifndef lethe_cahn_hilliard_scratch_data_h
-#  define lethe_cahn_hilliard_scratch_data_h
 
 using namespace dealii;
 

--- a/include/solvers/copy_data.h
+++ b/include/solvers/copy_data.h
@@ -15,15 +15,15 @@
  */
 
 
+#ifndef copy_data_navier_stokes_h
+#define copy_data_navier_stokes_h
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/vector.h>
 
 #include <vector>
-
-#ifndef copy_data_navier_stokes_h
-#  define copy_data_navier_stokes_h
 
 using namespace dealii;
 

--- a/include/solvers/copy_data.h
+++ b/include/solvers/copy_data.h
@@ -15,8 +15,8 @@
  */
 
 
-#ifndef copy_data_navier_stokes_h
-#define copy_data_navier_stokes_h
+#ifndef lethe_copy_data_h
+#define lethe_copy_data_h
 
 #include <deal.II/dofs/dof_handler.h>
 

--- a/include/solvers/flow_control.h
+++ b/include/solvers/flow_control.h
@@ -12,9 +12,6 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Audrey Collard-Daigneault, Polytechnique Montreal, 2020 -
  */
 
 #ifndef lethe_flow_control_h

--- a/include/solvers/gls_nitsche_navier_stokes.h
+++ b/include/solvers/gls_nitsche_navier_stokes.h
@@ -12,10 +12,6 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Bruno Blais, Carole-Anne Daunais, Valérie Bibeau, Polytechnique
- Montreal, 2020-
  */
 
 #ifndef lethe_gls_nitsche_navier_stokes_h

--- a/include/solvers/initial_conditions.h
+++ b/include/solvers/initial_conditions.h
@@ -12,9 +12,6 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Bruno Blais, Polytechnique Montreal, 2019 -
  */
 
 #ifndef lethe_initial_conditions_h

--- a/include/solvers/isothermal_compressible_navier_stokes_assembler.h
+++ b/include/solvers/isothermal_compressible_navier_stokes_assembler.h
@@ -13,6 +13,11 @@
  *
  * ---------------------------------------------------------------------*/
 
+
+
+#ifndef lethe_isothermal_compressible_navier_stokes_assembler_h
+#define lethe_isothermal_compressible_navier_stokes_assembler_h
+
 #include <core/boundary_conditions.h>
 #include <core/rheological_model.h>
 #include <core/simulation_control.h>
@@ -20,9 +25,6 @@
 #include <solvers/copy_data.h>
 #include <solvers/navier_stokes_assemblers.h>
 #include <solvers/navier_stokes_scratch_data.h>
-
-#ifndef lethe_isothermal_compressible_navier_stokes_assembler_h
-#  define lethe_isothermal_compressible_navier_stokes_assembler_h
 
 
 /**

--- a/include/solvers/isothermal_compressible_navier_stokes_vof_assembler.h
+++ b/include/solvers/isothermal_compressible_navier_stokes_vof_assembler.h
@@ -14,15 +14,15 @@
  * ---------------------------------------------------------------------*/
 
 
+#ifndef lethe_isothermal_compressible_navier_stokes_vof_assembler_h
+#define lethe_isothermal_compressible_navier_stokes_vof_assembler_h
+
 #include <core/simulation_control.h>
 
 #include <solvers/auxiliary_physics.h>
 #include <solvers/copy_data.h>
 #include <solvers/navier_stokes_assemblers.h>
 #include <solvers/navier_stokes_scratch_data.h>
-
-#ifndef lethe_isothermal_compressible_navier_stokes_vof_assembler_h
-#  define lethe_isothermal_compressible_navier_stokes_vof_assembler_h
 
 
 /**

--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -13,6 +13,8 @@
  *
  * ---------------------------------------------------------------------*/
 
+#ifndef lethe_navier_stokes_assemblers_h
+#define lethe_navier_stokes_assemblers_h
 
 #include <core/ale.h>
 #include <core/boundary_conditions.h>
@@ -21,9 +23,6 @@
 
 #include <solvers/copy_data.h>
 #include <solvers/navier_stokes_scratch_data.h>
-
-#ifndef lethe_navier_stokes_assemblers_h
-#  define lethe_navier_stokes_assemblers_h
 
 
 /*

--- a/include/solvers/navier_stokes_cahn_hilliard_assemblers.h
+++ b/include/solvers/navier_stokes_cahn_hilliard_assemblers.h
@@ -14,15 +14,15 @@
  * ---------------------------------------------------------------------*/
 
 
+#ifndef lethe_navier_stokes_cahn_hilliard_assemblers_h
+#define lethe_navier_stokes_cahn_hilliard_assemblers_h
+
 #include <core/simulation_control.h>
 
 #include <solvers/auxiliary_physics.h>
 #include <solvers/copy_data.h>
 #include <solvers/navier_stokes_assemblers.h>
 #include <solvers/navier_stokes_scratch_data.h>
-
-#ifndef lethe_navier_stokes_cahn_hilliard_assemblers_h
-#  define lethe_navier_stokes_cahn_hilliard_assemblers_h
 
 
 /**

--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -14,6 +14,10 @@
  * ---------------------------------------------------------------------
  */
 
+
+#ifndef lethe_navier_stokes_scratch_data_h
+#define lethe_navier_stokes_scratch_data_h
+
 #include <core/bdf.h>
 #include <core/dem_properties.h>
 #include <core/density_model.h>
@@ -38,11 +42,6 @@
 #include <deal.II/numerics/vector_tools.h>
 
 #include <deal.II/particles/particle_handler.h>
-
-
-
-#ifndef lethe_navier_stokes_scratch_data_h
-#  define lethe_navier_stokes_scratch_data_h
 
 using namespace dealii;
 

--- a/include/solvers/navier_stokes_vof_assemblers.h
+++ b/include/solvers/navier_stokes_vof_assemblers.h
@@ -13,6 +13,9 @@
  *
  * ---------------------------------------------------------------------*/
 
+#ifndef lethe_navier_stokes_vof_assemblers_h
+#define lethe_navier_stokes_vof_assemblers_h
+
 #include <core/evaporation_model.h>
 #include <core/simulation_control.h>
 
@@ -20,9 +23,6 @@
 #include <solvers/navier_stokes_assemblers.h>
 #include <solvers/navier_stokes_scratch_data.h>
 #include <solvers/simulation_parameters.h>
-
-#ifndef lethe_navier_stokes_vof_assemblers_h
-#  define lethe_navier_stokes_vof_assemblers_h
 
 
 /**

--- a/include/solvers/postprocessing_cfd.h
+++ b/include/solvers/postprocessing_cfd.h
@@ -12,35 +12,32 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Audrey Collard-Daigneault, Bruno Blais, Polytechnique Montreal, 2020
- -
  */
 
 
 #ifndef lethe_postprocessing_cfd_h
+#define lethe_postprocessing_cfd_h
 
 
 // Base
-#  include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/quadrature_lib.h>
 
 // Lac
-#  include <deal.II/lac/dynamic_sparsity_pattern.h>
-#  include <deal.II/lac/vector.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/vector.h>
 
 // Dofs
-#  include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_handler.h>
 
 // Fe
-#  include <deal.II/fe/fe.h>
-#  include <deal.II/fe/mapping_fe.h>
+#include <deal.II/fe/fe.h>
+#include <deal.II/fe/mapping_fe.h>
 
 // Lethe includes
-#  include <core/boundary_conditions.h>
-#  include <core/parameters.h>
+#include <core/boundary_conditions.h>
+#include <core/parameters.h>
 
-#  include <solvers/physical_properties_manager.h>
+#include <solvers/physical_properties_manager.h>
 
 /**
  * @brief Calculate the pressure drop and total pressure drop between two boundaries.
@@ -379,6 +376,6 @@ calculate_average_velocity(const DoFHandler<dim> &dof_handler,
 
 
 
-#  define lethe_postprocessing_cfd_h
+#define lethe_postprocessing_cfd_h
 
 #endif

--- a/include/solvers/postprocessing_velocities.h
+++ b/include/solvers/postprocessing_velocities.h
@@ -12,9 +12,6 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Audrey Collard-Daigneault, Polytechnique Montreal, 2020 -
  */
 
 #ifndef lethe_postprocessing_velocities_h

--- a/include/solvers/postprocessors.h
+++ b/include/solvers/postprocessors.h
@@ -1,3 +1,18 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
 
 #ifndef lethe_post_processors_h
 #define lethe_post_processors_h

--- a/include/solvers/postprocessors.h
+++ b/include/solvers/postprocessors.h
@@ -14,8 +14,8 @@
  * ---------------------------------------------------------------------
  */
 
-#ifndef lethe_post_processors_h
-#define lethe_post_processors_h
+#ifndef lethe_postprocessors_h
+#define lethe_postprocessors_h
 
 #include <core/rheological_model.h>
 

--- a/include/solvers/postprocessors_smoothing.h
+++ b/include/solvers/postprocessors_smoothing.h
@@ -14,8 +14,8 @@
  * ---------------------------------------------------------------------
  */
 
-#ifndef lethe_post_processors_smoothing_h
-#define lethe_post_processors_smoothing_h
+#ifndef lethe_postprocessors_smoothing_h
+#define lethe_postprocessors_smoothing_h
 
 #include <core/vector.h>
 

--- a/include/solvers/postprocessors_smoothing.h
+++ b/include/solvers/postprocessors_smoothing.h
@@ -1,3 +1,18 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2019 -  by the Lethe authors
+ *
+ * This file is part of the Lethe library
+ *
+ * The Lethe library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE at
+ * the top level of the Lethe distribution.
+ *
+ * ---------------------------------------------------------------------
+ */
 
 #ifndef lethe_post_processors_smoothing_h
 #define lethe_post_processors_smoothing_h

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -12,9 +12,6 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
-
- *
- * Author: Bruno Blais, Polytechnique Montreal, 2019 -
  */
 
 #ifndef lethe_navier_stokes_solver_parameters_h

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -15,7 +15,7 @@
  */
 
 #ifndef lethe_simulation_parameters_h
-#define lethe_navier_stokes_solver_parameters_h
+#define lethe_simulation_parameters_h
 
 #include <core/ale.h>
 #include <core/boundary_conditions.h>

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -14,7 +14,7 @@
  * ---------------------------------------------------------------------
  */
 
-#ifndef lethe_navier_stokes_solver_parameters_h
+#ifndef lethe_simulation_parameters_h
 #define lethe_navier_stokes_solver_parameters_h
 
 #include <core/ale.h>

--- a/include/solvers/stabilization.h
+++ b/include/solvers/stabilization.h
@@ -15,6 +15,9 @@
  *
  */
 
+#ifndef lethe_stabilization_h
+#define lethe_stabilization_h
+
 #include <deal.II/base/utilities.h>
 
 #include <cmath>
@@ -69,3 +72,6 @@ calculate_navier_stokes_gls_tau_transient(const double u_mag,
                         9 * Utilities::fixed_power<2>(4 * kinematic_viscosity /
                                                       (h * h)));
 }
+
+
+#endif

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -19,7 +19,6 @@
  * dT/dt +  u * gradT = D * div(grad T) + f
  * with T the tracer function, D the diffusivity and f the forcing
  *
- * Author: Bruno Blais, Polytechnique Montreal, 2020-
  */
 
 #ifndef lethe_tracer_h

--- a/include/solvers/tracer_assemblers.h
+++ b/include/solvers/tracer_assemblers.h
@@ -13,15 +13,13 @@
  *
  * ---------------------------------------------------------------------*/
 
+#ifndef lethe_tracer_assemblers_h
+#define lethe_tracer_assemblers_h
 
 #include <core/simulation_control.h>
 
 #include <solvers/copy_data.h>
 #include <solvers/tracer_scratch_data.h>
-
-
-#ifndef lethe_tracer_assemblers_h
-#  define lethe_tracer_assemblers_h
 
 /**
  * @brief A pure virtual class that serves as an interface for all

--- a/include/solvers/tracer_scratch_data.h
+++ b/include/solvers/tracer_scratch_data.h
@@ -12,9 +12,11 @@
  * the top level of the Lethe distribution.
  *
  * ---------------------------------------------------------------------
- *
- * Scratch data for the tracer auxiliary physics
  */
+
+
+#ifndef lethe_tracer_scratch_data_h
+#define lethe_tracer_scratch_data_h
 
 #include <core/ale.h>
 #include <core/multiphysics.h>
@@ -32,9 +34,6 @@
 
 #include <deal.II/numerics/vector_tools.h>
 
-
-#ifndef lethe_tracer_scratch_data_h
-#  define lethe_tracer_scratch_data_h
 
 using namespace dealii;
 

--- a/include/solvers/vof.h
+++ b/include/solvers/vof.h
@@ -14,8 +14,8 @@
  * ---------------------------------------------------------------------
  */
 
-#ifndef lethe_VOF_h
-#define lethe_VOF_h
+#ifndef lethe_vof_h
+#define lethe_vof_h
 
 #include <core/bdf.h>
 #include <core/simulation_control.h>

--- a/include/solvers/vof_assemblers.h
+++ b/include/solvers/vof_assemblers.h
@@ -14,14 +14,13 @@
  * ---------------------------------------------------------------------
  */
 
+#ifndef lethe_vof_assemblers_h
+#define lethe_vof_assemblers_h
+
 #include <core/simulation_control.h>
 
 #include <solvers/copy_data.h>
 #include <solvers/vof_scratch_data.h>
-
-
-#ifndef lethe_vof_assemblers_h
-#  define lethe_vof_assemblers_h
 
 
 /**

--- a/include/solvers/vof_scratch_data.h
+++ b/include/solvers/vof_scratch_data.h
@@ -16,6 +16,10 @@
  * Scratch data for the VOF auxiliary physics
  */
 
+
+#ifndef lethe_vof_scratch_data_h
+#define lethe_vof_scratch_data_h
+
 #include <core/multiphysics.h>
 #include <core/time_integration_utilities.h>
 
@@ -32,8 +36,6 @@
 
 #include <deal.II/numerics/vector_tools.h>
 
-#ifndef lethe_VOF_scratch_data_h
-#  define lethe_VOF_scratch_data_h
 
 using namespace dealii;
 


### PR DESCRIPTION

### Description

Everywhere throughout the include files of the core and the solver library, there were multiple includes that were defined before the #ifndef -> #define -> #endif statements. This is mostly aesthetics, but this can also have a small impact on compilation time, especially on systems with a slow filesystem (e.g. the clusters). See for example: https://stackoverflow.com/questions/20988705/is-an-include-before-ifdef-define-include-guard-okay

Additionally, some of the  include guards were in capital letters, some were not. Heck, some were even missing. So I took the opportunity to uniformize thing. I limited myself to core/solver as a first step, but in a follow-up PR I could do it for the other parts of the library.


### Testing

There are not tests required here. If the code compiles, everything will be fine.

### Documentation

No documentation was modified in the making of this PR.


### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] No other PR is open related to this refactoring
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] If any future works is planed, an issue is opened
- [X] The PR description is cleaned and ready for merge