### PR TITLE
Remove all last warnings identified by clang tidy

### DIFF
--- a/source/dem/adaptive_sparse_contacts.cc
+++ b/source/dem/adaptive_sparse_contacts.cc
@@ -156,8 +156,8 @@ AdaptiveSparseContacts<dim>::identify_mobility_status(
   const unsigned int dofs_per_cell = fe.dofs_per_cell;
 
   // Get locally owned and relevant dofs
-  const IndexSet locally_owned_dofs = background_dh.locally_owned_dofs();
-  IndexSet       locally_relevant_dofs =
+  const IndexSet &locally_owned_dofs = background_dh.locally_owned_dofs();
+  IndexSet        locally_relevant_dofs =
     DoFTools::extract_locally_relevant_dofs(background_dh);
 
   // Reinit all value of mobility at nodes as inactive

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -20,8 +20,7 @@ CFDDEMSolver<dim>::CFDDEMSolver(CFDDEMSimulationParameters<dim> &nsparam)
 {}
 
 template <int dim>
-CFDDEMSolver<dim>::~CFDDEMSolver()
-{}
+CFDDEMSolver<dim>::~CFDDEMSolver() = default;
 
 template <int dim>
 void

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -220,12 +220,10 @@ FluidDynamicsSharp<dim>::generate_cut_cells_map()
                           particles_cutting_this_cell.push_back(p);
                           if (particles_cutting_this_cell.size() > 1)
                             {
-                              for (unsigned int j = 0;
-                                   j < local_dof_indices.size();
-                                   ++j)
+                              for (const auto &dof_index : local_dof_indices)
                                 {
-                                  dof_with_more_then_one_particle
-                                    [local_dof_indices[j]] = true;
+                                  dof_with_more_then_one_particle[dof_index] =
+                                    true;
                                 }
                             }
                         }
@@ -250,10 +248,8 @@ FluidDynamicsSharp<dim>::generate_cut_cells_map()
               // cut, and consider them as cut cells.
               if (cell_is_cut)
                 {
-                  size_t id;
-                  for (unsigned int j = 0; j < local_dof_indices.size(); ++j)
+                  for (const auto &id : local_dof_indices)
                     {
-                      id                            = local_dof_indices[j];
                       local_dof_overconstrained(id) = 1;
                     }
                 }
@@ -267,12 +263,8 @@ FluidDynamicsSharp<dim>::generate_cut_cells_map()
                   if (face->at_boundary())
                     {
                       face->get_dof_indices(local_face_dof_indices);
-                      size_t id;
-                      for (unsigned int v = 0;
-                           v < local_face_dof_indices.size();
-                           ++v)
+                      for (const auto &id : local_face_dof_indices)
                         {
-                          id = local_face_dof_indices[v];
                           local_dof_overconstrained(id) = 1;
                         }
                     }
@@ -344,11 +336,10 @@ FluidDynamicsSharp<dim>::generate_cut_cells_map()
                             }
                         }
 
-                      for (unsigned int j = 0; j < local_dof_indices.size();
-                           ++j)
+                      for (const auto &local_dof_index : local_dof_indices)
                         {
-                          dof_with_more_then_one_particle
-                            [local_dof_indices[j]] = true;
+                          dof_with_more_then_one_particle[local_dof_index] =
+                            true;
                         }
 
                       overconstrained_fluid_cell_map[cell] = {
@@ -1102,12 +1093,8 @@ FluidDynamicsSharp<dim>::force_on_ib()
           if (cell_is_cut)
             {
               // loop over all particles that cut this precise cell
-              for (unsigned int iterator_over_cutting_particle = 0;
-                   iterator_over_cutting_particle < p_count.size();
-                   ++iterator_over_cutting_particle)
+              for (auto p : p_count)
                 {
-                  unsigned int p = p_count[iterator_over_cutting_particle];
-
                   // Loop over all cut cell faces'.
                   for (const auto face : cell->face_indices())
                     {
@@ -1116,16 +1103,13 @@ FluidDynamicsSharp<dim>::force_on_ib()
 
                       // Check if the face is cut
                       unsigned int nb_dof_inside = 0;
-                      for (unsigned int j = 0;
-                           j < local_face_dof_indices.size();
-                           ++j)
+                      for (const auto &dof_index : local_face_dof_indices)
                         {
                           // Count the number of DOFs that are inside
                           // of the particles. If all the DOfs are on one side
                           // the cell is not cut by the boundary.
                           if (particles[p].get_levelset(
-                                support_points[local_face_dof_indices[j]],
-                                cell) <= 0)
+                                support_points[dof_index], cell) <= 0)
                             ++nb_dof_inside;
                         }
 
@@ -2677,15 +2661,13 @@ FluidDynamicsSharp<dim>::Visualization_IB::build_patches(
   // Defining property field position
   int field_position = 0;
   // Iterating over properties
-  for (auto properties_iterator = properties_to_write.begin();
-       properties_iterator != properties_to_write.end();
-       ++properties_iterator, ++field_position)
+  for (const auto &properties_iterator : properties_to_write)
     {
       // Get the property field name
-      const std::string field_name = properties_iterator->first;
+      const std::string field_name = properties_iterator.first;
 
       // Number of components of the corresponding property
-      const unsigned components_number = properties_iterator->second;
+      const unsigned components_number = properties_iterator.second;
 
       // Check to see if the property is a vector
       if (components_number == 3)
@@ -2697,12 +2679,14 @@ FluidDynamicsSharp<dim>::Visualization_IB::build_patches(
             DataComponentInterpretation::component_is_part_of_vector));
         }
       dataset_names.push_back(field_name);
+      ++field_position;
     }
 
   // Building the patch data
   patches.resize(particles.size());
 
   // Looping over particle to get the properties from the particle_handler
+
   for (unsigned int p = 0; p < particles.size(); ++p)
     {
       // Particle location
@@ -2749,8 +2733,7 @@ FluidDynamicsSharp<dim>::Visualization_IB::get_nonscalar_data_ranges() const
 }
 
 template <int dim>
-FluidDynamicsSharp<dim>::Visualization_IB::~Visualization_IB()
-{}
+FluidDynamicsSharp<dim>::Visualization_IB::~Visualization_IB() = default;
 
 template <int dim>
 void

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -32,8 +32,7 @@ FluidDynamicsSharp<dim>::FluidDynamicsSharp(
 {}
 
 template <int dim>
-FluidDynamicsSharp<dim>::~FluidDynamicsSharp()
-{}
+FluidDynamicsSharp<dim>::~FluidDynamicsSharp() = default;
 
 
 template <int dim>

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -2671,7 +2671,7 @@ FluidDynamicsSharp<dim>::Visualization_IB::build_patches(
       // Check to see if the property is a vector
       if (components_number == 3)
         {
-          vector_datasets.push_back(std::make_tuple(
+          vector_datasets.emplace_back(std::make_tuple(
             field_position,
             field_position + components_number - 1,
             field_name,
@@ -3784,12 +3784,9 @@ FluidDynamicsSharp<dim>::sharp_edge()
                                     active_neighbors_set[m];
                                   neighbor_cell->get_dof_indices(
                                     local_dof_indices_3);
-                                  for (unsigned int o = 0;
-                                       o < local_dof_indices_3.size();
-                                       ++o)
+                                  for (const auto o : local_dof_indices_3)
                                     {
-                                      if (global_index_overwrite ==
-                                          local_dof_indices_3[o])
+                                      if (global_index_overwrite == o)
                                         {
                                           // neighbor_cell contain the same dof
                                           // check if this cell_cut is cut if

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -28,10 +28,9 @@ FluidDynamicsVANS<dim>::FluidDynamicsVANS(
     this->cfd_dem_simulation_parameters.cfd_parameters.boundary_conditions.type;
 
   unsigned int n_pbc = 0;
-  for (unsigned int i_bc = 0; i_bc < boundary_conditions_types.size(); ++i_bc)
+  for (auto &bc : boundary_conditions_types)
     {
-      if (boundary_conditions_types[i_bc] ==
-          BoundaryConditions::BoundaryType::periodic)
+      if (bc == BoundaryConditions::BoundaryType::periodic)
         {
           if (n_pbc++ > 1)
             {
@@ -235,8 +234,8 @@ void
 FluidDynamicsVANS<dim>::initialize_void_fraction()
 {
   calculate_void_fraction(this->simulation_control->get_current_time(), false);
-  for (unsigned int i = 0; i < previous_void_fraction.size(); ++i)
-    previous_void_fraction[i] = nodal_void_fraction_relevant;
+  for (auto &previous_solution : this->previous_void_fraction)
+    previous_solution = nodal_void_fraction_relevant;
 }
 
 template <int dim>

--- a/source/rpt/particle_visualization.cc
+++ b/source/rpt/particle_visualization.cc
@@ -36,7 +36,7 @@ ParticleVisualization<dim>::build_visualization_files()
   grid_out_faces.attach_dof_handler(empty_dof_handler);
   grid_out_faces.build_patches();
   std::string s        = visualization_filename;
-  std::string filename = s.substr(0, s.find(".")) + "_grid_";
+  std::string filename = s.substr(0, s.find('.')) + "_grid_";
   write_boundaries_vtu<dim>(
     grid_out_faces, "./", 0, 0, MPI_COMM_WORLD, filename, 0);
 

--- a/source/rpt/particle_visualization.cc
+++ b/source/rpt/particle_visualization.cc
@@ -91,7 +91,7 @@ ParticleVisualization<dim>::output_particles(unsigned int it)
                                 data_component_interpretation);
 
   std::string s        = visualization_filename;
-  std::string filename = s.substr(0, s.find(".")) + "_";
+  std::string filename = s.substr(0, s.find('.')) + "_";
   particle_output.write_vtu_with_pvtu_record("./",
                                              filename,
                                              it,

--- a/source/rpt/rpt.cc
+++ b/source/rpt/rpt.cc
@@ -99,7 +99,7 @@ RPT<dim>::export_data()
     filename += ".csv";
 
   myfile.open(filename);
-  if (filename.substr(filename.find_last_of(".") + 1) == ".dat")
+  if (filename.substr(filename.find_last_of('.') + 1) == ".dat")
     {
       myfile
         << "particle_positions_x particle_positions_y particle_positions_z detector_id counts"

--- a/source/rpt/rpt_cell_reconstruction.cc
+++ b/source/rpt/rpt_cell_reconstruction.cc
@@ -419,7 +419,7 @@ RPTCellReconstruction<dim>::export_positions()
   myfile.open(filename);
 
   // Headers with space or comma
-  if (filename.substr(filename.find_last_of(".") + 1) == ".dat")
+  if (filename.substr(filename.find_last_of('.') + 1) == ".dat")
     {
       myfile
         << "reconstructed_positions_id volumes particle_positions_x particle_positions_y particle_positions_z cell_level";

--- a/source/rpt/rpt_fem_reconstruction.cc
+++ b/source/rpt/rpt_fem_reconstruction.cc
@@ -1021,7 +1021,7 @@ RPTFEMReconstruction<dim>::export_found_positions()
   // Output in file and in terminal
   if (parameters.verbosity == Parameters::Verbosity::verbose)
     {
-      if (filename.substr(filename.find_last_of(".") + 1) == ".dat")
+      if (filename.substr(filename.find_last_of('.') + 1) == ".dat")
         {
           myfile << "position_x position_y position_z " << std::endl;
           for (const Point<dim> &position : found_positions)
@@ -1046,7 +1046,7 @@ RPTFEMReconstruction<dim>::export_found_positions()
     }
   else // Output only in file
     {
-      if (filename.substr(filename.find_last_of(".") + 1) == ".dat")
+      if (filename.substr(filename.find_last_of('.') + 1) == ".dat")
         {
           myfile << "position_x position_y position_z " << std::endl;
           for (const Point<dim> &position : found_positions)


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

This PR aims at removing all last warnings identified by clang tidy. It should only be merged when the clang tidy check passes.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [X] If parameters are modified, the tests and the documentation of examples are up to date
- [X] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [X] No other PR is open related to this refactoring
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] If any future works is planed, an issue is opened
- [X] The PR description is cleaned and ready for merge