### PR TITLE
change upload artifact from v2 to v4

### DIFF
--- a/.github/workflows/doc-github-pages.yml
+++ b/.github/workflows/doc-github-pages.yml
@@ -52,7 +52,7 @@ jobs:
           cp -r doxygen/html/ aggregate/doxygen/
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: html-doc
           path: doc/aggregate/


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

GitHub actions upload artifact version 2 has been deprecated which is making the `Publish doc to GitHub Pages` job of the CI fail.

### Solution

As suggested in the GitHub blog, v4 of upload artifact will be used.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge