### PR TITLE
Tracer flow rate at boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MINOR Renamed all the files related to the `lethe-fluid-matrix-free` application: `mf_navier_stokes` to `fluid_dynamics_matrix_free` and `mf_navier_stokes_operators` to `fluid_dynamics_matrix_free_operators`. The main class `MFNavierStokesSolver` was also renamed to `FluidDynamicsMatrixFree`. [#1222](https://github.com/chaos-polymtl/lethe/pull/1222)
 
+### Added
+
+- MINOR A post-processing feature for the tracer flow rate through boundaries is added. This allows to produce data useful for residence time distribution analyses. [#1197](https://github.com/chaos-polymtl/lethe/pull/1197)
+
+## [Master] - 2024-08-05
+
 ### Removed
 
 - MINOR Removed the gear3 DEM integrator. It was never used, it did not possess any unit test and it was not even clear if it still worked. [#1221](https://github.com/chaos-polymtl/lethe/pull/1211)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MINOR Conditions for whether a boundary condition should be updated were made less restrictive. Now, each physics is responsible for updating or not their boundary conditions. [#1197](https://github.com/chaos-polymtl/lethe/pull/1197)
 
-## [Master] - 2024-08-05
-
 ### Removed
 
 - MINOR Removed the gear3 DEM integrator. It was never used, it did not possess any unit test and it was not even clear if it still worked. [#1221](https://github.com/chaos-polymtl/lethe/pull/1211)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MINOR A post-processing feature for the tracer flow rate through boundaries is added. This allows to produce data useful for residence time distribution analyses. [#1197](https://github.com/chaos-polymtl/lethe/pull/1197)
 
+### Fixed
+
+- MINOR Conditions for whether a boundary condition should be updated were made less restrictive. Now, each physics is responsible for updating or not their boundary conditions. [#1197](https://github.com/chaos-polymtl/lethe/pull/1197)
+
 ## [Master] - 2024-08-05
 
 ### Removed

--- a/applications_tests/lethe-fluid/tracer_flow_rate.output
+++ b/applications_tests/lethe-fluid/tracer_flow_rate.output
@@ -11,16 +11,16 @@ Tracer statistics :
 ------------------
 Tracer flow rates
 ------------------
-Tracer flow rate at the boundaries : 
-	 boundary 0 : 8.2
-	 boundary 1 : 0
-	 boundary 2 : 0
-	 boundary 3 : 0
+Tracer flow rate at the boundaries:
+	 boundary 0: 8.2
+	 boundary 1: 0
+	 boundary 2: 0
+	 boundary 3: 0
 
 *****************************
 Steady iteration:        1/1
 *****************************
-Tracer statistics : 
+Tracer statistics :
 	     Min : 1
 	     Max : 1
 	 Average : 1
@@ -28,8 +28,8 @@ Tracer statistics :
 ------------------
 Tracer flow rates
 ------------------
-Tracer flow rate at the boundaries : 
-	 boundary 0 : 0.2
-	 boundary 1 : -0.200001
-	 boundary 2 : 9.02388e-10
-	 boundary 3 : 2.18592e-09
+Tracer flow rate at the boundaries:
+	 boundary 0: 0.2
+	 boundary 1: -0.200001
+	 boundary 2: 9.02388e-10
+	 boundary 3: 2.18592e-09

--- a/applications_tests/lethe-fluid/tracer_flow_rate.output
+++ b/applications_tests/lethe-fluid/tracer_flow_rate.output
@@ -1,0 +1,35 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       64
+   Number of degrees of freedom: 243
+   Volume of triangulation:      0.04
+   Number of tracer degrees of freedom: 81
+Tracer statistics : 
+	     Min : 0
+	     Max : 0.788675
+	 Average : 0.0625
+	 Std-Dev : 0.19432
+------------------
+Tracer flow rates
+------------------
+Tracer flow rate at the boundaries : 
+	 boundary 0 : 8.2
+	 boundary 1 : 0
+	 boundary 2 : 0
+	 boundary 3 : 0
+
+*****************************
+Steady iteration:        1/1
+*****************************
+Tracer statistics : 
+	     Min : 1
+	     Max : 1
+	 Average : 1
+	 Std-Dev : 3.37941e-09
+------------------
+Tracer flow rates
+------------------
+Tracer flow rate at the boundaries : 
+	 boundary 0 : 0.2
+	 boundary 1 : -0.200001
+	 boundary 2 : 9.02388e-10
+	 boundary 3 : 2.18592e-09

--- a/applications_tests/lethe-fluid/tracer_flow_rate.prm
+++ b/applications_tests/lethe-fluid/tracer_flow_rate.prm
@@ -1,7 +1,7 @@
 set dimension = 2
 
 subsection simulation control
-  set output frequency = 0
+  set output frequency = 1
 end
 
 subsection physical properties

--- a/applications_tests/lethe-fluid/tracer_flow_rate.prm
+++ b/applications_tests/lethe-fluid/tracer_flow_rate.prm
@@ -1,18 +1,10 @@
 set dimension = 2
 
 subsection simulation control
-  set method           = steady
   set output frequency = 0
 end
 
-subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
-end
-
 subsection physical properties
-  set number of fluids = 1
   subsection fluid 0
     set kinematic viscosity = 0.01
     set tracer diffusivity  = 1
@@ -20,8 +12,7 @@ subsection physical properties
 end
 
 subsection multiphysics
-  set fluid dynamics = true
-  set tracer         = true
+  set tracer = true
 end
 
 subsection mesh
@@ -70,9 +61,8 @@ subsection post-processing
   set verbosity                   = verbose
   set calculate tracer statistics = true
   set tracer statistics name      = tracer_statistics
-
-  set calculate tracer flow rate = true
-  set tracer flow rate name      = tracer_flow_rate_test
+  set calculate tracer flow rate  = true
+  set tracer flow rate name       = tracer_flow_rate_test
 end
 
 subsection non-linear solver

--- a/applications_tests/lethe-fluid/tracer_flow_rate.prm
+++ b/applications_tests/lethe-fluid/tracer_flow_rate.prm
@@ -1,0 +1,98 @@
+set dimension = 2
+
+subsection simulation control
+  set method           = steady
+  set output frequency = 0
+end
+
+subsection FEM
+  set velocity order = 1
+  set pressure order = 1
+  set tracer order   = 1
+end
+
+subsection physical properties
+  set number of fluids = 1
+  subsection fluid 0
+    set kinematic viscosity = 0.01
+    set tracer diffusivity  = 1
+  end
+end
+
+subsection multiphysics
+  set fluid dynamics = true
+  set tracer         = true
+end
+
+subsection mesh
+  set type               = dealii
+  set grid type          = subdivided_hyper_rectangle
+  set grid arguments     = 1,  1: -0.1, -0.1: 0.1, 0.1 : true
+  set initial refinement = 3
+end
+
+subsection boundary conditions
+  set number         = 4
+  set time dependent = true
+  subsection bc 0
+    set id   = 0
+    set type = function
+    subsection u
+      set Function expression = 1
+    end
+  end
+  subsection bc 1
+    set id   = 1
+    set type = outlet
+  end
+  subsection bc 2
+    set id   = 2
+    set type = noslip
+  end
+  subsection bc 3
+    set id   = 3
+    set type = noslip
+  end
+end
+
+subsection boundary conditions tracer
+  set number = 1
+  subsection bc 0
+    set id   = 0
+    set type = dirichlet
+    subsection dirichlet
+      set Function expression = 1
+    end
+  end
+end
+
+subsection post-processing
+  set verbosity                   = verbose
+  set calculate tracer statistics = true
+  set tracer statistics name      = tracer_statistics
+
+  set calculate tracer flow rate = true
+  set tracer flow rate name      = tracer_flow_rate_test
+end
+
+subsection non-linear solver
+  subsection fluid dynamics
+    set verbosity      = quiet
+    set tolerance      = 1e-4
+    set max iterations = 10
+  end
+  subsection tracer
+    set verbosity      = quiet
+    set tolerance      = 1e-7
+    set max iterations = 30
+  end
+end
+
+subsection linear solver
+  subsection fluid dynamics
+    set verbosity = quiet
+  end
+  subsection tracer
+    set verbosity = quiet
+  end
+end

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -55,9 +55,11 @@ This subsection controls the post-processing other than the forces and torque on
     #---------------------------------------------------
     # Multiphysics post-processing
     #---------------------------------------------------
-    # Tracer statistics
+    # Tracer postprocessing
     set calculate tracer statistics      = false
     set tracer statistics name           = tracer_statistics
+    set calculate tracer flow rate       = false
+    set tracer flow rate name            = tracer_flow_rate
 
     # Thermal postprocessing
     set postprocessed fluid              = both

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -883,7 +883,7 @@ namespace Parameters
     /// Enable flow rate post-processing
     bool calculate_flow_rate;
 
-    /// Enable flow rate post-processing
+    /// Enable tracer flow rate post-processing
     bool calculate_tracer_flow_rate;
 
     /// Set initial time to start calculations for velocities
@@ -904,7 +904,7 @@ namespace Parameters
     /// Prefix for flow rate output
     std::string flow_rate_output_name;
 
-    /// Prefix for flow rate output
+    /// Prefix for tracer flow rate output
     std::string tracer_flow_rate_output_name;
 
     /// Prefix for the enstrophy output

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -883,6 +883,9 @@ namespace Parameters
     /// Enable flow rate post-processing
     bool calculate_flow_rate;
 
+    /// Enable flow rate post-processing
+    bool calculate_tracer_flow_rate;
+
     /// Set initial time to start calculations for velocities
     double initial_time;
 
@@ -900,6 +903,9 @@ namespace Parameters
 
     /// Prefix for flow rate output
     std::string flow_rate_output_name;
+
+    /// Prefix for flow rate output
+    std::string tracer_flow_rate_output_name;
 
     /// Prefix for the enstrophy output
     std::string enstrophy_output_name;

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -376,12 +376,19 @@ private:
    * @param current_solution_fd current solution for the fluid dynamics, parsed
    * by postprocess
    *
+   * @return values of the tracer flow rate at each boundary
+   *
    * @tparam GlobalVectorType The type of the global vector used for the tracer physic
    */
-
   template <typename GlobalVectorType>
-  void
+  std::vector<double>
   postprocess_tracer_flow_rate(const GlobalVectorType &current_solution_fd);
+
+  /**
+   * @brief Writes the tracer flow rates to an output file
+   */
+  void
+  write_tracer_flow_rates(const std::vector<double> tracer_flow_rate_vector);
 
   /**
    * @brief Writes the tracer statistics to an output file

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -376,7 +376,7 @@ private:
    * @param current_solution_fd current solution for the fluid dynamics, parsed
    * by postprocess
    *
-   * @tparam GlobalVectorType The type of the global vector used for the tracer physics
+   * @tparam GlobalVectorType The type of the global vector used for the tracer physic
    */
 
   template <typename GlobalVectorType>

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -375,6 +375,8 @@ private:
    *
    * @param current_solution_fd current solution for the fluid dynamics, parsed
    * by postprocess
+   *
+   * @tparam GlobalVectorType The type of the global vector used for the tracer physics
    */
 
   template <typename GlobalVectorType>

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -77,6 +77,8 @@ public:
           simulation_parameters.fem_parameters.tracer_order);
         mapping         = std::make_shared<MappingFE<dim>>(*fe);
         cell_quadrature = std::make_shared<QGaussSimplex<dim>>(fe->degree + 1);
+        face_quadrature =
+          std::make_shared<QGaussSimplex<dim - 1>>(fe->degree + 1);
       }
     else
       {
@@ -85,6 +87,7 @@ public:
           simulation_parameters.fem_parameters.tracer_order);
         mapping         = std::make_shared<MappingQ<dim>>(fe->degree);
         cell_quadrature = std::make_shared<QGauss<dim>>(fe->degree + 1);
+        face_quadrature = std::make_shared<QGauss<dim - 1>>(fe->degree + 1);
       }
 
     // Allocate solution transfer
@@ -366,6 +369,18 @@ private:
   void
   calculate_tracer_statistics();
 
+
+  /**
+   * Post-processing. Calculate the tracer flow rate at every boundary.
+   *
+   * @param current_solution_fd current solution for the fluid dynamics, parsed
+   * by postprocess
+   */
+
+  template <typename GlobalVectorType>
+  void
+  postprocess_tracer_flow_rate(const GlobalVectorType &current_solution_fd);
+
   /**
    * @brief Writes the tracer statistics to an output file
    */
@@ -386,9 +401,11 @@ private:
 
   // Finite element spce
   std::shared_ptr<FiniteElement<dim>> fe;
+
   // Mapping and Quadrature
-  std::shared_ptr<Mapping<dim>>    mapping;
-  std::shared_ptr<Quadrature<dim>> cell_quadrature;
+  std::shared_ptr<Mapping<dim>>        mapping;
+  std::shared_ptr<Quadrature<dim>>     cell_quadrature;
+  std::shared_ptr<Quadrature<dim - 1>> face_quadrature;
 
 
   ConvergenceTable error_table;
@@ -422,8 +439,9 @@ private:
   // Assemblers for the matrix and rhs
   std::vector<std::shared_ptr<TracerAssemblerBase<dim>>> assemblers;
 
-  // Tracer statistics table
+  // Tracer post-processing tables
   TableHandler statistics_table;
+  TableHandler tracer_flow_rate_table;
 };
 
 

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -399,7 +399,7 @@ private:
   std::shared_ptr<SimulationControl> simulation_control;
   DoFHandler<dim>                    dof_handler;
 
-  // Finite element spce
+  // Finite element space
   std::shared_ptr<FiniteElement<dim>> fe;
 
   // Mapping and Quadrature

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1807,6 +1807,12 @@ namespace Parameters
                         "Enable calculation of flow rate at boundaries.");
 
       prm.declare_entry(
+        "calculate tracer flow rate",
+        "false",
+        Patterns::Bool(),
+        "Enable calculation of tracer flow rate at boundaries.");
+
+      prm.declare_entry(
         "initial time",
         "0.0",
         Patterns::Double(),
@@ -1826,6 +1832,11 @@ namespace Parameters
                         "flow_rate",
                         Patterns::FileName(),
                         "File output volumetric flux");
+
+      prm.declare_entry("tracer flow rate name",
+                        "tracer_flow_rate",
+                        Patterns::FileName(),
+                        "File output tracer flux");
 
       prm.declare_entry("enstrophy name",
                         "enstrophy",

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1836,7 +1836,7 @@ namespace Parameters
       prm.declare_entry("tracer flow rate name",
                         "tracer_flow_rate",
                         Patterns::FileName(),
-                        "File output tracer flux");
+                        "Output file name for tracer flow rate");
 
       prm.declare_entry("enstrophy name",
                         "enstrophy",

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2008,16 +2008,18 @@ namespace Parameters
         prm.get_bool("calculate apparent viscosity");
       calculate_average_velocities =
         prm.get_bool("calculate average velocities");
-      calculate_pressure_drop         = prm.get_bool("calculate pressure drop");
-      inlet_boundary_id               = prm.get_integer("inlet boundary id");
-      outlet_boundary_id              = prm.get_integer("outlet boundary id");
-      calculate_flow_rate             = prm.get_bool("calculate flow rate");
-      initial_time                    = prm.get_double("initial time");
-      kinetic_energy_output_name      = prm.get("kinetic energy name");
-      pressure_drop_output_name       = prm.get("pressure drop name");
-      flow_rate_output_name           = prm.get("flow rate name");
-      enstrophy_output_name           = prm.get("enstrophy name");
-      pressure_power_output_name      = prm.get("pressure power name");
+      calculate_pressure_drop      = prm.get_bool("calculate pressure drop");
+      inlet_boundary_id            = prm.get_integer("inlet boundary id");
+      outlet_boundary_id           = prm.get_integer("outlet boundary id");
+      calculate_flow_rate          = prm.get_bool("calculate flow rate");
+      calculate_tracer_flow_rate   = prm.get_bool("calculate tracer flow rate");
+      initial_time                 = prm.get_double("initial time");
+      kinetic_energy_output_name   = prm.get("kinetic energy name");
+      pressure_drop_output_name    = prm.get("pressure drop name");
+      flow_rate_output_name        = prm.get("flow rate name");
+      tracer_flow_rate_output_name = prm.get("tracer flow rate name");
+      enstrophy_output_name        = prm.get("enstrophy name");
+      pressure_power_output_name   = prm.get("pressure power name");
       viscous_dissipation_output_name = prm.get("viscous dissipation name");
       apparent_viscosity_output_name  = prm.get("apparent viscosity name");
       output_frequency                = prm.get_integer("output frequency");

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -1373,24 +1373,11 @@ CFDDEMSolver<dim>::solve()
   while (this->simulation_control->integrate())
     {
       this->simulation_control->print_progression(this->pcout);
-      bool refinement_step;
-      if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
-        refinement_step =
-          this->simulation_control->get_step_number() %
-            this->simulation_parameters.mesh_adaptation.frequency !=
-          0;
-      else
-        refinement_step = this->simulation_control->get_step_number() == 0;
-      if (refinement_step ||
-          this->simulation_parameters.mesh_adaptation.type ==
-            Parameters::MeshAdaptation::Type::none ||
-          this->simulation_control->is_at_start())
-        {
-          // We allow the physics to update their boundary conditions
-          // according to their own parameters
-          this->update_boundary_conditions();
-          this->multiphysics->update_boundary_conditions();
-        }
+
+      // We allow the physics to update their boundary conditions
+      // according to their own parameters
+      this->update_boundary_conditions();
+      this->multiphysics->update_boundary_conditions();
 
       this->dynamic_flow_control();
 

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -1994,24 +1994,11 @@ FluidDynamicsVANS<dim>::solve()
   while (this->simulation_control->integrate())
     {
       this->simulation_control->print_progression(this->pcout);
-      bool refinement_step;
-      if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
-        refinement_step =
-          this->simulation_control->get_step_number() %
-            this->simulation_parameters.mesh_adaptation.frequency !=
-          0;
-      else
-        refinement_step = this->simulation_control->get_step_number() == 0;
-      if ((refinement_step ||
-           this->simulation_parameters.mesh_adaptation.type ==
-             Parameters::MeshAdaptation::Type::none ||
-           this->simulation_control->is_at_start()))
-        {
-          // We allow the physics to update their boundary conditions
-          // according to their own parameters
-          this->update_boundary_conditions();
-          this->multiphysics->update_boundary_conditions();
-        }
+
+      // We allow the physics to update their boundary conditions
+      // according to their own parameters
+      this->update_boundary_conditions();
+      this->multiphysics->update_boundary_conditions();
 
       this->dynamic_flow_control();
 

--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -4885,24 +4885,10 @@ GLSSharpNavierStokesSolver<dim>::solve()
       this->forcing_function->set_time(
         this->simulation_control->get_current_time());
 
-      bool refinement_step;
-      if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
-        refinement_step =
-          this->simulation_control->get_step_number() %
-            this->simulation_parameters.mesh_adaptation.frequency !=
-          0;
-      else
-        refinement_step = this->simulation_control->get_step_number() == 0;
-      if (refinement_step ||
-          this->simulation_parameters.mesh_adaptation.type ==
-            Parameters::MeshAdaptation::Type::none ||
-          this->simulation_control->is_at_start())
-        {
-          // We allow the physics to update their boundary conditions
-          // according to their own parameters
-          this->update_boundary_conditions();
-          this->multiphysics->update_boundary_conditions();
-        }
+      // We allow the physics to update their boundary conditions
+      // according to their own parameters
+      this->update_boundary_conditions();
+      this->multiphysics->update_boundary_conditions();
 
       if (some_particles_are_coupled == false)
         integrate_particles();

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -1915,23 +1915,8 @@ FluidDynamicsMatrixFree<dim>::solve()
         this->forcing_function->set_time(
           this->simulation_control->get_current_time());
 
-      bool refinement_step;
-      if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
-        refinement_step =
-          this->simulation_control->get_step_number() %
-            this->simulation_parameters.mesh_adaptation.frequency !=
-          0;
-      else
-        refinement_step = this->simulation_control->get_step_number() == 0;
-      if ((refinement_step ||
-           this->simulation_parameters.mesh_adaptation.type ==
-             Parameters::MeshAdaptation::Type::none ||
-           this->simulation_control->is_at_start()) &&
-          this->simulation_parameters.boundary_conditions.time_dependent)
-        {
-          update_boundary_conditions();
-          this->multiphysics->update_boundary_conditions();
-        }
+      update_boundary_conditions();
+      this->multiphysics->update_boundary_conditions();
 
       this->simulation_control->print_progression(this->pcout);
       this->dynamic_flow_control();

--- a/source/solvers/gls_navier_stokes.cc
+++ b/source/solvers/gls_navier_stokes.cc
@@ -1826,24 +1826,10 @@ GLSNavierStokesSolver<dim>::solve()
       this->forcing_function->set_time(
         this->simulation_control->get_current_time());
 
-      bool refinement_step;
-      if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
-        refinement_step =
-          this->simulation_control->get_step_number() %
-            this->simulation_parameters.mesh_adaptation.frequency !=
-          0;
-      else
-        refinement_step = this->simulation_control->get_step_number() == 0;
-      if (refinement_step ||
-          this->simulation_parameters.mesh_adaptation.type ==
-            Parameters::MeshAdaptation::Type::none ||
-          this->simulation_control->is_at_start())
-        {
-          // We allow the physics to update their boundary conditions
-          // according to their own parameters
-          this->update_boundary_conditions();
-          this->multiphysics->update_boundary_conditions();
-        }
+      // We allow the physics to update their boundary conditions
+      // according to their own parameters
+      this->update_boundary_conditions();
+      this->multiphysics->update_boundary_conditions();
 
       this->simulation_control->print_progression(this->pcout);
       this->dynamic_flow_control();

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1548,8 +1548,6 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
         }
     }
 
-  // this->computing_timer.leave_subsection("Postprocessing");
-
   if (!firstIter)
     {
       // Calculate forces on the boundary conditions

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -687,7 +687,7 @@ Tracer<dim>::postprocess_tracer_flow_rate(const VectorType &current_solution_fd)
     tracer_flow_rate_vector[i_bc] =
       Utilities::MPI::sum(tracer_flow_rate_vector[i_bc], mpi_communicator);
 
-  // Filling table
+  // Fill table
   this->tracer_flow_rate_table.add_value(
     "time", this->simulation_control->get_current_time());
   this->tracer_flow_rate_table.set_precision("time", 12);
@@ -707,11 +707,11 @@ Tracer<dim>::postprocess_tracer_flow_rate(const VectorType &current_solution_fd)
   if (simulation_parameters.post_processing.verbosity ==
       Parameters::Verbosity::verbose)
     {
-      this->pcout << "Tracer flow rate at the boundaries : " << std::endl;
+      this->pcout << "Tracer flow rate at the boundaries: " << std::endl;
       for (unsigned int i_bc = 0;
            i_bc < this->simulation_parameters.boundary_conditions.size;
            ++i_bc)
-        this->pcout << "\t boundary " << i_bc << " : "
+        this->pcout << "\t boundary " << i_bc << ": "
                     << tracer_flow_rate_vector[i_bc] << std::endl;
     }
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

An application of the tracer physics is to obtain the residence time distribution (RTD) of a flow through a domain. This PR adds the post-processing option that outputs the tracer flow rate at every boundary, providing the data for RTD analyses.

In addition, a bug where the conditions to allow `boundary conditions` to update their values were too strict was rectified. Each physics is now responsible for deciding when to update their boundary conditions, and this condition was already based on whether boundary conditions were time-dependent. 

<!-- Explain the content of the new feature
       What are the motivations? 
       How is it integrated to the current code? -->

### Testing



<!-- How has this been tested?
       What are the new test(s) and what feature(s)/parameter(s) does it test?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works?
       How will you ensure that it will continue to work in the future? -->

### Documentation

<!-- Does this new feature introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Lethe documentation is up to date
- [x] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge