### PR TITLE
Add new scaling parameters for the Cahn-Hilliard model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-09-20
+
+### Added
+
+- MINOR Added dimensionality for the mobility and interface thickness in the CHNS solver, and surface tension related parameters in the VOF solver. [#1274](https://github.com/chaos-polymtl/lethe/pull/1274)
+
 ## [Master] - 2024-09-12
 
 ### Fixed

--- a/include/core/dimensionality.h
+++ b/include/core/dimensionality.h
@@ -102,6 +102,9 @@ namespace Parameters
     double enthalpy_scaling;
     double diffusivity_scaling;
     double thermal_expansion_scaling;
+    double surface_tension_scaling;
+    double cahn_hilliard_mobility_scaling;
+    double cahn_hilliard_epsilon_scaling;
   };
 } // namespace Parameters
 

--- a/include/core/dimensionality.h
+++ b/include/core/dimensionality.h
@@ -103,6 +103,7 @@ namespace Parameters
     double diffusivity_scaling;
     double thermal_expansion_scaling;
     double surface_tension_scaling;
+    double surface_tension_gradient_scaling;
     double cahn_hilliard_mobility_scaling;
     double cahn_hilliard_epsilon_scaling;
   };

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -353,7 +353,8 @@ namespace Parameters
     void
     declare_parameters(ParameterHandler &prm);
     void
-    parse_parameters(ParameterHandler &prm);
+    parse_parameters(ParameterHandler &prm,
+                     const Parameters::Dimensionality dimensions);
   };
 
   /**
@@ -368,7 +369,8 @@ namespace Parameters
     void
     declare_parameters(ParameterHandler &prm);
     void
-    parse_parameters(ParameterHandler &prm);
+    parse_parameters(ParameterHandler &prm,
+                     const Parameters::Dimensionality dimensions);
   };
 
 
@@ -502,7 +504,8 @@ namespace Parameters
     declare_parameters(ParameterHandler &prm, unsigned int id);
 
     void
-    parse_parameters(ParameterHandler &prm, const unsigned int id);
+    parse_parameters(ParameterHandler &prm, const unsigned int id,
+                     const Parameters::Dimensionality dimensions);
   };
 
   /**

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -350,22 +350,22 @@ namespace Parameters
     // Liquidus temperature - Units in K
     double T_liquidus;
 
-      /**
-       * @brief Declare the parameters.
-       *
-       * @param[in,out] prm The ParameterHandler.
-       */
+    /**
+     * @brief Declare the parameters.
+     *
+     * @param[in,out] prm The ParameterHandler.
+     */
     void
     declare_parameters(ParameterHandler &prm);
     void
     /**
- * @brief Parse the parameters.
- *
- * @param[in,out] prm The ParameterHandler.
- *
- * @param[in] dimensions The Dimensionality object controling the
- * fundamental dimensions (length, time, mass, temperature) of the problem.
- */
+     * @brief Parse the parameters.
+     *
+     * @param[in,out] prm The ParameterHandler.
+     *
+     * @param[in] dimensions The Dimensionality object controling the
+     * fundamental dimensions (length, time, mass, temperature) of the problem.
+     */
     parse_parameters(ParameterHandler                &prm,
                      const Parameters::Dimensionality dimensions);
   };
@@ -379,22 +379,22 @@ namespace Parameters
     // Mobility constant (M) in m^2/s
     double mobility_cahn_hilliard_constant;
 
-      /**
-   * @brief Declare the parameters.
-   *
-   * @param[in,out] prm The ParameterHandler.
-   */
+    /**
+     * @brief Declare the parameters.
+     *
+     * @param[in,out] prm The ParameterHandler.
+     */
     void
     declare_parameters(ParameterHandler &prm);
 
-      /**
-* @brief Parse the parameters.
-*
-* @param[in,out] prm The ParameterHandler.
-*
-* @param[in] dimensions The Dimensionality object controling the
-* fundamental dimensions (length, time, mass, temperature) of the problem.
-*/
+    /**
+     * @brief Parse the parameters.
+     *
+     * @param[in,out] prm The ParameterHandler.
+     *
+     * @param[in] dimensions The Dimensionality object controling the
+     * fundamental dimensions (length, time, mass, temperature) of the problem.
+     */
     void
     parse_parameters(ParameterHandler                &prm,
                      const Parameters::Dimensionality dimensions);
@@ -527,7 +527,7 @@ namespace Parameters
     std::pair<std::pair<unsigned int, unsigned int>, unsigned int>
       fluid_solid_interaction_with_material_interaction_id;
 
-/**
+    /**
      * @brief Declare the parameters.
      *
      * @param[in,out] prm The ParameterHandler.
@@ -537,16 +537,16 @@ namespace Parameters
     void
     declare_parameters(ParameterHandler &prm, unsigned int id);
 
-      /**
-   * @brief Parse the parameters.
-   *
-   * @param[in,out] prm The ParameterHandler.
-   *
-   * @param[in] id The material id.
-   *
-   * @param[in] dimensions The Dimensionality object controling the
-   * fundamental dimensions (length, time, mass, temperature) of the problem.
-   */
+    /**
+     * @brief Parse the parameters.
+     *
+     * @param[in,out] prm The ParameterHandler.
+     *
+     * @param[in] id The material id.
+     *
+     * @param[in] dimensions The Dimensionality object controling the
+     * fundamental dimensions (length, time, mass, temperature) of the problem.
+     */
     void
     parse_parameters(ParameterHandler                &prm,
                      const unsigned int               id,

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -353,7 +353,7 @@ namespace Parameters
     void
     declare_parameters(ParameterHandler &prm);
     void
-    parse_parameters(ParameterHandler &prm,
+    parse_parameters(ParameterHandler                &prm,
                      const Parameters::Dimensionality dimensions);
   };
 
@@ -369,7 +369,7 @@ namespace Parameters
     void
     declare_parameters(ParameterHandler &prm);
     void
-    parse_parameters(ParameterHandler &prm,
+    parse_parameters(ParameterHandler                &prm,
                      const Parameters::Dimensionality dimensions);
   };
 
@@ -504,7 +504,8 @@ namespace Parameters
     declare_parameters(ParameterHandler &prm, unsigned int id);
 
     void
-    parse_parameters(ParameterHandler &prm, const unsigned int id,
+    parse_parameters(ParameterHandler                &prm,
+                     const unsigned int               id,
                      const Parameters::Dimensionality dimensions);
   };
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -350,9 +350,22 @@ namespace Parameters
     // Liquidus temperature - Units in K
     double T_liquidus;
 
+      /**
+       * @brief Declare the parameters.
+       *
+       * @param[in,out] prm The ParameterHandler.
+       */
     void
     declare_parameters(ParameterHandler &prm);
     void
+    /**
+ * @brief Parse the parameters.
+ *
+ * @param[in,out] prm The ParameterHandler.
+ *
+ * @param[in] dimensions The Dimensionality object controling the
+ * fundamental dimensions (length, time, mass, temperature) of the problem.
+ */
     parse_parameters(ParameterHandler                &prm,
                      const Parameters::Dimensionality dimensions);
   };
@@ -366,8 +379,22 @@ namespace Parameters
     // Mobility constant (M) in m^2/s
     double mobility_cahn_hilliard_constant;
 
+      /**
+   * @brief Declare the parameters.
+   *
+   * @param[in,out] prm The ParameterHandler.
+   */
     void
     declare_parameters(ParameterHandler &prm);
+
+      /**
+* @brief Parse the parameters.
+*
+* @param[in,out] prm The ParameterHandler.
+*
+* @param[in] dimensions The Dimensionality object controling the
+* fundamental dimensions (length, time, mass, temperature) of the problem.
+*/
     void
     parse_parameters(ParameterHandler                &prm,
                      const Parameters::Dimensionality dimensions);
@@ -500,9 +527,26 @@ namespace Parameters
     std::pair<std::pair<unsigned int, unsigned int>, unsigned int>
       fluid_solid_interaction_with_material_interaction_id;
 
+/**
+     * @brief Declare the parameters.
+     *
+     * @param[in,out] prm The ParameterHandler.
+     *
+     * @param[in] id The material id.
+     */
     void
     declare_parameters(ParameterHandler &prm, unsigned int id);
 
+      /**
+   * @brief Parse the parameters.
+   *
+   * @param[in,out] prm The ParameterHandler.
+   *
+   * @param[in] id The material id.
+   *
+   * @param[in] dimensions The Dimensionality object controling the
+   * fundamental dimensions (length, time, mass, temperature) of the problem.
+   */
     void
     parse_parameters(ParameterHandler                &prm,
                      const unsigned int               id,

--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -217,7 +217,7 @@ namespace Parameters
     void
     declare_parameters(ParameterHandler &prm);
     void
-    parse_parameters(ParameterHandler &prm);
+    parse_parameters(ParameterHandler &prm, const Dimensionality dimensions);
   };
 
   /**
@@ -242,7 +242,7 @@ namespace Parameters
     void
     declare_parameters(ParameterHandler &prm);
     void
-    parse_parameters(ParameterHandler &prm);
+    parse_parameters(ParameterHandler &prm, const Dimensionality dimensions);
   };
 } // namespace Parameters
 #endif

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -162,7 +162,7 @@ public:
     mesh_box_refinement->parse_parameters(prm);
     nitsche->parse_parameters(prm);
     physical_properties.parse_parameters(prm, dimensionality);
-    multiphysics.parse_parameters(prm);
+    multiphysics.parse_parameters(prm,dimensionality);
     timer.parse_parameters(prm);
     fem_parameters.parse_parameters(prm);
     laser_parameters->parse_parameters(prm);
@@ -182,7 +182,7 @@ public:
     simulation_control.parse_parameters(prm);
     velocity_sources.parse_parameters(prm);
     particlesParameters->parse_parameters(prm);
-    multiphysics.parse_parameters(prm);
+    //multiphysics.parse_parameters(prm);
     constrain_solid_domain.parse_parameters(prm);
     stabilization.parse_parameters(prm);
     ale.parse_parameters(prm);

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -162,7 +162,7 @@ public:
     mesh_box_refinement->parse_parameters(prm);
     nitsche->parse_parameters(prm);
     physical_properties.parse_parameters(prm, dimensionality);
-    multiphysics.parse_parameters(prm,dimensionality);
+    multiphysics.parse_parameters(prm, dimensionality);
     timer.parse_parameters(prm);
     fem_parameters.parse_parameters(prm);
     laser_parameters->parse_parameters(prm);
@@ -182,7 +182,6 @@ public:
     simulation_control.parse_parameters(prm);
     velocity_sources.parse_parameters(prm);
     particlesParameters->parse_parameters(prm);
-    //multiphysics.parse_parameters(prm);
     constrain_solid_domain.parse_parameters(prm);
     stabilization.parse_parameters(prm);
     ale.parse_parameters(prm);

--- a/source/core/dimensionality.cc
+++ b/source/core/dimensionality.cc
@@ -13,14 +13,17 @@ namespace Parameters
     const double theta = temperature;
     const double T     = time;
 
-    density_scaling               = 1. * L * L * L / M;
-    specific_gas_constant_scaling = 1. / L / L * T * T * theta;
-    viscosity_scaling             = 1. / L / L * T;
-    specific_heat_scaling         = 1. / L / L * T * T * theta;
-    thermal_conductivity_scaling  = 1. / M / L * T * T * T * theta;
-    enthalpy_scaling              = 1. / M / L / L * T * T;
-    diffusivity_scaling           = 1. / L / L * T;
-    thermal_expansion_scaling     = T;
+    density_scaling                = 1. * L * L * L / M;
+    specific_gas_constant_scaling  = 1. / L / L * T * T * theta;
+    viscosity_scaling              = 1. / L / L * T;
+    specific_heat_scaling          = 1. / L / L * T * T * theta;
+    thermal_conductivity_scaling   = 1. / M / L * T * T * T * theta;
+    enthalpy_scaling               = 1. / M / L / L * T * T;
+    diffusivity_scaling            = 1. / L / L * T;
+    thermal_expansion_scaling      = T;
+    surface_tension_scaling        = 1. * T * T / M;
+    cahn_hilliard_mobility_scaling = 1. * M / L / L / L / T;
+    cahn_hilliard_epsilon_scaling  = 1. / L;
   }
 
   void

--- a/source/core/dimensionality.cc
+++ b/source/core/dimensionality.cc
@@ -13,17 +13,18 @@ namespace Parameters
     const double theta = temperature;
     const double T     = time;
 
-    density_scaling                = 1. * L * L * L / M;
-    specific_gas_constant_scaling  = 1. / L / L * T * T * theta;
-    viscosity_scaling              = 1. / L / L * T;
-    specific_heat_scaling          = 1. / L / L * T * T * theta;
-    thermal_conductivity_scaling   = 1. / M / L * T * T * T * theta;
-    enthalpy_scaling               = 1. / M / L / L * T * T;
-    diffusivity_scaling            = 1. / L / L * T;
-    thermal_expansion_scaling      = T;
-    surface_tension_scaling        = 1. * T * T / M;
-    cahn_hilliard_mobility_scaling = 1. * M / L / L / L / T;
-    cahn_hilliard_epsilon_scaling  = 1. / L;
+    density_scaling                  = 1. * L * L * L / M;
+    specific_gas_constant_scaling    = 1. / L / L * T * T * theta;
+    viscosity_scaling                = 1. / L / L * T;
+    specific_heat_scaling            = 1. / L / L * T * T * theta;
+    thermal_conductivity_scaling     = 1. / M / L * T * T * T * theta;
+    enthalpy_scaling                 = 1. / M / L / L * T * T;
+    diffusivity_scaling              = 1. / L / L * T;
+    thermal_expansion_scaling        = 1. * theta;
+    surface_tension_scaling          = 1. * T * T / M;
+    surface_tension_gradient_scaling = 1. * theta * T * T / M;
+    cahn_hilliard_mobility_scaling   = 1. * M / L / L / L / T;
+    cahn_hilliard_epsilon_scaling    = 1. / L;
   }
 
   void

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1371,7 +1371,6 @@ namespace Parameters
               {
                 mobility_cahn_hilliard_model =
                   MobilityCahnHilliardModel::constant;
-
               }
             else if (op == "quartic")
               {
@@ -1382,8 +1381,7 @@ namespace Parameters
               throw(std::runtime_error(
                 "Invalid mobility model. The choices are <constant|quartic>."));
 
-            mobility_cahn_hilliard_parameters.parse_parameters(prm,
-                                                                 dimensions);
+            mobility_cahn_hilliard_parameters.parse_parameters(prm, dimensions);
           }
           prm.leave_subsection();
         }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -514,9 +514,11 @@ namespace Parameters
   }
 
   void
-  SurfaceTensionParameters::parse_parameters(ParameterHandler &prm)
+  SurfaceTensionParameters::parse_parameters(ParameterHandler &prm,
+                                             const Parameters::Dimensionality dimensions)
   {
     surface_tension_coefficient = prm.get_double("surface tension coefficient");
+    surface_tension_coefficient *= dimensions.surface_tension_scaling;
     T_0                         = prm.get_double("reference state temperature");
     surface_tension_gradient =
       prm.get_double("temperature-driven surface tension gradient");
@@ -539,10 +541,13 @@ namespace Parameters
   }
 
   void
-  MobilityCahnHilliardParameters::parse_parameters(ParameterHandler &prm)
+  MobilityCahnHilliardParameters::parse_parameters(ParameterHandler &prm,
+                                                   const Parameters::Dimensionality dimensions)
   {
     mobility_cahn_hilliard_constant =
       prm.get_double("cahn hilliard mobility constant");
+    mobility_cahn_hilliard_constant *=
+              dimensions.cahn_hilliard_mobility_scaling;
   }
 
   template <int dim>
@@ -962,7 +967,7 @@ namespace Parameters
            ++i_material_interaction)
         {
           material_interactions[i_material_interaction].parse_parameters(
-            prm, i_material_interaction);
+            prm, i_material_interaction,dimensions);
           if (material_interactions[i_material_interaction]
                 .material_interaction_type ==
               MaterialInteractions::MaterialInteractionsType::fluid_fluid)
@@ -1304,7 +1309,8 @@ namespace Parameters
   }
 
   void
-  MaterialInteractions::parse_parameters(ParameterHandler &prm, unsigned int id)
+  MaterialInteractions::parse_parameters(ParameterHandler &prm, unsigned int id,
+                                         const Parameters::Dimensionality dimensions)
   {
     prm.enter_subsection("material interaction " +
                          Utilities::int_to_string(id, 1));
@@ -1339,17 +1345,17 @@ namespace Parameters
             if (op == "constant")
               {
                 surface_tension_model = SurfaceTensionModel::constant;
-                surface_tension_parameters.parse_parameters(prm);
+                surface_tension_parameters.parse_parameters(prm,dimensions);
               }
             else if (op == "linear")
               {
                 surface_tension_model = SurfaceTensionModel::linear;
-                surface_tension_parameters.parse_parameters(prm);
+                surface_tension_parameters.parse_parameters(prm,dimensions);
               }
             else if (op == "phase change")
               {
                 surface_tension_model = SurfaceTensionModel::phase_change;
-                surface_tension_parameters.parse_parameters(prm);
+                surface_tension_parameters.parse_parameters(prm,dimensions);
               }
             else
               throw(std::runtime_error(
@@ -1361,13 +1367,13 @@ namespace Parameters
               {
                 mobility_cahn_hilliard_model =
                   MobilityCahnHilliardModel::constant;
-                mobility_cahn_hilliard_parameters.parse_parameters(prm);
+                mobility_cahn_hilliard_parameters.parse_parameters(prm,dimensions);
               }
             else if (op == "quartic")
               {
                 mobility_cahn_hilliard_model =
                   MobilityCahnHilliardModel::quartic;
-                mobility_cahn_hilliard_parameters.parse_parameters(prm);
+                mobility_cahn_hilliard_parameters.parse_parameters(prm,dimensions);
               }
             else
               throw(std::runtime_error(
@@ -1390,17 +1396,17 @@ namespace Parameters
           if (op == "constant")
             {
               surface_tension_model = SurfaceTensionModel::constant;
-              surface_tension_parameters.parse_parameters(prm);
+              surface_tension_parameters.parse_parameters(prm,dimensions);
             }
           else if (op == "linear")
             {
               surface_tension_model = SurfaceTensionModel::linear;
-              surface_tension_parameters.parse_parameters(prm);
+              surface_tension_parameters.parse_parameters(prm,dimensions);
             }
           else if (op == "phase change")
             {
               surface_tension_model = SurfaceTensionModel::phase_change;
-              surface_tension_parameters.parse_parameters(prm);
+              surface_tension_parameters.parse_parameters(prm,dimensions);
             }
           else
             throw(std::runtime_error(

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -514,17 +514,20 @@ namespace Parameters
   }
 
   void
-  SurfaceTensionParameters::parse_parameters(ParameterHandler &prm,
-                                             const Parameters::Dimensionality dimensions)
+  SurfaceTensionParameters::parse_parameters(
+    ParameterHandler                &prm,
+    const Parameters::Dimensionality dimensions)
   {
     surface_tension_coefficient = prm.get_double("surface tension coefficient");
     surface_tension_coefficient *= dimensions.surface_tension_scaling;
-    T_0                         = prm.get_double("reference state temperature");
+    T_0 = prm.get_double("reference state temperature");
     surface_tension_gradient =
       prm.get_double("temperature-driven surface tension gradient");
-    T_solidus  = prm.get_double("solidus temperature");
+    surface_tension_gradient *= dimensions.surface_tension_gradient_scaling;
+    T_solidus = prm.get_double("solidus temperature");
+    T_solidus *= 1. / dimensions.temperature;
     T_liquidus = prm.get_double("liquidus temperature");
-
+    T_liquidus *= 1. / dimensions.temperature;
     Assert(T_liquidus > T_solidus,
            PhaseChangeIntervalError(T_liquidus, T_solidus));
   }
@@ -541,13 +544,14 @@ namespace Parameters
   }
 
   void
-  MobilityCahnHilliardParameters::parse_parameters(ParameterHandler &prm,
-                                                   const Parameters::Dimensionality dimensions)
+  MobilityCahnHilliardParameters::parse_parameters(
+    ParameterHandler                &prm,
+    const Parameters::Dimensionality dimensions)
   {
     mobility_cahn_hilliard_constant =
       prm.get_double("cahn hilliard mobility constant");
     mobility_cahn_hilliard_constant *=
-              dimensions.cahn_hilliard_mobility_scaling;
+      dimensions.cahn_hilliard_mobility_scaling;
   }
 
   template <int dim>
@@ -967,7 +971,7 @@ namespace Parameters
            ++i_material_interaction)
         {
           material_interactions[i_material_interaction].parse_parameters(
-            prm, i_material_interaction,dimensions);
+            prm, i_material_interaction, dimensions);
           if (material_interactions[i_material_interaction]
                 .material_interaction_type ==
               MaterialInteractions::MaterialInteractionsType::fluid_fluid)
@@ -1309,8 +1313,10 @@ namespace Parameters
   }
 
   void
-  MaterialInteractions::parse_parameters(ParameterHandler &prm, unsigned int id,
-                                         const Parameters::Dimensionality dimensions)
+  MaterialInteractions::parse_parameters(
+    ParameterHandler                &prm,
+    unsigned int                     id,
+    const Parameters::Dimensionality dimensions)
   {
     prm.enter_subsection("material interaction " +
                          Utilities::int_to_string(id, 1));
@@ -1345,17 +1351,17 @@ namespace Parameters
             if (op == "constant")
               {
                 surface_tension_model = SurfaceTensionModel::constant;
-                surface_tension_parameters.parse_parameters(prm,dimensions);
+                surface_tension_parameters.parse_parameters(prm, dimensions);
               }
             else if (op == "linear")
               {
                 surface_tension_model = SurfaceTensionModel::linear;
-                surface_tension_parameters.parse_parameters(prm,dimensions);
+                surface_tension_parameters.parse_parameters(prm, dimensions);
               }
             else if (op == "phase change")
               {
                 surface_tension_model = SurfaceTensionModel::phase_change;
-                surface_tension_parameters.parse_parameters(prm,dimensions);
+                surface_tension_parameters.parse_parameters(prm, dimensions);
               }
             else
               throw(std::runtime_error(
@@ -1367,13 +1373,15 @@ namespace Parameters
               {
                 mobility_cahn_hilliard_model =
                   MobilityCahnHilliardModel::constant;
-                mobility_cahn_hilliard_parameters.parse_parameters(prm,dimensions);
+                mobility_cahn_hilliard_parameters.parse_parameters(prm,
+                                                                   dimensions);
               }
             else if (op == "quartic")
               {
                 mobility_cahn_hilliard_model =
                   MobilityCahnHilliardModel::quartic;
-                mobility_cahn_hilliard_parameters.parse_parameters(prm,dimensions);
+                mobility_cahn_hilliard_parameters.parse_parameters(prm,
+                                                                   dimensions);
               }
             else
               throw(std::runtime_error(
@@ -1396,17 +1404,17 @@ namespace Parameters
           if (op == "constant")
             {
               surface_tension_model = SurfaceTensionModel::constant;
-              surface_tension_parameters.parse_parameters(prm,dimensions);
+              surface_tension_parameters.parse_parameters(prm, dimensions);
             }
           else if (op == "linear")
             {
               surface_tension_model = SurfaceTensionModel::linear;
-              surface_tension_parameters.parse_parameters(prm,dimensions);
+              surface_tension_parameters.parse_parameters(prm, dimensions);
             }
           else if (op == "phase change")
             {
               surface_tension_model = SurfaceTensionModel::phase_change;
-              surface_tension_parameters.parse_parameters(prm,dimensions);
+              surface_tension_parameters.parse_parameters(prm, dimensions);
             }
           else
             throw(std::runtime_error(

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -521,6 +521,7 @@ namespace Parameters
     surface_tension_coefficient = prm.get_double("surface tension coefficient");
     surface_tension_coefficient *= dimensions.surface_tension_scaling;
     T_0 = prm.get_double("reference state temperature");
+    T_0 *= 1. / dimensions.temperature;
     surface_tension_gradient =
       prm.get_double("temperature-driven surface tension gradient");
     surface_tension_gradient *= dimensions.surface_tension_gradient_scaling;
@@ -1351,41 +1352,38 @@ namespace Parameters
             if (op == "constant")
               {
                 surface_tension_model = SurfaceTensionModel::constant;
-                surface_tension_parameters.parse_parameters(prm, dimensions);
               }
             else if (op == "linear")
               {
                 surface_tension_model = SurfaceTensionModel::linear;
-                surface_tension_parameters.parse_parameters(prm, dimensions);
               }
             else if (op == "phase change")
               {
                 surface_tension_model = SurfaceTensionModel::phase_change;
-                surface_tension_parameters.parse_parameters(prm, dimensions);
               }
             else
               throw(std::runtime_error(
                 "Invalid surface tension model. The choices are <constant|linear|phase change>."));
-
+            surface_tension_parameters.parse_parameters(prm, dimensions);
             // Cahn-Hilliard mobility
             op = prm.get("cahn hilliard mobility model");
             if (op == "constant")
               {
                 mobility_cahn_hilliard_model =
                   MobilityCahnHilliardModel::constant;
-                mobility_cahn_hilliard_parameters.parse_parameters(prm,
-                                                                   dimensions);
+
               }
             else if (op == "quartic")
               {
                 mobility_cahn_hilliard_model =
                   MobilityCahnHilliardModel::quartic;
-                mobility_cahn_hilliard_parameters.parse_parameters(prm,
-                                                                   dimensions);
               }
             else
               throw(std::runtime_error(
                 "Invalid mobility model. The choices are <constant|quartic>."));
+
+            mobility_cahn_hilliard_parameters.parse_parameters(prm,
+                                                                 dimensions);
           }
           prm.leave_subsection();
         }

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -73,7 +73,8 @@ Parameters::Multiphysics::declare_parameters(ParameterHandler &prm)
 }
 
 void
-Parameters::Multiphysics::parse_parameters(ParameterHandler &prm)
+Parameters::Multiphysics::parse_parameters(ParameterHandler &prm,
+                                           const Dimensionality dimensions)
 {
   prm.enter_subsection("multiphysics");
   {
@@ -89,7 +90,7 @@ Parameters::Multiphysics::parse_parameters(ParameterHandler &prm)
   }
   prm.leave_subsection();
   vof_parameters.parse_parameters(prm);
-  cahn_hilliard_parameters.parse_parameters(prm);
+  cahn_hilliard_parameters.parse_parameters(prm, dimensions);
 }
 
 void
@@ -525,7 +526,8 @@ Parameters::CahnHilliard::declare_parameters(ParameterHandler &prm)
 }
 
 void
-Parameters::CahnHilliard::parse_parameters(ParameterHandler &prm)
+Parameters::CahnHilliard::parse_parameters(ParameterHandler &prm,
+                                           const Dimensionality dimensions)
 {
   prm.enter_subsection("cahn hilliard");
   {
@@ -552,6 +554,7 @@ Parameters::CahnHilliard::parse_parameters(ParameterHandler &prm)
                                  "Options are 'automatic' or 'manual'."));
 
       epsilon = prm.get_double("value");
+      epsilon *= dimensions.cahn_hilliard_epsilon_scaling;
     }
     prm.leave_subsection();
   }

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -73,7 +73,7 @@ Parameters::Multiphysics::declare_parameters(ParameterHandler &prm)
 }
 
 void
-Parameters::Multiphysics::parse_parameters(ParameterHandler &prm,
+Parameters::Multiphysics::parse_parameters(ParameterHandler    &prm,
                                            const Dimensionality dimensions)
 {
   prm.enter_subsection("multiphysics");
@@ -526,7 +526,7 @@ Parameters::CahnHilliard::declare_parameters(ParameterHandler &prm)
 }
 
 void
-Parameters::CahnHilliard::parse_parameters(ParameterHandler &prm,
+Parameters::CahnHilliard::parse_parameters(ParameterHandler    &prm,
                                            const Dimensionality dimensions)
 {
   prm.enter_subsection("cahn hilliard");


### PR DESCRIPTION
### Description

With new models come new parameters that need to be dimensionalised adequately when changing the units in the "Dimensionality" section of the parameter file. 
With the Cahn-Hilliard model, it was the mobility coefficient, the interface thickness and the surface tension.
Three new scalings were added at first, for those three parameters. Since surface tension is also used in VOF model, a fourth scaling parameter was added for the surface tension gradient for completion.

There was a mistake in the scaling of thermal expansion which was corrected.

### Testing

No testing because it would imply coding an output for the physical properties which is unnecessary.It works fine.

### Documentation

No new documentation

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Lethe documentation is up to date
- [ ] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] The PR description is cleaned and ready for merge