### PR TITLE
Fix the ASC application test for CFD-DEM

### DIFF
--- a/applications_tests/lethe-fluid-particles/adaptive_sparse_contacts.mpirun=1.output
+++ b/applications_tests/lethe-fluid-particles/adaptive_sparse_contacts.mpirun=1.output
@@ -1,23 +1,23 @@
 Running on 1 MPI rank(s)...
 DEM time-step is 2.34951% of Rayleigh time step
-Reading DEM checkpoint
-Finished reading DEM checkpoint
-350 particles are in the simulation
+Reading DEM checkpoint 
+Finished reading DEM checkpoint 
+350 particles are in the simulation 
    Number of active cells:       8
    Number of degrees of freedom: 144
    Volume of triangulation:      0.00125
 ---------------------------------------------------------------
-Initializing DEM parameters
-Warning: expansion of particle-wall contact list is disabled.
-This feature is useful in geometries with concave boundaries.
-Finished initializing DEM parameters
-DEM time-step is 2e-05 s
+Initializing DEM parameters 
+Warning: expansion of particle-wall contact list is disabled. 
+This feature is useful in geometries with concave boundaries. 
+Finished initializing DEM parameters 
+DEM time-step is 2e-05 s 
 --------------
 Void Fraction
 --------------
 
 *******************************************************************************
-Transient iteration: 1        Time: 0.001    Time step: 0.001    CFL: 0
+Transient iteration: 1        Time: 0.001    Time step: 0.001    CFL: 0       
 *******************************************************************************
 --------------
 Void Fraction
@@ -30,7 +30,7 @@ DEM
 ----
 DEM contact search at dem step 0
 DEM contact search at dem step 1
-Finished 50 DEM iterations
+Finished 50 DEM iterations 
 ---------------------------------------------------------------
 Global continuity equation error: 2.803e-09 s^-1
 Max local continuity error: 7.07295e-08 s^-1
@@ -44,140 +44,86 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-----
-DEM
-----
-DEM contact search at dem step 1
-Finished 50 DEM iterations
----------------------------------------------------------------
-Global continuity equation error: -1.26904e-09 s^-1
-Max local continuity error: 7.28588e-07 s^-1
-
-**********************************************************************************
-Transient iteration: 3        Time: 0.003    Time step: 0.001    CFL: 0.000149645
-**********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-----
-DEM
-----
-DEM contact search at dem step 1
-Finished 50 DEM iterations
----------------------------------------------------------------
-Global continuity equation error: 3.9841e-09 s^-1
-Max local continuity error: 1.05602e-06 s^-1
-
-**********************************************************************************
-Transient iteration: 4        Time: 0.004    Time step: 0.001    CFL: 0.000224447
-**********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-----
-DEM
-----
-DEM contact search at dem step 1
-Finished 50 DEM iterations
----------------------------------------------------------------
-Global continuity equation error: 1.16336e-09 s^-1
-Max local continuity error: 1.41713e-06 s^-1
-
-**********************************************************************************
-Transient iteration: 5        Time: 0.005    Time step: 0.001    CFL: 0.000299344
-**********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
 print_from_processor_0
 8
 [deal.II intermediate Patch<3,3>]
 7
-0 0 0 0.05 0 0 0 0.0625 0 0.05 0.0625 0 0 0 0.05 0.05 0 0.05 0 0.0625 0.05 0.05 0.0625 0.05
-4294967295 4294967295 4294967295 1 4294967295 4294967295
+0 0 0 0.05 0 0 0 0.0625 0 0.05 0.0625 0 0 0 0.05 0.05 0 0.05 0 0.0625 0.05 0.05 0.0625 0.05 
+4294967295 4294967295 4294967295 1 4294967295 4294967295 
 0 1
 0
 1 8
-4 4 4 4 4 4 4 4
+4 4 4 4 4 4 4 4 
 
 
 [deal.II intermediate Patch<3,3>]
 7
-0 0.0625 0 0.05 0.0625 0 0 0.125 0 0.05 0.125 0 0 0.0625 0.05 0.05 0.0625 0.05 0 0.125 0.05 0.05 0.125 0.05
-4294967295 4294967295 0 2 4294967295 4294967295
+0 0.0625 0 0.05 0.0625 0 0 0.125 0 0.05 0.125 0 0 0.0625 0.05 0.05 0.0625 0.05 0 0.125 0.05 0.05 0.125 0.05 
+4294967295 4294967295 0 2 4294967295 4294967295 
 1 1
 0
 1 8
-4 4 4 4 4 4 4 4
+4 4 4 4 4 4 4 4 
 
 
 [deal.II intermediate Patch<3,3>]
 7
-0 0.125 0 0.05 0.125 0 0 0.1875 0 0.05 0.1875 0 0 0.125 0.05 0.05 0.125 0.05 0 0.1875 0.05 0.05 0.1875 0.05
-4294967295 4294967295 1 3 4294967295 4294967295
+0 0.125 0 0.05 0.125 0 0 0.1875 0 0.05 0.1875 0 0 0.125 0.05 0.05 0.125 0.05 0 0.1875 0.05 0.05 0.1875 0.05 
+4294967295 4294967295 1 3 4294967295 4294967295 
 2 1
 0
 1 8
-4 4 4 4 4 4 4 4
+3 3 3 3 3 3 3 3 
 
 
 [deal.II intermediate Patch<3,3>]
 7
-0 0.1875 0 0.05 0.1875 0 0 0.25 0 0.05 0.25 0 0 0.1875 0.05 0.05 0.1875 0.05 0 0.25 0.05 0.05 0.25 0.05
-4294967295 4294967295 2 4 4294967295 4294967295
+0 0.1875 0 0.05 0.1875 0 0 0.25 0 0.05 0.25 0 0 0.1875 0.05 0.05 0.1875 0.05 0 0.25 0.05 0.05 0.25 0.05 
+4294967295 4294967295 2 4 4294967295 4294967295 
 3 1
 0
 1 8
-4 4 4 4 4 4 4 4
+2 2 2 2 2 2 2 2 
 
 
 [deal.II intermediate Patch<3,3>]
 7
-0 0.25 0 0.05 0.25 0 0 0.3125 0 0.05 0.3125 0 0 0.25 0.05 0.05 0.25 0.05 0 0.3125 0.05 0.05 0.3125 0.05
-4294967295 4294967295 3 5 4294967295 4294967295
+0 0.25 0 0.05 0.25 0 0 0.3125 0 0.05 0.3125 0 0 0.25 0.05 0.05 0.25 0.05 0 0.3125 0.05 0.05 0.3125 0.05 
+4294967295 4294967295 3 5 4294967295 4294967295 
 4 1
 0
 1 8
-4 4 4 4 4 4 4 4
+3 3 3 3 3 3 3 3 
 
 
 [deal.II intermediate Patch<3,3>]
 7
-0 0.3125 0 0.05 0.3125 0 0 0.375 0 0.05 0.375 0 0 0.3125 0.05 0.05 0.3125 0.05 0 0.375 0.05 0.05 0.375 0.05
-4294967295 4294967295 4 6 4294967295 4294967295
+0 0.3125 0 0.05 0.3125 0 0 0.375 0 0.05 0.375 0 0 0.3125 0.05 0.05 0.3125 0.05 0 0.375 0.05 0.05 0.375 0.05 
+4294967295 4294967295 4 6 4294967295 4294967295 
 5 1
 0
 1 8
-4 4 4 4 4 4 4 4
+4 4 4 4 4 4 4 4 
 
 
 [deal.II intermediate Patch<3,3>]
 7
-0 0.375 0 0.05 0.375 0 0 0.4375 0 0.05 0.4375 0 0 0.375 0.05 0.05 0.375 0.05 0 0.4375 0.05 0.05 0.4375 0.05
-4294967295 4294967295 5 7 4294967295 4294967295
+0 0.375 0 0.05 0.375 0 0 0.4375 0 0.05 0.4375 0 0 0.375 0.05 0.05 0.375 0.05 0 0.4375 0.05 0.05 0.4375 0.05 
+4294967295 4294967295 5 7 4294967295 4294967295 
 6 1
 0
 1 8
-4 4 4 4 4 4 4 4
+4 4 4 4 4 4 4 4 
 
 
 [deal.II intermediate Patch<3,3>]
 7
-0 0.4375 0 0.05 0.4375 0 0 0.5 0 0.05 0.5 0 0 0.4375 0.05 0.05 0.4375 0.05 0 0.5 0.05 0.05 0.5 0.05
-4294967295 4294967295 6 4294967295 4294967295 4294967295
+0 0.4375 0 0.05 0.4375 0 0 0.5 0 0.05 0.5 0 0 0.4375 0.05 0.05 0.4375 0.05 0 0.5 0.05 0.05 0.5 0.05 
+4294967295 4294967295 6 4294967295 4294967295 4294967295 
 7 1
 0
 1 8
-4 4 4 4 4 4 4 4
+4 4 4 4 4 4 4 4 
 
 
 0
@@ -186,7 +132,7 @@ print_from_processor_0
 DEM
 ----
 DEM contact search at dem step 1
-Finished 50 DEM iterations
+Finished 50 DEM iterations 
 ---------------------------------------------------------------
-Global continuity equation error: -8.07686e-10 s^-1
-Max local continuity error: 1.81029e-06 s^-1
+Global continuity equation error: -2.28117e-09 s^-1
+Max local continuity error: 6.96484e-07 s^-1

--- a/applications_tests/lethe-fluid-particles/adaptive_sparse_contacts.prm
+++ b/applications_tests/lethe-fluid-particles/adaptive_sparse_contacts.prm
@@ -13,7 +13,7 @@ subsection simulation control
   set output frequency     = 0
   set log frequency        = 1
   set startup time scaling = 0.6
-  set time end             = 0.005
+  set time end             = 0.002
   set time step            = 0.001
 end
 
@@ -51,7 +51,7 @@ subsection model parameters
   subsection adaptive sparse contacts
     set enable adaptive sparse contacts = true
     set enable particle advection       = true
-    set granular temperature threshold  = 1e-4
+    set granular temperature threshold  = 5e-4
     set solid fraction threshold        = 0.1
   end
 end


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->
The ASC applications was not testing all the mobility status after the change of restart files in PR #1181.

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->
Change the granular temperature threshold to get the 3 mobility status at the start of the simulation and output the status sooner.
Close issue #1182.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->
Make sure there are cells with the 3 possibles mobility status at output.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->
The previous test probably did not get the same restart files as the initial application test, making a different output at the same time step.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge