### PR TITLE
Fixed bug with weak boundary function evaluation

### DIFF
--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -905,6 +905,14 @@ NavierStokesOperatorBase<dim, number>::
           const auto boundary_index =
             boundary_id - this->boundary_conditions.id.begin();
 
+
+          // Calculate the target velocity for the boundary condition if the
+          // boundary condition is a weak dirichlet boundary condition
+          // Otherwise there is no need to do this calculation
+          if (this->boundary_conditions.type[boundary_index] !=
+              BoundaryConditions::BoundaryType::function_weak)
+            continue;
+
           for (const auto q : face_integrator.quadrature_point_indices())
             {
               nonlinear_previous_face_values(face - n_inner_faces, q) =
@@ -912,7 +920,6 @@ NavierStokesOperatorBase<dim, number>::
               nonlinear_previous_face_gradient(face - n_inner_faces, q) =
                 face_integrator.get_gradient(q);
 
-              // Calculate the target velocity for the boundary condition
               Point<dim, VectorizedArray<number>> point_batch =
                 face_integrator.quadrature_point(q);
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

When multiple boundary conditions are presents, not all boundary have a function that is initialized. Currently, the matrix_free architecture still tried to evaluate functions for all boundaries at the face. This is not a good idea (and it is anyway completely useless). This PR ensures that functions are only evaluated if they are function_weak boundary condition (aka it the function really needs to be evaluated).



Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Lethe documentation is up to date
- [X] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [X] The branch is rebased onto master
- [X] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [X ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ X] If the fix is temporary, an issue is opened
- [ X] The PR description is cleaned and ready for merge