### PR TITLE
Ensure compilation works with dealii distributed vectors

### DIFF
--- a/.github/workflows/main_dealii_distributed_vectors.yml
+++ b/.github/workflows/main_dealii_distributed_vectors.yml
@@ -59,5 +59,5 @@ jobs:
         run: |
           mkdir build-warnings
           cd build-warnings
-          cmake ../ -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DLETHE_USE_LDV=ON
+          cmake ../ -DCMAKE_BUILD_TYPE=Debug -DLETHE_USE_LDV=ON
           make -j${{ env.COMPILE_JOBS }}

--- a/.github/workflows/main_dealii_distributed_vectors.yml
+++ b/.github/workflows/main_dealii_distributed_vectors.yml
@@ -1,0 +1,63 @@
+name: CI-Warnings
+
+on: 
+  push:
+    # Runs on every push on master branch
+    branches:
+      - master
+  # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'contrib/**'
+      - 'examples/**'
+
+# Cancels running instances when a pull request is updated by a commit
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  COMPILE_JOBS: 4
+  MULTI_CORE_TESTS_REGEX: "mpirun=2"
+
+jobs:
+  build:
+    name: Build (deal.ii:${{ matrix.dealii_version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        dealii_version: ["master", "v9.5.0"]
+    
+    # Run steps in container of dealii's master branch
+    container:
+      image: dealii/dealii:${{ matrix.dealii_version }}-focal
+      options: --user root
+
+    steps:
+      - name: Setup
+        run: |
+          # Since dealii image doesn't include Node.js, we'll install it
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends nodejs
+
+
+
+          echo "Github actions is sane!"
+          echo "Running build with deal.ii version ${{ matrix.dealii_version }} on branch ${GITHUB_REF#refs/heads/}"
+
+      # Checks-out Lethe with branch of triggering commit
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      #
+      # Warnings
+      #
+      - name: Compile Lethe to check for warnings (deal.ii:${{ matrix.dealii_version }})
+        run: |
+          mkdir build-warnings
+          cd build-warnings
+          cmake ../ -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DLETHE_USE_LDV=ON
+          make -j${{ env.COMPILE_JOBS }}

--- a/.github/workflows/main_dealii_distributed_vectors.yml
+++ b/.github/workflows/main_dealii_distributed_vectors.yml
@@ -1,4 +1,4 @@
-name: CI-Warnings
+name: CI-Lethe-with-dealii-vectors
 
 on: 
   push:

--- a/.github/workflows/main_dealii_distributed_vectors.yml
+++ b/.github/workflows/main_dealii_distributed_vectors.yml
@@ -55,7 +55,7 @@ jobs:
       #
       # Warnings
       #
-      - name: Compile Lethe to check for warnings (deal.ii:${{ matrix.dealii_version }})
+      - name: Compile Lethe with deal.II distribtued vectors (deal.ii:${{ matrix.dealii_version }})
         run: |
           mkdir build-warnings
           cd build-warnings

--- a/.github/workflows/main_dealii_distributed_vectors.yml
+++ b/.github/workflows/main_dealii_distributed_vectors.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dealii_version: ["master", "v9.5.0"]
+        dealii_version: ["master"]
     
     # Run steps in container of dealii's master branch
     container:

--- a/include/solvers/cahn_hilliard.h
+++ b/include/solvers/cahn_hilliard.h
@@ -474,7 +474,7 @@ private:
   AffineConstraints<double>      nonzero_constraints;
   AffineConstraints<double>      zero_constraints;
   TrilinosWrappers::SparseMatrix system_matrix;
-  TrilinosWrappers::MPI::Vector  filtered_solution;
+  GlobalVectorType  filtered_solution;
 
 
   // Previous solutions vectors

--- a/include/solvers/cahn_hilliard.h
+++ b/include/solvers/cahn_hilliard.h
@@ -474,7 +474,7 @@ private:
   AffineConstraints<double>      nonzero_constraints;
   AffineConstraints<double>      zero_constraints;
   TrilinosWrappers::SparseMatrix system_matrix;
-  GlobalVectorType  filtered_solution;
+  GlobalVectorType               filtered_solution;
 
 
   // Previous solutions vectors

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -485,7 +485,7 @@ protected:
   get_cell_temperature_values(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
     const DoFHandler<dim>                                *dof_handler_ht,
-    const TrilinosWrappers::MPI::Vector                  &temperature_solution,
+    const GlobalVectorType                               &temperature_solution,
     std::vector<double> &local_temperature_values)
   {
     const typename DoFHandler<dim>::active_cell_iterator temperature_cell(
@@ -515,8 +515,8 @@ protected:
   get_cell_filtered_phase_fraction_values(
     const typename DoFHandler<dim>::active_cell_iterator &cell,
     const DoFHandler<dim>                                *dof_handler_vof,
-    const TrilinosWrappers::MPI::Vector &filtered_phase_fraction_solution,
-    std::vector<double>                 &local_filtered_phase_fraction_values)
+    const GlobalVectorType &filtered_phase_fraction_solution,
+    std::vector<double>    &local_filtered_phase_fraction_values)
   {
     const typename DoFHandler<dim>::active_cell_iterator vof_cell(
       &(*(this->triangulation)), cell->level(), cell->index(), dof_handler_vof);

--- a/source/solvers/cahn_hilliard.cc
+++ b/source/solvers/cahn_hilliard.cc
@@ -1405,8 +1405,8 @@ CahnHilliard<dim>::apply_phase_filter()
 
   const FEValuesExtractors::Scalar phase_order(0);
 
-  TrilinosWrappers::MPI::Vector filtered_solution_owned(
-    this->locally_owned_dofs, mpi_communicator);
+  GlobalVectorType filtered_solution_owned(this->locally_owned_dofs,
+                                           mpi_communicator);
   filtered_solution_owned = this->present_solution;
 
   filtered_solution.reinit(this->present_solution);

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -2417,8 +2417,14 @@ FluidDynamicsMatrixFree<dim>::update_multiphysics_time_average_solution()
         this->average_velocities->get_average_velocities());
       this->multiphysics_average_velocities = temp_average_velocities;
 
+#ifndef LETHE_USE_LDV
       this->multiphysics->set_time_average_solution(
         PhysicsID::fluid_dynamics, &this->multiphysics_average_velocities);
+#else
+      this->multiphysics->set_time_average_solution(
+        PhysicsID::fluid_dynamics,
+        &this->average_velocities->get_average_velocities());
+#endif
     }
 }
 
@@ -2548,8 +2554,13 @@ FluidDynamicsMatrixFree<dim>::update_solutions_for_multiphysics()
   convert_vector_dealii_to_trilinos(temp_solution, this->present_solution);
   multiphysics_present_solution = temp_solution;
 
+#ifndef LETHE_USE_LDV
   this->multiphysics->set_solution(PhysicsID::fluid_dynamics,
                                    &this->multiphysics_present_solution);
+#else
+  this->multiphysics->set_solution(PhysicsID::fluid_dynamics,
+                                   &this->present_solution);
+#endif
 
   // Convert the previous solutions to multiphysics vector type and provide them
   // to the multiphysics interface
@@ -2571,8 +2582,13 @@ FluidDynamicsMatrixFree<dim>::update_solutions_for_multiphysics()
       this->multiphysics_previous_solutions[i] = temp_previous_solutions[i];
     }
 
+#ifndef LETHE_USE_LDV
   this->multiphysics->set_previous_solutions(
     PhysicsID::fluid_dynamics, &this->multiphysics_previous_solutions);
+#else
+  this->multiphysics->set_previous_solutions(PhysicsID::fluid_dynamics,
+                                             &this->previous_solutions);
+#endif
 }
 
 template <int dim>

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -778,6 +778,7 @@ double
 HeatTransfer<dim>::calculate_delta_T_ref(double minimum_delta_T_ref)
 {
   double solution_maximum, solution_minimum;
+#ifndef LETHE_USE_LDV
   if (is_steady(simulation_parameters.simulation_control.method))
     {
       solution_maximum = this->present_solution.max();
@@ -788,6 +789,7 @@ HeatTransfer<dim>::calculate_delta_T_ref(double minimum_delta_T_ref)
       solution_maximum = this->previous_solutions[0].max();
       solution_minimum = this->previous_solutions[0].min();
     }
+#endif
 
   // Calculate delta_T_ref.
   double delta_T_ref =


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

Compilation with deal.II distributed vectors did not work anymore because of an addition in the CHN equation. This has been fixed. To ensure that this does not happen again I have added a CI step to test LDV compilation. This is a first step in removing Trilinos Vectors from Lethe.

FYI @peterrum 

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Lethe documentation is up to date
- [X] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [X] The branch is rebased onto master
- [X] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] If the fix is temporary, an issue is opened
- [X] The PR description is cleaned and ready for merge