### PR TITLE
fix multiphysics examples diagram

### DIFF
--- a/doc/source/examples/multiphysics/multiphysics.rst
+++ b/doc/source/examples/multiphysics/multiphysics.rst
@@ -77,6 +77,7 @@ Multiphysics
       multiphysics_1 -> multiphysics_1_7:w;
       multiphysics_1 -> multiphysics_1_8:w;
       multiphysics_1 -> multiphysics_1_9:w;
+      multiphysics_1 -> multiphysics_1_10:w;
 
       multiphysics_2 -> multiphysics_2_1:w;
       multiphysics_2 -> multiphysics_2_2:w;


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description
Quick fix of the multiphysics diagram in the documentation. The last VOF example ("Air Bubble Compression") was hanging there without being attached to the diagram tree.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planed, an issue is opened
- [x] The PR description is cleaned and ready for merge