### PR TITLE
Rename all block Navier Stokes files using Fluid Dynamics prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-08-06
+
+### Changed
+
+- MINOR Renamed the main file related to the `lethe-fluid-block` application: `gd_navier_stokes` to `fluid_dynamics_block`. The name of the `GDNavierStokesAssembler...` classes were changed to `BlockNavierStokesAssembler...`, and the main class `GDNavierStokesSolver` was also renamed to `FluidDynamicsBlock`. [#1226](https://github.com/chaos-polymtl/lethe/pull/1226)
+
 ## [Master] - 2024-08-05
 
 ### Changed

--- a/applications/lethe-fluid-block/CMakeLists.txt
+++ b/applications/lethe-fluid-block/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_executable(lethe-fluid-block gd_navier_stokes.cc)
+add_executable(lethe-fluid-block fluid_dynamics_block.cc)
 deal_ii_setup_target(lethe-fluid-block)
 target_link_libraries(lethe-fluid-block lethe-solvers)

--- a/applications/lethe-fluid-block/fluid_dynamics_block.cc
+++ b/applications/lethe-fluid-block/fluid_dynamics_block.cc
@@ -30,8 +30,8 @@ main(int argc, char *argv[])
 
           AssertThrow(NSparam.nitsche->number_solids == 0,
                       SolidWarning(NSparam.nitsche->number_solids,
-                                   "fluid_dynamics_block_2d",
-                                   "gls_nitsche_navier_stokes_22"));
+                                   "lethe-fluid-block",
+                                   "lethe-fluid-nitsche"));
 
           FluidDynamicsBlock<2> problem(NSparam);
           problem.solve();
@@ -48,8 +48,8 @@ main(int argc, char *argv[])
 
           AssertThrow(NSparam.nitsche->number_solids == 0,
                       SolidWarning(NSparam.nitsche->number_solids,
-                                   "fluid_dynamics_block_2d",
-                                   "gls_nitsche_navier_stokes_22"));
+                                   "lethe-fluid-block",
+                                   "lethe-fluid-nitsche"));
 
           FluidDynamicsBlock<3> problem(NSparam);
           problem.solve();

--- a/applications/lethe-fluid-block/fluid_dynamics_block.cc
+++ b/applications/lethe-fluid-block/fluid_dynamics_block.cc
@@ -1,4 +1,4 @@
-#include <solvers/gd_navier_stokes.h>
+#include <solvers/fluid_dynamics_block.h>
 
 #include <deal.II/base/convergence_table.h>
 
@@ -30,10 +30,10 @@ main(int argc, char *argv[])
 
           AssertThrow(NSparam.nitsche->number_solids == 0,
                       SolidWarning(NSparam.nitsche->number_solids,
-                                   "gd_navier_stokes_2d",
+                                   "fluid_dynamics_block_2d",
                                    "gls_nitsche_navier_stokes_22"));
 
-          GDNavierStokesSolver<2> problem(NSparam);
+          FluidDynamicsBlock<2> problem(NSparam);
           problem.solve();
         }
 
@@ -48,10 +48,10 @@ main(int argc, char *argv[])
 
           AssertThrow(NSparam.nitsche->number_solids == 0,
                       SolidWarning(NSparam.nitsche->number_solids,
-                                   "gd_navier_stokes_2d",
+                                   "fluid_dynamics_block_2d",
                                    "gls_nitsche_navier_stokes_22"));
 
-          GDNavierStokesSolver<3> problem(NSparam);
+          FluidDynamicsBlock<3> problem(NSparam);
           problem.solve();
         }
 

--- a/doc/doxygen/main.h
+++ b/doc/doxygen/main.h
@@ -24,7 +24,7 @@
       physics_solver:e -> auxiliary_physics:w [dir=back];
 
       navier_stokes_base_1 [label=<<B>GLSNavierStokesSolver</B> <br/>(lethe-fluid)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classGLSNavierStokesSolver.html", tooltip="GLSNavierStokesSolver"];
-      navier_stokes_base_2 [label=<<B>GDNavierStokesSolver</B> <br/> (lethe-fluid-block)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classGDNavierStokesSolver.html", tooltip="GDNavierStokesSolver"];
+      navier_stokes_base_2 [label=<<B>FluidDynamicsBlock</B> <br/> (lethe-fluid-block)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classFluidDynamicsBlock.html", tooltip="FluidDynamicsBlock"];
       navier_stokes_base_3 [label=<<B>FluidDynamicsMatrixFree</B> <br/> (lethe-fluid-matrix-free)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classFluidDynamicsMatrixFree.html", tooltip="FluidDynamicsMatrixFree"];
 
       navier_stokes_base:e -> navier_stokes_base_1:w [dir=back];

--- a/include/solvers/fluid_dynamics_block.h
+++ b/include/solvers/fluid_dynamics_block.h
@@ -14,8 +14,8 @@
  * ---------------------------------------------------------------------
  */
 
-#ifndef lethe_gd_navier_stokes_h
-#define lethe_gd_navier_stokes_h
+#ifndef lethe_fluid_dynamics_block_h
+#define lethe_fluid_dynamics_block_h
 
 #include <core/exceptions.h>
 #include <core/vector.h>
@@ -72,12 +72,12 @@ private:
  */
 
 template <int dim>
-class GDNavierStokesSolver
+class FluidDynamicsBlock
   : public NavierStokesBase<dim, GlobalBlockVectorType, std::vector<IndexSet>>
 {
 public:
-  GDNavierStokesSolver(SimulationParameters<dim> &nsparam);
-  ~GDNavierStokesSolver();
+  FluidDynamicsBlock(SimulationParameters<dim> &nsparam);
+  ~FluidDynamicsBlock();
 
   void
   solve();

--- a/include/solvers/navier_stokes_assemblers.h
+++ b/include/solvers/navier_stokes_assemblers.h
@@ -369,10 +369,10 @@ public:
 
 
 template <int dim>
-class GDNavierStokesAssemblerCore : public NavierStokesAssemblerBase<dim>
+class BlockNavierStokesAssemblerCore : public NavierStokesAssemblerBase<dim>
 {
 public:
-  GDNavierStokesAssemblerCore(
+  BlockNavierStokesAssemblerCore(
     std::shared_ptr<SimulationControl> simulation_control,
     const double                       gamma)
     : simulation_control(simulation_control)
@@ -404,11 +404,11 @@ public:
 };
 
 template <int dim>
-class GDNavierStokesAssemblerNonNewtonianCore
+class BlockNavierStokesAssemblerNonNewtonianCore
   : public NavierStokesAssemblerBase<dim>
 {
 public:
-  GDNavierStokesAssemblerNonNewtonianCore(
+  BlockNavierStokesAssemblerNonNewtonianCore(
     std::shared_ptr<SimulationControl> simulation_control,
     const double                       gamma)
     : simulation_control(simulation_control)

--- a/source/solvers/CMakeLists.txt
+++ b/source/solvers/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(lethe-solvers
   cahn_hilliard_filter.cc
   cahn_hilliard_scratch_data.cc
   flow_control.cc
-  gd_navier_stokes.cc
+  fluid_dynamics_block.cc
   gls_navier_stokes.cc
   gls_nitsche_navier_stokes.cc
   heat_transfer.cc
@@ -47,7 +47,7 @@ add_library(lethe-solvers
   ../../include/solvers/cahn_hilliard_scratch_data.h
   ../../include/solvers/copy_data.h
   ../../include/solvers/flow_control.h
-  ../../include/solvers/gd_navier_stokes.h
+  ../../include/solvers/fluid_dynamics_block.h
   ../../include/solvers/gls_navier_stokes.h
   ../../include/solvers/gls_nitsche_navier_stokes.h
   ../../include/solvers/heat_transfer.h

--- a/source/solvers/fluid_dynamics_block.cc
+++ b/source/solvers/fluid_dynamics_block.cc
@@ -20,7 +20,7 @@
 #include <core/time_integration_utilities.h>
 #include <core/utilities.h>
 
-#include <solvers/gd_navier_stokes.h>
+#include <solvers/fluid_dynamics_block.h>
 #include <solvers/isothermal_compressible_navier_stokes_vof_assembler.h>
 #include <solvers/navier_stokes_assemblers.h>
 #include <solvers/navier_stokes_vof_assemblers.h>
@@ -40,23 +40,23 @@
 
 
 
-// Constructor for class GDNavierStokesSolver
+// Constructor for class FluidDynamicsBlock
 template <int dim>
-GDNavierStokesSolver<dim>::GDNavierStokesSolver(
+FluidDynamicsBlock<dim>::FluidDynamicsBlock(
   SimulationParameters<dim> &p_nsparam)
   : NavierStokesBase<dim, GlobalBlockVectorType, std::vector<IndexSet>>(
       p_nsparam)
 {}
 
 template <int dim>
-GDNavierStokesSolver<dim>::~GDNavierStokesSolver()
+FluidDynamicsBlock<dim>::~FluidDynamicsBlock()
 {
   this->dof_handler.clear();
 }
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::setup_assemblers()
+FluidDynamicsBlock<dim>::setup_assemblers()
 {
   this->assemblers.clear();
 
@@ -162,7 +162,7 @@ GDNavierStokesSolver<dim>::setup_assemblers()
         {
           // Core assembler with non-Newtonian viscosity
           this->assemblers.push_back(
-            std::make_shared<GDNavierStokesAssemblerNonNewtonianCore<dim>>(
+            std::make_shared<BlockNavierStokesAssemblerNonNewtonianCore<dim>>(
               this->simulation_control, gamma));
         }
       else
@@ -173,7 +173,7 @@ GDNavierStokesSolver<dim>::setup_assemblers()
               this->simulation_parameters.stabilization.stabilization ==
                 Parameters::Stabilization::NavierStokesStabilization::grad_div)
             this->assemblers.push_back(
-              std::make_shared<GDNavierStokesAssemblerCore<dim>>(
+              std::make_shared<BlockNavierStokesAssemblerCore<dim>>(
                 this->simulation_control, gamma));
 
           else
@@ -186,7 +186,7 @@ GDNavierStokesSolver<dim>::setup_assemblers()
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::update_multiphysics_time_average_solution()
+FluidDynamicsBlock<dim>::update_multiphysics_time_average_solution()
 {
   if (this->simulation_parameters.post_processing.calculate_average_velocities)
     {
@@ -198,7 +198,7 @@ GDNavierStokesSolver<dim>::update_multiphysics_time_average_solution()
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::assemble_system_matrix()
+FluidDynamicsBlock<dim>::assemble_system_matrix()
 {
   TimerOutput::Scope t(this->computing_timer, "Assemble matrix");
   // this->simulation_control->set_assembly_method(this->time_stepping_method);
@@ -230,8 +230,8 @@ GDNavierStokesSolver<dim>::assemble_system_matrix()
     this->dof_handler.begin_active(),
     this->dof_handler.end(),
     *this,
-    &GDNavierStokesSolver::assemble_local_system_matrix,
-    &GDNavierStokesSolver::copy_local_matrix_to_global_matrix,
+    &FluidDynamicsBlock::assemble_local_system_matrix,
+    &FluidDynamicsBlock::copy_local_matrix_to_global_matrix,
     scratch_data,
     StabilizedMethodsTensorCopyData<dim>(this->fe->n_dofs_per_cell(),
                                          this->cell_quadrature->size()));
@@ -256,7 +256,7 @@ GDNavierStokesSolver<dim>::assemble_system_matrix()
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::assemble_local_system_matrix(
+FluidDynamicsBlock<dim>::assemble_local_system_matrix(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
   NavierStokesScratchData<dim>                         &scratch_data,
   StabilizedMethodsTensorCopyData<dim>                 &copy_data)
@@ -313,7 +313,7 @@ GDNavierStokesSolver<dim>::assemble_local_system_matrix(
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::copy_local_matrix_to_global_matrix(
+FluidDynamicsBlock<dim>::copy_local_matrix_to_global_matrix(
   const StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!copy_data.cell_is_local)
@@ -328,7 +328,7 @@ GDNavierStokesSolver<dim>::copy_local_matrix_to_global_matrix(
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::assemble_system_rhs()
+FluidDynamicsBlock<dim>::assemble_system_rhs()
 {
   TimerOutput::Scope t(this->computing_timer, "Assemble RHS");
   // this->simulation_control->set_assembly_method(this->time_stepping_method);
@@ -369,8 +369,8 @@ GDNavierStokesSolver<dim>::assemble_system_rhs()
     this->dof_handler.begin_active(),
     this->dof_handler.end(),
     *this,
-    &GDNavierStokesSolver::assemble_local_system_rhs,
-    &GDNavierStokesSolver::copy_local_rhs_to_global_rhs,
+    &FluidDynamicsBlock::assemble_local_system_rhs,
+    &FluidDynamicsBlock::copy_local_rhs_to_global_rhs,
     scratch_data,
     StabilizedMethodsTensorCopyData<dim>(this->fe->n_dofs_per_cell(),
                                          this->cell_quadrature->size()));
@@ -383,12 +383,12 @@ GDNavierStokesSolver<dim>::assemble_system_rhs()
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::setup_preconditioner()
+FluidDynamicsBlock<dim>::setup_preconditioner()
 {}
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::assemble_local_system_rhs(
+FluidDynamicsBlock<dim>::assemble_local_system_rhs(
   const typename DoFHandler<dim>::active_cell_iterator &cell,
   NavierStokesScratchData<dim>                         &scratch_data,
   StabilizedMethodsTensorCopyData<dim>                 &copy_data)
@@ -454,7 +454,7 @@ GDNavierStokesSolver<dim>::assemble_local_system_rhs(
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::copy_local_rhs_to_global_rhs(
+FluidDynamicsBlock<dim>::copy_local_rhs_to_global_rhs(
   const StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   if (!copy_data.cell_is_local)
@@ -470,7 +470,7 @@ GDNavierStokesSolver<dim>::copy_local_rhs_to_global_rhs(
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::assemble_L2_projection()
+FluidDynamicsBlock<dim>::assemble_L2_projection()
 {
   system_matrix    = 0;
   auto &system_rhs = this->system_rhs;
@@ -555,7 +555,7 @@ GDNavierStokesSolver<dim>::assemble_L2_projection()
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::setup_dofs_fd()
+FluidDynamicsBlock<dim>::setup_dofs_fd()
 {
   TimerOutput::Scope t(this->computing_timer, "Setup DOFs");
 
@@ -810,7 +810,7 @@ GDNavierStokesSolver<dim>::setup_dofs_fd()
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::set_solution_vector(double value)
+FluidDynamicsBlock<dim>::set_solution_vector(double value)
 {
   this->present_solution = value;
 }
@@ -821,7 +821,7 @@ GDNavierStokesSolver<dim>::set_solution_vector(double value)
  **/
 template <int dim>
 void
-GDNavierStokesSolver<dim>::set_initial_condition_fd(
+FluidDynamicsBlock<dim>::set_initial_condition_fd(
   Parameters::InitialConditionType initial_condition_type,
   bool                             restart)
 {
@@ -877,8 +877,8 @@ GDNavierStokesSolver<dim>::set_initial_condition_fd(
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::solve_linear_system(const bool initial_step,
-                                               const bool renewed_matrix)
+FluidDynamicsBlock<dim>::solve_linear_system(const bool initial_step,
+                                             const bool renewed_matrix)
 {
   const double absolute_residual =
     this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
@@ -904,7 +904,7 @@ GDNavierStokesSolver<dim>::solve_linear_system(const bool initial_step,
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::setup_ILU()
+FluidDynamicsBlock<dim>::setup_ILU()
 {
   TimerOutput::Scope t(this->computing_timer, "setup_ILU");
 
@@ -947,7 +947,7 @@ GDNavierStokesSolver<dim>::setup_ILU()
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::setup_AMG()
+FluidDynamicsBlock<dim>::setup_AMG()
 {
   TimerOutput::Scope t(this->computing_timer, "setup_AMG");
 
@@ -1076,10 +1076,10 @@ GDNavierStokesSolver<dim>::setup_AMG()
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
-                                              const double absolute_residual,
-                                              const double relative_residual,
-                                              const bool   renewed_matrix)
+FluidDynamicsBlock<dim>::solve_system_GMRES(const bool   initial_step,
+                                            const double absolute_residual,
+                                            const double relative_residual,
+                                            const bool   renewed_matrix)
 {
   const AffineConstraints<double> &constraints_used =
     initial_step ? this->nonzero_constraints : this->zero_constraints;
@@ -1166,9 +1166,9 @@ GDNavierStokesSolver<dim>::solve_system_GMRES(const bool   initial_step,
 
 template <int dim>
 void
-GDNavierStokesSolver<dim>::solve_L2_system(const bool initial_step,
-                                           double     absolute_residual,
-                                           double     relative_residual)
+FluidDynamicsBlock<dim>::solve_L2_system(const bool initial_step,
+                                         double     absolute_residual,
+                                         double     relative_residual)
 {
   auto &system_rhs          = this->system_rhs;
   auto &nonzero_constraints = this->nonzero_constraints;
@@ -1243,7 +1243,7 @@ GDNavierStokesSolver<dim>::solve_L2_system(const bool initial_step,
  */
 template <int dim>
 void
-GDNavierStokesSolver<dim>::solve()
+FluidDynamicsBlock<dim>::solve()
 {
   read_mesh_and_manifolds(
     *this->triangulation,
@@ -1294,5 +1294,5 @@ GDNavierStokesSolver<dim>::solve()
 
 // Pre-compile the 2D and 3D Navier-Stokes solver to ensure that the library is
 // valid before we actually compile the solver This greatly helps with debugging
-template class GDNavierStokesSolver<2>;
-template class GDNavierStokesSolver<3>;
+template class FluidDynamicsBlock<2>;
+template class FluidDynamicsBlock<3>;

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -1227,7 +1227,7 @@ template class GLSNavierStokesAssemblerBDF<3>;
 
 template <int dim>
 void
-GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
+BlockNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -1315,7 +1315,7 @@ GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
 
 template <int dim>
 void
-GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
+BlockNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -1383,13 +1383,13 @@ GDNavierStokesAssemblerNonNewtonianCore<dim>::assemble_rhs(
     }
 }
 
-template class GDNavierStokesAssemblerNonNewtonianCore<2>;
-template class GDNavierStokesAssemblerNonNewtonianCore<3>;
+template class BlockNavierStokesAssemblerNonNewtonianCore<2>;
+template class BlockNavierStokesAssemblerNonNewtonianCore<3>;
 
 
 template <int dim>
 void
-GDNavierStokesAssemblerCore<dim>::assemble_matrix(
+BlockNavierStokesAssemblerCore<dim>::assemble_matrix(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -1476,7 +1476,7 @@ GDNavierStokesAssemblerCore<dim>::assemble_matrix(
 
 template <int dim>
 void
-GDNavierStokesAssemblerCore<dim>::assemble_rhs(
+BlockNavierStokesAssemblerCore<dim>::assemble_rhs(
   NavierStokesScratchData<dim>         &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
@@ -1543,8 +1543,8 @@ GDNavierStokesAssemblerCore<dim>::assemble_rhs(
 
 
 
-template class GDNavierStokesAssemblerCore<2>;
-template class GDNavierStokesAssemblerCore<3>;
+template class BlockNavierStokesAssemblerCore<2>;
+template class BlockNavierStokesAssemblerCore<3>;
 
 template <int dim>
 void


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

This PR changes the name of the main class and the name of the files related to the lethe-fluid-block application. Is the third PR on a series of PRs that aim to rename all the Navier Stokes solvers of Lethe using the prefix FluidDynamics and removing GLS or GD. 

### Testing

<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

All the existent tests pass without any change.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [X] No other PR is open related to this refactoring
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] The PR description is cleaned and ready for merge