### PR TITLE
Specify GMRES parameters whent iterating intermediate GMG levels

### DIFF
--- a/doc/source/parameters/cfd/linear_solver_control.rst
+++ b/doc/source/parameters/cfd/linear_solver_control.rst
@@ -264,7 +264,7 @@ Different parameters for the main components of the two geometric multigrid algo
   Evaluating terms involving the hessian is expensive. Therefore, one can turn on or off those terms in the mg level operators to improve performance by setting ``mg enable hessians in jacobian`` to ``false``. This is useful for certain problems and must be used carefully.
 
 .. tip::
-  The ``mg int level`` option only works for ``gcmg`` preconditioner. It allows to choose an intermediate level as coarse grid solver and to perform several multigrid v-cycles there.
+  The ``mg int level`` option only works for the ``gcmg`` preconditioner. It allows to choose an intermediate level as coarse grid solver where a GMRES preconditioned by several multigrid v-cycles is used. The following parameters: ``set mg gmres max iterations``, ``set mg gmres tolerance`` and ``set mg gmres reduce`` can be used to set the desired number of maximum iterations, the absolute tolerance and the relative tolerance. 
 
 In addition, Lethe supports `p-multigrid` through the ``gcmg`` preconditioner. It can be used by specifying two additional parameters:
 

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -1647,9 +1647,19 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
             std::make_shared<PreconditionMG<dim, VectorType, GCTransferType>>(
               this->dof_handler, *this->mg_intermediate, *this->mg_transfer_gc);
 
-          // TODO: introduce parameters
+          const int max_iterations = this->simulation_parameters.linear_solver
+                                       .at(PhysicsID::fluid_dynamics)
+                                       .mg_gmres_max_iterations;
+          const double tolerance = this->simulation_parameters.linear_solver
+                                     .at(PhysicsID::fluid_dynamics)
+                                     .mg_gmres_tolerance;
+          const double reduce = this->simulation_parameters.linear_solver
+                                  .at(PhysicsID::fluid_dynamics)
+                                  .mg_gmres_reduce;
+
           this->coarse_grid_solver_control_intermediate =
-            std::make_shared<ReductionControl>(1000, 1e-20, 1e-2, false, false);
+            std::make_shared<ReductionControl>(
+              max_iterations, tolerance, reduce, false, false);
 
           this->coarse_grid_solver_intermediate =
             std::make_shared<SolverGMRES<VectorType>>(


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the content of the new feature
       What are the motivations? 
       How is it integrated to the current code? -->

In PR #1211 a new parameter was introduced that allow to iterate intermediate GMG levels. This allows to choose a level as coarse grid and used there a GMRES iterative solver preconditioned by a MG. So far, only one parameter was present: `mg int level`, however, the parameters for the number of iterations and tolerances were being hardcoded. This PR changes that by using already existing GMRES parameters..

### Testing

<!-- How has this been tested?
       What are the new test(s) and what feature(s)/parameter(s) does it test?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works?
       How will you ensure that it will continue to work in the future? -->

I have tested this in the flow around a sphere case and seems to work just fine. 

### Documentation

<!-- Does this new feature introduce new simulation parameters? If so, describe them. -->

The documentation was updated by adding a note that specifies the use of these parameters for this purpose as well. 

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] The PR description is cleaned and ready for merge