### PR TITLE
Fix the critical rayleigh time step calculation in cfd-dem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-07-20
+
+### Fixed
+
+- MINOR The ratio of the critical Rayleigh time step was wrong in CFD-DEM and was modified as done in DEM. [#1203](https://github.com/chaos-polymtl/lethe/pull/1203)
+
 ## [Master] - 2024-07-14
 
 ### Added

--- a/applications_tests/lethe-fluid-particles/adaptive_sparse_contacts.mpirun=1.output
+++ b/applications_tests/lethe-fluid-particles/adaptive_sparse_contacts.mpirun=1.output
@@ -1,5 +1,5 @@
 Running on 1 MPI rank(s)...
-DEM time-step is 2.34951% of Rayleigh time step
+DEM time-step is 2.61468% of Rayleigh time step
 Reading DEM checkpoint 
 Finished reading DEM checkpoint 
 350 particles are in the simulation 

--- a/applications_tests/lethe-fluid-particles/conserve_phase_volumes.mpirun=1.output
+++ b/applications_tests/lethe-fluid-particles/conserve_phase_volumes.mpirun=1.output
@@ -1,5 +1,5 @@
 Running on 1 MPI rank(s)...
-DEM time-step is 2.186842813% of Rayleigh time step
+DEM time-step is 2.433653979% of Rayleigh time step
 Reading DEM checkpoint 
 Finished reading DEM checkpoint 
 10000 particles are in the simulation 

--- a/applications_tests/lethe-fluid-particles/dynamic_contact_search.mpirun=1.output
+++ b/applications_tests/lethe-fluid-particles/dynamic_contact_search.mpirun=1.output
@@ -1,5 +1,5 @@
 Running on 1 MPI rank(s)...
-DEM time-step is 16.41771423% of Rayleigh time step
+DEM time-step is 18.27064813% of Rayleigh time step
 Reading DEM checkpoint 
 Finished reading DEM checkpoint 
 1 particles are in the simulation 

--- a/applications_tests/lethe-fluid-particles/liquid_fluidized_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-particles/liquid_fluidized_bed.mpirun=1.output
@@ -1,5 +1,5 @@
 Running on 1 MPI rank(s)...
-DEM time-step is 2.186842813% of Rayleigh time step
+DEM time-step is 2.433653979% of Rayleigh time step
 Reading DEM checkpoint 
 Finished reading DEM checkpoint 
 10000 particles are in the simulation 

--- a/applications_tests/lethe-fluid-particles/particle_sedimentation.mpirun=1.output
+++ b/applications_tests/lethe-fluid-particles/particle_sedimentation.mpirun=1.output
@@ -1,5 +1,5 @@
 Running on 1 MPI rank(s)...
-DEM time-step is 16.41771423% of Rayleigh time step
+DEM time-step is 18.27064813% of Rayleigh time step
 Reading DEM checkpoint 
 Finished reading DEM checkpoint 
 1 particles are in the simulation 

--- a/applications_tests/lethe-fluid-particles/periodic_particles_qcm.mpirun=1.output
+++ b/applications_tests/lethe-fluid-particles/periodic_particles_qcm.mpirun=1.output
@@ -1,5 +1,5 @@
 Running on 1 MPI rank(s)...
-DEM time-step is 4.74073% of Rayleigh time step
+DEM time-step is 5.13612% of Rayleigh time step
 Reading DEM checkpoint 
 Finished reading DEM checkpoint 
 2 particles are in the simulation 

--- a/applications_tests/lethe-fluid-particles/restart-gas-solid-fluidized-bed.mpirun=2.output
+++ b/applications_tests/lethe-fluid-particles/restart-gas-solid-fluidized-bed.mpirun=2.output
@@ -1,5 +1,5 @@
 Running on 2 MPI rank(s)...
-DEM time-step is 3.28354% of Rayleigh time step
+DEM time-step is 3.65413% of Rayleigh time step
    Number of active cells:       40
    Number of degrees of freedom: 656
    Volume of triangulation:      0.00108

--- a/applications_tests/lethe-fluid-particles/restart_particle_sedimentation.mpirun=1.output
+++ b/applications_tests/lethe-fluid-particles/restart_particle_sedimentation.mpirun=1.output
@@ -1,5 +1,5 @@
 Running on 1 MPI rank(s)...
-DEM time-step is 16.41771423% of Rayleigh time step
+DEM time-step is 18.27064813% of Rayleigh time step
    Number of active cells:       25
    Number of degrees of freedom: 192
    Volume of triangulation:      0.001


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->
The critical Rayleigh time step was not properly implemented in CFD-DEM, even tho it was fixed in the past for DEM (see #776 and #939)

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->
Changed to the same calculation as done in DEM.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->
Unresolved CFD-DEM application tests were modified according to the new ratio.

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge