### PR TITLE
Uniformize timer labels

### DIFF
--- a/source/fem-dem/gls_sharp_navier_stokes.cc
+++ b/source/fem-dem/gls_sharp_navier_stokes.cc
@@ -41,7 +41,7 @@ void
 GLSSharpNavierStokesSolver<dim>::vertices_cell_mapping()
 {
   // Find all the cells around each vertices
-  TimerOutput::Scope t(this->computing_timer, "vertices_to_cell_map");
+  TimerOutput::Scope t(this->computing_timer, "Map vertices to cell");
 
   LetheGridTools::vertices_cell_mapping(this->dof_handler, vertices_to_cell);
 }
@@ -83,7 +83,7 @@ GLSSharpNavierStokesSolver<dim>::generate_cut_cells_map()
 
   // check all the cells if they are cut or not. Put the information in a map
   // with the key being the cell.
-  TimerOutput::Scope t(this->computing_timer, "cut_cells_mapping");
+  TimerOutput::Scope t(this->computing_timer, "Map cut cells");
   std::map<types::global_dof_index, Point<dim>> support_points;
 
   // A vector of the unordered map. Each map stores if a point is inside or
@@ -438,7 +438,7 @@ GLSSharpNavierStokesSolver<dim>::refinement_control(
     {
       for (unsigned int p_i = 0; p_i < particles.size(); ++p_i)
         {
-          TimerOutput::Scope t(this->computing_timer, "removing_rbf_nodes");
+          TimerOutput::Scope t(this->computing_timer, "Remove RBF nodes");
           particles[p_i].remove_superfluous_data(
             this->dof_handler, particles[p_i].mesh_based_precalculations);
         }
@@ -508,7 +508,7 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::optimized_generate_cut_cells_map()
 {
-  TimerOutput::Scope t(this->computing_timer, "optimized_cut_cells_mapping");
+  TimerOutput::Scope t(this->computing_timer, "Optmize cut cells mapping");
   MappingQ1<dim>     mapping;
   unsigned int       max_children = GeometryInfo<dim>::max_children_per_cell;
 
@@ -826,8 +826,9 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::refine_ib()
 {
-  TimerOutput::Scope t(this->computing_timer, "refine_around_ib");
-  Point<dim>         center_immersed;
+  TimerOutput::Scope                            t(this->computing_timer,
+                       "Refine around immersed boundary");
+  Point<dim>                                    center_immersed;
   std::map<types::global_dof_index, Point<dim>> support_points;
   DoFTools::map_dofs_to_support_points(*this->mapping,
                                        this->dof_handler,
@@ -972,7 +973,8 @@ GLSSharpNavierStokesSolver<dim>::force_on_ib()
   // This function defines the force and torque applied on an Immersed Boundary
   // based on the sharp edge method on a hyper_sphere of dim=2 or dim=3
 
-  TimerOutput::Scope t(this->computing_timer, "new force_eval");
+  TimerOutput::Scope t(this->computing_timer,
+                       "Evaluate force on immersed boundary");
 
   const FEValuesExtractors::Scalar pressure(dim);
   const FEValuesExtractors::Vector velocities(0);
@@ -1644,7 +1646,8 @@ template <int dim>
 void
 GLSSharpNavierStokesSolver<dim>::write_force_ib()
 {
-  TimerOutput::Scope t(this->computing_timer, "output_forces_ib");
+  TimerOutput::Scope t(this->computing_timer,
+                       "Output forces on immersed boundary");
   for (unsigned int p = 0; p < particles.size(); ++p)
     {
       {
@@ -2089,7 +2092,7 @@ GLSSharpNavierStokesSolver<dim>::integrate_particles()
   particle_residual = 0;
 
 
-  TimerOutput::Scope t(this->computing_timer, "integrate particles");
+  TimerOutput::Scope t(this->computing_timer, "Integrate particles");
   // Integrate the velocity of the particle. If integrate motion is set to
   // true in the parameter this function will also integrate the force to update
   // the velocity. Otherwise the velocity is kept constant
@@ -3107,7 +3110,7 @@ GLSSharpNavierStokesSolver<dim>::sharp_edge()
   // This function defines an Immersed Boundary based on the sharp edge method
   // on a solid of dim=2 or dim=3
 
-  TimerOutput::Scope t(this->computing_timer, "assemble_sharp");
+  TimerOutput::Scope t(this->computing_timer, "Assemble sharp");
   using dealii::numbers::PI;
   Point<dim>                                                  center_immersed;
   Point<dim>                                                  pressure_bridge;
@@ -4539,7 +4542,7 @@ GLSSharpNavierStokesSolver<dim>::read_checkpoint()
   update_precalculations_for_ib();
   for (unsigned int p_i = 0; p_i < particles.size(); ++p_i)
     {
-      TimerOutput::Scope t(this->computing_timer, "removing_rbf_nodes");
+      TimerOutput::Scope t(this->computing_timer, "Remove RBF nodes");
       particles[p_i].remove_superfluous_data(
         this->dof_handler, particles[p_i].mesh_based_precalculations);
     }
@@ -4837,7 +4840,7 @@ void
 GLSSharpNavierStokesSolver<dim>::update_precalculations_for_ib()
 {
   TimerOutput::Scope t(this->computing_timer,
-                       "update_precalculations_shape_distance");
+                       "Update precalculated shape distance");
   for (unsigned int p_i = 0; p_i < particles.size(); ++p_i)
     {
       particles[p_i].update_precalculations(

--- a/source/fem-dem/gls_vans.cc
+++ b/source/fem-dem/gls_vans.cc
@@ -245,7 +245,7 @@ GLSVANSSolver<dim>::calculate_void_fraction(const double time,
 {
   announce_string(this->pcout, "Void Fraction");
 
-  TimerOutput::Scope t(this->computing_timer, "calculate_void_fraction");
+  TimerOutput::Scope t(this->computing_timer, "Calculate void fraction");
   if (this->cfd_dem_simulation_parameters.void_fraction->mode ==
       Parameters::VoidFractionMode::function)
     {
@@ -432,7 +432,7 @@ void
 GLSVANSSolver<dim>::vertices_cell_mapping()
 {
   // Find all the cells around each vertex
-  TimerOutput::Scope t(this->computing_timer, "vertices_to_cell_map");
+  TimerOutput::Scope t(this->computing_timer, "Map vertices to cell");
 
   LetheGridTools::vertices_cell_mapping(this->void_fraction_dof_handler,
                                         vertices_to_cell);
@@ -1576,7 +1576,7 @@ void
 GLSVANSSolver<dim>::assemble_system_matrix()
 {
   {
-    TimerOutput::Scope t(this->computing_timer, "Assemble_Matrix");
+    TimerOutput::Scope t(this->computing_timer, "Assemble matrix");
     this->system_matrix = 0;
 
     setup_assemblers();
@@ -1680,7 +1680,7 @@ template <int dim>
 void
 GLSVANSSolver<dim>::assemble_system_rhs()
 {
-  TimerOutput::Scope t(this->computing_timer, "Assemble_RHS");
+  TimerOutput::Scope t(this->computing_timer, "Assemble RHS");
 
   this->system_rhs = 0;
 

--- a/source/solvers/gls_nitsche_navier_stokes.cc
+++ b/source/solvers/gls_nitsche_navier_stokes.cc
@@ -62,7 +62,7 @@ template <bool assemble_matrix>
 void
 GLSNitscheNavierStokesSolver<dim, spacedim>::assemble_nitsche_restriction()
 {
-  TimerOutput::Scope t(this->computing_timer, "assemble Nitsche restriction");
+  TimerOutput::Scope t(this->computing_timer, "Nitsche assemble restriction");
 
   Assert(
     !this->simulation_parameters.physical_properties_manager.is_non_newtonian(),
@@ -528,7 +528,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::postprocess_solid_forces(
   const unsigned int i_solid,
   bool               first_solid_forces)
 {
-  TimerOutput::Scope t(this->computing_timer, "calculate_force_on_solid");
+  TimerOutput::Scope t(this->computing_timer, "Calculate force on solid");
 
   std::vector<Tensor<1, spacedim>> force;
   std::vector<unsigned int>        solid_indices;
@@ -612,7 +612,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::postprocess_solid_torques(
   const unsigned int i_solid,
   bool               first_solid_torques)
 {
-  TimerOutput::Scope t(this->computing_timer, "calculate_torque_on_solid");
+  TimerOutput::Scope t(this->computing_timer, "Calculate torque on solid");
 
   std::vector<Tensor<1, 3>> torque;
   std::vector<unsigned int> solid_indices;
@@ -707,7 +707,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::solve()
   if (!this->simulation_parameters.restart_parameters.restart)
     {
       TimerOutput::Scope t(this->computing_timer,
-                           "Nitsche solid mesh and particles");
+                           "Nitsche setup solid mesh and particles");
       for (unsigned int i_solid = 0; i_solid < solids.size(); ++i_solid)
         {
           solids[i_solid]->initial_setup();
@@ -738,7 +738,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::solve()
       this->simulation_control->print_progression(this->pcout);
 
       {
-        TimerOutput::Scope t(this->computing_timer, "Nitsche particles motion");
+        TimerOutput::Scope t(this->computing_timer, "Nitsche move particles");
         for (unsigned int i_solid = 0; i_solid < solids.size(); ++i_solid)
           {
             if (this->simulation_parameters.nitsche->nitsche_solids[i_solid]
@@ -1012,7 +1012,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::read_checkpoint()
   this->GLSNavierStokesSolver<spacedim>::read_checkpoint();
 
   TimerOutput::Scope t(this->computing_timer,
-                       "Reload Nitsche solid mesh and particles");
+                       "Nitsche reload solid mesh and particles");
 
   // Reload initial configurations
   // This must be done after the background triangulation is read

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -261,7 +261,7 @@ void
 NavierStokesBase<dim, VectorType, DofsType>::postprocessing_forces(
   const VectorType &evaluation_point)
 {
-  TimerOutput::Scope t(this->computing_timer, "calculate_forces");
+  TimerOutput::Scope t(this->computing_timer, "Calculate forces");
 
   this->forces_on_boundaries =
     calculate_forces(this->dof_handler,
@@ -382,7 +382,7 @@ void
 NavierStokesBase<dim, VectorType, DofsType>::postprocessing_torques(
   const VectorType &evaluation_point)
 {
-  TimerOutput::Scope t(this->computing_timer, "calculate_torques");
+  TimerOutput::Scope t(this->computing_timer, "Calculate torques");
 
   this->torques_on_boundaries =
     calculate_torques(this->dof_handler,
@@ -2581,7 +2581,7 @@ NavierStokesBase<dim, VectorType, DofsType>::
   if (abs(pressure_scaling_factor - 1) < 1e-8)
     return;
 
-  TimerOutput::Scope t(this->computing_timer, "rescale_pressure");
+  TimerOutput::Scope t(this->computing_timer, "Rescale pressure");
 
   const unsigned int                   dofs_per_cell = this->fe->dofs_per_cell;
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The labels for the timer outputs where a bit all over the place. The majority of them follow the format "This is a sentence", but some previous output followed the syntax "this_is_a_sentence". I have made the labels uniform following the "This is a sentence" format. This is a very minor change towards a more unified Lethe.



Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [X] If parameters are modified, the tests and the documentation of examples are up to date
- [X] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [X] No other PR is open related to this refactoring
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] If any future works is planed, an issue is opened
- [X] The PR description is cleaned and ready for merge