### PR TITLE
Add parameter to rescale mesh once it has been read from input files

### DIFF
--- a/applications_tests/lethe-fluid/taylorcouette_gls_scaled.output
+++ b/applications_tests/lethe-fluid/taylorcouette_gls_scaled.output
@@ -1,0 +1,51 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       64
+   Number of degrees of freedom: 864
+   Volume of triangulation:      2.95
+Viscous dissipation : 0.627
+
+*****************************
+Steady iteration:        1/3
+*****************************
+Viscous dissipation : 0.285
+
++------------------------------------------+
+|  Torque summary                          |
++------------------------------------------+
+Boundary ID  T_x   T_y   T_z   
+          0 0.000 0.000 -0.787 
+          1 0.000 0.000  0.829 
+
+*****************************
+Steady iteration:        2/3
+*****************************
+   Number of active cells:       256
+   Number of degrees of freedom: 3264
+   Volume of triangulation:      2.95
+Viscous dissipation : 0.284
+
++------------------------------------------+
+|  Torque summary                          |
++------------------------------------------+
+Boundary ID  T_x   T_y   T_z   
+          0 0.000 0.000 -0.819 
+          1 0.000 0.000  0.836 
+
+*****************************
+Steady iteration:        3/3
+*****************************
+   Number of active cells:       1024
+   Number of degrees of freedom: 12672
+   Volume of triangulation:      2.95
+Viscous dissipation : 0.284
+
++------------------------------------------+
+|  Torque summary                          |
++------------------------------------------+
+Boundary ID  T_x   T_y   T_z   
+          0 0.000 0.000 -0.832 
+          1 0.000 0.000  0.837 
+cells error_velocity error_pressure 
+   64 6.563e-04    - 1.277e-04    - 
+  256 9.623e-05 2.77 2.293e-05 2.48 
+ 1024 1.271e-05 2.92 3.819e-06 2.59 

--- a/applications_tests/lethe-fluid/taylorcouette_gls_scaled.prm
+++ b/applications_tests/lethe-fluid/taylorcouette_gls_scaled.prm
@@ -1,0 +1,153 @@
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method            = steady
+  set output name       = couette
+  set output frequency  = 0
+  set number mesh adapt = 2 # If steady, nb mesh adaptation
+  set log precision     = 3 # Log precision
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+
+subsection FEM
+  set velocity order = 2
+  set pressure order = 2
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  set number of fluids = 1
+  subsection fluid 0
+    set kinematic viscosity = 1.0000
+  end
+end
+
+#---------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+
+subsection analytical solution
+  set enable = true
+  subsection uvwp
+    # A= -(eta_ * eta_) / (1. - eta_ * eta_);
+    # B= ri_ * ri_ / (1. - eta_ * eta_);
+    set Function constants  = eta=0.25, ri=0.25, A=-0.06666666666666667, B=0.06666666666666666667
+    set Function expression = -sin(atan2(y,x))*(-(eta*eta) / (1-eta*eta)* sqrt(x*x+y*y)+ ri*ri/(1-eta*eta)/sqrt(x*x+y*y)); cos(atan2(y,x))*(-(eta*eta) / (1-eta*eta)* sqrt(x*x+y*y)+ ri*ri/(1-eta*eta)/sqrt(x*x+y*y)) ; A*A*(x^2+y^2)/2 + 2 *A*B *ln(sqrt(x^2+y^2)) - 0.5*B*B/(x^2+y^2)
+  end
+end
+
+#---------------------------------------------------
+# Forces
+#---------------------------------------------------
+
+subsection forces
+  set verbosity             = verbose # Output force and torques in log <quiet|verbose>
+  set calculate force       = false   # Enable force calculation
+  set calculate torque      = true    # Enable torque calculation
+  set force name            = force   # Name prefix of force files
+  set torque name           = torque  # Name prefix of torque files
+  set output precision      = 10      # Output precision
+  set calculation frequency = 1       # Frequency of the force calculation
+  set output frequency      = 1       # Frequency of file update
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = hyper_shell
+  set grid arguments     = 0, 0 : 0.025 : 0.1 : 4:  true
+  set initial refinement = 2
+  set scale = 10
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions
+  set number = 2
+  subsection bc 1
+    set type = noslip
+  end
+  subsection bc 0
+    set type = function
+    subsection u
+      set Function expression = -y
+    end
+    subsection v
+      set Function expression = x
+    end
+    subsection w
+      set Function expression = 0
+    end
+  end
+end
+
+#---------------------------------------------------
+# Post-processing
+#---------------------------------------------------
+
+subsection post-processing
+  set verbosity                     = verbose
+  set calculate viscous dissipation = true
+end
+
+#---------------------------------------------------
+# Mesh Adaptation Control
+#---------------------------------------------------
+
+subsection mesh adaptation
+  set type = uniform
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection fluid dynamics
+    set tolerance          = 1e-10
+    set max iterations     = 10
+    set residual precision = 2
+    set verbosity          = quiet
+  end
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection fluid dynamics
+    set method                                    = gmres
+    set max iters                                 = 100
+    set relative residual                         = 1e-4
+    set minimum residual                          = 1e-11
+    set preconditioner                            = amg
+    set amg preconditioner ilu fill               = 1
+    set amg preconditioner ilu absolute tolerance = 1e-10
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg aggregation threshold                 = 1e-14 # Aggregation
+    set amg n cycles                              = 1     # Number of AMG cycles
+    set amg w cycles                              = true  # W cycles, otherwise V cycles
+    set amg smoother sweeps                       = 2     # Sweeps
+    set amg smoother overlap                      = 1     # Overlap
+    set verbosity                                 = quiet
+  end
+end

--- a/doc/source/parameters/cfd/mesh.rst
+++ b/doc/source/parameters/cfd/mesh.rst
@@ -27,6 +27,9 @@ This subsection provides information of the simulation geometry and its mesh. Th
 
     # Indicates that the mesh is a simplex mesh
     set simplex            = false
+
+    # Mesh scaling factor
+    set scale              = 1
   end
 
 * The following choices for the mesh type are available:
@@ -45,8 +48,10 @@ This subsection provides information of the simulation geometry and its mesh. Th
     :width: 600
     :align: center
 
-* The initial refinement number determines the number of refinements the grid will undergo in the simulation before the simulation is run. This allows one to refine a coarse grid automatically. By default, most deal.II grids will be as coarse as possible and need to be refined. This is a desirable behavior for parallel simulations, since for quad/hex meshes, the coarsest level of the grid is shared amongst all cores. Consequently, using a coarse grid with too many cells will lead to a prohibitive memory consumption.
+* The `initial refinement` number determines the number of refinements the grid will undergo in the simulation before the simulation is run. This allows one to refine a coarse grid automatically. By default, most deal.II grids will be as coarse as possible and need to be refined. This is a desirable behavior for parallel simulations, since for quad/hex meshes, the coarsest level of the grid is shared amongst all cores. Consequently, using a coarse grid with too many cells will lead to a prohibitive memory consumption.
 
-* The initial boundary refinement determines the number of refinements the grid will undergo in the simulation in the vicinities of the boundary specified by the ``boundaries refined`` parameter.
+* The `initial boundary refinement` determines the number of refinements the grid will undergo in the simulation in the vicinities of the boundary specified by the ``boundaries refined`` parameter.
 
 * `simplex`. If simplex is set to true, it indicates that the mesh being read is made of only simplex elements. If the mesh is of ``type = dealii`` it will be converted from a quad/hex mesh to a simplex mesh. If the mesh is of ``type = gsmh``, it will be read from a file as long as it is only made of simplices.
+
+* The `scale` parameter is used to scale the mesh. This is useful when the mesh is made in a different set of unit than what is desired by the simulation.

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1337,6 +1337,9 @@ namespace Parameters
     Tensor<1, 3> rotation_axis;
     double       rotation_angle;
 
+    /// Rescale the grid by the scale factor
+    double scale;
+
     static void
     declare_parameters(ParameterHandler &prm);
     void

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -51,6 +51,7 @@ attach_grid_to_triangulation(
               dealii::Triangulation<dim, spacedim>::none);
 
           triangulation.create_triangulation(construction_data);
+          GridTools::scale(mesh_parameters.scale, triangulation);
         }
       else
         {
@@ -58,6 +59,7 @@ attach_grid_to_triangulation(
           grid_in.attach_triangulation(triangulation);
           std::ifstream input_file(mesh_parameters.file_name);
           grid_in.read_msh(input_file);
+          GridTools::scale(mesh_parameters.scale, triangulation);
         }
     }
   // Dealii grids
@@ -70,6 +72,8 @@ attach_grid_to_triangulation(
             temporary_quad_triangulation,
             mesh_parameters.grid_type,
             mesh_parameters.grid_arguments);
+
+          GridTools::scale(mesh_parameters.scale, temporary_quad_triangulation);
 
           // initial refinement
           const unsigned int initial_refinement =
@@ -106,6 +110,8 @@ attach_grid_to_triangulation(
             triangulation,
             mesh_parameters.grid_type,
             mesh_parameters.grid_arguments);
+
+          GridTools::scale(mesh_parameters.scale, triangulation);
         }
     }
   // Customizable cylinder mesh
@@ -158,6 +164,8 @@ attach_grid_to_triangulation(
                                                  subdivisions,
                                                  radius,
                                                  half_height);
+
+              GridTools::scale(mesh_parameters.scale, triangulation);
             }
           else
             {
@@ -250,112 +258,10 @@ attach_grid_to_triangulation(
               // Add a cylindrical manifold on the final unrefined mesh
               const CylindricalManifold<3, spacedim> m1(0);
               triangulation.set_manifold(0, m1);
+
+              GridTools::scale(mesh_parameters.scale, triangulation);
             }
         }
-    }
-
-  // Colorized cylinder shell
-  else if (mesh_parameters.type ==
-           Parameters::Mesh::Type::colorized_cylinder_shell)
-    {
-      if (mesh_parameters.simplex)
-        {
-          throw std::runtime_error(
-            "Unsupported mesh type - colorized cylinder shell with simplex is not supported.");
-        }
-      else if (dim != 3)
-        {
-          throw std::runtime_error(
-            "Unsupported mesh type - colorized cylinder shell is only supported in 3d.");
-        }
-
-      // First generate the regular deal.II cylinder_shell using the
-      // mesh_parameters arguments
-      GridGenerator::generate_from_name_and_arguments(
-        triangulation, "cylinder_shell", mesh_parameters.grid_arguments);
-
-      // Now that we have our grid, colorize the boundary conditions.
-      // Inner cylinder has boundary id 0
-      // Outer cylinder has boundary id 1
-      // Bottom (Z-) part of the cylinder has boundary id 2
-      // Top (Z+) part of the cylinder has boundary id 3
-
-      // Split the argument to extract the radius
-      std::vector<std::string> split_arguments =
-        Utilities::split_string_list(mesh_parameters.grid_arguments, ":");
-
-      const double length = Utilities::string_to_double(split_arguments[0]);
-
-      // Tolerance along z
-      const double eps_z = 1e-6 * length;
-
-      // Gather the inner radius from the faces instead of the argument, this is
-      // more robust for some aspect ratios. First initialize the outer to 0 and
-      // the inner to a large value
-      double inner_radius = DBL_MAX;
-      double outer_radius = 0.;
-
-      // Loop over the cells once to acquire the min and max radius at the face
-      // centers Otherwise, for some cell ratio, the center of the faces can be
-      // at a radius which is significantly different from the one prescribed.
-      for (const auto &cell : triangulation.active_cell_iterators())
-        for (const unsigned int f : GeometryInfo<3>::face_indices())
-          {
-            if (!cell->face(f)->at_boundary())
-              continue;
-
-            const auto   face_center = cell->face(f)->center();
-            const double z           = face_center[2];
-
-            if ((std::fabs(z) > eps_z) &&
-                (std::fabs(z - length) > eps_z)) // Not a zmin or zmax boundary
-              {
-                const double radius =
-                  std::sqrt(face_center[0] * face_center[0] +
-                            face_center[1] * face_center[1]);
-                inner_radius = std::min(inner_radius, radius);
-                outer_radius = std::max(outer_radius, radius);
-              }
-          }
-
-      // Use the gathered radius to define the medium radial distance.
-      double mid_radial_distance = 0.5 * (outer_radius - inner_radius);
-
-      for (const auto &cell : triangulation.active_cell_iterators())
-        for (const unsigned int f : GeometryInfo<3>::face_indices())
-          {
-            if (!cell->face(f)->at_boundary())
-              continue;
-
-            const auto face_center = cell->face(f)->center();
-
-            const double radius = std::sqrt(face_center[0] * face_center[0] +
-                                            face_center[1] * face_center[1]);
-
-            const double z = face_center[2];
-
-            if (std::fabs(z) < eps_z) // z = 0 set boundary 2
-              {
-                cell->face(f)->set_boundary_id(2);
-              }
-            else if (std::fabs(z - length) < eps_z) // z = length set boundary 3
-              {
-                cell->face(f)->set_boundary_id(3);
-              }
-            else if (std::fabs(radius - inner_radius) >
-                     mid_radial_distance) // r =  outer_radius set boundary 1
-              {
-                cell->face(f)->set_boundary_id(1);
-              }
-            else if (std::fabs(radius - inner_radius) <
-                     mid_radial_distance) // r =  inner_radius set boundary 0
-              {
-                cell->face(f)->set_boundary_id(0);
-              }
-            else
-              throw std::runtime_error(
-                "There was an error while setting up this mesh");
-          }
     }
 
   // Periodic Hills grid
@@ -371,6 +277,8 @@ attach_grid_to_triangulation(
         {
           PeriodicHillsGrid<dim, spacedim> grid(mesh_parameters.grid_arguments);
           grid.make_grid(triangulation);
+
+          GridTools::scale(mesh_parameters.scale, triangulation);
         }
     }
   else

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2305,6 +2305,11 @@ namespace Parameters
         "0",
         Patterns::Double(),
         "Angle of rotation of the mesh at initialization around the axis in radian");
+
+      prm.declare_entry("scale",
+                        "1",
+                        Patterns::Double(),
+                        "Scaling factor used for the mesh.");
     }
     prm.leave_subsection();
   }
@@ -2357,6 +2362,9 @@ namespace Parameters
       rotation_axis =
         value_string_to_tensor<3>(prm.get("initial rotation axis"));
       rotation_angle = prm.get_double("initial rotation angle");
+
+      // Scaling factor
+      scale = prm.get_double("scale");
     }
     prm.leave_subsection();
   }


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

Sometimes we read mesh files and rapidly realize that the simulation would be done more easily in a different set of unit (such that for example, the characteristic length of the mesh becomes 1 instead of 0.001). This is annoying since it requires regenerating the mesh, which is not always a trivial task. This PR adds a scaling parameter for every mesh read that allows a user to rapidly rescale a mesh by a constant factor > 0. This uses the deal.II GridTools.

### Testing

To test the new feature I have added an application_test which is the traditional taylor-couette analytical solution, but where the mesh is actually rescaled once it has been established. This works well.

### Documentation

Parameter has been added top the documentation.


### Miscellaneous (will be removed when merged)

@oguevremont  thhere are some parameters regarding mesh handling taht I think you have added and that are not documented. It would be great to documente them in another PR.



Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Lethe documentation is up to date
- [X] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [X] The branch is rebased onto master
- [X] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] If the fix is temporary, an issue is opened
- [X] The PR description is cleaned and ready for merge