### PR TITLE
Correct minor issues in multigrid time summary

### DIFF
--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1178,6 +1178,8 @@ GLSNavierStokesSolver<dim>::set_initial_condition_fd(
       this->pcout << " Initial condition using ramp " << std::endl;
       this->pcout << "*********************************" << std::endl;
 
+      Timer timer(this->mpi_communicator);
+
       this->set_nodal_values();
 
       // Create a pointer to the current viscosity model
@@ -1255,6 +1257,17 @@ GLSNavierStokesSolver<dim>::set_initial_condition_fd(
 
       // Reset kinematic viscosity to simulation parameters
       viscosity_model->set_kinematic_viscosity(viscosity_end);
+
+      timer.stop();
+
+      if (this->simulation_parameters.timer.type !=
+          Parameters::Timer::Type::none)
+        {
+          this->pcout << "*********************************" << std::endl;
+          this->pcout << " Time spent in ramp: " << timer.wall_time() << "s"
+                      << std::endl;
+          this->pcout << "*********************************" << std::endl;
+        }
     }
   else
     {

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1123,9 +1123,6 @@ GLSNavierStokesSolver<dim>::set_initial_condition_fd(
   Parameters::InitialConditionType initial_condition_type,
   bool                             restart)
 {
-  if (this->simulation_parameters.timer.type == Parameters::Timer::Type::end)
-    TimerOutput::Scope t(this->computing_timer, "Set initial conditions");
-
   if (restart)
     {
       this->pcout << "************************" << std::endl;

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -303,6 +303,21 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
           this->pcout << std::endl;
         }
 
+      if (this->simulation_parameters.linear_solver
+            .at(PhysicsID::fluid_dynamics)
+            .mg_verbosity == Parameters::Verbosity::extra_verbose)
+        {
+          this->pcout << "  -MG vertical communication efficiency: "
+                      << MGTools::vertical_communication_efficiency(
+                           this->dof_handler.get_triangulation())
+                      << std::endl;
+
+          this->pcout << "  -MG workload imbalance: "
+                      << MGTools::workload_imbalance(
+                           this->dof_handler.get_triangulation())
+                      << std::endl;
+        }
+
       std::vector<std::shared_ptr<const Utilities::MPI::Partitioner>>
         partitioners(this->dof_handler.get_triangulation().n_global_levels());
 
@@ -643,6 +658,21 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
                              ->n_global_active_cells()
                         << " cells" << std::endl;
           this->pcout << std::endl;
+        }
+
+      if (this->simulation_parameters.linear_solver
+            .at(PhysicsID::fluid_dynamics)
+            .mg_verbosity == Parameters::Verbosity::extra_verbose)
+        {
+          this->pcout << "  -MG vertical communication efficiency: "
+                      << MGTools::vertical_communication_efficiency(
+                           this->coarse_grid_triangulations)
+                      << std::endl;
+
+          this->pcout << "  -MG workload imbalance: "
+                      << MGTools::workload_imbalance(
+                           this->coarse_grid_triangulations)
+                      << std::endl;
         }
 
       // Apply constraints and create mg operators for each level

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -221,14 +221,8 @@ MFNavierStokesPreconditionGMG<dim>::MFNavierStokesPreconditionGMG(
   , simulation_parameters(simulation_parameters)
   , dof_handler(dof_handler)
   , dof_handler_fe_q_iso_q1(dof_handler_fe_q_iso_q1)
-  , mg_setup_timer(MPI_COMM_WORLD,
-                   this->pcout,
-                   TimerOutput::never,
-                   TimerOutput::wall_times)
-  , mg_vmult_timer(MPI_COMM_WORLD,
-                   this->pcout,
-                   TimerOutput::never,
-                   TimerOutput::wall_times)
+  , mg_setup_timer(this->pcout, TimerOutput::never, TimerOutput::wall_times)
+  , mg_vmult_timer(this->pcout, TimerOutput::never, TimerOutput::wall_times)
 {
   if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
         .preconditioner == Parameters::LinearSolver::PreconditionerType::lsmg)

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1743,9 +1743,6 @@ MFNavierStokesSolver<dim>::set_initial_condition_fd(
   Parameters::InitialConditionType initial_condition_type,
   bool                             restart)
 {
-  if (this->simulation_parameters.timer.type == Parameters::Timer::Type::end)
-    TimerOutput::Scope t(this->computing_timer, "Set initial conditions");
-
   if (restart)
     {
       this->pcout << "************************" << std::endl;

--- a/source/solvers/mf_navier_stokes.cc
+++ b/source/solvers/mf_navier_stokes.cc
@@ -1853,6 +1853,8 @@ MFNavierStokesSolver<dim>::set_initial_condition_fd(
       this->pcout << " Initial condition using ramp " << std::endl;
       this->pcout << "*********************************" << std::endl;
 
+      Timer timer(this->mpi_communicator);
+
       // Set the nodal values to have an initial condition that is adequate
       this->set_nodal_values();
       this->present_solution.update_ghost_values();
@@ -1960,6 +1962,17 @@ MFNavierStokesSolver<dim>::set_initial_condition_fd(
             {
               mg_operators[level]->set_kinematic_viscosity(viscosity_end);
             }
+        }
+
+      timer.stop();
+
+      if (this->simulation_parameters.timer.type !=
+          Parameters::Timer::Type::none)
+        {
+          this->pcout << "*********************************" << std::endl;
+          this->pcout << " Time spent in ramp: " << timer.wall_time() << "s"
+                      << std::endl;
+          this->pcout << "*********************************" << std::endl;
         }
     }
   else

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1122,7 +1122,9 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
   if (this->simulation_parameters.post_processing.calculate_average_velocities)
     average_velocities->post_mesh_adaptation();
 
-  this->update_multiphysics_time_average_solution();
+  // Only needed if other physics apart from fluid dynamics are enabled.
+  if (this->multiphysics->get_active_physics().size() > 1)
+    this->update_multiphysics_time_average_solution();
 }
 
 template <int dim, typename VectorType, typename DofsType>
@@ -1198,7 +1200,9 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_uniform()
   if (this->simulation_parameters.post_processing.calculate_average_velocities)
     average_velocities->post_mesh_adaptation();
 
-  this->update_multiphysics_time_average_solution();
+  // Only needed if other physics apart from fluid dynamics are enabled.
+  if (this->multiphysics->get_active_physics().size() > 1)
+    this->update_multiphysics_time_average_solution();
 }
 
 template <int dim, typename VectorType, typename DofsType>


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

The following small problems were found:
1. The timers for mg detailed times were created by specifying the MPI Communicator, however, this does not output the correct min, max and average times. 
2. The initial condition time was somehow overlapping with other timers.
3. The `update_multiphysics_time_average_solution()` was being called when the meshes were refined, however, this is only needed if more than one physics is active. 
- 
### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->

1. The MG timers are now constructed without the MPI communicator.
2. An independent timer was created for the ramp initial condition and it prints the wall time at the end of the ramp. 
3. An if condition checks whether other physics are active.

The last two were solved for both the matrix-based and matrix-free application.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

This was tested locally by using the benchmarks for locally refined meshes. 

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

Nothing needs to be modified. 

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] The PR description is cleaned and ready for merge