### PR TITLE
Rename all relevant matrix-free files using Fluid Dynamics prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Master] - 2024-08-05
 
+### Changed
+
+- MINOR Renamed all the files related to the `lethe-fluid-matrix-free` application: `mf_navier_stokes` to `fluid_dynamics_matrix_free` and `mf_navier_stokes_operators` to `fluid_dynamics_matrix_free_operators`. The main class `MFNavierStokesSolver` was also renamed to `FluidDynamicsMatrixFree`. [#1222](https://github.com/chaos-polymtl/lethe/pull/1222)
+
+## [Master] - 2024-08-05
+
 ### Removed
 
 - MINOR Removed the gear3 DEM integrator. It was never used, it did not possess any unit test and it was not even clear if it still worked. [#1221](https://github.com/chaos-polymtl/lethe/pull/1211)

--- a/applications/lethe-fluid-matrix-free/CMakeLists.txt
+++ b/applications/lethe-fluid-matrix-free/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_executable(lethe-fluid-matrix-free mf_navier_stokes.cc)
+add_executable(lethe-fluid-matrix-free fluid_dynamics_matrix_free.cc)
 deal_ii_setup_target(lethe-fluid-matrix-free)
 target_link_libraries(lethe-fluid-matrix-free lethe-solvers)

--- a/applications/lethe-fluid-matrix-free/fluid_dynamics_matrix_free.cc
+++ b/applications/lethe-fluid-matrix-free/fluid_dynamics_matrix_free.cc
@@ -13,7 +13,7 @@
  *
  ---------------------------------------------------------------------*/
 
-#include "solvers/mf_navier_stokes.h"
+#include "solvers/fluid_dynamics_matrix_free.h"
 
 int
 main(int argc, char *argv[])
@@ -41,7 +41,7 @@ main(int argc, char *argv[])
           prm.parse_input(argv[1]);
           NSparam.parse(prm);
 
-          MFNavierStokesSolver<2> problem(NSparam);
+          FluidDynamicsMatrixFree<2> problem(NSparam);
           problem.solve();
         }
 
@@ -54,7 +54,7 @@ main(int argc, char *argv[])
           prm.parse_input(argv[1]);
           NSparam.parse(prm);
 
-          MFNavierStokesSolver<3> problem(NSparam);
+          FluidDynamicsMatrixFree<3> problem(NSparam);
           problem.solve();
         }
       else

--- a/doc/doxygen/main.h
+++ b/doc/doxygen/main.h
@@ -25,7 +25,7 @@
 
       navier_stokes_base_1 [label=<<B>GLSNavierStokesSolver</B> <br/>(lethe-fluid)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classGLSNavierStokesSolver.html", tooltip="GLSNavierStokesSolver"];
       navier_stokes_base_2 [label=<<B>GDNavierStokesSolver</B> <br/> (lethe-fluid-block)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classGDNavierStokesSolver.html", tooltip="GDNavierStokesSolver"];
-      navier_stokes_base_3 [label=<<B>MFNavierStokesSolver</B> <br/> (lethe-fluid-matrix-free)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classMFNavierStokesSolver.html", tooltip="MFNavierStokesSolver"];
+      navier_stokes_base_3 [label=<<B>FluidDynamicsMatrixFree</B> <br/> (lethe-fluid-matrix-free)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classFluidDynamicsMatrixFree.html", tooltip="FluidDynamicsMatrixFree"];
 
       navier_stokes_base:e -> navier_stokes_base_1:w [dir=back];
       navier_stokes_base:e -> navier_stokes_base_2:w [dir=back];

--- a/include/solvers/fluid_dynamics_matrix_free.h
+++ b/include/solvers/fluid_dynamics_matrix_free.h
@@ -13,12 +13,12 @@
  *
  * ---------------------------------------------------------------------*/
 
-#ifndef lethe_mf_navier_stokes_h
-#define lethe_mf_navier_stokes_h
+#ifndef lehte_fluid_dynamics_matrix_free_h
+#define lehte_fluid_dynamics_matrix_free_h
 
 #include <core/exceptions.h>
 
-#include <solvers/mf_navier_stokes_operators.h>
+#include <solvers/fluid_dynamics_matrix_free_operators.h>
 #include <solvers/navier_stokes_base.h>
 
 #include <deal.II/lac/precondition.h>
@@ -274,7 +274,7 @@ public:
  * the flow is solved.
  */
 template <int dim>
-class MFNavierStokesSolver
+class FluidDynamicsMatrixFree
   : public NavierStokesBase<dim,
                             LinearAlgebra::distributed::Vector<double>,
                             IndexSet>
@@ -288,13 +288,13 @@ public:
    *
    * @param[in] nsparam Relevant parameters for the solver.
    */
-  MFNavierStokesSolver(SimulationParameters<dim> &nsparam);
+  FluidDynamicsMatrixFree(SimulationParameters<dim> &nsparam);
 
   /**
    * @brief Destructor.
    *
    */
-  ~MFNavierStokesSolver();
+  ~FluidDynamicsMatrixFree();
 
   /**
    * @brief Solve the problem defined by simulation parameters by iterating

--- a/include/solvers/fluid_dynamics_matrix_free.h
+++ b/include/solvers/fluid_dynamics_matrix_free.h
@@ -13,7 +13,7 @@
  *
  * ---------------------------------------------------------------------*/
 
-#ifndef lehte_fluid_dynamics_matrix_free_h
+#ifndef lethe_fluid_dynamics_matrix_free_h
 #define lehte_fluid_dynamics_matrix_free_h
 
 #include <core/exceptions.h>

--- a/include/solvers/fluid_dynamics_matrix_free.h
+++ b/include/solvers/fluid_dynamics_matrix_free.h
@@ -14,7 +14,7 @@
  * ---------------------------------------------------------------------*/
 
 #ifndef lethe_fluid_dynamics_matrix_free_h
-#define lehte_fluid_dynamics_matrix_free_h
+#define lethe_fluid_dynamics_matrix_free_h
 
 #include <core/exceptions.h>
 

--- a/include/solvers/fluid_dynamics_matrix_free_operators.h
+++ b/include/solvers/fluid_dynamics_matrix_free_operators.h
@@ -13,8 +13,8 @@
  *
  * ---------------------------------------------------------------------*/
 
-#ifndef lethe_mf_navier_stokes_operators_h
-#define lethe_mf_navier_stokes_operators_h
+#ifndef lethe_fluid_dynamics_matrix_free_operators_h
+#define lethe_fluid_dynamics_matrix_free_operators_h
 
 #include <core/bdf.h>
 #include <core/simulation_control.h>

--- a/source/solvers/CMakeLists.txt
+++ b/source/solvers/CMakeLists.txt
@@ -16,8 +16,8 @@ add_library(lethe-solvers
   initial_conditions.cc
   isothermal_compressible_navier_stokes_assembler.cc
   isothermal_compressible_navier_stokes_vof_assembler.cc
-  mf_navier_stokes.cc
-  mf_navier_stokes_operators.cc
+  fluid_dynamics_matrix_free.cc
+  fluid_dynamics_matrix_free_operators.cc
   multiphysics_interface.cc
   navier_stokes_assemblers.cc
   navier_stokes_base.cc
@@ -56,8 +56,8 @@ add_library(lethe-solvers
   ../../include/solvers/initial_conditions.h
   ../../include/solvers/isothermal_compressible_navier_stokes_assembler.h
   ../../include/solvers/isothermal_compressible_navier_stokes_vof_assembler.h
-  ../../include/solvers/mf_navier_stokes.h
-  ../../include/solvers/mf_navier_stokes_operators.h
+  ../../include/solvers/fluid_dynamics_matrix_free.h
+  ../../include/solvers/fluid_dynamics_matrix_free_operators.h
   ../../include/solvers/multiphysics_interface.h
   ../../include/solvers/navier_stokes_assemblers.h
   ../../include/solvers/navier_stokes_base.h

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -20,7 +20,7 @@
 #include <core/time_integration_utilities.h>
 #include <core/utilities.h>
 
-#include <solvers/mf_navier_stokes.h>
+#include <solvers/fluid_dynamics_matrix_free.h>
 
 #include <deal.II/base/multithread_info.h>
 
@@ -1857,7 +1857,7 @@ MFNavierStokesPreconditionGMG<dim>::setup_ILU()
 }
 
 template <int dim>
-MFNavierStokesSolver<dim>::MFNavierStokesSolver(
+FluidDynamicsMatrixFree<dim>::FluidDynamicsMatrixFree(
   SimulationParameters<dim> &nsparam)
   : NavierStokesBase<dim, VectorType, IndexSet>(nsparam)
 {
@@ -1880,14 +1880,14 @@ MFNavierStokesSolver<dim>::MFNavierStokesSolver(
 }
 
 template <int dim>
-MFNavierStokesSolver<dim>::~MFNavierStokesSolver()
+FluidDynamicsMatrixFree<dim>::~FluidDynamicsMatrixFree()
 {
   this->dof_handler.clear();
 }
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::solve()
+FluidDynamicsMatrixFree<dim>::solve()
 {
   this->computing_timer.enter_subsection("Read mesh and manifolds");
 
@@ -1982,7 +1982,7 @@ MFNavierStokesSolver<dim>::solve()
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::setup_dofs_fd()
+FluidDynamicsMatrixFree<dim>::setup_dofs_fd()
 {
   TimerOutput::Scope t(this->computing_timer, "Setup DoFs");
 
@@ -2119,7 +2119,7 @@ MFNavierStokesSolver<dim>::setup_dofs_fd()
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::update_boundary_conditions()
+FluidDynamicsMatrixFree<dim>::update_boundary_conditions()
 {
   if (this->simulation_parameters.boundary_conditions.time_dependent)
     {
@@ -2148,7 +2148,7 @@ MFNavierStokesSolver<dim>::update_boundary_conditions()
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::set_initial_condition_fd(
+FluidDynamicsMatrixFree<dim>::set_initial_condition_fd(
   Parameters::InitialConditionType initial_condition_type,
   bool                             restart)
 {
@@ -2393,7 +2393,7 @@ MFNavierStokesSolver<dim>::set_initial_condition_fd(
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::assemble_system_matrix()
+FluidDynamicsMatrixFree<dim>::assemble_system_matrix()
 {
   // Required for compilation but not used for matrix free solvers.
   TimerOutput::Scope t(this->computing_timer, "Assemble matrix");
@@ -2401,7 +2401,7 @@ MFNavierStokesSolver<dim>::assemble_system_matrix()
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::assemble_system_rhs()
+FluidDynamicsMatrixFree<dim>::assemble_system_rhs()
 {
   TimerOutput::Scope t(this->computing_timer, "Assemble RHS");
 
@@ -2418,7 +2418,7 @@ MFNavierStokesSolver<dim>::assemble_system_rhs()
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::update_multiphysics_time_average_solution()
+FluidDynamicsMatrixFree<dim>::update_multiphysics_time_average_solution()
 {
   TimerOutput::Scope t(this->computing_timer,
                        "Update multiphysics average solution");
@@ -2439,7 +2439,7 @@ MFNavierStokesSolver<dim>::update_multiphysics_time_average_solution()
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::calculate_time_derivative_previous_solutions()
+FluidDynamicsMatrixFree<dim>::calculate_time_derivative_previous_solutions()
 {
   this->time_derivative_previous_solutions = 0;
 
@@ -2458,7 +2458,7 @@ MFNavierStokesSolver<dim>::calculate_time_derivative_previous_solutions()
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::setup_GMG()
+FluidDynamicsMatrixFree<dim>::setup_GMG()
 {
   TimerOutput::Scope t(this->computing_timer, "Setup GMG");
 
@@ -2481,7 +2481,7 @@ MFNavierStokesSolver<dim>::setup_GMG()
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::setup_ILU()
+FluidDynamicsMatrixFree<dim>::setup_ILU()
 {
   TimerOutput::Scope t(this->computing_timer, "Setup ILU");
 
@@ -2506,7 +2506,7 @@ MFNavierStokesSolver<dim>::setup_ILU()
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::print_mg_setup_times()
+FluidDynamicsMatrixFree<dim>::print_mg_setup_times()
 {
   if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
         .mg_verbosity == Parameters::Verbosity::extra_verbose)
@@ -2543,7 +2543,7 @@ MFNavierStokesSolver<dim>::print_mg_setup_times()
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::update_solutions_for_multiphysics()
+FluidDynamicsMatrixFree<dim>::update_solutions_for_multiphysics()
 {
   TimerOutput::Scope t(this->computing_timer,
                        "Update solutions for multiphysics");
@@ -2592,7 +2592,7 @@ MFNavierStokesSolver<dim>::update_solutions_for_multiphysics()
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::define_non_zero_constraints()
+FluidDynamicsMatrixFree<dim>::define_non_zero_constraints()
 {
   double time = this->simulation_control->get_current_time();
   FEValuesExtractors::Vector velocities(0);
@@ -2682,7 +2682,7 @@ MFNavierStokesSolver<dim>::define_non_zero_constraints()
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::define_zero_constraints()
+FluidDynamicsMatrixFree<dim>::define_zero_constraints()
 {
   FEValuesExtractors::Vector velocities(0);
   FEValuesExtractors::Scalar pressure(dim);
@@ -2761,7 +2761,7 @@ MFNavierStokesSolver<dim>::define_zero_constraints()
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::setup_preconditioner()
+FluidDynamicsMatrixFree<dim>::setup_preconditioner()
 {
   this->present_solution.update_ghost_values();
 
@@ -2798,7 +2798,7 @@ MFNavierStokesSolver<dim>::setup_preconditioner()
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::solve_linear_system(const bool initial_step,
+FluidDynamicsMatrixFree<dim>::solve_linear_system(const bool initial_step,
                                                const bool /* renewed_matrix */)
 {
   const double absolute_residual =
@@ -2818,14 +2818,14 @@ MFNavierStokesSolver<dim>::solve_linear_system(const bool initial_step,
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::assemble_L2_projection()
+FluidDynamicsMatrixFree<dim>::assemble_L2_projection()
 {
   // TODO
 }
 
 template <int dim>
 void
-MFNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
+FluidDynamicsMatrixFree<dim>::solve_system_GMRES(const bool   initial_step,
                                               const double absolute_residual,
                                               const double relative_residual)
 {
@@ -2921,5 +2921,5 @@ MFNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
     "Distribute constraints after linear solve");
 }
 
-template class MFNavierStokesSolver<2>;
-template class MFNavierStokesSolver<3>;
+template class FluidDynamicsMatrixFree<2>;
+template class FluidDynamicsMatrixFree<3>;

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -2798,8 +2798,9 @@ FluidDynamicsMatrixFree<dim>::setup_preconditioner()
 
 template <int dim>
 void
-FluidDynamicsMatrixFree<dim>::solve_linear_system(const bool initial_step,
-                                               const bool /* renewed_matrix */)
+FluidDynamicsMatrixFree<dim>::solve_linear_system(
+  const bool initial_step,
+  const bool /* renewed_matrix */)
 {
   const double absolute_residual =
     this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
@@ -2826,8 +2827,8 @@ FluidDynamicsMatrixFree<dim>::assemble_L2_projection()
 template <int dim>
 void
 FluidDynamicsMatrixFree<dim>::solve_system_GMRES(const bool   initial_step,
-                                              const double absolute_residual,
-                                              const double relative_residual)
+                                                 const double absolute_residual,
+                                                 const double relative_residual)
 {
   auto &system_rhs          = this->system_rhs;
   auto &nonzero_constraints = this->nonzero_constraints;

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -13,7 +13,7 @@
  *
  * ---------------------------------------------------------------------*/
 
-#include "solvers/mf_navier_stokes_operators.h"
+#include "solvers/fluid_dynamics_matrix_free_operators.h"
 
 #include <deal.II/grid/grid_generator.h>
 /**


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

This PR changes the name of the main class and the name of the files related to the matrix-free application. Is the first PR on a series of PRs that aim to rename all the Navier Stokes solvers of Lethe using the prefix FluidDynamics.

### Testing

<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

All the matrix-free tests should pass as only the name of the class and the name of files were changed. 

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [X] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] The PR description is cleaned and ready for merge