### PR TITLE
Rename all Nitsche files using Fluid Dynamics prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-08-07
+
+### Changed
+
+- MINOR Renamed the main file related to the `lethe-fluid-nitsche` application: `gls_nitsche_navier_stokes` to `fluid_dynamics_nitsche`. The name of the `GLSNitscheNavierStokesSolver` class was changed to `FluidDynamicsNitsche`. [#1228](https://github.com/chaos-polymtl/lethe/pull/1228)
+
 ## [Master] - 2024-08-06
 
 ### Changed

--- a/applications/lethe-fluid-nitsche/CMakeLists.txt
+++ b/applications/lethe-fluid-nitsche/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_executable(lethe-fluid-nitsche nitsche_navier_stokes.cc)
+add_executable(lethe-fluid-nitsche fluid_dynamics_nitsche.cc)
 deal_ii_setup_target(lethe-fluid-nitsche)
 target_link_libraries(lethe-fluid-nitsche lethe-solvers)

--- a/applications/lethe-fluid-nitsche/fluid_dynamics_nitsche.cc
+++ b/applications/lethe-fluid-nitsche/fluid_dynamics_nitsche.cc
@@ -14,7 +14,7 @@
  * ---------------------------------------------------------------------
  */
 
-#include "solvers/gls_nitsche_navier_stokes.h"
+#include "solvers/fluid_dynamics_nitsche.h"
 
 int
 main(int argc, char *argv[])
@@ -43,7 +43,7 @@ main(int argc, char *argv[])
           prm.parse_input(argv[1]);
           NSparam.parse(prm);
 
-          GLSNitscheNavierStokesSolver<2> problem_22(NSparam);
+          FluidDynamicsNitsche<2> problem_22(NSparam);
           problem_22.solve();
         }
 
@@ -56,7 +56,7 @@ main(int argc, char *argv[])
           prm.parse_input(argv[1]);
           NSparam.parse(prm);
 
-          GLSNitscheNavierStokesSolver<3> problem_33(NSparam);
+          FluidDynamicsNitsche<3> problem_33(NSparam);
           problem_33.solve();
         }
 

--- a/applications/lethe-fluid/gls_navier_stokes.cc
+++ b/applications/lethe-fluid/gls_navier_stokes.cc
@@ -45,7 +45,7 @@ main(int argc, char *argv[])
 
           AssertThrow(NSparam.nitsche->number_solids == 0,
                       SolidWarning(NSparam.nitsche->number_solids,
-                                   "gls_navier_stokes_2d",
+                                   "lethe-fluid",
                                    "lethe-fluid-nitsche"));
 
           GLSNavierStokesSolver<2> problem(NSparam);
@@ -63,7 +63,7 @@ main(int argc, char *argv[])
 
           AssertThrow(NSparam.nitsche->number_solids == 0,
                       SolidWarning(NSparam.nitsche->number_solids,
-                                   "gls_navier_stokes_2d",
+                                   "lethe-fluid",
                                    "lethe-fluid-nitsche"));
 
           GLSNavierStokesSolver<3> problem(NSparam);

--- a/applications/lethe-fluid/gls_navier_stokes.cc
+++ b/applications/lethe-fluid/gls_navier_stokes.cc
@@ -46,7 +46,7 @@ main(int argc, char *argv[])
           AssertThrow(NSparam.nitsche->number_solids == 0,
                       SolidWarning(NSparam.nitsche->number_solids,
                                    "gls_navier_stokes_2d",
-                                   "gls_nitsche_navier_stokes_22"));
+                                   "lethe-fluid-nitsche"));
 
           GLSNavierStokesSolver<2> problem(NSparam);
           problem.solve();
@@ -64,7 +64,7 @@ main(int argc, char *argv[])
           AssertThrow(NSparam.nitsche->number_solids == 0,
                       SolidWarning(NSparam.nitsche->number_solids,
                                    "gls_navier_stokes_2d",
-                                   "gls_nitsche_navier_stokes_22"));
+                                   "lethe-fluid-nitsche"));
 
           GLSNavierStokesSolver<3> problem(NSparam);
           problem.solve();

--- a/doc/doxygen/main.h
+++ b/doc/doxygen/main.h
@@ -43,7 +43,7 @@
 
       navier_stokes_base_1_1 [label=<<B>FluidDynamicsVANS</B> <br/>(lethe-fluid-vans)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classFluidDynamicsVANS.html", tooltip="FluidDynamicsVANS"];
       navier_stokes_base_1_2 [label=<<B>GLSSharpNavierStokesSolver</B> <br/>(lethe-fluid-sharp)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classGLSSharpNavierStokesSolver.html", tooltip="GLSSharpNavierStokesSolver"];
-      navier_stokes_base_1_3 [label=<<B>GLSNitscheNavierStokesSolver</B> <br/>(lethe-fluid-nitsche)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classGLSNitscheNavierStokesSolver.html", tooltip="GLSNitscheNavierStokesSolver"];
+      navier_stokes_base_1_3 [label=<<B>FluidDynamicsNitsche</B> <br/>(lethe-fluid-nitsche)>,href="https://chaos-polymtl.github.io/lethe/doxygen/classFluidDynamicsNitsche.html", tooltip="FluidDynamicsNitsche"];
 
       navier_stokes_base_1:e -> navier_stokes_base_1_1:w [dir=back];
       navier_stokes_base_1:e -> navier_stokes_base_1_2:w [dir=back];

--- a/include/solvers/fluid_dynamics_nitsche.h
+++ b/include/solvers/fluid_dynamics_nitsche.h
@@ -14,8 +14,8 @@
  * ---------------------------------------------------------------------
  */
 
-#ifndef lethe_gls_nitsche_navier_stokes_h
-#define lethe_gls_nitsche_navier_stokes_h
+#ifndef lethe_fluid_dynamics_nitsche_h
+#define lethe_fluid_dynamics_nitsche_h
 
 #include <core/exceptions.h>
 #include <core/solid_base.h>
@@ -38,10 +38,10 @@ using namespace dealii;
  */
 
 template <int dim, int spacedim = dim>
-class GLSNitscheNavierStokesSolver : public GLSNavierStokesSolver<spacedim>
+class FluidDynamicsNitsche : public GLSNavierStokesSolver<spacedim>
 {
 public:
-  GLSNitscheNavierStokesSolver(SimulationParameters<spacedim> &nsparam);
+  FluidDynamicsNitsche(SimulationParameters<spacedim> &nsparam);
 
   virtual void
   solve() override;

--- a/source/solvers/CMakeLists.txt
+++ b/source/solvers/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(lethe-solvers
   flow_control.cc
   fluid_dynamics_block.cc
   gls_navier_stokes.cc
-  gls_nitsche_navier_stokes.cc
+  fluid_dynamics_nitsche.cc
   heat_transfer.cc
   heat_transfer_assemblers.cc
   heat_transfer_scratch_data.cc
@@ -49,7 +49,7 @@ add_library(lethe-solvers
   ../../include/solvers/flow_control.h
   ../../include/solvers/fluid_dynamics_block.h
   ../../include/solvers/gls_navier_stokes.h
-  ../../include/solvers/gls_nitsche_navier_stokes.h
+  ../../include/solvers/fluid_dynamics_nitsche.h
   ../../include/solvers/heat_transfer.h
   ../../include/solvers/heat_transfer_assemblers.h
   ../../include/solvers/heat_transfer_scratch_data.h

--- a/source/solvers/fluid_dynamics_nitsche.cc
+++ b/source/solvers/fluid_dynamics_nitsche.cc
@@ -21,7 +21,7 @@
 #include <core/time_integration_utilities.h>
 #include <core/utilities.h>
 
-#include <solvers/gls_nitsche_navier_stokes.h>
+#include <solvers/fluid_dynamics_nitsche.h>
 
 #include <deal.II/base/multithread_info.h>
 
@@ -32,9 +32,9 @@
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
 
-// Constructor for class GLSNitscheNavierStokesSolver
+// Constructor for class FluidDynamicsNitsche
 template <int dim, int spacedim>
-GLSNitscheNavierStokesSolver<dim, spacedim>::GLSNitscheNavierStokesSolver(
+FluidDynamicsNitsche<dim, spacedim>::FluidDynamicsNitsche(
   SimulationParameters<spacedim> &p_nsparam)
   : GLSNavierStokesSolver<spacedim>(p_nsparam)
 {
@@ -60,7 +60,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::GLSNitscheNavierStokesSolver(
 template <int dim, int spacedim>
 template <bool assemble_matrix>
 void
-GLSNitscheNavierStokesSolver<dim, spacedim>::assemble_nitsche_restriction()
+FluidDynamicsNitsche<dim, spacedim>::assemble_nitsche_restriction()
 {
   TimerOutput::Scope t(this->computing_timer, "Nitsche assemble restriction");
 
@@ -238,7 +238,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::assemble_nitsche_restriction()
 
 template <>
 Tensor<1, 3>
-GLSNitscheNavierStokesSolver<2, 3>::calculate_forces_on_solid(
+FluidDynamicsNitsche<2, 3>::calculate_forces_on_solid(
   const unsigned int i_solid)
 {
   std::shared_ptr<Particles::ParticleHandler<3>> &solid_ph =
@@ -334,7 +334,7 @@ GLSNitscheNavierStokesSolver<2, 3>::calculate_forces_on_solid(
 
 template <int dim, int spacedim>
 Tensor<1, spacedim>
-GLSNitscheNavierStokesSolver<dim, spacedim>::calculate_forces_on_solid(
+FluidDynamicsNitsche<dim, spacedim>::calculate_forces_on_solid(
   const unsigned int i_solid)
 {
   std::shared_ptr<Particles::ParticleHandler<dim, spacedim>> &solid_ph =
@@ -418,7 +418,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::calculate_forces_on_solid(
 
 template <int dim, int spacedim>
 Tensor<1, 3>
-GLSNitscheNavierStokesSolver<dim, spacedim>::calculate_torque_on_solid(
+FluidDynamicsNitsche<dim, spacedim>::calculate_torque_on_solid(
   const unsigned int i_solid)
 {
   std::shared_ptr<Particles::ParticleHandler<spacedim>> &solid_ph =
@@ -524,7 +524,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::calculate_torque_on_solid(
 
 template <int dim, int spacedim>
 void
-GLSNitscheNavierStokesSolver<dim, spacedim>::postprocess_solid_forces(
+FluidDynamicsNitsche<dim, spacedim>::postprocess_solid_forces(
   const unsigned int i_solid,
   bool               first_solid_forces)
 {
@@ -608,7 +608,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::postprocess_solid_forces(
 
 template <int dim, int spacedim>
 void
-GLSNitscheNavierStokesSolver<dim, spacedim>::postprocess_solid_torques(
+FluidDynamicsNitsche<dim, spacedim>::postprocess_solid_torques(
   const unsigned int i_solid,
   bool               first_solid_torques)
 {
@@ -691,7 +691,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::postprocess_solid_torques(
 
 template <int dim, int spacedim>
 void
-GLSNitscheNavierStokesSolver<dim, spacedim>::solve()
+FluidDynamicsNitsche<dim, spacedim>::solve()
 {
   // Fluid setup
   read_mesh_and_manifolds(
@@ -817,7 +817,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::solve()
 
 template <int dim, int spacedim>
 void
-GLSNitscheNavierStokesSolver<dim, spacedim>::output_solid_particles(
+FluidDynamicsNitsche<dim, spacedim>::output_solid_particles(
   const unsigned int i_solid)
 {
   std::shared_ptr<Particles::ParticleHandler<spacedim>> &particle_handler =
@@ -845,7 +845,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::output_solid_particles(
 
 template <int dim, int spacedim>
 void
-GLSNitscheNavierStokesSolver<dim, spacedim>::output_solid_triangulation(
+FluidDynamicsNitsche<dim, spacedim>::output_solid_triangulation(
   const unsigned int i_solid)
 {
 #if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
@@ -905,7 +905,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::output_solid_triangulation(
 
 template <int dim, int spacedim>
 void
-GLSNitscheNavierStokesSolver<dim, spacedim>::refine_mesh()
+FluidDynamicsNitsche<dim, spacedim>::refine_mesh()
 {
   bool refinement_step;
   if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
@@ -946,7 +946,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::refine_mesh()
 
 template <int dim, int spacedim>
 void
-GLSNitscheNavierStokesSolver<dim, spacedim>::assemble_matrix_and_rhs()
+FluidDynamicsNitsche<dim, spacedim>::assemble_matrix_and_rhs()
 {
   this->GLSNavierStokesSolver<spacedim>::assemble_system_matrix();
 
@@ -957,7 +957,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::assemble_matrix_and_rhs()
 
 template <int dim, int spacedim>
 void
-GLSNitscheNavierStokesSolver<dim, spacedim>::assemble_rhs()
+FluidDynamicsNitsche<dim, spacedim>::assemble_rhs()
 {
   this->GLSNavierStokesSolver<spacedim>::assemble_system_rhs();
 
@@ -966,7 +966,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::assemble_rhs()
 
 template <int dim, int spacedim>
 void
-GLSNitscheNavierStokesSolver<dim, spacedim>::write_checkpoint()
+FluidDynamicsNitsche<dim, spacedim>::write_checkpoint()
 {
   // Write solid base checkpoint
   for (unsigned int i_solid = 0; i_solid < solids.size(); ++i_solid)
@@ -1007,7 +1007,7 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::write_checkpoint()
 
 template <int dim, int spacedim>
 void
-GLSNitscheNavierStokesSolver<dim, spacedim>::read_checkpoint()
+FluidDynamicsNitsche<dim, spacedim>::read_checkpoint()
 {
   this->GLSNavierStokesSolver<spacedim>::read_checkpoint();
 
@@ -1070,6 +1070,6 @@ GLSNitscheNavierStokesSolver<dim, spacedim>::read_checkpoint()
 // Pre-compile the 2D and 3D Navier-Stokes solver to ensure that the library
 // is valid before we actually compile the solver This greatly helps with
 // debugging
-template class GLSNitscheNavierStokesSolver<2>;
-template class GLSNitscheNavierStokesSolver<2, 3>;
-template class GLSNitscheNavierStokesSolver<3>;
+template class FluidDynamicsNitsche<2>;
+template class FluidDynamicsNitsche<2, 3>;
+template class FluidDynamicsNitsche<3>;


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

This PR changes the name of the main class and the name of the files related to the lethe-fluid-nitsche application. Is the fourth PR of a series of PRs that aim to rename all the Navier Stokes solvers of Lethe using the prefix FluidDynamics and removing GLS.

### Testing

<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

All the existent tests pass without any change.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [X] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [X] No other PR is open related to this refactoring
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] The PR description is cleaned and ready for merge