### PR TITLE
Print parameters (lethe-fluid-matrix-free)

### DIFF
--- a/applications/lethe-fluid-matrix-free/fluid_dynamics_matrix_free.cc
+++ b/applications/lethe-fluid-matrix-free/fluid_dynamics_matrix_free.cc
@@ -22,18 +22,25 @@ main(int argc, char *argv[])
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
-      if (argc != 2)
+      if (argc == 1)
         {
           std::cout << "Usage:" << argv[0] << " input_file" << std::endl;
           std::exit(1);
         }
 
-      const unsigned int                  dim = get_dimension(argv[1]);
-      const Parameters::SizeOfSubsections size_of_subsections =
-        Parameters::get_size_of_subsections(argv[1]);
 
-      ConditionalOStream pcout(
-        std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0);
+      const std::string file_name(argv[argc - 1]);
+      const bool        print_parameters =
+        (argc == 2) ? false : (std::string(argv[1]) == "--print-parameters");
+
+      const unsigned int                  dim = get_dimension(file_name);
+      const Parameters::SizeOfSubsections size_of_subsections =
+        Parameters::get_size_of_subsections(file_name);
+
+      ConditionalOStream pcout(std::cout,
+                               (Utilities::MPI::this_mpi_process(
+                                  MPI_COMM_WORLD) == 0) &&
+                                 print_parameters);
 
       if (dim == 2)
         {
@@ -41,7 +48,7 @@ main(int argc, char *argv[])
           SimulationParameters<2> NSparam;
           NSparam.declare(prm, size_of_subsections);
           // Parsing of the file
-          prm.parse_input(argv[1]);
+          prm.parse_input(file_name);
           NSparam.parse(prm);
 
           if (pcout.is_active())
@@ -49,7 +56,7 @@ main(int argc, char *argv[])
                                  ParameterHandler::OutputStyle::PRM |
                                    ParameterHandler::OutputStyle::Short |
                                    ParameterHandler::KeepDeclarationOrder |
-                                   ParameterHandler::KeepChanged);
+                                   ParameterHandler::KeepOnlyChanged);
           pcout << std::endl << std::endl;
 
           FluidDynamicsMatrixFree<2> problem(NSparam);
@@ -62,7 +69,7 @@ main(int argc, char *argv[])
           SimulationParameters<3> NSparam;
           NSparam.declare(prm, size_of_subsections);
           // Parsing of the file
-          prm.parse_input(argv[1]);
+          prm.parse_input(file_name);
           NSparam.parse(prm);
 
           if (pcout.is_active())
@@ -70,7 +77,7 @@ main(int argc, char *argv[])
                                  ParameterHandler::OutputStyle::PRM |
                                    ParameterHandler::OutputStyle::Short |
                                    ParameterHandler::KeepDeclarationOrder |
-                                   ParameterHandler::KeepChanged);
+                                   ParameterHandler::KeepOnlyChanged);
           pcout << std::endl << std::endl;
 
           FluidDynamicsMatrixFree<3> problem(NSparam);

--- a/applications/lethe-fluid-matrix-free/fluid_dynamics_matrix_free.cc
+++ b/applications/lethe-fluid-matrix-free/fluid_dynamics_matrix_free.cc
@@ -55,8 +55,12 @@ main(int argc, char *argv[])
             prm.print_parameters(pcout.get_stream(),
                                  ParameterHandler::OutputStyle::PRM |
                                    ParameterHandler::OutputStyle::Short |
-                                   ParameterHandler::KeepDeclarationOrder |
-                                   ParameterHandler::KeepOnlyChanged);
+                                   ParameterHandler::KeepDeclarationOrder
+                                   #if DEAL_II_VERSION_GTE(9, 7, 0)
+                                    |
+                                   ParameterHandler::KeepOnlyChanged
+                                   #endif
+                                   );
           pcout << std::endl << std::endl;
 
           FluidDynamicsMatrixFree<2> problem(NSparam);
@@ -76,8 +80,12 @@ main(int argc, char *argv[])
             prm.print_parameters(pcout.get_stream(),
                                  ParameterHandler::OutputStyle::PRM |
                                    ParameterHandler::OutputStyle::Short |
-                                   ParameterHandler::KeepDeclarationOrder |
-                                   ParameterHandler::KeepOnlyChanged);
+                                   ParameterHandler::KeepDeclarationOrder
+                                   #if DEAL_II_VERSION_GTE(9, 7, 0)
+                                    |
+                                   ParameterHandler::KeepOnlyChanged
+                                   #endif
+                                   );
           pcout << std::endl << std::endl;
 
           FluidDynamicsMatrixFree<3> problem(NSparam);

--- a/applications/lethe-fluid-matrix-free/fluid_dynamics_matrix_free.cc
+++ b/applications/lethe-fluid-matrix-free/fluid_dynamics_matrix_free.cc
@@ -32,6 +32,9 @@ main(int argc, char *argv[])
       const Parameters::SizeOfSubsections size_of_subsections =
         Parameters::get_size_of_subsections(argv[1]);
 
+      ConditionalOStream pcout(
+        std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0);
+
       if (dim == 2)
         {
           ParameterHandler        prm;
@@ -40,6 +43,14 @@ main(int argc, char *argv[])
           // Parsing of the file
           prm.parse_input(argv[1]);
           NSparam.parse(prm);
+
+          if (pcout.is_active())
+            prm.print_parameters(pcout.get_stream(),
+                                 ParameterHandler::OutputStyle::PRM |
+                                   ParameterHandler::OutputStyle::Short |
+                                   ParameterHandler::KeepDeclarationOrder |
+                                   ParameterHandler::KeepChanged);
+          pcout << std::endl << std::endl;
 
           FluidDynamicsMatrixFree<2> problem(NSparam);
           problem.solve();
@@ -53,6 +64,14 @@ main(int argc, char *argv[])
           // Parsing of the file
           prm.parse_input(argv[1]);
           NSparam.parse(prm);
+
+          if (pcout.is_active())
+            prm.print_parameters(pcout.get_stream(),
+                                 ParameterHandler::OutputStyle::PRM |
+                                   ParameterHandler::OutputStyle::Short |
+                                   ParameterHandler::KeepDeclarationOrder |
+                                   ParameterHandler::KeepChanged);
+          pcout << std::endl << std::endl;
 
           FluidDynamicsMatrixFree<3> problem(NSparam);
           problem.solve();


### PR DESCRIPTION
The output is like this:
```
set dimension = 3
subsection simulation control
  set time step                    = 0.05
  set adapt                        = true
  set max cfl                      = 1000
  set stop tolerance               = 1e-5
  set adaptative time step scaling = 1.2
  set output path                  = output/
  set output frequency             = 0
end
subsection physical properties
  subsection fluid 0
    set kinematic viscosity = 0.006666667
  end
end
subsection mesh
  set type               = gmsh
  set file name          = ./sphere.msh
  set initial refinement = 1
end
subsection boundary conditions
  subsection bc 0
    set type = noslip
  end
  subsection bc 1
    set type = function
    subsection u
      set Function expression = 1
    end
  end
  subsection bc 2
    set type = slip
  end
  subsection bc 3
    set type = outlet
  end
end
subsection initial conditions
  set type = ramp
  subsection ramp
    subsection kinematic viscosity
      set initial kinematic viscosity = 0.1
      set iterations                  = 6
    end
  end
end
subsection FEM
  set velocity order = 3
  set pressure order = 3
end
subsection timer
  set type = end
end
subsection forces
  set verbosity       = verbose
  set calculate force = true
end
subsection linear solver
  subsection fluid dynamics
    set verbosity                                 = extra verbose
    set relative residual                         = 1e-4
    set minimum residual                          = 1e-5
    set max iters                                 = 200
    set max krylov vectors                        = 200
    set preconditioner                            = gcmg
    set ilu preconditioner fill                   = 1
    set ilu preconditioner absolute tolerance     = 1e-6
    set ilu preconditioner relative tolerance     = 1
    set amg preconditioner ilu fill               = 1.00
    set amg preconditioner ilu absolute tolerance = 1e-6
    set mg smoother iterations                    = 2
    set mg smoother relaxation                    = 0.15
    set mg smoother preconditioner type           = additive schwarz method
    set mg smoother eig estimation                = true
    set eig estimation smoothing range            = 5
    set eig estimation cg n iterations            = 4
    set mg coarse grid solver                     = direct
    set mg coarsening type                        = hp
    set mg gmres max iterations                   = 500
    set mg gmres tolerance                        = 1e-5
    set mg gmres max krylov vectors               = 500
    set mg gmres preconditioner                   = ilu
    set mg verbosity                              = extra verbose
  end
end
subsection non-linear solver
  subsection fluid dynamics
    set tolerance = 1e-4
  end
end
subsection manifolds
  set number = 1
  subsection manifold 0
    set type              = spherical
    set id                = 0
    set point coordinates = 0, 0, 0
  end
end
subsection source term
  subsection fluid dynamics
    set enable = false
  end
end
```
Only the changed parameters are printed (Lethe just has too many parameters).

depends on https://github.com/dealii/dealii/pull/17593