### PR TITLE
Correct typo in heat transfer documentation

### DIFF
--- a/doc/source/theory/multiphysics/heat_transfer/heat_equation.rst
+++ b/doc/source/theory/multiphysics/heat_transfer/heat_equation.rst
@@ -44,7 +44,7 @@ where :math:`\mathbf{n}` is the normal vector to the boundary, :math:`q` is the 
 The weak form of the heat equation is obtained by multiplying the strong form by a test function :math:`v` and integrating over the domain :math:`\Omega`. After applying the integration by part and the Gauss-Ostrogradsky theorem, the weak form of the heat equation is given by the following equation:
 
 .. math::
-    \int_{\Omega} \left[ v \rho C_p \frac{\partial T}{\partial t} + v \rho C_p (\mathbf{u} \cdot \nabla)T + k (\nabla v \cdot \nabla T) \right] \;d\Omega - \int_{\Gamma} v k (\nabla T \cdot \mathbf{n}) \;d\Gamma = - \int_{\Omega} v \left[ \phi + Q \right] \;d\Omega
+    \int_{\Omega} \left[ v \rho C_p \frac{\partial T}{\partial t} + v \rho C_p (\mathbf{u} \cdot \nabla)T + k (\nabla v \cdot \nabla T) \right] \;d\Omega - \int_{\Gamma} v k (\nabla T \cdot \mathbf{n}) \;d\Gamma = - \int_{\Omega} v \left[ \phi - Q \right] \;d\Omega
 
 Note that this formulation treats the thermal conductivity :math:`k` as a constant.
 


### PR DESCRIPTION
### Description
A small sign mistake in the finite element formulation of the energy conservation equation was spotted and corrected.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planed, an issue is opened
- [x] The PR description is cleaned and ready for merge