### PR TITLE
Fix the executable templates to actually print PRM

### DIFF
--- a/applications/dem_parameter_template/dem_parameter_template.cc
+++ b/applications/dem_parameter_template/dem_parameter_template.cc
@@ -15,7 +15,7 @@ main()
         dem_parameters.declare(prm);
         std::ofstream output_prm("dem-2d.prm");
 #if DEAL_II_VERSION_GTE(9, 7, 0)
-        prm.print_parameters(output_prm, prm.DefaultStyle);
+        prm.print_parameters(output_prm, prm.PRM);
 #else
         prm.print_parameters(output_prm, prm.Text);
 #endif
@@ -26,7 +26,7 @@ main()
         dem_parameters.declare(prm);
         std::ofstream output_prm("dem-3d.prm");
 #if DEAL_II_VERSION_GTE(9, 7, 0)
-        prm.print_parameters(output_prm, prm.DefaultStyle);
+        prm.print_parameters(output_prm, prm.PRM);
 #else
         prm.print_parameters(output_prm, prm.Text);
 #endif

--- a/applications/navier_stokes_parameter_template/navier_stokes_parameter_template.cc
+++ b/applications/navier_stokes_parameter_template/navier_stokes_parameter_template.cc
@@ -20,7 +20,7 @@ main()
         nsparam.declare(prm, size_of_subsections);
         std::ofstream output_prm("template-2d.prm");
 #if DEAL_II_VERSION_GTE(9, 7, 0)
-        prm.print_parameters(output_prm, prm.DefaultStyle);
+        prm.print_parameters(output_prm, prm.PRM);
 #else
         prm.print_parameters(output_prm, prm.Text);
 #endif
@@ -32,7 +32,7 @@ main()
         nsparam.declare(prm, size_of_subsections);
         std::ofstream output_prm("template-3d.prm");
 #if DEAL_II_VERSION_GTE(9, 7, 0)
-        prm.print_parameters(output_prm, prm.DefaultStyle);
+        prm.print_parameters(output_prm, prm.PRM);
 #else
         prm.print_parameters(output_prm, prm.Text);
 #endif


### PR DESCRIPTION

### Description

Since the last deal.II version change, the template executable production did not adequately product a template file because they were not using the right form of output argument. This PR fixes that.

Code related list:
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] The PR description is cleaned and ready for merge