### PR TITLE
Rename all files related to the VANS solver using Fluid Dynamics prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
-- MINOR Renamed all the files related to the `lethe-fluid-matrix-free` application: `mf_navier_stokes` to `fluid_dynamics_matrix_free` and `mf_navier_stokes_operators` to `fluid_dynamics_matrix_free_operators`. The main class `MFNavierStokesSolver` was also renamed to `FluidDynamicsMatrixFree`. [#1222](https://github.com/chaos-polymtl/lethe/pull/1222)
+- MINOR Renamed the main file related to the `lethe-fluid-vans` application: `gls_vans` to `fluid_dynamics_vans`. The name of the `GLSVansAssembler...` classes were changed to `VANSAssembler...`, and the main class `GLSVANSSolver` was also renamed to `FluidDynamicsVANS`. [#1225](https://github.com/chaos-polymtl/lethe/pull/1225)
 
-## [Master] - 2024-08-05
+### Changed
+
+- MINOR Renamed all the files related to the `lethe-fluid-matrix-free` application: `mf_navier_stokes` to `fluid_dynamics_matrix_free` and `mf_navier_stokes_operators` to `fluid_dynamics_matrix_free_operators`. The main class `MFNavierStokesSolver` was also renamed to `FluidDynamicsMatrixFree`. [#1222](https://github.com/chaos-polymtl/lethe/pull/1222)
 
 ### Removed
 

--- a/applications/lethe-fluid-vans/CMakeLists.txt
+++ b/applications/lethe-fluid-vans/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_executable(lethe-fluid-vans gls_vans.cc)
+add_executable(lethe-fluid-vans fluid_dynamics_vans.cc)
 deal_ii_setup_target(lethe-fluid-vans)
 target_link_libraries(lethe-fluid-vans lethe-fem-dem)

--- a/applications/lethe-fluid-vans/fluid_dynamics_vans.cc
+++ b/applications/lethe-fluid-vans/fluid_dynamics_vans.cc
@@ -14,7 +14,7 @@
  * ---------------------------------------------------------------------
  */
 
-#include "fem-dem/gls_vans.h"
+#include "fem-dem/fluid_dynamics_vans.h"
 
 int
 main(int argc, char *argv[])
@@ -42,7 +42,7 @@ main(int argc, char *argv[])
           prm.parse_input(argv[1]);
           NSparam.parse(prm);
 
-          GLSVANSSolver<2> problem(NSparam);
+          FluidDynamicsVANS<2> problem(NSparam);
           problem.solve();
         }
 
@@ -55,7 +55,7 @@ main(int argc, char *argv[])
           prm.parse_input(argv[1]);
           NSparam.parse(prm);
 
-          GLSVANSSolver<3> problem(NSparam);
+          FluidDynamicsVANS<3> problem(NSparam);
           problem.solve();
         }
 

--- a/doc/doxygen/main.h
+++ b/doc/doxygen/main.h
@@ -41,7 +41,7 @@
       auxiliary_physics:e -> auxiliary_physics_3:w [dir=back];
       auxiliary_physics:e -> auxiliary_physics_4:w [dir=back];
 
-      navier_stokes_base_1_1 [label=<<B>GLSVANSSolver</B> <br/>(lethe-fluid-vans)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classGLSVANSSolver.html", tooltip="GLSVANSSolver"];
+      navier_stokes_base_1_1 [label=<<B>FluidDynamicsVANS</B> <br/>(lethe-fluid-vans)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classFluidDynamicsVANS.html", tooltip="FluidDynamicsVANS"];
       navier_stokes_base_1_2 [label=<<B>GLSSharpNavierStokesSolver</B> <br/>(lethe-fluid-sharp)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classGLSSharpNavierStokesSolver.html", tooltip="GLSSharpNavierStokesSolver"];
       navier_stokes_base_1_3 [label=<<B>GLSNitscheNavierStokesSolver</B> <br/>(lethe-fluid-nitsche)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classGLSNitscheNavierStokesSolver.html", tooltip="GLSNitscheNavierStokesSolver"];
 

--- a/doc/source/parameters/unresolved-cfd-dem/cfd-dem.rst
+++ b/doc/source/parameters/unresolved-cfd-dem/cfd-dem.rst
@@ -1,7 +1,7 @@
 =======
 CFD-DEM
 =======
-This subsection includes parameters related to multiphase flow simulations using the both the gls_vans solver and the cfd-dem_coupling solver within Lethe.
+This subsection includes parameters related to multiphase flow simulations using the both the `lethe-fluid-vans` solver and the `lethe-fluid-particles` solver within Lethe.
 
 .. code-block:: text
 

--- a/doc/source/parameters/unresolved-cfd-dem/void-fraction.rst
+++ b/doc/source/parameters/unresolved-cfd-dem/void-fraction.rst
@@ -35,7 +35,7 @@ If the ``mode`` chosen is ``pcm``, then the void fraction is calculated using th
   set particle refinement factor   = 0
 
 
-* The ``read dem`` allows us to read an already existing dem simulation result which can be obtained from checkpointing the Lethe-DEM simulation. This is important as the gls_vans solver requires reading an initial dem triangulation and particle information to simulate flows in the presence of particles. 
+* The ``read dem`` allows us to read an already existing dem simulation result which can be obtained from checkpointing the Lethe-DEM simulation. This is important as the `lethe-fluid-vans` solver requires reading an initial dem triangulation and particle information to simulate flows in the presence of particles. 
 * The ``dem_file_name`` parameter specifies the prefix of the dem files that must be read.
 * The ``l2 smoothing factor`` is a smoothing length used for smoothing the L2 projection of the void fraction to avoid sharp discontinuities which can lead to instabilities in the simulation.
 * The ``l2 lower bound`` and ``l2 upper bound`` are the minimum and maximum values around which the void fraction is bounded. This is important especially for upper bounds as the void fraction can sometimes slightly exceed a value of 1 when projected.

--- a/include/fem-dem/cfd_dem_coupling.h
+++ b/include/fem-dem/cfd_dem_coupling.h
@@ -31,7 +31,7 @@
 #include <dem/lagrangian_post_processing.h>
 #include <dem/periodic_boundaries_manipulator.h>
 #include <fem-dem/cfd_dem_simulation_parameters.h>
-#include <fem-dem/gls_vans.h>
+#include <fem-dem/fluid_dynamics_vans.h>
 #include <fem-dem/postprocessing_cfd_dem.h>
 
 #include <deal.II/base/work_stream.h>
@@ -53,7 +53,7 @@ using namespace dealii;
  * simulate solid-fluid flow with two-way coupling.
  */
 template <int dim>
-class CFDDEMSolver : public GLSVANSSolver<dim>
+class CFDDEMSolver : public FluidDynamicsVANS<dim>
 {
 public:
   CFDDEMSolver(CFDDEMSimulationParameters<dim> &nsparam);

--- a/include/fem-dem/fluid_dynamics_vans.h
+++ b/include/fem-dem/fluid_dynamics_vans.h
@@ -40,8 +40,8 @@
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
 
-#ifndef lethe_gls_vans_h
-#  define lethe_gls_vans_h
+#ifndef lethe_fluid_dynamics_vans_h
+#  define lethe_fluid_dynamics_vans_h
 
 using namespace dealii;
 
@@ -112,12 +112,12 @@ particle_sphere_intersection_3d(double r_particle,
  */
 
 template <int dim>
-class GLSVANSSolver : public GLSNavierStokesSolver<dim>
+class FluidDynamicsVANS : public GLSNavierStokesSolver<dim>
 {
 public:
-  GLSVANSSolver(CFDDEMSimulationParameters<dim> &nsparam);
+  FluidDynamicsVANS(CFDDEMSimulationParameters<dim> &nsparam);
 
-  ~GLSVANSSolver();
+  ~FluidDynamicsVANS();
 
   virtual void
   solve() override;

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -64,10 +64,10 @@ public:
  * @ingroup assemblers
  */
 template <int dim>
-class VansAssemblerCoreModelB : public NavierStokesAssemblerBase<dim>
+class VANSAssemblerCoreModelB : public NavierStokesAssemblerBase<dim>
 {
 public:
-  VansAssemblerCoreModelB(std::shared_ptr<SimulationControl> simulation_control,
+  VANSAssemblerCoreModelB(std::shared_ptr<SimulationControl> simulation_control,
                           Parameters::CFDDEM                 cfd_dem)
     : simulation_control(simulation_control)
     , cfd_dem(cfd_dem)
@@ -105,10 +105,10 @@ public:
  * @ingroup assemblers
  */
 template <int dim>
-class VansAssemblerCoreModelA : public NavierStokesAssemblerBase<dim>
+class VANSAssemblerCoreModelA : public NavierStokesAssemblerBase<dim>
 {
 public:
-  VansAssemblerCoreModelA(std::shared_ptr<SimulationControl> simulation_control,
+  VANSAssemblerCoreModelA(std::shared_ptr<SimulationControl> simulation_control,
                           Parameters::CFDDEM                 cfd_dem)
     : simulation_control(simulation_control)
     , cfd_dem(cfd_dem)
@@ -151,10 +151,10 @@ public:
  */
 
 template <int dim>
-class VansAssemblerBDF : public NavierStokesAssemblerBase<dim>
+class VANSAssemblerBDF : public NavierStokesAssemblerBase<dim>
 {
 public:
-  VansAssemblerBDF(std::shared_ptr<SimulationControl> simulation_control,
+  VANSAssemblerBDF(std::shared_ptr<SimulationControl> simulation_control,
                    Parameters::CFDDEM                 cfd_dem)
     : simulation_control(simulation_control)
     , cfd_dem(cfd_dem)
@@ -199,10 +199,10 @@ public:
  */
 
 template <int dim>
-class VansAssemblerDiFelice : public ParticleFluidAssemblerBase<dim>
+class VANSAssemblerDiFelice : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VansAssemblerDiFelice(Parameters::CFDDEM cfd_dem)
+  VANSAssemblerDiFelice(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -235,10 +235,10 @@ public:
  */
 
 template <int dim>
-class VansAssemblerRong : public ParticleFluidAssemblerBase<dim>
+class VANSAssemblerRong : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VansAssemblerRong(Parameters::CFDDEM cfd_dem)
+  VANSAssemblerRong(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -267,10 +267,10 @@ public:
  */
 
 template <int dim>
-class VansAssemblerDallavalle : public ParticleFluidAssemblerBase<dim>
+class VANSAssemblerDallavalle : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VansAssemblerDallavalle(Parameters::CFDDEM cfd_dem)
+  VANSAssemblerDallavalle(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -315,10 +315,10 @@ public:
  */
 
 template <int dim>
-class VansAssemblerKochHill : public ParticleFluidAssemblerBase<dim>
+class VANSAssemblerKochHill : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VansAssemblerKochHill(Parameters::CFDDEM cfd_dem)
+  VANSAssemblerKochHill(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -356,10 +356,10 @@ public:
  */
 
 template <int dim>
-class VansAssemblerBeetstra : public ParticleFluidAssemblerBase<dim>
+class VANSAssemblerBeetstra : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VansAssemblerBeetstra(Parameters::CFDDEM cfd_dem)
+  VANSAssemblerBeetstra(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -405,10 +405,10 @@ public:
  */
 
 template <int dim>
-class VansAssemblerGidaspow : public ParticleFluidAssemblerBase<dim>
+class VANSAssemblerGidaspow : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VansAssemblerGidaspow(Parameters::CFDDEM cfd_dem)
+  VANSAssemblerGidaspow(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -439,10 +439,10 @@ public:
  */
 
 template <int dim>
-class VansAssemblerSaffmanMei : public ParticleFluidAssemblerBase<dim>
+class VANSAssemblerSaffmanMei : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VansAssemblerSaffmanMei(Parameters::Lagrangian::LagrangianPhysicalProperties
+  VANSAssemblerSaffmanMei(Parameters::Lagrangian::LagrangianPhysicalProperties
                             lagrangian_physical_properties)
     : lagrangian_physical_properties(lagrangian_physical_properties)
 
@@ -474,10 +474,10 @@ public:
  */
 
 template <int dim>
-class VansAssemblerMagnus : public ParticleFluidAssemblerBase<dim>
+class VANSAssemblerMagnus : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VansAssemblerMagnus(Parameters::Lagrangian::LagrangianPhysicalProperties
+  VANSAssemblerMagnus(Parameters::Lagrangian::LagrangianPhysicalProperties
                         lagrangian_physical_properties)
     : lagrangian_physical_properties(lagrangian_physical_properties)
 
@@ -503,7 +503,7 @@ public:
  * M_viscous_rotation = pi * pow(dp, 3) * mu * (- omega_p)
  *
  * The complete model described by Derksen is composed of
- * VansAssemblerViscousTorque + VansAssemblerVorticalTorque
+ * VANSAssemblerViscousTorque + VANSAssemblerVorticalTorque
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
@@ -511,10 +511,10 @@ public:
  */
 
 template <int dim>
-class VansAssemblerViscousTorque : public ParticleFluidAssemblerBase<dim>
+class VANSAssemblerViscousTorque : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VansAssemblerViscousTorque(
+  VANSAssemblerViscousTorque(
     Parameters::Lagrangian::LagrangianPhysicalProperties
       lagrangian_physical_properties)
     : lagrangian_physical_properties(lagrangian_physical_properties)
@@ -540,7 +540,7 @@ public:
  * M_viscous_vorticity = pi * pow(dp, 3) * mu * (0.5 * vorticity)
  *
  * The complete model described by Derksen is composed of
- * VansAssemblerViscousTorque + VansAssemblerVorticalTorque
+ * VANSAssemblerViscousTorque + VANSAssemblerVorticalTorque
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
@@ -548,10 +548,10 @@ public:
  */
 
 template <int dim>
-class VansAssemblerVorticalTorque : public ParticleFluidAssemblerBase<dim>
+class VANSAssemblerVorticalTorque : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VansAssemblerVorticalTorque(
+  VANSAssemblerVorticalTorque(
     Parameters::Lagrangian::LagrangianPhysicalProperties
       lagrangian_physical_properties)
     : lagrangian_physical_properties(lagrangian_physical_properties)
@@ -583,10 +583,10 @@ public:
  */
 
 template <int dim>
-class VansAssemblerBuoyancy : public ParticleFluidAssemblerBase<dim>
+class VANSAssemblerBuoyancy : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VansAssemblerBuoyancy(Parameters::Lagrangian::LagrangianPhysicalProperties
+  VANSAssemblerBuoyancy(Parameters::Lagrangian::LagrangianPhysicalProperties
                           lagrangian_physical_properties)
     : lagrangian_physical_properties(lagrangian_physical_properties)
 
@@ -616,10 +616,10 @@ public:
  */
 
 template <int dim>
-class VansAssemblerPressureForce : public ParticleFluidAssemblerBase<dim>
+class VANSAssemblerPressureForce : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VansAssemblerPressureForce(Parameters::CFDDEM cfd_dem)
+  VANSAssemblerPressureForce(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -645,10 +645,10 @@ public:
  */
 
 template <int dim>
-class VansAssemblerShearForce : public ParticleFluidAssemblerBase<dim>
+class VANSAssemblerShearForce : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VansAssemblerShearForce(Parameters::CFDDEM cfd_dem)
+  VANSAssemblerShearForce(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -674,10 +674,10 @@ public:
  */
 
 template <int dim>
-class VansAssemblerFPI : public NavierStokesAssemblerBase<dim>
+class VANSAssemblerFPI : public NavierStokesAssemblerBase<dim>
 {
 public:
-  VansAssemblerFPI(Parameters::CFDDEM cfd_dem)
+  VANSAssemblerFPI(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
 
   {}

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -64,12 +64,11 @@ public:
  * @ingroup assemblers
  */
 template <int dim>
-class GLSVansAssemblerCoreModelB : public NavierStokesAssemblerBase<dim>
+class VansAssemblerCoreModelB : public NavierStokesAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerCoreModelB(
-    std::shared_ptr<SimulationControl> simulation_control,
-    Parameters::CFDDEM                 cfd_dem)
+  VansAssemblerCoreModelB(std::shared_ptr<SimulationControl> simulation_control,
+                          Parameters::CFDDEM                 cfd_dem)
     : simulation_control(simulation_control)
     , cfd_dem(cfd_dem)
   {}
@@ -106,12 +105,11 @@ public:
  * @ingroup assemblers
  */
 template <int dim>
-class GLSVansAssemblerCoreModelA : public NavierStokesAssemblerBase<dim>
+class VansAssemblerCoreModelA : public NavierStokesAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerCoreModelA(
-    std::shared_ptr<SimulationControl> simulation_control,
-    Parameters::CFDDEM                 cfd_dem)
+  VansAssemblerCoreModelA(std::shared_ptr<SimulationControl> simulation_control,
+                          Parameters::CFDDEM                 cfd_dem)
     : simulation_control(simulation_control)
     , cfd_dem(cfd_dem)
   {}
@@ -153,11 +151,11 @@ public:
  */
 
 template <int dim>
-class GLSVansAssemblerBDF : public NavierStokesAssemblerBase<dim>
+class VansAssemblerBDF : public NavierStokesAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerBDF(std::shared_ptr<SimulationControl> simulation_control,
-                      Parameters::CFDDEM                 cfd_dem)
+  VansAssemblerBDF(std::shared_ptr<SimulationControl> simulation_control,
+                   Parameters::CFDDEM                 cfd_dem)
     : simulation_control(simulation_control)
     , cfd_dem(cfd_dem)
   {}
@@ -201,10 +199,10 @@ public:
  */
 
 template <int dim>
-class GLSVansAssemblerDiFelice : public ParticleFluidAssemblerBase<dim>
+class VansAssemblerDiFelice : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerDiFelice(Parameters::CFDDEM cfd_dem)
+  VansAssemblerDiFelice(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -237,10 +235,10 @@ public:
  */
 
 template <int dim>
-class GLSVansAssemblerRong : public ParticleFluidAssemblerBase<dim>
+class VansAssemblerRong : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerRong(Parameters::CFDDEM cfd_dem)
+  VansAssemblerRong(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -269,10 +267,10 @@ public:
  */
 
 template <int dim>
-class GLSVansAssemblerDallavalle : public ParticleFluidAssemblerBase<dim>
+class VansAssemblerDallavalle : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerDallavalle(Parameters::CFDDEM cfd_dem)
+  VansAssemblerDallavalle(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -317,10 +315,10 @@ public:
  */
 
 template <int dim>
-class GLSVansAssemblerKochHill : public ParticleFluidAssemblerBase<dim>
+class VansAssemblerKochHill : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerKochHill(Parameters::CFDDEM cfd_dem)
+  VansAssemblerKochHill(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -358,10 +356,10 @@ public:
  */
 
 template <int dim>
-class GLSVansAssemblerBeetstra : public ParticleFluidAssemblerBase<dim>
+class VansAssemblerBeetstra : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerBeetstra(Parameters::CFDDEM cfd_dem)
+  VansAssemblerBeetstra(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -407,10 +405,10 @@ public:
  */
 
 template <int dim>
-class GLSVansAssemblerGidaspow : public ParticleFluidAssemblerBase<dim>
+class VansAssemblerGidaspow : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerGidaspow(Parameters::CFDDEM cfd_dem)
+  VansAssemblerGidaspow(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -441,12 +439,11 @@ public:
  */
 
 template <int dim>
-class GLSVansAssemblerSaffmanMei : public ParticleFluidAssemblerBase<dim>
+class VansAssemblerSaffmanMei : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerSaffmanMei(
-    Parameters::Lagrangian::LagrangianPhysicalProperties
-      lagrangian_physical_properties)
+  VansAssemblerSaffmanMei(Parameters::Lagrangian::LagrangianPhysicalProperties
+                            lagrangian_physical_properties)
     : lagrangian_physical_properties(lagrangian_physical_properties)
 
   {}
@@ -477,11 +474,11 @@ public:
  */
 
 template <int dim>
-class GLSVansAssemblerMagnus : public ParticleFluidAssemblerBase<dim>
+class VansAssemblerMagnus : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerMagnus(Parameters::Lagrangian::LagrangianPhysicalProperties
-                           lagrangian_physical_properties)
+  VansAssemblerMagnus(Parameters::Lagrangian::LagrangianPhysicalProperties
+                        lagrangian_physical_properties)
     : lagrangian_physical_properties(lagrangian_physical_properties)
 
   {}
@@ -506,7 +503,7 @@ public:
  * M_viscous_rotation = pi * pow(dp, 3) * mu * (- omega_p)
  *
  * The complete model described by Derksen is composed of
- * GLSVansAssemblerViscousTorque + GLSVansAssemblerVorticalTorque
+ * VansAssemblerViscousTorque + VansAssemblerVorticalTorque
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
@@ -514,10 +511,10 @@ public:
  */
 
 template <int dim>
-class GLSVansAssemblerViscousTorque : public ParticleFluidAssemblerBase<dim>
+class VansAssemblerViscousTorque : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerViscousTorque(
+  VansAssemblerViscousTorque(
     Parameters::Lagrangian::LagrangianPhysicalProperties
       lagrangian_physical_properties)
     : lagrangian_physical_properties(lagrangian_physical_properties)
@@ -543,7 +540,7 @@ public:
  * M_viscous_vorticity = pi * pow(dp, 3) * mu * (0.5 * vorticity)
  *
  * The complete model described by Derksen is composed of
- * GLSVansAssemblerViscousTorque + GLSVansAssemblerVorticalTorque
+ * VansAssemblerViscousTorque + VansAssemblerVorticalTorque
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *
@@ -551,10 +548,10 @@ public:
  */
 
 template <int dim>
-class GLSVansAssemblerVorticalTorque : public ParticleFluidAssemblerBase<dim>
+class VansAssemblerVorticalTorque : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerVorticalTorque(
+  VansAssemblerVorticalTorque(
     Parameters::Lagrangian::LagrangianPhysicalProperties
       lagrangian_physical_properties)
     : lagrangian_physical_properties(lagrangian_physical_properties)
@@ -586,11 +583,11 @@ public:
  */
 
 template <int dim>
-class GLSVansAssemblerBuoyancy : public ParticleFluidAssemblerBase<dim>
+class VansAssemblerBuoyancy : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerBuoyancy(Parameters::Lagrangian::LagrangianPhysicalProperties
-                             lagrangian_physical_properties)
+  VansAssemblerBuoyancy(Parameters::Lagrangian::LagrangianPhysicalProperties
+                          lagrangian_physical_properties)
     : lagrangian_physical_properties(lagrangian_physical_properties)
 
   {}
@@ -619,10 +616,10 @@ public:
  */
 
 template <int dim>
-class GLSVansAssemblerPressureForce : public ParticleFluidAssemblerBase<dim>
+class VansAssemblerPressureForce : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerPressureForce(Parameters::CFDDEM cfd_dem)
+  VansAssemblerPressureForce(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -648,10 +645,10 @@ public:
  */
 
 template <int dim>
-class GLSVansAssemblerShearForce : public ParticleFluidAssemblerBase<dim>
+class VansAssemblerShearForce : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerShearForce(Parameters::CFDDEM cfd_dem)
+  VansAssemblerShearForce(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
   {}
 
@@ -677,10 +674,10 @@ public:
  */
 
 template <int dim>
-class GLSVansAssemblerFPI : public NavierStokesAssemblerBase<dim>
+class VansAssemblerFPI : public NavierStokesAssemblerBase<dim>
 {
 public:
-  GLSVansAssemblerFPI(Parameters::CFDDEM cfd_dem)
+  VansAssemblerFPI(Parameters::CFDDEM cfd_dem)
     : cfd_dem(cfd_dem)
 
   {}

--- a/source/fem-dem/CMakeLists.txt
+++ b/source/fem-dem/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(lethe-fem-dem
   cfd_dem_coupling.cc
   cfd_dem_simulation_parameters.cc
   gls_sharp_navier_stokes.cc
-  gls_vans.cc
+  fluid_dynamics_vans.cc
   ib_particles_dem.cc
   parameters_cfd_dem.cc
   postprocessing_cfd_dem.cc
@@ -12,7 +12,7 @@ add_library(lethe-fem-dem
   ../../include/fem-dem/cfd_dem_coupling.h
   ../../include/fem-dem/cfd_dem_simulation_parameters.h
   ../../include/fem-dem/gls_sharp_navier_stokes.h
-  ../../include/fem-dem/gls_vans.h
+  ../../include/fem-dem/fluid_dynamics_vans.h
   ../../include/fem-dem/ib_particles_dem.h
   ../../include/fem-dem/parameters_cfd_dem.h
   ../../include/fem-dem/postprocessing_cfd_dem.h

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -14,7 +14,7 @@
 // Constructor for the class CFD-DEM class
 template <int dim>
 CFDDEMSolver<dim>::CFDDEMSolver(CFDDEMSimulationParameters<dim> &nsparam)
-  : GLSVANSSolver<dim>(nsparam)
+  : FluidDynamicsVANS<dim>(nsparam)
   , this_mpi_process(Utilities::MPI::this_mpi_process(this->mpi_communicator))
   , n_mpi_processes(Utilities::MPI::n_mpi_processes(this->mpi_communicator))
 {}
@@ -1469,7 +1469,7 @@ CFDDEMSolver<dim>::solve()
       this->postprocess_cfd_dem();
       this->finish_time_step_fd();
 
-      this->GLSVANSSolver<dim>::monitor_mass_conservation();
+      this->FluidDynamicsVANS<dim>::monitor_mass_conservation();
 
       if (this->cfd_dem_simulation_parameters.cfd_dem.particle_statistics)
         report_particle_statistics();

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -1,6 +1,6 @@
 #include <core/lethe_grid_tools.h>
 
-#include <fem-dem/gls_vans.h>
+#include <fem-dem/fluid_dynamics_vans.h>
 
 #include <deal.II/base/work_stream.h>
 
@@ -8,9 +8,10 @@
 
 #include <deal.II/numerics/vector_tools.h>
 
-// Constructor for class GLS_VANS
+// Constructor for class FluidDynamicsVANS
 template <int dim>
-GLSVANSSolver<dim>::GLSVANSSolver(CFDDEMSimulationParameters<dim> &nsparam)
+FluidDynamicsVANS<dim>::FluidDynamicsVANS(
+  CFDDEMSimulationParameters<dim> &nsparam)
   : GLSNavierStokesSolver<dim>(nsparam.cfd_parameters)
   , cfd_dem_simulation_parameters(nsparam)
   , void_fraction_dof_handler(*this->triangulation)
@@ -46,7 +47,7 @@ GLSVANSSolver<dim>::GLSVANSSolver(CFDDEMSimulationParameters<dim> &nsparam)
 }
 
 template <int dim>
-GLSVANSSolver<dim>::~GLSVANSSolver()
+FluidDynamicsVANS<dim>::~FluidDynamicsVANS()
 {
   this->dof_handler.clear();
   void_fraction_dof_handler.clear();
@@ -54,7 +55,7 @@ GLSVANSSolver<dim>::~GLSVANSSolver()
 
 template <int dim>
 void
-GLSVANSSolver<dim>::setup_dofs()
+FluidDynamicsVANS<dim>::setup_dofs()
 {
   GLSNavierStokesSolver<dim>::setup_dofs();
 
@@ -154,7 +155,7 @@ GLSVANSSolver<dim>::setup_dofs()
 
 template <int dim>
 void
-GLSVANSSolver<dim>::percolate_void_fraction()
+FluidDynamicsVANS<dim>::percolate_void_fraction()
 {
   for (unsigned int i = previous_void_fraction.size() - 1; i > 0; --i)
     {
@@ -165,7 +166,7 @@ GLSVANSSolver<dim>::percolate_void_fraction()
 
 template <int dim>
 void
-GLSVANSSolver<dim>::finish_time_step_fd()
+FluidDynamicsVANS<dim>::finish_time_step_fd()
 {
   // Void fraction percolation must be done before the time step is finished to
   // ensure that the checkpointed information is correct
@@ -176,7 +177,7 @@ GLSVANSSolver<dim>::finish_time_step_fd()
 
 template <int dim>
 void
-GLSVANSSolver<dim>::read_dem()
+FluidDynamicsVANS<dim>::read_dem()
 {
   std::string prefix =
     this->cfd_dem_simulation_parameters.void_fraction->dem_file_name;
@@ -231,7 +232,7 @@ GLSVANSSolver<dim>::read_dem()
 
 template <int dim>
 void
-GLSVANSSolver<dim>::initialize_void_fraction()
+FluidDynamicsVANS<dim>::initialize_void_fraction()
 {
   calculate_void_fraction(this->simulation_control->get_current_time(), false);
   for (unsigned int i = 0; i < previous_void_fraction.size(); ++i)
@@ -240,8 +241,8 @@ GLSVANSSolver<dim>::initialize_void_fraction()
 
 template <int dim>
 void
-GLSVANSSolver<dim>::calculate_void_fraction(const double time,
-                                            bool         load_balance_step)
+FluidDynamicsVANS<dim>::calculate_void_fraction(const double time,
+                                                bool         load_balance_step)
 {
   announce_string(this->pcout, "Void Fraction");
 
@@ -283,7 +284,7 @@ GLSVANSSolver<dim>::calculate_void_fraction(const double time,
 
 template <int dim>
 void
-GLSVANSSolver<dim>::assemble_mass_matrix_diagonal(
+FluidDynamicsVANS<dim>::assemble_mass_matrix_diagonal(
   TrilinosWrappers::SparseMatrix &mass_matrix)
 {
   Assert(fe_void_fraction.degree == 1, ExcNotImplemented());
@@ -315,7 +316,7 @@ GLSVANSSolver<dim>::assemble_mass_matrix_diagonal(
 
 template <int dim>
 void
-GLSVANSSolver<dim>::update_solution_and_constraints()
+FluidDynamicsVANS<dim>::update_solution_and_constraints()
 {
   const double penalty_parameter = 100;
 
@@ -429,7 +430,7 @@ GLSVANSSolver<dim>::update_solution_and_constraints()
 
 template <int dim>
 void
-GLSVANSSolver<dim>::vertices_cell_mapping()
+FluidDynamicsVANS<dim>::vertices_cell_mapping()
 {
   // Find all the cells around each vertex
   TimerOutput::Scope t(this->computing_timer, "Map vertices to cell");
@@ -444,7 +445,7 @@ GLSVANSSolver<dim>::vertices_cell_mapping()
 
 template <int dim>
 void
-GLSVANSSolver<dim>::particle_centered_method()
+FluidDynamicsVANS<dim>::particle_centered_method()
 {
   QGauss<dim>         quadrature_formula(this->number_quadrature_points);
   const MappingQ<dim> mapping(1);
@@ -537,7 +538,8 @@ GLSVANSSolver<dim>::particle_centered_method()
 
 template <int dim>
 void
-GLSVANSSolver<dim>::quadrature_centered_sphere_method(bool load_balance_step)
+FluidDynamicsVANS<dim>::quadrature_centered_sphere_method(
+  bool load_balance_step)
 {
   QGauss<dim>         quadrature_formula(this->number_quadrature_points);
   const MappingQ<dim> mapping(1);
@@ -1079,7 +1081,7 @@ GLSVANSSolver<dim>::quadrature_centered_sphere_method(bool load_balance_step)
 
 template <int dim>
 void
-GLSVANSSolver<dim>::satellite_point_method()
+FluidDynamicsVANS<dim>::satellite_point_method()
 {
   QGauss<dim>         quadrature_formula(this->number_quadrature_points);
   const MappingQ<dim> mapping(1);
@@ -1318,7 +1320,7 @@ GLSVANSSolver<dim>::satellite_point_method()
 
 template <int dim>
 void
-GLSVANSSolver<dim>::solve_L2_system_void_fraction()
+FluidDynamicsVANS<dim>::solve_L2_system_void_fraction()
 {
   // Solve the L2 projection system
   const double linear_solver_tolerance = 1e-15;
@@ -1393,7 +1395,7 @@ GLSVANSSolver<dim>::solve_L2_system_void_fraction()
 // iteration with the solver and sets the initial conditions
 template <int dim>
 void
-GLSVANSSolver<dim>::iterate()
+FluidDynamicsVANS<dim>::iterate()
 {
   announce_string(this->pcout, "Volume-Averaged Fluid Dynamics");
   this->forcing_function->set_time(
@@ -1404,7 +1406,7 @@ GLSVANSSolver<dim>::iterate()
 
 template <int dim>
 void
-GLSVANSSolver<dim>::setup_assemblers()
+FluidDynamicsVANS<dim>::setup_assemblers()
 {
   this->assemblers.clear();
   particle_fluid_assemblers.clear();
@@ -1573,7 +1575,7 @@ GLSVANSSolver<dim>::setup_assemblers()
 
 template <int dim>
 void
-GLSVANSSolver<dim>::assemble_system_matrix()
+FluidDynamicsVANS<dim>::assemble_system_matrix()
 {
   {
     TimerOutput::Scope t(this->computing_timer, "Assemble matrix");
@@ -1601,8 +1603,8 @@ GLSVANSSolver<dim>::assemble_system_matrix()
       this->dof_handler.begin_active(),
       this->dof_handler.end(),
       *this,
-      &GLSVANSSolver::assemble_local_system_matrix,
-      &GLSVANSSolver::copy_local_matrix_to_global_matrix,
+      &FluidDynamicsVANS::assemble_local_system_matrix,
+      &FluidDynamicsVANS::copy_local_matrix_to_global_matrix,
       scratch_data,
       StabilizedMethodsTensorCopyData<dim>(this->fe->n_dofs_per_cell(),
                                            this->cell_quadrature->size()));
@@ -1612,7 +1614,7 @@ GLSVANSSolver<dim>::assemble_system_matrix()
 
 template <int dim>
 void
-GLSVANSSolver<dim>::assemble_local_system_matrix(
+FluidDynamicsVANS<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
   NavierStokesScratchData<dim>                         &scratch_data,
   StabilizedMethodsTensorCopyData<dim>                 &copy_data)
@@ -1664,7 +1666,7 @@ GLSVANSSolver<dim>::assemble_local_system_matrix(
 
 template <int dim>
 void
-GLSVANSSolver<dim>::copy_local_matrix_to_global_matrix(
+FluidDynamicsVANS<dim>::copy_local_matrix_to_global_matrix(
   const StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!copy_data.cell_is_local)
@@ -1678,7 +1680,7 @@ GLSVANSSolver<dim>::copy_local_matrix_to_global_matrix(
 
 template <int dim>
 void
-GLSVANSSolver<dim>::assemble_system_rhs()
+FluidDynamicsVANS<dim>::assemble_system_rhs()
 {
   TimerOutput::Scope t(this->computing_timer, "Assemble RHS");
 
@@ -1706,8 +1708,8 @@ GLSVANSSolver<dim>::assemble_system_rhs()
     this->dof_handler.begin_active(),
     this->dof_handler.end(),
     *this,
-    &GLSVANSSolver::assemble_local_system_rhs,
-    &GLSVANSSolver::copy_local_rhs_to_global_rhs,
+    &FluidDynamicsVANS::assemble_local_system_rhs,
+    &FluidDynamicsVANS::copy_local_rhs_to_global_rhs,
     scratch_data,
     StabilizedMethodsTensorCopyData<dim>(this->fe->n_dofs_per_cell(),
                                          this->cell_quadrature->size()));
@@ -1720,7 +1722,7 @@ GLSVANSSolver<dim>::assemble_system_rhs()
 
 template <int dim>
 void
-GLSVANSSolver<dim>::assemble_local_system_rhs(
+FluidDynamicsVANS<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
   NavierStokesScratchData<dim>                         &scratch_data,
   StabilizedMethodsTensorCopyData<dim>                 &copy_data)
@@ -1773,7 +1775,7 @@ GLSVANSSolver<dim>::assemble_local_system_rhs(
 
 template <int dim>
 void
-GLSVANSSolver<dim>::copy_local_rhs_to_global_rhs(
+FluidDynamicsVANS<dim>::copy_local_rhs_to_global_rhs(
   const StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!copy_data.cell_is_local)
@@ -1787,7 +1789,7 @@ GLSVANSSolver<dim>::copy_local_rhs_to_global_rhs(
 
 template <int dim>
 void
-GLSVANSSolver<dim>::output_field_hook(DataOut<dim> &data_out)
+FluidDynamicsVANS<dim>::output_field_hook(DataOut<dim> &data_out)
 {
   data_out.add_data_vector(void_fraction_dof_handler,
                            nodal_void_fraction_relevant,
@@ -1796,7 +1798,7 @@ GLSVANSSolver<dim>::output_field_hook(DataOut<dim> &data_out)
 
 template <int dim>
 void
-GLSVANSSolver<dim>::monitor_mass_conservation()
+FluidDynamicsVANS<dim>::monitor_mass_conservation()
 {
   QGauss<dim> quadrature_formula(this->number_quadrature_points);
 
@@ -1966,7 +1968,7 @@ GLSVANSSolver<dim>::monitor_mass_conservation()
 
 template <int dim>
 void
-GLSVANSSolver<dim>::solve()
+FluidDynamicsVANS<dim>::solve()
 {
   read_mesh_and_manifolds(
     *this->triangulation,
@@ -2041,5 +2043,5 @@ GLSVANSSolver<dim>::solve()
 // Pre-compile the 2D and 3D Navier-Stokes solver to ensure that the
 // library is valid before we actually compile the solver This greatly
 // helps with debugging
-template class GLSVANSSolver<2>;
-template class GLSVANSSolver<3>;
+template class FluidDynamicsVANS<2>;
+template class FluidDynamicsVANS<3>;

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -1449,7 +1449,7 @@ FluidDynamicsVANS<dim>::setup_assemblers()
         {
           // DiFelice Model drag Assembler
           particle_fluid_assemblers.push_back(
-            std::make_shared<GLSVansAssemblerDiFelice<dim>>(
+            std::make_shared<VansAssemblerDiFelice<dim>>(
               this->cfd_dem_simulation_parameters.cfd_dem));
         }
 
@@ -1458,7 +1458,7 @@ FluidDynamicsVANS<dim>::setup_assemblers()
         {
           // Rong Model drag Assembler
           particle_fluid_assemblers.push_back(
-            std::make_shared<GLSVansAssemblerRong<dim>>(
+            std::make_shared<VansAssemblerRong<dim>>(
               this->cfd_dem_simulation_parameters.cfd_dem));
         }
 
@@ -1467,7 +1467,7 @@ FluidDynamicsVANS<dim>::setup_assemblers()
         {
           // Dallavalle Model drag Assembler
           particle_fluid_assemblers.push_back(
-            std::make_shared<GLSVansAssemblerDallavalle<dim>>(
+            std::make_shared<VansAssemblerDallavalle<dim>>(
               this->cfd_dem_simulation_parameters.cfd_dem));
         }
 
@@ -1476,7 +1476,7 @@ FluidDynamicsVANS<dim>::setup_assemblers()
         {
           // Koch and Hill Model drag Assembler
           particle_fluid_assemblers.push_back(
-            std::make_shared<GLSVansAssemblerKochHill<dim>>(
+            std::make_shared<VansAssemblerKochHill<dim>>(
               this->cfd_dem_simulation_parameters.cfd_dem));
         }
       if (this->cfd_dem_simulation_parameters.cfd_dem.drag_model ==
@@ -1484,7 +1484,7 @@ FluidDynamicsVANS<dim>::setup_assemblers()
         {
           // Beetstra drag model assembler
           particle_fluid_assemblers.push_back(
-            std::make_shared<GLSVansAssemblerBeetstra<dim>>(
+            std::make_shared<VansAssemblerBeetstra<dim>>(
               this->cfd_dem_simulation_parameters.cfd_dem));
         }
       if (this->cfd_dem_simulation_parameters.cfd_dem.drag_model ==
@@ -1492,7 +1492,7 @@ FluidDynamicsVANS<dim>::setup_assemblers()
         {
           // Gidaspow Model drag Assembler
           particle_fluid_assemblers.push_back(
-            std::make_shared<GLSVansAssemblerGidaspow<dim>>(
+            std::make_shared<VansAssemblerGidaspow<dim>>(
               this->cfd_dem_simulation_parameters.cfd_dem));
         }
     }
@@ -1500,14 +1500,14 @@ FluidDynamicsVANS<dim>::setup_assemblers()
   if (this->cfd_dem_simulation_parameters.cfd_dem.saffman_lift_force == true)
     // Saffman Mei Lift Force Assembler
     particle_fluid_assemblers.push_back(
-      std::make_shared<GLSVansAssemblerSaffmanMei<dim>>(
+      std::make_shared<VansAssemblerSaffmanMei<dim>>(
         this->cfd_dem_simulation_parameters.dem_parameters
           .lagrangian_physical_properties));
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.magnus_lift_force == true)
     // Magnus Lift Force Assembler
     particle_fluid_assemblers.push_back(
-      std::make_shared<GLSVansAssemblerMagnus<dim>>(
+      std::make_shared<VansAssemblerMagnus<dim>>(
         this->cfd_dem_simulation_parameters.dem_parameters
           .lagrangian_physical_properties));
 
@@ -1515,7 +1515,7 @@ FluidDynamicsVANS<dim>::setup_assemblers()
       true)
     // Viscous Torque Assembler
     particle_fluid_assemblers.push_back(
-      std::make_shared<GLSVansAssemblerViscousTorque<dim>>(
+      std::make_shared<VansAssemblerViscousTorque<dim>>(
         this->cfd_dem_simulation_parameters.dem_parameters
           .lagrangian_physical_properties));
 
@@ -1523,38 +1523,38 @@ FluidDynamicsVANS<dim>::setup_assemblers()
       true)
     // Vortical Torque Assembler
     particle_fluid_assemblers.push_back(
-      std::make_shared<GLSVansAssemblerVorticalTorque<dim>>(
+      std::make_shared<VansAssemblerVorticalTorque<dim>>(
         this->cfd_dem_simulation_parameters.dem_parameters
           .lagrangian_physical_properties));
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.buoyancy_force == true)
     // Buoyancy Force Assembler
     particle_fluid_assemblers.push_back(
-      std::make_shared<GLSVansAssemblerBuoyancy<dim>>(
+      std::make_shared<VansAssemblerBuoyancy<dim>>(
         this->cfd_dem_simulation_parameters.dem_parameters
           .lagrangian_physical_properties));
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.pressure_force == true)
     // Pressure Force
     particle_fluid_assemblers.push_back(
-      std::make_shared<GLSVansAssemblerPressureForce<dim>>(
+      std::make_shared<VansAssemblerPressureForce<dim>>(
         this->cfd_dem_simulation_parameters.cfd_dem));
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.shear_force == true)
     // Shear Force
     particle_fluid_assemblers.push_back(
-      std::make_shared<GLSVansAssemblerShearForce<dim>>(
+      std::make_shared<VansAssemblerShearForce<dim>>(
         this->cfd_dem_simulation_parameters.cfd_dem));
 
   // Time-stepping schemes
   if (is_bdf(this->simulation_control->get_assembly_method()))
     {
-      this->assemblers.push_back(std::make_shared<GLSVansAssemblerBDF<dim>>(
+      this->assemblers.push_back(std::make_shared<VansAssemblerBDF<dim>>(
         this->simulation_control, this->cfd_dem_simulation_parameters.cfd_dem));
     }
 
   //  Fluid_Particle Interactions Assembler
-  this->assemblers.push_back(std::make_shared<GLSVansAssemblerFPI<dim>>(
+  this->assemblers.push_back(std::make_shared<VansAssemblerFPI<dim>>(
     this->cfd_dem_simulation_parameters.cfd_dem));
 
   // The core assembler should always be the last assembler to be called
@@ -1562,15 +1562,13 @@ FluidDynamicsVANS<dim>::setup_assemblers()
   // jacobian stored. Core assembler
   if (this->cfd_dem_simulation_parameters.cfd_dem.vans_model ==
       Parameters::VANSModel::modelA)
-    this->assemblers.push_back(
-      std::make_shared<GLSVansAssemblerCoreModelA<dim>>(
-        this->simulation_control, this->cfd_dem_simulation_parameters.cfd_dem));
+    this->assemblers.push_back(std::make_shared<VansAssemblerCoreModelA<dim>>(
+      this->simulation_control, this->cfd_dem_simulation_parameters.cfd_dem));
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.vans_model ==
       Parameters::VANSModel::modelB)
-    this->assemblers.push_back(
-      std::make_shared<GLSVansAssemblerCoreModelB<dim>>(
-        this->simulation_control, this->cfd_dem_simulation_parameters.cfd_dem));
+    this->assemblers.push_back(std::make_shared<VansAssemblerCoreModelB<dim>>(
+      this->simulation_control, this->cfd_dem_simulation_parameters.cfd_dem));
 }
 
 template <int dim>

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -1449,7 +1449,7 @@ FluidDynamicsVANS<dim>::setup_assemblers()
         {
           // DiFelice Model drag Assembler
           particle_fluid_assemblers.push_back(
-            std::make_shared<VansAssemblerDiFelice<dim>>(
+            std::make_shared<VANSAssemblerDiFelice<dim>>(
               this->cfd_dem_simulation_parameters.cfd_dem));
         }
 
@@ -1458,7 +1458,7 @@ FluidDynamicsVANS<dim>::setup_assemblers()
         {
           // Rong Model drag Assembler
           particle_fluid_assemblers.push_back(
-            std::make_shared<VansAssemblerRong<dim>>(
+            std::make_shared<VANSAssemblerRong<dim>>(
               this->cfd_dem_simulation_parameters.cfd_dem));
         }
 
@@ -1467,7 +1467,7 @@ FluidDynamicsVANS<dim>::setup_assemblers()
         {
           // Dallavalle Model drag Assembler
           particle_fluid_assemblers.push_back(
-            std::make_shared<VansAssemblerDallavalle<dim>>(
+            std::make_shared<VANSAssemblerDallavalle<dim>>(
               this->cfd_dem_simulation_parameters.cfd_dem));
         }
 
@@ -1476,7 +1476,7 @@ FluidDynamicsVANS<dim>::setup_assemblers()
         {
           // Koch and Hill Model drag Assembler
           particle_fluid_assemblers.push_back(
-            std::make_shared<VansAssemblerKochHill<dim>>(
+            std::make_shared<VANSAssemblerKochHill<dim>>(
               this->cfd_dem_simulation_parameters.cfd_dem));
         }
       if (this->cfd_dem_simulation_parameters.cfd_dem.drag_model ==
@@ -1484,7 +1484,7 @@ FluidDynamicsVANS<dim>::setup_assemblers()
         {
           // Beetstra drag model assembler
           particle_fluid_assemblers.push_back(
-            std::make_shared<VansAssemblerBeetstra<dim>>(
+            std::make_shared<VANSAssemblerBeetstra<dim>>(
               this->cfd_dem_simulation_parameters.cfd_dem));
         }
       if (this->cfd_dem_simulation_parameters.cfd_dem.drag_model ==
@@ -1492,7 +1492,7 @@ FluidDynamicsVANS<dim>::setup_assemblers()
         {
           // Gidaspow Model drag Assembler
           particle_fluid_assemblers.push_back(
-            std::make_shared<VansAssemblerGidaspow<dim>>(
+            std::make_shared<VANSAssemblerGidaspow<dim>>(
               this->cfd_dem_simulation_parameters.cfd_dem));
         }
     }
@@ -1500,14 +1500,14 @@ FluidDynamicsVANS<dim>::setup_assemblers()
   if (this->cfd_dem_simulation_parameters.cfd_dem.saffman_lift_force == true)
     // Saffman Mei Lift Force Assembler
     particle_fluid_assemblers.push_back(
-      std::make_shared<VansAssemblerSaffmanMei<dim>>(
+      std::make_shared<VANSAssemblerSaffmanMei<dim>>(
         this->cfd_dem_simulation_parameters.dem_parameters
           .lagrangian_physical_properties));
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.magnus_lift_force == true)
     // Magnus Lift Force Assembler
     particle_fluid_assemblers.push_back(
-      std::make_shared<VansAssemblerMagnus<dim>>(
+      std::make_shared<VANSAssemblerMagnus<dim>>(
         this->cfd_dem_simulation_parameters.dem_parameters
           .lagrangian_physical_properties));
 
@@ -1515,7 +1515,7 @@ FluidDynamicsVANS<dim>::setup_assemblers()
       true)
     // Viscous Torque Assembler
     particle_fluid_assemblers.push_back(
-      std::make_shared<VansAssemblerViscousTorque<dim>>(
+      std::make_shared<VANSAssemblerViscousTorque<dim>>(
         this->cfd_dem_simulation_parameters.dem_parameters
           .lagrangian_physical_properties));
 
@@ -1523,38 +1523,38 @@ FluidDynamicsVANS<dim>::setup_assemblers()
       true)
     // Vortical Torque Assembler
     particle_fluid_assemblers.push_back(
-      std::make_shared<VansAssemblerVorticalTorque<dim>>(
+      std::make_shared<VANSAssemblerVorticalTorque<dim>>(
         this->cfd_dem_simulation_parameters.dem_parameters
           .lagrangian_physical_properties));
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.buoyancy_force == true)
     // Buoyancy Force Assembler
     particle_fluid_assemblers.push_back(
-      std::make_shared<VansAssemblerBuoyancy<dim>>(
+      std::make_shared<VANSAssemblerBuoyancy<dim>>(
         this->cfd_dem_simulation_parameters.dem_parameters
           .lagrangian_physical_properties));
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.pressure_force == true)
     // Pressure Force
     particle_fluid_assemblers.push_back(
-      std::make_shared<VansAssemblerPressureForce<dim>>(
+      std::make_shared<VANSAssemblerPressureForce<dim>>(
         this->cfd_dem_simulation_parameters.cfd_dem));
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.shear_force == true)
     // Shear Force
     particle_fluid_assemblers.push_back(
-      std::make_shared<VansAssemblerShearForce<dim>>(
+      std::make_shared<VANSAssemblerShearForce<dim>>(
         this->cfd_dem_simulation_parameters.cfd_dem));
 
   // Time-stepping schemes
   if (is_bdf(this->simulation_control->get_assembly_method()))
     {
-      this->assemblers.push_back(std::make_shared<VansAssemblerBDF<dim>>(
+      this->assemblers.push_back(std::make_shared<VANSAssemblerBDF<dim>>(
         this->simulation_control, this->cfd_dem_simulation_parameters.cfd_dem));
     }
 
   //  Fluid_Particle Interactions Assembler
-  this->assemblers.push_back(std::make_shared<VansAssemblerFPI<dim>>(
+  this->assemblers.push_back(std::make_shared<VANSAssemblerFPI<dim>>(
     this->cfd_dem_simulation_parameters.cfd_dem));
 
   // The core assembler should always be the last assembler to be called
@@ -1562,12 +1562,12 @@ FluidDynamicsVANS<dim>::setup_assemblers()
   // jacobian stored. Core assembler
   if (this->cfd_dem_simulation_parameters.cfd_dem.vans_model ==
       Parameters::VANSModel::modelA)
-    this->assemblers.push_back(std::make_shared<VansAssemblerCoreModelA<dim>>(
+    this->assemblers.push_back(std::make_shared<VANSAssemblerCoreModelA<dim>>(
       this->simulation_control, this->cfd_dem_simulation_parameters.cfd_dem));
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.vans_model ==
       Parameters::VANSModel::modelB)
-    this->assemblers.push_back(std::make_shared<VansAssemblerCoreModelB<dim>>(
+    this->assemblers.push_back(std::make_shared<VANSAssemblerCoreModelB<dim>>(
       this->simulation_control, this->cfd_dem_simulation_parameters.cfd_dem));
 }
 

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -9,7 +9,7 @@
 
 template <int dim>
 void
-GLSVansAssemblerCoreModelB<dim>::assemble_matrix(
+VansAssemblerCoreModelB<dim>::assemble_matrix(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -212,7 +212,7 @@ GLSVansAssemblerCoreModelB<dim>::assemble_matrix(
 
 template <int dim>
 void
-GLSVansAssemblerCoreModelB<dim>::assemble_rhs(
+VansAssemblerCoreModelB<dim>::assemble_rhs(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -364,12 +364,12 @@ GLSVansAssemblerCoreModelB<dim>::assemble_rhs(
 }
 
 
-template class GLSVansAssemblerCoreModelB<2>;
-template class GLSVansAssemblerCoreModelB<3>;
+template class VansAssemblerCoreModelB<2>;
+template class VansAssemblerCoreModelB<3>;
 
 template <int dim>
 void
-GLSVansAssemblerCoreModelA<dim>::assemble_matrix(
+VansAssemblerCoreModelA<dim>::assemble_matrix(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -576,7 +576,7 @@ GLSVansAssemblerCoreModelA<dim>::assemble_matrix(
 
 template <int dim>
 void
-GLSVansAssemblerCoreModelA<dim>::assemble_rhs(
+VansAssemblerCoreModelA<dim>::assemble_rhs(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -734,12 +734,12 @@ GLSVansAssemblerCoreModelA<dim>::assemble_rhs(
     }
 }
 
-template class GLSVansAssemblerCoreModelA<2>;
-template class GLSVansAssemblerCoreModelA<3>;
+template class VansAssemblerCoreModelA<2>;
+template class VansAssemblerCoreModelA<3>;
 
 template <int dim>
 void
-GLSVansAssemblerBDF<dim>::assemble_matrix(
+VansAssemblerBDF<dim>::assemble_matrix(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -799,7 +799,7 @@ GLSVansAssemblerBDF<dim>::assemble_matrix(
 
 template <int dim>
 void
-GLSVansAssemblerBDF<dim>::assemble_rhs(
+VansAssemblerBDF<dim>::assemble_rhs(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -890,12 +890,12 @@ GLSVansAssemblerBDF<dim>::assemble_rhs(
     }
 }
 
-template class GLSVansAssemblerBDF<2>;
-template class GLSVansAssemblerBDF<3>;
+template class VansAssemblerBDF<2>;
+template class VansAssemblerBDF<3>;
 
 template <int dim>
 void
-GLSVansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions(
+VansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   // particle_number is an increment that goes from 0 to n_particles_in_cell.
@@ -917,12 +917,12 @@ GLSVansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "GLSVansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions"));
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "GLSVansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   const auto pic               = scratch_data.pic;
@@ -966,12 +966,12 @@ GLSVansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions(
   beta_drag = beta_drag / scratch_data.cell_volume;
 }
 
-template class GLSVansAssemblerDiFelice<2>;
-template class GLSVansAssemblerDiFelice<3>;
+template class VansAssemblerDiFelice<2>;
+template class VansAssemblerDiFelice<3>;
 
 template <int dim>
 void
-GLSVansAssemblerRong<dim>::calculate_particle_fluid_interactions(
+VansAssemblerRong<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   double      cell_void_fraction = 0;
@@ -986,11 +986,11 @@ GLSVansAssemblerRong<dim>::calculate_particle_fluid_interactions(
   // Physical Properties
   Assert(!scratch_data.properties_manager.is_non_newtonian(),
          RequiresConstantViscosity(
-           "GLSVansAssemblerRong<dim>::calculate_particle_fluid_interactions"));
+           "VansAssemblerRong<dim>::calculate_particle_fluid_interactions"));
 
   Assert(scratch_data.properties_manager.density_is_constant(),
          RequiresConstantDensity(
-           "GLSVansAssemblerRong<dim>::calculate_particle_fluid_interactions"));
+           "VansAssemblerRong<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   const auto pic               = scratch_data.pic;
@@ -1035,12 +1035,12 @@ GLSVansAssemblerRong<dim>::calculate_particle_fluid_interactions(
   beta_drag = beta_drag / scratch_data.cell_volume;
 }
 
-template class GLSVansAssemblerRong<2>;
-template class GLSVansAssemblerRong<3>;
+template class VansAssemblerRong<2>;
+template class VansAssemblerRong<3>;
 
 template <int dim>
 void
-GLSVansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions(
+VansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   double      C_d = 0;
@@ -1055,12 +1055,12 @@ GLSVansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "GLSVansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions"));
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "GLSVansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   const auto pic               = scratch_data.pic;
@@ -1097,12 +1097,12 @@ GLSVansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions(
   beta_drag = beta_drag / scratch_data.cell_volume;
 }
 
-template class GLSVansAssemblerDallavalle<2>;
-template class GLSVansAssemblerDallavalle<3>;
+template class VansAssemblerDallavalle<2>;
+template class VansAssemblerDallavalle<3>;
 
 template <int dim>
 void
-GLSVansAssemblerKochHill<dim>::calculate_particle_fluid_interactions(
+VansAssemblerKochHill<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   double      cell_void_fraction = 0;
@@ -1117,14 +1117,14 @@ GLSVansAssemblerKochHill<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "GLSVansAssemblerKochHill<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerKochHill<dim>::calculate_particle_fluid_interactions"));
   const double kinematic_viscosity =
     scratch_data.properties_manager.get_kinematic_viscosity_scale();
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "GLSVansAssemblerKochHill<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerKochHill<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   const auto pic               = scratch_data.pic;
@@ -1186,12 +1186,12 @@ GLSVansAssemblerKochHill<dim>::calculate_particle_fluid_interactions(
   beta_drag = beta_drag / scratch_data.cell_volume;
 }
 
-template class GLSVansAssemblerKochHill<2>;
-template class GLSVansAssemblerKochHill<3>;
+template class VansAssemblerKochHill<2>;
+template class VansAssemblerKochHill<3>;
 
 template <int dim>
 void
-GLSVansAssemblerBeetstra<dim>::calculate_particle_fluid_interactions(
+VansAssemblerBeetstra<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   double      cell_void_fraction = 0;
@@ -1209,14 +1209,14 @@ GLSVansAssemblerBeetstra<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "GLSVansAssemblerBeetstra<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerBeetstra<dim>::calculate_particle_fluid_interactions"));
   const double kinematic_viscosity =
     scratch_data.properties_manager.get_kinematic_viscosity_scale();
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "GLSVansAssemblerBeetstra<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerBeetstra<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   const auto pic               = scratch_data.pic;
@@ -1264,12 +1264,12 @@ GLSVansAssemblerBeetstra<dim>::calculate_particle_fluid_interactions(
   beta_drag = beta_drag / scratch_data.cell_volume;
 }
 
-template class GLSVansAssemblerBeetstra<2>;
-template class GLSVansAssemblerBeetstra<3>;
+template class VansAssemblerBeetstra<2>;
+template class VansAssemblerBeetstra<3>;
 
 template <int dim>
 void
-GLSVansAssemblerGidaspow<dim>::calculate_particle_fluid_interactions(
+VansAssemblerGidaspow<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   // particle_number is an increment that goes from 0 to n_particles_in_cell.
@@ -1290,14 +1290,14 @@ GLSVansAssemblerGidaspow<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "GLSVansAssemblerGidaspow<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerGidaspow<dim>::calculate_particle_fluid_interactions"));
   const double kinematic_viscosity =
     scratch_data.properties_manager.get_kinematic_viscosity_scale();
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "GLSVansAssemblerGidaspow<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerGidaspow<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
 
@@ -1363,12 +1363,12 @@ GLSVansAssemblerGidaspow<dim>::calculate_particle_fluid_interactions(
   beta_drag = beta_drag / scratch_data.cell_volume;
 }
 
-template class GLSVansAssemblerGidaspow<2>;
-template class GLSVansAssemblerGidaspow<3>;
+template class VansAssemblerGidaspow<2>;
+template class VansAssemblerGidaspow<3>;
 
 template <int dim>
 void
-GLSVansAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions(
+VansAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   // particle_number is an increment that goes from 0 to n_particles_in_cell.
@@ -1400,14 +1400,14 @@ GLSVansAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "GLSVansAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions"));
   const double kinematic_viscosity =
     scratch_data.properties_manager.get_kinematic_viscosity_scale();
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "GLSVansAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   const auto   pic             = scratch_data.pic;
@@ -1509,12 +1509,12 @@ GLSVansAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions(
     }
 }
 
-template class GLSVansAssemblerSaffmanMei<2>;
-template class GLSVansAssemblerSaffmanMei<3>;
+template class VansAssemblerSaffmanMei<2>;
+template class VansAssemblerSaffmanMei<3>;
 
 template <int dim>
 void
-GLSVansAssemblerMagnus<dim>::calculate_particle_fluid_interactions(
+VansAssemblerMagnus<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   // particle_number is an increment that goes from 0 to n_particles_in_cell.
@@ -1536,10 +1536,9 @@ GLSVansAssemblerMagnus<dim>::calculate_particle_fluid_interactions(
   Tensor<1, dim> lift_force;
 
   // Physical Properties
-  Assert(
-    scratch_data.properties_manager.density_is_constant(),
-    RequiresConstantDensity(
-      "GLSVansAssemblerMagnus<dim>::calculate_particle_fluid_interactions"));
+  Assert(scratch_data.properties_manager.density_is_constant(),
+         RequiresConstantDensity(
+           "VansAssemblerMagnus<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   const auto   pic             = scratch_data.pic;
@@ -1657,12 +1656,12 @@ GLSVansAssemblerMagnus<dim>::calculate_particle_fluid_interactions(
     }
 }
 
-template class GLSVansAssemblerMagnus<2>;
-template class GLSVansAssemblerMagnus<3>;
+template class VansAssemblerMagnus<2>;
+template class VansAssemblerMagnus<3>;
 
 template <int dim>
 void
-GLSVansAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions(
+VansAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   // particle_number is an increment that goes from 0 to n_particles_in_cell.
@@ -1672,12 +1671,12 @@ GLSVansAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "GLSVansAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions"));
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "GLSVansAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions"));
 
   const double density = scratch_data.properties_manager.get_density_scale();
   const double kinematic_viscosity =
@@ -1707,24 +1706,24 @@ GLSVansAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions(
   particle_number += 1;
 }
 
-template class GLSVansAssemblerViscousTorque<2>;
-template class GLSVansAssemblerViscousTorque<3>;
+template class VansAssemblerViscousTorque<2>;
+template class VansAssemblerViscousTorque<3>;
 
 template <int dim>
 void
-GLSVansAssemblerVorticalTorque<dim>::calculate_particle_fluid_interactions(
+VansAssemblerVorticalTorque<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   // Physical Properties
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "GLSVansAssemblerVorticalTorque<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerVorticalTorque<dim>::calculate_particle_fluid_interactions"));
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "GLSVansAssemblerVorticalTorque<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerVorticalTorque<dim>::calculate_particle_fluid_interactions"));
 
   const double density = scratch_data.properties_manager.get_density_scale();
   const double kinematic_viscosity =
@@ -1760,12 +1759,12 @@ GLSVansAssemblerVorticalTorque<dim>::calculate_particle_fluid_interactions(
   i_particle += 1;
 }
 
-template class GLSVansAssemblerVorticalTorque<2>;
-template class GLSVansAssemblerVorticalTorque<3>;
+template class VansAssemblerVorticalTorque<2>;
+template class VansAssemblerVorticalTorque<3>;
 
 template <int dim>
 void
-GLSVansAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions(
+VansAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   const auto   pic = scratch_data.pic;
@@ -1775,7 +1774,7 @@ GLSVansAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions(
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "GLSVansAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions"));
 
   const double density = scratch_data.properties_manager.get_density_scale();
 
@@ -1797,12 +1796,12 @@ GLSVansAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions(
     }
 }
 
-template class GLSVansAssemblerBuoyancy<2>;
-template class GLSVansAssemblerBuoyancy<3>;
+template class VansAssemblerBuoyancy<2>;
+template class VansAssemblerBuoyancy<3>;
 
 template <int dim>
 void
-GLSVansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions(
+VansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   const auto pic                    = scratch_data.pic;
@@ -1817,7 +1816,7 @@ GLSVansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions(
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "GLSVansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions"));
 
 
   const double density = scratch_data.properties_manager.get_density_scale();
@@ -1852,12 +1851,12 @@ GLSVansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions(
     }
 }
 
-template class GLSVansAssemblerPressureForce<2>;
-template class GLSVansAssemblerPressureForce<3>;
+template class VansAssemblerPressureForce<2>;
+template class VansAssemblerPressureForce<3>;
 
 template <int dim>
 void
-GLSVansAssemblerShearForce<dim>::calculate_particle_fluid_interactions(
+VansAssemblerShearForce<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   const auto pic                    = scratch_data.pic;
@@ -1874,14 +1873,14 @@ GLSVansAssemblerShearForce<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "GLSVansAssemblerShearForce<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerShearForce<dim>::calculate_particle_fluid_interactions"));
   const double kinematic_viscosity =
     scratch_data.properties_manager.get_kinematic_viscosity_scale();
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "GLSVansAssemblerShearForce<dim>::calculate_particle_fluid_interactions"));
+      "VansAssemblerShearForce<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   // Loop over particles in cell
@@ -1915,13 +1914,13 @@ GLSVansAssemblerShearForce<dim>::calculate_particle_fluid_interactions(
     }
 }
 
-template class GLSVansAssemblerShearForce<2>;
-template class GLSVansAssemblerShearForce<3>;
+template class VansAssemblerShearForce<2>;
+template class VansAssemblerShearForce<3>;
 
 
 template <int dim>
 void
-GLSVansAssemblerFPI<dim>::assemble_matrix(
+VansAssemblerFPI<dim>::assemble_matrix(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -1986,7 +1985,7 @@ GLSVansAssemblerFPI<dim>::assemble_matrix(
 
 template <int dim>
 void
-GLSVansAssemblerFPI<dim>::assemble_rhs(
+VansAssemblerFPI<dim>::assemble_rhs(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -2049,5 +2048,5 @@ GLSVansAssemblerFPI<dim>::assemble_rhs(
     }
 }
 
-template class GLSVansAssemblerFPI<2>;
-template class GLSVansAssemblerFPI<3>;
+template class VansAssemblerFPI<2>;
+template class VansAssemblerFPI<3>;

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -9,7 +9,7 @@
 
 template <int dim>
 void
-VansAssemblerCoreModelB<dim>::assemble_matrix(
+VANSAssemblerCoreModelB<dim>::assemble_matrix(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -212,7 +212,7 @@ VansAssemblerCoreModelB<dim>::assemble_matrix(
 
 template <int dim>
 void
-VansAssemblerCoreModelB<dim>::assemble_rhs(
+VANSAssemblerCoreModelB<dim>::assemble_rhs(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -364,12 +364,12 @@ VansAssemblerCoreModelB<dim>::assemble_rhs(
 }
 
 
-template class VansAssemblerCoreModelB<2>;
-template class VansAssemblerCoreModelB<3>;
+template class VANSAssemblerCoreModelB<2>;
+template class VANSAssemblerCoreModelB<3>;
 
 template <int dim>
 void
-VansAssemblerCoreModelA<dim>::assemble_matrix(
+VANSAssemblerCoreModelA<dim>::assemble_matrix(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -576,7 +576,7 @@ VansAssemblerCoreModelA<dim>::assemble_matrix(
 
 template <int dim>
 void
-VansAssemblerCoreModelA<dim>::assemble_rhs(
+VANSAssemblerCoreModelA<dim>::assemble_rhs(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -734,12 +734,12 @@ VansAssemblerCoreModelA<dim>::assemble_rhs(
     }
 }
 
-template class VansAssemblerCoreModelA<2>;
-template class VansAssemblerCoreModelA<3>;
+template class VANSAssemblerCoreModelA<2>;
+template class VANSAssemblerCoreModelA<3>;
 
 template <int dim>
 void
-VansAssemblerBDF<dim>::assemble_matrix(
+VANSAssemblerBDF<dim>::assemble_matrix(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -799,7 +799,7 @@ VansAssemblerBDF<dim>::assemble_matrix(
 
 template <int dim>
 void
-VansAssemblerBDF<dim>::assemble_rhs(
+VANSAssemblerBDF<dim>::assemble_rhs(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -890,12 +890,12 @@ VansAssemblerBDF<dim>::assemble_rhs(
     }
 }
 
-template class VansAssemblerBDF<2>;
-template class VansAssemblerBDF<3>;
+template class VANSAssemblerBDF<2>;
+template class VANSAssemblerBDF<3>;
 
 template <int dim>
 void
-VansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions(
+VANSAssemblerDiFelice<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   // particle_number is an increment that goes from 0 to n_particles_in_cell.
@@ -917,12 +917,12 @@ VansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "VansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerDiFelice<dim>::calculate_particle_fluid_interactions"));
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "VansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerDiFelice<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   const auto pic               = scratch_data.pic;
@@ -966,12 +966,12 @@ VansAssemblerDiFelice<dim>::calculate_particle_fluid_interactions(
   beta_drag = beta_drag / scratch_data.cell_volume;
 }
 
-template class VansAssemblerDiFelice<2>;
-template class VansAssemblerDiFelice<3>;
+template class VANSAssemblerDiFelice<2>;
+template class VANSAssemblerDiFelice<3>;
 
 template <int dim>
 void
-VansAssemblerRong<dim>::calculate_particle_fluid_interactions(
+VANSAssemblerRong<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   double      cell_void_fraction = 0;
@@ -986,11 +986,11 @@ VansAssemblerRong<dim>::calculate_particle_fluid_interactions(
   // Physical Properties
   Assert(!scratch_data.properties_manager.is_non_newtonian(),
          RequiresConstantViscosity(
-           "VansAssemblerRong<dim>::calculate_particle_fluid_interactions"));
+           "VANSAssemblerRong<dim>::calculate_particle_fluid_interactions"));
 
   Assert(scratch_data.properties_manager.density_is_constant(),
          RequiresConstantDensity(
-           "VansAssemblerRong<dim>::calculate_particle_fluid_interactions"));
+           "VANSAssemblerRong<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   const auto pic               = scratch_data.pic;
@@ -1035,12 +1035,12 @@ VansAssemblerRong<dim>::calculate_particle_fluid_interactions(
   beta_drag = beta_drag / scratch_data.cell_volume;
 }
 
-template class VansAssemblerRong<2>;
-template class VansAssemblerRong<3>;
+template class VANSAssemblerRong<2>;
+template class VANSAssemblerRong<3>;
 
 template <int dim>
 void
-VansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions(
+VANSAssemblerDallavalle<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   double      C_d = 0;
@@ -1055,12 +1055,12 @@ VansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "VansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerDallavalle<dim>::calculate_particle_fluid_interactions"));
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "VansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerDallavalle<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   const auto pic               = scratch_data.pic;
@@ -1097,12 +1097,12 @@ VansAssemblerDallavalle<dim>::calculate_particle_fluid_interactions(
   beta_drag = beta_drag / scratch_data.cell_volume;
 }
 
-template class VansAssemblerDallavalle<2>;
-template class VansAssemblerDallavalle<3>;
+template class VANSAssemblerDallavalle<2>;
+template class VANSAssemblerDallavalle<3>;
 
 template <int dim>
 void
-VansAssemblerKochHill<dim>::calculate_particle_fluid_interactions(
+VANSAssemblerKochHill<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   double      cell_void_fraction = 0;
@@ -1117,14 +1117,14 @@ VansAssemblerKochHill<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "VansAssemblerKochHill<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerKochHill<dim>::calculate_particle_fluid_interactions"));
   const double kinematic_viscosity =
     scratch_data.properties_manager.get_kinematic_viscosity_scale();
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "VansAssemblerKochHill<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerKochHill<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   const auto pic               = scratch_data.pic;
@@ -1186,12 +1186,12 @@ VansAssemblerKochHill<dim>::calculate_particle_fluid_interactions(
   beta_drag = beta_drag / scratch_data.cell_volume;
 }
 
-template class VansAssemblerKochHill<2>;
-template class VansAssemblerKochHill<3>;
+template class VANSAssemblerKochHill<2>;
+template class VANSAssemblerKochHill<3>;
 
 template <int dim>
 void
-VansAssemblerBeetstra<dim>::calculate_particle_fluid_interactions(
+VANSAssemblerBeetstra<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   double      cell_void_fraction = 0;
@@ -1209,14 +1209,14 @@ VansAssemblerBeetstra<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "VansAssemblerBeetstra<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerBeetstra<dim>::calculate_particle_fluid_interactions"));
   const double kinematic_viscosity =
     scratch_data.properties_manager.get_kinematic_viscosity_scale();
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "VansAssemblerBeetstra<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerBeetstra<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   const auto pic               = scratch_data.pic;
@@ -1264,12 +1264,12 @@ VansAssemblerBeetstra<dim>::calculate_particle_fluid_interactions(
   beta_drag = beta_drag / scratch_data.cell_volume;
 }
 
-template class VansAssemblerBeetstra<2>;
-template class VansAssemblerBeetstra<3>;
+template class VANSAssemblerBeetstra<2>;
+template class VANSAssemblerBeetstra<3>;
 
 template <int dim>
 void
-VansAssemblerGidaspow<dim>::calculate_particle_fluid_interactions(
+VANSAssemblerGidaspow<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   // particle_number is an increment that goes from 0 to n_particles_in_cell.
@@ -1290,14 +1290,14 @@ VansAssemblerGidaspow<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "VansAssemblerGidaspow<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerGidaspow<dim>::calculate_particle_fluid_interactions"));
   const double kinematic_viscosity =
     scratch_data.properties_manager.get_kinematic_viscosity_scale();
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "VansAssemblerGidaspow<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerGidaspow<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
 
@@ -1363,12 +1363,12 @@ VansAssemblerGidaspow<dim>::calculate_particle_fluid_interactions(
   beta_drag = beta_drag / scratch_data.cell_volume;
 }
 
-template class VansAssemblerGidaspow<2>;
-template class VansAssemblerGidaspow<3>;
+template class VANSAssemblerGidaspow<2>;
+template class VANSAssemblerGidaspow<3>;
 
 template <int dim>
 void
-VansAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions(
+VANSAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   // particle_number is an increment that goes from 0 to n_particles_in_cell.
@@ -1400,14 +1400,14 @@ VansAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "VansAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions"));
   const double kinematic_viscosity =
     scratch_data.properties_manager.get_kinematic_viscosity_scale();
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "VansAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   const auto   pic             = scratch_data.pic;
@@ -1509,12 +1509,12 @@ VansAssemblerSaffmanMei<dim>::calculate_particle_fluid_interactions(
     }
 }
 
-template class VansAssemblerSaffmanMei<2>;
-template class VansAssemblerSaffmanMei<3>;
+template class VANSAssemblerSaffmanMei<2>;
+template class VANSAssemblerSaffmanMei<3>;
 
 template <int dim>
 void
-VansAssemblerMagnus<dim>::calculate_particle_fluid_interactions(
+VANSAssemblerMagnus<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   // particle_number is an increment that goes from 0 to n_particles_in_cell.
@@ -1538,7 +1538,7 @@ VansAssemblerMagnus<dim>::calculate_particle_fluid_interactions(
   // Physical Properties
   Assert(scratch_data.properties_manager.density_is_constant(),
          RequiresConstantDensity(
-           "VansAssemblerMagnus<dim>::calculate_particle_fluid_interactions"));
+           "VANSAssemblerMagnus<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   const auto   pic             = scratch_data.pic;
@@ -1656,12 +1656,12 @@ VansAssemblerMagnus<dim>::calculate_particle_fluid_interactions(
     }
 }
 
-template class VansAssemblerMagnus<2>;
-template class VansAssemblerMagnus<3>;
+template class VANSAssemblerMagnus<2>;
+template class VANSAssemblerMagnus<3>;
 
 template <int dim>
 void
-VansAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions(
+VANSAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   // particle_number is an increment that goes from 0 to n_particles_in_cell.
@@ -1671,12 +1671,12 @@ VansAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "VansAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions"));
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "VansAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions"));
 
   const double density = scratch_data.properties_manager.get_density_scale();
   const double kinematic_viscosity =
@@ -1706,24 +1706,24 @@ VansAssemblerViscousTorque<dim>::calculate_particle_fluid_interactions(
   particle_number += 1;
 }
 
-template class VansAssemblerViscousTorque<2>;
-template class VansAssemblerViscousTorque<3>;
+template class VANSAssemblerViscousTorque<2>;
+template class VANSAssemblerViscousTorque<3>;
 
 template <int dim>
 void
-VansAssemblerVorticalTorque<dim>::calculate_particle_fluid_interactions(
+VANSAssemblerVorticalTorque<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   // Physical Properties
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "VansAssemblerVorticalTorque<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerVorticalTorque<dim>::calculate_particle_fluid_interactions"));
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "VansAssemblerVorticalTorque<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerVorticalTorque<dim>::calculate_particle_fluid_interactions"));
 
   const double density = scratch_data.properties_manager.get_density_scale();
   const double kinematic_viscosity =
@@ -1759,12 +1759,12 @@ VansAssemblerVorticalTorque<dim>::calculate_particle_fluid_interactions(
   i_particle += 1;
 }
 
-template class VansAssemblerVorticalTorque<2>;
-template class VansAssemblerVorticalTorque<3>;
+template class VANSAssemblerVorticalTorque<2>;
+template class VANSAssemblerVorticalTorque<3>;
 
 template <int dim>
 void
-VansAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions(
+VANSAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   const auto   pic = scratch_data.pic;
@@ -1774,7 +1774,7 @@ VansAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions(
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "VansAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions"));
 
   const double density = scratch_data.properties_manager.get_density_scale();
 
@@ -1796,12 +1796,12 @@ VansAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions(
     }
 }
 
-template class VansAssemblerBuoyancy<2>;
-template class VansAssemblerBuoyancy<3>;
+template class VANSAssemblerBuoyancy<2>;
+template class VANSAssemblerBuoyancy<3>;
 
 template <int dim>
 void
-VansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions(
+VANSAssemblerPressureForce<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   const auto pic                    = scratch_data.pic;
@@ -1816,7 +1816,7 @@ VansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions(
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "VansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerPressureForce<dim>::calculate_particle_fluid_interactions"));
 
 
   const double density = scratch_data.properties_manager.get_density_scale();
@@ -1851,12 +1851,12 @@ VansAssemblerPressureForce<dim>::calculate_particle_fluid_interactions(
     }
 }
 
-template class VansAssemblerPressureForce<2>;
-template class VansAssemblerPressureForce<3>;
+template class VANSAssemblerPressureForce<2>;
+template class VANSAssemblerPressureForce<3>;
 
 template <int dim>
 void
-VansAssemblerShearForce<dim>::calculate_particle_fluid_interactions(
+VANSAssemblerShearForce<dim>::calculate_particle_fluid_interactions(
   NavierStokesScratchData<dim> &scratch_data)
 {
   const auto pic                    = scratch_data.pic;
@@ -1873,14 +1873,14 @@ VansAssemblerShearForce<dim>::calculate_particle_fluid_interactions(
   Assert(
     !scratch_data.properties_manager.is_non_newtonian(),
     RequiresConstantViscosity(
-      "VansAssemblerShearForce<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerShearForce<dim>::calculate_particle_fluid_interactions"));
   const double kinematic_viscosity =
     scratch_data.properties_manager.get_kinematic_viscosity_scale();
 
   Assert(
     scratch_data.properties_manager.density_is_constant(),
     RequiresConstantDensity(
-      "VansAssemblerShearForce<dim>::calculate_particle_fluid_interactions"));
+      "VANSAssemblerShearForce<dim>::calculate_particle_fluid_interactions"));
   const double density = scratch_data.properties_manager.get_density_scale();
 
   // Loop over particles in cell
@@ -1914,13 +1914,13 @@ VansAssemblerShearForce<dim>::calculate_particle_fluid_interactions(
     }
 }
 
-template class VansAssemblerShearForce<2>;
-template class VansAssemblerShearForce<3>;
+template class VANSAssemblerShearForce<2>;
+template class VANSAssemblerShearForce<3>;
 
 
 template <int dim>
 void
-VansAssemblerFPI<dim>::assemble_matrix(
+VANSAssemblerFPI<dim>::assemble_matrix(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -1985,7 +1985,7 @@ VansAssemblerFPI<dim>::assemble_matrix(
 
 template <int dim>
 void
-VansAssemblerFPI<dim>::assemble_rhs(
+VANSAssemblerFPI<dim>::assemble_rhs(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -2048,5 +2048,5 @@ VansAssemblerFPI<dim>::assemble_rhs(
     }
 }
 
-template class VansAssemblerFPI<2>;
-template class VansAssemblerFPI<3>;
+template class VANSAssemblerFPI<2>;
+template class VANSAssemblerFPI<3>;


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

This PR changes the name of the main class and the name of the files related to the `lethe-fluid-vans` application. Is the second PR on a series of PRs that aim to rename all the Navier Stokes solvers of Lethe using the prefix FluidDynamics and removing GLS.

### Testing

<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

All the existent tests pass without any change.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

- The name of all the VANS assemblers had to be modified as well so that everything is uniform. 

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [X] No other PR is open related to this refactoring
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] The PR description is cleaned and ready for merge