### PR TITLE
PID mesh adaptation quick fix

### DIFF
--- a/include/core/mesh_controller.h
+++ b/include/core/mesh_controller.h
@@ -31,6 +31,8 @@ public:
    */
   MeshController(const unsigned int target_number_of_elements)
     : target_number_of_elements(target_number_of_elements)
+    , previous_number_of_elements(0)
+    , previous_mesh_control_error(0.0)
   {}
   virtual ~MeshController()
   {}


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

Initialized previous_mesh_controller and previous number of elements to 0 in the constructor of the mesh controller object. previous_mesh_control_error which controls the intregral part of the error was not initialized. This affected geatly the PID controller convergence because really high values would sometimes be attributed at start to previous_mesh_control_error.

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->

Initialized the value in the constructor.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

old tests were kept

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Lethe documentation is up to date
- [ ] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [ ] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge