### PR TITLE
Improve timer output for the fluid applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-07-08
+
+### Changed
+
+- MINOR  The timer output for the lethe-fluid and lethe-fluid-matrix-free applications contains now more detailed elements. Including post-processing capabilities that were not timed, the time spent in reading mesh and manifolds, and setting the initial conditions. [#1187](https://github.com/chaos-polymtl/lethe/pull/1187) 
+
 ## [Master] - 2024-07-05
 
 ### Changed

--- a/doc/source/parameters/cfd/timer.rst
+++ b/doc/source/parameters/cfd/timer.rst
@@ -19,20 +19,18 @@ The following table shows an example of the output of the timer:
 .. code-block:: text
 
     +---------------------------------------------------------+------------+------------+
-    | Total wallclock time elapsed since start                |      16.1s |            |
+    | Total wallclock time elapsed since start                |      1.11s |            |
     |                                                         |            |            |
     | Section                                     | no. calls |  wall time | % of total |
     +---------------------------------------------+-----------+------------+------------+
-    | Assemble RHS                                |         9 |      5.72s |        36% |
-    | Assemble matrix                             |         7 |      7.59s |        47% |
-    | Calculate and output norms after Newton its |         8 |     0.318s |         2% |
-    | Distribute constraints after linear solve   |         7 |   0.00887s |         0% |
-    | Output VTU                                  |         2 |     0.765s |       4.8% |
-    | Read mesh and manifolds                     |         1 |     0.296s |       1.8% |
-    | Set initial conditions                      |         1 |     0.243s |       1.5% |
-    | Setup DOFs                                  |         1 |     0.727s |       4.5% |
-    | Setup ILU                                   |         7 |     0.104s |      0.65% |
-    | Solve linear system                         |         7 |     0.267s |       1.7% |
+    | Assemble RHS                                |         9 |     0.275s |        25% |
+    | Assemble matrix                             |         7 |     0.293s |        26% |
+    | Calculate and output norms after Newton its |         8 |    0.0135s |       1.2% |
+    | Output VTU                                  |         2 |    0.0491s |       4.4% |
+    | Read mesh and manifolds                     |         1 |   0.00733s |      0.66% |
+    | Setup DOFs                                  |         1 |    0.0144s |       1.3% |
+    | Setup ILU                                   |         7 |    0.0801s |       7.2% |
+    | Solve linear system                         |         7 |     0.369s |        33% |
     +---------------------------------------------+-----------+------------+------------+
 
 For every block of functions, Lethe reports the number of calls, the wall time spent and the percentage of time spent in the function. It is important to monitor this when running a simulation. The most important ones from a user perspective in most of the simulations are:

--- a/doc/source/parameters/cfd/timer.rst
+++ b/doc/source/parameters/cfd/timer.rst
@@ -18,29 +18,35 @@ The following table shows an example of the output of the timer:
 
 .. code-block:: text
 
-   +---------------------------------------------+------------+------------+
-   | Total wallclock time elapsed since start    |      11.5s |            |
-   |                                             |            |            |
-   | Section                         | no. calls |  wall time | % of total |
-   +---------------------------------+-----------+------------+------------+
-   | assemble_rhs                    |         4 |      2.28s |        20% |
-   | assemble_system                 |         4 |      7.78s |        68% |
-   | output                          |         2 |      1.21s |        11% |
-   | setup_ILU                       |         4 |     0.164s |       1.4% |
-   | solve_linear_system             |         4 |    0.0812s |      0.71% |
-   +---------------------------------+-----------+------------+------------+
+    +---------------------------------------------------------+------------+------------+
+    | Total wallclock time elapsed since start                |      16.1s |            |
+    |                                                         |            |            |
+    | Section                                     | no. calls |  wall time | % of total |
+    +---------------------------------------------+-----------+------------+------------+
+    | Assemble RHS                                |         9 |      5.72s |        36% |
+    | Assemble matrix                             |         7 |      7.59s |        47% |
+    | Calculate and output norms after Newton its |         8 |     0.318s |         2% |
+    | Distribute constraints after linear solve   |         7 |   0.00887s |         0% |
+    | Output VTU                                  |         2 |     0.765s |       4.8% |
+    | Read mesh and manifolds                     |         1 |     0.296s |       1.8% |
+    | Set initial conditions                      |         1 |     0.243s |       1.5% |
+    | Setup DOFs                                  |         1 |     0.727s |       4.5% |
+    | Setup ILU                                   |         7 |     0.104s |      0.65% |
+    | Solve linear system                         |         7 |     0.267s |       1.7% |
+    +---------------------------------------------+-----------+------------+------------+
 
-For every block of functions, Lethe reports the number of calls, the wall time spent and the percentage of time spent in the function. It is important to monitor this when running a simulation.
+For every block of functions, Lethe reports the number of calls, the wall time spent and the percentage of time spent in the function. It is important to monitor this when running a simulation. The most important ones from a user perspective in most of the simulations are:
 
-* ``assemble_rhs`` refers to the assembly of the right-hand side of the equation, that is the residual of the equation.
+* ``Assemble RHS`` refers to the assembly of the right-hand side of the equation, that is the residual of the equation.
 
-* ``assemble_system`` refers to the time spent assembling the matrix associated with the equation.
+* ``Assemble matrix`` refers to the time spent assembling the matrix associated with the equation.
 
-* ``output`` refers to the output of the ``.vtu``, ``.pvtu`` and ``.pvd`` files.
+* ``Output VTU`` refers to the output of the ``.vtu``, ``.pvtu`` and ``.pvd`` files.
 
-* ``setup_ILU`` or ``setup_AMG`` describe the time spent to set-up the preconditioner.
+* ``Read mesh and manifolds`` refers to the time it takes to create a ``dealii`` triangulation or read a ``gmsh`` one, and attach corresponding manifolds.
 
-* ``solve_linear_system`` refers to the time spent solving the linear system of equations, without the time required to assemble the preconditioner.
+* ``Setup ILU`` describe the time spent to set-up the preconditioner. Other options are ``Setup AMG`` and ``Setup GMG``.
 
+* ``Solve linear system`` refers to the time spent solving the linear system of equations, without the time required to assemble the preconditioner.
 
 Depending on the type of simulation, there may be other categories that appear in the timer. This is useful to monitor the functions responsible for taking up most of the simulation time. 

--- a/source/dem/read_checkpoint.cc
+++ b/source/dem/read_checkpoint.cc
@@ -15,7 +15,7 @@ read_checkpoint(
   std::shared_ptr<Insertion<dim>>                         &insertion_object,
   std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solid_surfaces)
 {
-  TimerOutput::Scope timer(computing_timer, "read_checkpoint");
+  TimerOutput::Scope timer(computing_timer, "Read checkpoint");
   std::string        prefix = parameters.restart.filename;
   simulation_control->read(prefix);
   particles_pvdhandler.read(prefix);

--- a/source/dem/write_checkpoint.cc
+++ b/source/dem/write_checkpoint.cc
@@ -17,7 +17,7 @@ write_checkpoint(
   const ConditionalOStream                                &pcout,
   MPI_Comm                                                &mpi_communicator)
 {
-  TimerOutput::Scope timer(computing_timer, "write_checkpoint");
+  TimerOutput::Scope timer(computing_timer, "Write checkpoint");
 
   pcout << "Writing restart file" << std::endl;
 

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -207,7 +207,7 @@ template <int dim>
 void
 CFDDEMSolver<dim>::write_checkpoint()
 {
-  TimerOutput::Scope timer(this->computing_timer, "write_checkpoint");
+  TimerOutput::Scope timer(this->computing_timer, "Write checkpoint");
 
   std::string prefix =
     this->simulation_parameters.simulation_control.output_folder +
@@ -290,7 +290,7 @@ template <int dim>
 void
 CFDDEMSolver<dim>::read_checkpoint()
 {
-  TimerOutput::Scope timer(this->computing_timer, "read_checkpoint");
+  TimerOutput::Scope timer(this->computing_timer, "Read checkpoint");
   std::string        prefix =
     this->simulation_parameters.simulation_control.output_folder +
     this->simulation_parameters.restart_parameters.filename;

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1123,6 +1123,8 @@ GLSNavierStokesSolver<dim>::set_initial_condition_fd(
   Parameters::InitialConditionType initial_condition_type,
   bool                             restart)
 {
+  TimerOutput::Scope t(this->computing_timer, "Set initial conditions");
+
   if (restart)
     {
       this->pcout << "************************" << std::endl;
@@ -1608,7 +1610,15 @@ GLSNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
                   << solver_control.last_value() << std::endl;
               }
           }
+
+          this->computing_timer.enter_subsection(
+            "Distribute constraints after linear solve");
+
           constraints_used.distribute(completely_distributed_solution);
+
+          this->computing_timer.leave_subsection(
+            "Distribute constraints after linear solve");
+
           auto &newton_update = this->newton_update;
           newton_update       = completely_distributed_solution;
           success             = true;

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1794,12 +1794,16 @@ template <int dim>
 void
 GLSNavierStokesSolver<dim>::solve()
 {
+  this->computing_timer.enter_subsection("Read mesh and manifolds");
+
   read_mesh_and_manifolds(
     *this->triangulation,
     this->simulation_parameters.mesh,
     this->simulation_parameters.manifolds_parameters,
     this->simulation_parameters.restart_parameters.restart,
     this->simulation_parameters.boundary_conditions);
+
+  this->computing_timer.leave_subsection("Read mesh and manifolds");
 
   this->setup_dofs();
   this->enable_dynamic_zero_constraints_fd();

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1123,7 +1123,8 @@ GLSNavierStokesSolver<dim>::set_initial_condition_fd(
   Parameters::InitialConditionType initial_condition_type,
   bool                             restart)
 {
-  TimerOutput::Scope t(this->computing_timer, "Set initial conditions");
+  if (this->simulation_parameters.timer.type == Parameters::Timer::Type::end)
+    TimerOutput::Scope t(this->computing_timer, "Set initial conditions");
 
   if (restart)
     {

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1719,7 +1719,8 @@ MFNavierStokesSolver<dim>::set_initial_condition_fd(
   Parameters::InitialConditionType initial_condition_type,
   bool                             restart)
 {
-  TimerOutput::Scope t(this->computing_timer, "Set initial conditions");
+  if (this->simulation_parameters.timer.type == Parameters::Timer::Type::end)
+    TimerOutput::Scope t(this->computing_timer, "Set initial conditions");
 
   if (restart)
     {

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1471,7 +1471,10 @@ MFNavierStokesSolver<dim>::solve()
   this->set_initial_condition(
     this->simulation_parameters.initial_condition->type,
     this->simulation_parameters.restart_parameters.restart);
-  this->update_multiphysics_time_average_solution();
+
+  // Only needed if other physics apart from fluid dynamics are enabled.
+  if (this->multiphysics->get_active_physics().size() > 1)
+    this->update_multiphysics_time_average_solution();
 
   while (this->simulation_control->integrate())
     {
@@ -1524,8 +1527,10 @@ MFNavierStokesSolver<dim>::solve()
         }
 
       // Provide the fluid dynamics dof_handler, present solution and previous
-      // solution to the multiphysics interface
-      update_solutions_for_multiphysics();
+      // solution to the multiphysics interface only if other physics
+      // apart from fluid dynamics are enabled
+      if (this->multiphysics->get_active_physics().size() > 1)
+        update_solutions_for_multiphysics();
 
       this->iterate();
       this->postprocess(false);
@@ -1673,8 +1678,10 @@ MFNavierStokesSolver<dim>::setup_dofs_fd()
                     this->locally_relevant_dofs,
                     this->mpi_communicator);
 
-  // Provide relevant solution to multiphysics interface
-  update_solutions_for_multiphysics();
+  // Provide relevant solution to multiphysics interface only if other physics
+  // apart from fluid dynamics are enabled.
+  if (this->multiphysics->get_active_physics().size() > 1)
+    update_solutions_for_multiphysics();
 }
 
 template <int dim>

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1456,12 +1456,16 @@ template <int dim>
 void
 MFNavierStokesSolver<dim>::solve()
 {
+  this->computing_timer.enter_subsection("Read mesh and manifolds");
+
   read_mesh_and_manifolds(
     *this->triangulation,
     this->simulation_parameters.mesh,
     this->simulation_parameters.manifolds_parameters,
     this->simulation_parameters.restart_parameters.restart,
     this->simulation_parameters.boundary_conditions);
+
+  this->computing_timer.leave_subsection("Read mesh and manifolds");
 
   this->setup_dofs();
   this->set_initial_condition(
@@ -1503,10 +1507,16 @@ MFNavierStokesSolver<dim>::solve()
 
       if (is_bdf(this->simulation_control->get_assembly_method()))
         {
+          this->computing_timer.enter_subsection(
+            "Calculate time derivative previous solutions");
+
           calculate_time_derivative_previous_solutions();
           this->time_derivative_previous_solutions.update_ghost_values();
           this->system_operator->evaluate_time_derivative_previous_solutions(
             this->time_derivative_previous_solutions);
+
+          this->computing_timer.leave_subsection(
+            "Calculate time derivative previous solutions");
 
           if (this->simulation_parameters.flow_control.enable_flow_control)
             this->system_operator->update_beta_force(
@@ -1702,6 +1712,8 @@ MFNavierStokesSolver<dim>::set_initial_condition_fd(
   Parameters::InitialConditionType initial_condition_type,
   bool                             restart)
 {
+  TimerOutput::Scope t(this->computing_timer, "Set initial conditions");
+
   if (restart)
     {
       this->pcout << "************************" << std::endl;
@@ -1933,9 +1945,7 @@ void
 MFNavierStokesSolver<dim>::assemble_system_matrix()
 {
   // Required for compilation but not used for matrix free solvers.
-  this->computing_timer.enter_subsection("Assemble matrix");
-
-  this->computing_timer.leave_subsection("Assemble matrix");
+  TimerOutput::Scope t(this->computing_timer, "Assemble matrix");
 }
 
 template <int dim>
@@ -1959,6 +1969,9 @@ template <int dim>
 void
 MFNavierStokesSolver<dim>::update_multiphysics_time_average_solution()
 {
+  TimerOutput::Scope t(this->computing_timer,
+                       "Update multiphysics average solution");
+
   if (this->simulation_parameters.post_processing.calculate_average_velocities)
     {
       TrilinosWrappers::MPI::Vector temp_average_velocities(
@@ -1996,7 +2009,7 @@ template <int dim>
 void
 MFNavierStokesSolver<dim>::setup_GMG()
 {
-  this->computing_timer.enter_subsection("Setup GMG");
+  TimerOutput::Scope t(this->computing_timer, "Setup GMG");
 
   if (!gmg_preconditioner)
     gmg_preconditioner = std::make_shared<MFNavierStokesPreconditionGMG<dim>>(
@@ -2013,15 +2026,13 @@ MFNavierStokesSolver<dim>::setup_GMG()
                                  this->flow_control,
                                  this->present_solution,
                                  this->time_derivative_previous_solutions);
-
-  this->computing_timer.leave_subsection("Setup GMG");
 }
 
 template <int dim>
 void
 MFNavierStokesSolver<dim>::setup_ILU()
 {
-  this->computing_timer.enter_subsection("Setup ILU");
+  TimerOutput::Scope t(this->computing_timer, "Setup ILU");
 
   int current_preconditioner_fill_level =
     this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
@@ -2039,8 +2050,6 @@ MFNavierStokesSolver<dim>::setup_ILU()
 
   ilu_preconditioner->initialize(system_operator->get_system_matrix(),
                                  preconditionerOptions);
-
-  this->computing_timer.leave_subsection("Setup ILU");
 }
 
 
@@ -2085,6 +2094,9 @@ template <int dim>
 void
 MFNavierStokesSolver<dim>::update_solutions_for_multiphysics()
 {
+  TimerOutput::Scope t(this->computing_timer,
+                       "Update solutions for multiphysics");
+
   // Provide the fluid dynamics dof_handler to the multiphysics interface
   this->multiphysics->set_dof_handler(PhysicsID::fluid_dynamics,
                                       &this->dof_handler);
@@ -2301,8 +2313,13 @@ void
 MFNavierStokesSolver<dim>::setup_preconditioner()
 {
   this->present_solution.update_ghost_values();
+
+  this->computing_timer.enter_subsection("Evaluate non linear term and tau");
+
   this->system_operator->evaluate_non_linear_term_and_calculate_tau(
     this->present_solution);
+
+  this->computing_timer.leave_subsection("Evaluate non linear term and tau");
 
   if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
         .preconditioner == Parameters::LinearSolver::PreconditionerType::ilu)
@@ -2444,7 +2461,13 @@ MFNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
                   << solver_control.last_value() << std::endl;
     }
 
+  this->computing_timer.enter_subsection(
+    "Distribute constraints after linear solve");
+
   constraints_used.distribute(this->newton_update);
+
+  this->computing_timer.leave_subsection(
+    "Distribute constraints after linear solve");
 }
 
 template class MFNavierStokesSolver<2>;


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

Trying to analyze times for different benchmarks using the matrix-free application, I realized that there were time sections missing, i.e., there was 10-15% of the total time that was not reported in the final time table. In addition, the functions to update multiphysics vectors were always being executed even if only the fluid dynamics was enabled (in these calls we convert from deal.II to Trilinos vectors), which lead to unnecessary time spent there. 

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->

Added additional time sections so that the time summary table reflects the overall time reported at the top.  The changes were also applied to the matrix-based application so that they can be easily compared. The matrix-free application now checks whether other physics are enabled or not to only perform the update of the multiphysics vectors when needed. 

As examples of the new timer output, this is how it would look like for the TGV case:

- For `lethe-fluid`:
```
+---------------------------------------------------------+------------+------------+
| Total wallclock time elapsed since start                |        16s |            |
|                                                         |            |            |
| Section                                     | no. calls |  wall time | % of total |
+---------------------------------------------+-----------+------------+------------+
| Assemble RHS                                |       335 |      4.43s |        28% |
| Assemble matrix                             |       224 |      5.31s |        33% |
| Calculate CFL and percolate time vectors    |       112 |    0.0411s |      0.26% |
| Calculate and output norms after Newton its |       224 |    0.0336s |      0.21% |
| Calculate enstrophy                         |       112 |    0.0717s |      0.45% |
| Calculate kinetic energy                    |       112 |    0.0514s |      0.32% |
| Distribute constraints after linear solve   |       224 |   0.00389s |         0% |
| Read mesh and manifolds                     |         1 |   0.00292s |         0% |
| Set initial conditions                      |         1 |  7.72e-07s |         0% |
| Setup DOFs                                  |         1 |   0.00489s |         0% |
| Setup ILU                                   |       111 |      5.78s |        36% |
| Solve linear system                         |       224 |     0.254s |       1.6% |
| Write checkpoint                            |         1 |   0.00411s |         0% |
+---------------------------------------------+-----------+------------+------------+
```
- For `lethe-fluid-matrix-free`:
```
+----------------------------------------------------------+------------+------------+
| Total wallclock time elapsed since start                 |      8.17s |            |
|                                                          |            |            |
| Section                                      | no. calls |  wall time | % of total |
+----------------------------------------------+-----------+------------+------------+
| Assemble RHS                                 |       338 |    0.0937s |       1.1% |
| Assemble matrix                              |       227 |  0.000153s |         0% |
| Calculate CFL and percolate time vectors     |       112 |    0.0349s |      0.43% |
| Calculate and output norms after Newton its  |       227 |    0.0309s |      0.38% |
| Calculate enstrophy                          |       112 |    0.0642s |      0.79% |
| Calculate kinetic energy                     |       112 |    0.0447s |      0.55% |
| Calculate time derivative previous solutions |       111 |   0.00199s |         0% |
| Distribute constraints after linear solve    |       227 |   0.00216s |         0% |
| Evaluate non linear term and tau             |       111 |    0.0124s |      0.15% |
| Read mesh and manifolds                      |         1 |    0.0029s |         0% |
| Set initial conditions                       |         1 |  6.51e-07s |         0% |
| Setup DoFs                                   |         1 |   0.00221s |         0% |
| Setup GMG                                    |       111 |       2.4s |        29% |
| Solve linear system                          |       227 |      5.46s |        67% |
+----------------------------------------------+-----------+------------+------------+
```
### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

No time outputs are present in any test. However, I tested this with two of the matrix-free benchmarks (steady and transient) to verify that everything works as it should when outputting the timer per iteration or at the end of the simulation. 

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

The `Timer` section in the `General, CFD and Multiphysics ` parameters section of the documentation was updated.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] The PR description is cleaned and ready for merge