### PR TITLE
Update print parameters for prototype 

### DIFF
--- a/prototypes/matrix_based_non_linear_poisson/matrix_based_non_linear_poisson.cc
+++ b/prototypes/matrix_based_non_linear_poisson/matrix_based_non_linear_poisson.cc
@@ -162,7 +162,11 @@ Settings::try_parse(const std::string &prm_filename)
         << "****  directory, or use the following default values\n"
         << "****  to create an input file:\n";
       if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+#if DEAL_II_VERSION_GTE(9, 7, 0)
+        prm.print_parameters(std::cout, ParameterHandler::DefaultStyle);
+#else
         prm.print_parameters(std::cout, ParameterHandler::Text);
+#endif
       return false;
     }
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

The prototypes were not compiling due to `print_parameters` call. Following commit 1fa5306, the print parameters call for the matrix-based non linear poisson prototype is corrected.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] The PR description is cleaned and ready for merge