### PR TITLE
Add a warnings clang CI

### DIFF
--- a/.github/workflows/warnings-clang.yml
+++ b/.github/workflows/warnings-clang.yml
@@ -40,11 +40,21 @@ jobs:
       - name: Setup
         run: |
           # Since dealii image doesn't include Node.js, we'll install it
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository ppa:ginggs/deal.ii-9.5.1-backports
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends nodejs clang-12
-
-          echo "Github actions is sane!"
-          echo "Running build with deal.ii version ${{ matrix.dealii_version }} on branch ${GITHUB_REF#refs/heads/}"
+          sudo apt-get install -y --no-install-recommends nodejs \
+            clang-12 \
+            clang-tidy-12 \
+            numdiff \
+            libboost-all-dev \
+            libcgal-dev \
+            libp4est-dev \
+            trilinos-all-dev \
+            petsc-dev \
+            libmetis-dev \
+            libhdf5-mpi-dev \
+            deal.ii
 
       # Checks-out Lethe with branch of triggering commit
       - name: Checkout code
@@ -59,4 +69,4 @@ jobs:
           mkdir build-warnings
           cd build-warnings
           CC=clang CXX=clang++ cmake ../ -DCMAKE_BUILD_TYPE=Debug -DBUILD_PROTOTYPES=ON
-          make -j${{ env.COMPILE_JOBS }}
+          cmake --build . -j${{ env.COMPILE_JOBS }}

--- a/.github/workflows/warnings-clang.yml
+++ b/.github/workflows/warnings-clang.yml
@@ -1,0 +1,62 @@
+name: CI-Warnings-Clang
+
+on: 
+  push:
+    # Runs on every push on master branch
+    branches:
+      - master
+  # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'contrib/**'
+      - 'examples/**'
+
+# Cancels running instances when a pull request is updated by a commit
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  COMPILE_JOBS: 4
+  MULTI_CORE_TESTS_REGEX: "mpirun=2"
+
+jobs:
+  build:
+    name: Build (deal.ii:${{ matrix.dealii_version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        dealii_version: ["master-focal"]
+    
+    # Run steps in container of dealii's master branch
+    container:
+      image: dealii/dealii:${{ matrix.dealii_version }}
+      options: --user root
+
+    steps:
+      - name: Setup
+        run: |
+          # Since dealii image doesn't include Node.js, we'll install it
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends nodejs clang-12
+
+          echo "Github actions is sane!"
+          echo "Running build with deal.ii version ${{ matrix.dealii_version }} on branch ${GITHUB_REF#refs/heads/}"
+
+      # Checks-out Lethe with branch of triggering commit
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      #
+      # Warnings
+      #
+      - name: Compile Lethe to check for warnings using Clang (deal.ii:${{ matrix.dealii_version }})
+        run: |
+          export PATH=/usr/lib/llvm-12/share/clang/:$PATH
+          mkdir build-warnings
+          cd build-warnings
+          CC=clang CXX=clang++ cmake ../ -DCMAKE_BUILD_TYPE=Debug -DBUILD_PROTOTYPES=ON
+          make -j${{ env.COMPILE_JOBS }}


### PR DESCRIPTION

### Description

We currently only test warnings using GCC and not using Clang. Clang really seems to give more thorough warnings and I think it would be relevant to ensure we compile without warnings using both compiles. This is hard to ask of everyone, so the idea here is to deploy a new CI steps to identify the Clang warnings and to be able to progressively work towards eliminating all of them.

### Testing

This just adds a CI step so this should not be overly difficult.
