### PR TITLE
Add CLANG Tidy as a CI step

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,9 +1,42 @@
 # Settings file automatically used by clang-tidy
+# Heavily adapted from the deal.II clang-tidy file
 #
 # See ./contrib/utilities/run_clang_tidy.sh for details
 
-# We disable performance-inefficient-string-concatenation because we don't care about "a"+to_string(5)+...
+#
+# Rationale for disabling warnings:
+#
+# - selected modernize-* warnings:
+#   Some of these produce a lot of noise for limited utility.
+#
+# - performance-inefficient-string-concatenation:
+#   We don't care about "a"+to_string(5)+...
+#
+# - performance-no-automatic-move:
+#   All modern compilers perform the return value optimization and we prefer
+#   to keep things const.
+#
 
-Checks: "-*,cppcoreguidelines-pro-type-static-cast-downcast,google-readability-casting,modernize-*,-modernize-pass-by-value,-modernize-raw-string-literal,-modernize-use-auto,-modernize-use-override,-modernize-use-default-member-init,-modernize-use-transparent-functors,use-emplace,mpi-*,performance-*,-performance-inefficient-string-concatenation"
+Checks: >
+  -*,
+  cppcoreguidelines-pro-type-static-cast-downcast,
+  modernize-*,
+  -modernize-avoid-c-arrays,
+  -modernize-concat-nested-namespaces,
+  -modernize-pass-by-value,
+  -modernize-raw-string-literal,
+  -modernize-return-braced-init-list,
+  -modernize-use-auto,
+  -modernize-use-default-member-init,
+  -modernize-use-nodiscard,
+  -modernize-use-override,
+  -modernize-use-trailing-return-type,
+  -modernize-use-transparent-functors,
+  mpi-*,
+  performance-*,
+  -performance-inefficient-string-concatenation,
+  -performance-no-automatic-move,
+  -performance-avoid-endl,
+  readability-qualified-auto
 
 WarningsAsErrors: '*'

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Setup
         run: |
           # Since dealii image doesn't include Node.js, we'll install it
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository -y ppa:ginggs/deal.ii-9.4.0-backports
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends nodejs \
             clang-12 \

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -30,9 +30,9 @@ jobs:
         dealii_version: ["master"]
     
     # Run steps in container of dealii's master branch
-    container:
-      image: dealii/dealii:${{ matrix.dealii_version }}-focal
-      options: --user root
+    #container:
+    #  image: dealii/dealii:${{ matrix.dealii_version }}-focal
+    #  options: --user root
 
     steps:
       - name: Setup
@@ -44,15 +44,20 @@ jobs:
           sudo apt-get install -y --no-install-recommends nodejs \
             clang-12 \
             clang-tidy-12 \
-
-          echo "Github actions is sane!"
-          echo "Running build with deal.ii version ${{ matrix.dealii_version }} on branch ${GITHUB_REF#refs/heads/}"
+            numdiff \
+            libboost-all-dev \
+            libcgal-dev \
+            libp4est-dev \
+            trilinos-all-dev \
+            petsc-dev \
+            libmetis-dev \
+            libhdf5-mpi-dev
 
       # Checks-out Lethe with branch of triggering commit
       - name: Checkout code
         uses: actions/checkout@v2
       
-      - name: tidy
+      - name: Tidy
         run: |
           mkdir build
           cd build

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -51,7 +51,8 @@ jobs:
             trilinos-all-dev \
             petsc-dev \
             libmetis-dev \
-            libhdf5-mpi-dev 
+            libhdf5-mpi-dev \
+            dealii
 
       # Checks-out Lethe with branch of triggering commit
       - name: Checkout code

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           # Since dealii image doesn't include Node.js, we'll install it
           sudo apt-get install -y software-properties-common
-          sudo add-apt-repository -y ppa:ginggs/deal.ii-9.5.0-backports
+          sudo add-apt-repository ppa:ginggs/deal.ii-9.5.1-backports
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends nodejs \
             clang-12 \
@@ -51,7 +51,7 @@ jobs:
             trilinos-all-dev \
             petsc-dev \
             libmetis-dev \
-            libhdf5-mpi-dev
+            libhdf5-mpi-dev 
 
       # Checks-out Lethe with branch of triggering commit
       - name: Checkout code

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -52,7 +52,7 @@ jobs:
             petsc-dev \
             libmetis-dev \
             libhdf5-mpi-dev \
-            dealii
+            dealii-9.5.1
 
       # Checks-out Lethe with branch of triggering commit
       - name: Checkout code

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           # Since dealii image doesn't include Node.js, we'll install it
           sudo apt-get install -y software-properties-common
-          sudo add-apt-repository -y ppa:ginggs/deal.ii-9.4.0-backports
+          sudo add-apt-repository -y ppa:ginggs/deal.ii-9.5.0-backports
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends nodejs \
             clang-12 \

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -52,7 +52,7 @@ jobs:
             petsc-dev \
             libmetis-dev \
             libhdf5-mpi-dev \
-            dealii-9.5.1
+            deal.ii
 
       # Checks-out Lethe with branch of triggering commit
       - name: Checkout code

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -1,0 +1,58 @@
+#Heavily inspired by the deal.II version of this workflow
+#https://github.com/dealii/dealii
+
+name: Clang tidy
+
+on: 
+  push:
+    # Runs on every push on master branch
+    branches:
+      - master
+  # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'contrib/**'
+
+# Cancels running instances when a pull request is updated by a commit
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+  
+jobs:
+  tidy:
+    name: tidy
+    runs-on: [ubuntu-22.04]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        dealii_version: ["master"]
+    
+    # Run steps in container of dealii's master branch
+    container:
+      image: dealii/dealii:${{ matrix.dealii_version }}-focal
+      options: --user root
+
+    steps:
+      - name: Setup
+        run: |
+          # Since dealii image doesn't include Node.js, we'll install it
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends nodejs \
+            clang-12 \
+            clang-tidy-12 \
+
+          echo "Github actions is sane!"
+          echo "Running build with deal.ii version ${{ matrix.dealii_version }} on branch ${GITHUB_REF#refs/heads/}"
+
+      # Checks-out Lethe with branch of triggering commit
+      - name: Checkout code
+        uses: actions/checkout@v2
+      
+      - name: tidy
+        run: |
+          mkdir build
+          cd build
+          export PATH=/usr/lib/llvm-12/share/clang/:$PATH
+          ../contrib/utilities/run_clang_tidy.sh ..

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -18,6 +18,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
+
+env:
+  COMPILE_JOBS: 4
   
 jobs:
   tidy:

--- a/contrib/utilities/run_clang_tidy.sh
+++ b/contrib/utilities/run_clang_tidy.sh
@@ -57,9 +57,9 @@ CC=clang CXX=clang++ cmake "${ARGS[@]}" "$SRC" || (echo "cmake failed!"; false) 
 cmake --build . 
 
 # generate allheaders.h
-(cd include; find . -name '*.h'; cd $SRC/include/; find . -name '*.h') | grep -v allheaders.h | grep -v undefine_macros.h | sed 's|^./|#include <|' | sed 's|$|>|' >include/deal.II/allheaders.h
+#(cd include; find . -name '*.h'; cd $SRC/include/; find . -name '*.h') | grep -v allheaders.h | grep -v undefine_macros.h | sed 's|^./|#include <|' | sed 's|$|>|' >include/deal.II/allheaders.h
 
-# finally run clang-tidy on deal.II
+# finally run clang-tidy on lethe
 #
 # pipe away stderr (just contains nonsensical "x warnings generated")
 # pipe output to output.txt

--- a/contrib/utilities/run_clang_tidy.sh
+++ b/contrib/utilities/run_clang_tidy.sh
@@ -42,7 +42,7 @@ echo "SRC-DIR=$SRC"
 
 # enable MPI (to get MPI warnings)
 # export compile commands (so that run-clang-tidy.py works)
-ARGS=("-D" "-D" "CMAKE_EXPORT_COMPILE_COMMANDS=ON" "-D" "CMAKE_BUILD_TYPE=Debug" "$@")
+ARGS=("-D" "CMAKE_EXPORT_COMPILE_COMMANDS=ON" "-D" "CMAKE_BUILD_TYPE=Debug" "$@")
 
 # for a list of checks, see /.clang-tidy
 cat "$SRC/.clang-tidy"

--- a/contrib/utilities/run_clang_tidy.sh
+++ b/contrib/utilities/run_clang_tidy.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+## ------------------------------------------------------------------------
+##
+## SPDX-License-Identifier: LGPL-2.1-or-later
+## Copyright (C) 2018 - 2020 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## Part of the source code is dual licensed under Apache-2.0 WITH
+## LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+## governing the source code and code contributions can be found in
+## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+##
+## ------------------------------------------------------------------------
+
+#
+# This script runs the clang-tidy tool on the deal.II code base.
+#
+#
+# Usage:
+# /contrib/utilities/run_clang_tidy.sh SRC_DIR OPTIONAL_CMAKE_ARGS
+#   with:
+#     SRC_DIR points to a deal.II source directory
+#     OPTIONAL_CMAKE_ARGS are optional arguments to pass to CMake
+#   make sure to run this script in an empty build directory
+#
+# Requirements:
+# Clang 5.0.1+ and have clang, clang++, and run-clang-tidy.py in
+# your path.
+
+# grab first argument and make relative path an absolute one:
+SRC=$1
+SRC=$(cd "$SRC";pwd)
+shift
+
+if test ! -d "$SRC/source" -o ! -d "$SRC/include" -o ! -d "$SRC/examples" -o ! -f "$SRC/CMakeLists.txt" ; then
+    echo "Usage:"
+    echo "  run_clang_tidy.sh /path/to/dealII"
+    exit 1
+fi
+echo "SRC-DIR=$SRC"
+
+# enable MPI (to get MPI warnings)
+# export compile commands (so that run-clang-tidy.py works)
+ARGS=("-D" "DEAL_II_WITH_MPI=ON" "-D" "CMAKE_EXPORT_COMPILE_COMMANDS=ON" "-D" "CMAKE_BUILD_TYPE=Debug" "$@")
+
+# for a list of checks, see /.clang-tidy
+cat "$SRC/.clang-tidy"
+
+if ! [ -x "$(command -v run-clang-tidy.py)" ] || ! [ -x "$(command -v clang++)" ]; then
+    echo "make sure clang, clang++, and run-clang-tidy.py (part of clang) are in the path"
+    exit 2
+fi
+
+CC=clang CXX=clang++ cmake "${ARGS[@]}" "$SRC" || (echo "cmake failed!"; false) || exit 2
+
+cmake --build . --target expand_all_instantiations || (echo "make expand_all_instantiations failed!"; false) || exit 3
+
+# generate allheaders.h
+(cd include; find . -name '*.h'; cd $SRC/include/; find . -name '*.h') | grep -v allheaders.h | grep -v undefine_macros.h | sed 's|^./|#include <|' | sed 's|$|>|' >include/deal.II/allheaders.h
+
+# finally run clang-tidy on deal.II
+#
+# pipe away stderr (just contains nonsensical "x warnings generated")
+# pipe output to output.txt
+run-clang-tidy.py -p . -quiet -header-filter "$SRC/include/*" -extra-arg='-DCLANG_TIDY' 2>error.txt >output.txt
+
+# grep interesting errors and make sure we remove duplicates:
+grep -E '(warning|error): ' output.txt | sort | uniq >clang-tidy.log
+
+# if we have errors, report them and set exit status to failure
+if [ -s clang-tidy.log ]; then
+    cat clang-tidy.log
+    exit 4
+fi
+
+echo "OK"
+exit 0
+

--- a/contrib/utilities/run_clang_tidy.sh
+++ b/contrib/utilities/run_clang_tidy.sh
@@ -54,7 +54,7 @@ fi
 
 CC=clang CXX=clang++ cmake "${ARGS[@]}" "$SRC" || (echo "cmake failed!"; false) || exit 2
 
-cmake --build . 
+cmake --build . -j
 
 # generate allheaders.h
 #(cd include; find . -name '*.h'; cd $SRC/include/; find . -name '*.h') | grep -v allheaders.h | grep -v undefine_macros.h | sed 's|^./|#include <|' | sed 's|$|>|' >include/deal.II/allheaders.h

--- a/contrib/utilities/run_clang_tidy.sh
+++ b/contrib/utilities/run_clang_tidy.sh
@@ -42,7 +42,7 @@ echo "SRC-DIR=$SRC"
 
 # enable MPI (to get MPI warnings)
 # export compile commands (so that run-clang-tidy.py works)
-ARGS=("-D" "DEAL_II_WITH_MPI=ON" "-D" "CMAKE_EXPORT_COMPILE_COMMANDS=ON" "-D" "CMAKE_BUILD_TYPE=Debug" "$@")
+ARGS=("-D" "-D" "CMAKE_EXPORT_COMPILE_COMMANDS=ON" "-D" "CMAKE_BUILD_TYPE=Debug" "$@")
 
 # for a list of checks, see /.clang-tidy
 cat "$SRC/.clang-tidy"
@@ -54,7 +54,7 @@ fi
 
 CC=clang CXX=clang++ cmake "${ARGS[@]}" "$SRC" || (echo "cmake failed!"; false) || exit 2
 
-cmake --build . --target expand_all_instantiations || (echo "make expand_all_instantiations failed!"; false) || exit 3
+cmake --build . 
 
 # generate allheaders.h
 (cd include; find . -name '*.h'; cd $SRC/include/; find . -name '*.h') | grep -v allheaders.h | grep -v undefine_macros.h | sed 's|^./|#include <|' | sed 's|$|>|' >include/deal.II/allheaders.h

--- a/contrib/utilities/run_clang_tidy.sh
+++ b/contrib/utilities/run_clang_tidy.sh
@@ -54,7 +54,7 @@ fi
 
 CC=clang CXX=clang++ cmake "${ARGS[@]}" "$SRC" || (echo "cmake failed!"; false) || exit 2
 
-cmake --build . -j
+cmake --build . -j4
 
 # generate allheaders.h
 #(cd include; find . -name '*.h'; cd $SRC/include/; find . -name '*.h') | grep -v allheaders.h | grep -v undefine_macros.h | sed 's|^./|#include <|' | sed 's|$|>|' >include/deal.II/allheaders.h


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

Our current CI has a check for GCC warnings, but this is clearly not as deep as the tests done by clang tidy. I am adding a new CI step to check the code using clang tidy. Right now this will throw some warnings and errors which I will fix progressively.

### Testing

This is actually adding tests, so I am using this PR as a testing environment.
Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Lethe documentation is up to date
- [X] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [X] The branch is rebased onto master
- [X] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] If the fix is temporary, an issue is opened
- [X] The PR description is cleaned and ready for merge