### PR TITLE
Write checkpoint when the end time of the simulation is reached

### DIFF
--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -530,9 +530,10 @@ NavierStokesBase<dim, VectorType, DofsType>::finish_time_step()
     }
   if (this->simulation_parameters.restart_parameters.checkpoint &&
       simulation_control->get_step_number() != 0 &&
-      simulation_control->get_step_number() %
-          this->simulation_parameters.restart_parameters.frequency ==
-        0)
+      (simulation_control->get_step_number() %
+           this->simulation_parameters.restart_parameters.frequency ==
+         0 ||
+       simulation_control->is_at_end()))
     {
       this->write_checkpoint();
     }


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the content of the new feature
       What are the motivations? 
       How is it integrated to the current code? -->

This small change ensures that a checkpoint is written if the end simulation time has been reached regardless of the frequency for the check pointing specified in the parameter file.

### Testing

<!-- How has this been tested?
       What are the new test(s) and what feature(s)/parameter(s) does it test?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works?
       How will you ensure that it will continue to work in the future? -->

All test involving a restart should pass without any issue. I have tested the feature with an example on my local machine and it works as expected.

### Documentation

<!-- Does this new feature introduce new simulation parameters? If so, describe them. -->

No change needed in the documentation. 

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] The PR description is cleaned and ready for merge