### PR TITLE
Fix bdf extrapolation bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     # Runs on every push on master branch
     branches:
       - master
-      - fix-bdf-extrapolation-bug
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
   pull_request:
     paths-ignore:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     # Runs on every push on master branch
     branches:
       - master
+      - fix-bdf-extrapolation-bug
   # Runs on every push on master branch. If a push contains multiple commits, it will be ran on the latest one.
   pull_request:
     paths-ignore:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+
+## [Master] - 2024-09-23
+
+### Fixed
+
+- MINOR In the [PR #994](https://github.com/chaos-polymtl/lethe/pull/994), BDF extrapolation of the velocity in the VOF auxiliary physic was moved to the scratch data. However, the implementation was bypassed by an if condition. This bug is fixed with this PR, and an application test was added to ensure that the feature remains intact with future implementations. [#1286](https://github.com/chaos-polymtl/lethe/pull/1286)
+
 ## [Master] - 2024-09-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- MINOR In the [PR #994](https://github.com/chaos-polymtl/lethe/pull/994), BDF extrapolation of the velocity in the VOF auxiliary physic was moved to the scratch data. However, the implementation was bypassed by an if condition. This bug is fixed with this PR, and an application test was added to ensure that the feature remains intact with future implementations. [#1286](https://github.com/chaos-polymtl/lethe/pull/1286)
+- MINOR In the [PR #994](https://github.com/chaos-polymtl/lethe/pull/994), BDF extrapolation of the velocity in the VOF auxiliary physics was moved to the scratch data. However, the implementation was bypassed by an if condition. This bug is fixed with this PR, and an application test was added to ensure that the feature remains intact with future implementations. [#1286](https://github.com/chaos-polymtl/lethe/pull/1286)
 
 ## [Master] - 2024-09-20
 

--- a/applications_tests/lethe-fluid/heat_transfer_vof_lpbf_benchmark.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_vof_lpbf_benchmark.prm
@@ -31,12 +31,8 @@ end
 #---------------------------------------------------
 
 subsection mesh
-  set type = gmsh
-
-  # GMSH file name
-  set file name = ../../lpbf_benchmark_mesh.msh
-
-  # Initial refinement of the mesh
+  set type               = gmsh
+  set file name          = ../../lpbf_benchmark_mesh.msh
   set initial refinement = 3
 end
 
@@ -117,16 +113,8 @@ end
 #---------------------------------------------------
 
 subsection initial conditions
-  set type = nodal
-  subsection uvwp
-    set Function expression = 0; 0; 0
-  end
   subsection VOF
     set Function expression = if (y<0.43 , 1, 0)
-    subsection projection step
-      set enable           = false
-      set diffusion factor = 1
-    end
   end
   subsection temperature
     set Function expression = 298
@@ -171,8 +159,6 @@ subsection physical properties
   subsection material interaction 0
     set type = fluid-fluid
     subsection fluid-fluid interaction
-      set first fluid id                              = 0
-      set second fluid id                             = 1
       set surface tension model                       = phase change
       set surface tension coefficient                 = 1.52
       set reference state temperature                 = 1928
@@ -188,16 +174,13 @@ end
 #---------------------------------------------------
 
 subsection laser parameters
-  set enable               = true
-  set type                 = gaussian_heat_flux_vof_interface
-  set concentration factor = 2
-  set power                = 156e6 # M*L^2*T^-3
-  set absorptivity         = 0.35
-  set penetration depth    = 0.0
-  set beam radius          = 0.07 # L
-  set start time           = 0
-  set end time             = 0.002
-  set beam orientation     = y-
+  set enable            = true
+  set power             = 156e6 # M*L^2*T^-3
+  set absorptivity      = 0.35
+  set penetration depth = 0.0
+  set beam radius       = 0.07 # L
+  set end time          = 0.002
+  set beam orientation  = y-
   subsection path
     set Function expression = 0.3; 0.43
   end
@@ -209,28 +192,20 @@ end
 
 subsection VOF
   subsection phase filtration
-    set type      = tanh
-    set verbosity = quiet
-    set beta      = 20
+    set type = tanh
   end
   subsection interface sharpening
     set enable                  = true
-    set threshold               = 0.5
     set interface sharpness     = 1.5
-    set frequency               = 10
     set type                    = adaptive
     set threshold max deviation = 0.4
     set max iterations          = 50
-    set monitored fluid         = fluid 1
     set tolerance               = 1e-7
-    set verbosity               = quiet
   end
   subsection surface tension force
-    set enable                                   = true
-    set phase fraction gradient diffusion factor = 4
-    set curvature diffusion factor               = 1
-    set output auxiliary fields                  = true
-    set enable marangoni effect                  = true
+    set enable                  = true
+    set output auxiliary fields = true
+    set enable marangoni effect = true
   end
 end
 
@@ -245,9 +220,6 @@ subsection evaporation
   set evaporation latent heat     = 8.9e12
   set molar mass                  = 4.58e-2
   set boiling temperature         = 3550
-
-  set evaporation coefficient     = 0.82
-  set recoil pressure coefficient = 0.56
   set ambient pressure            = 101325e-3
   set liquid density              = 4420.0e-9
   set universal gas constant      = 8.314e6
@@ -291,38 +263,27 @@ end
 
 subsection linear solver
   subsection fluid dynamics
-    set verbosity                             = quiet
-    set method                                = gmres
-    set relative residual                     = 1e-3
-    set minimum residual                      = 1e-5
-    set preconditioner                        = ilu
-    set ilu preconditioner fill               = 1
-    set ilu preconditioner absolute tolerance = 1e-12
-    set ilu preconditioner relative tolerance = 1.00
+    set verbosity               = quiet
+    set minimum residual        = 1e-5
+    set ilu preconditioner fill = 1
   end
   subsection heat transfer
-    set verbosity                             = quiet
-    set method                                = gmres
-    set relative residual                     = 1e-2
-    set minimum residual                      = 1e-1
-    set preconditioner                        = ilu
-    set ilu preconditioner fill               = 1
-    set ilu preconditioner absolute tolerance = 1e-12
-    set ilu preconditioner relative tolerance = 1.00
+    set verbosity               = quiet
+    set relative residual       = 1e-2
+    set minimum residual        = 1e-1
+    set ilu preconditioner fill = 1
   end
   subsection VOF
-    set verbosity                             = quiet
-    set method                                = gmres
-    set relative residual                     = 1e-3
-    set minimum residual                      = 1e-5
-    set preconditioner                        = ilu
-    set ilu preconditioner fill               = 1
-    set ilu preconditioner absolute tolerance = 1e-12
-    set ilu preconditioner relative tolerance = 1.00
+    set verbosity               = quiet
+    set minimum residual        = 1e-5
+    set ilu preconditioner fill = 1
   end
 end
 
+#---------------------------------------------------
+# Restart
+#---------------------------------------------------
+
 subsection restart
-  set filename = restart
-  set restart  = true
+  set restart = true
 end

--- a/applications_tests/lethe-fluid/heat_transfer_vof_lpbf_benchmark_box_ref.mpirun=1.output
+++ b/applications_tests/lethe-fluid/heat_transfer_vof_lpbf_benchmark_box_ref.mpirun=1.output
@@ -28,12 +28,12 @@ Temperature statistics on fluid :
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-6.0120e-06      1.0266e-01              1.8314e-10         1.6379e-11         1.5173e-13      2.5734e-01              1.1375e-06         9.1910e-12         1.1415e-10           5.0000e-01 
+6.0120e-06      1.0266e-01              1.8314e-10         1.6379e-11         1.5171e-13      2.5734e-01              1.1375e-06         9.1914e-12         1.1421e-10           5.0000e-01
 
-*********************************************************************************
-Transient iteration: 32       Time: 6.212e-06 Time step: 2e-07    CFL: 0.0023602
-*********************************************************************************
-Temperature statistics on fluid : 
+**********************************************************************************
+Transient iteration: 32       Time: 6.212e-06 Time step: 2e-07    CFL: 0.00236028
+**********************************************************************************
+Temperature statistics on fluid :
 	     Min : 298
 	     Max : 2071.62
 	 Average : 306.259
@@ -42,13 +42,13 @@ Temperature statistics on fluid :
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-6.2120e-06      1.0266e-01              1.8314e-10         1.6362e-11         1.4320e-13      2.5734e-01              1.1375e-06         1.0181e-11         1.8352e-10           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold
+6.2120e-06      1.0266e-01              1.8314e-10         1.6362e-11         1.4312e-13      2.5734e-01              1.1375e-06         1.0182e-11         1.8370e-10           5.0000e-01
 
 **********************************************************************************
-Transient iteration: 33       Time: 6.412e-06 Time step: 2e-07    CFL: 0.00260532
+Transient iteration: 33       Time: 6.412e-06 Time step: 2e-07    CFL: 0.00260547
 **********************************************************************************
-Temperature statistics on fluid : 
+Temperature statistics on fluid :
 	     Min : 298
 	     Max : 2098.95
 	 Average : 306.498
@@ -57,13 +57,13 @@ Temperature statistics on fluid :
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-6.4120e-06      1.0266e-01              1.8314e-10         1.6288e-11         1.3142e-13      2.5734e-01              1.1375e-06         1.0457e-11         2.6216e-10           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold
+6.4120e-06      1.0266e-01              1.8314e-10         1.6288e-11         1.3128e-13      2.5734e-01              1.1375e-06         1.0459e-11         2.6252e-10           5.0000e-01
 
 *********************************************************************************
-Transient iteration: 34       Time: 6.5e-06  Time step: 8.8e-08  CFL: 0.00271902
+Transient iteration: 34       Time: 6.5e-06  Time step: 8.8e-08  CFL: 0.00271918
 *********************************************************************************
-Temperature statistics on fluid : 
+Temperature statistics on fluid :
 	     Min : 298
 	     Max : 2110.78
 	 Average : 306.603
@@ -72,5 +72,5 @@ Temperature statistics on fluid :
 ----------------------
 VOF Mass Conservation
 ----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-6.5000e-06      1.0266e-01              1.8314e-10         1.6208e-11         1.3455e-13      2.5734e-01              1.1375e-06         1.0018e-11         2.0102e-10           5.0000e-01 
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold
+6.5000e-06      1.0266e-01              1.8314e-10         1.6208e-11         1.3445e-13      2.5734e-01              1.1375e-06         1.0019e-11         2.0129e-10           5.0000e-01

--- a/applications_tests/lethe-fluid/vof-velocity-extrapolation.output
+++ b/applications_tests/lethe-fluid/vof-velocity-extrapolation.output
@@ -1,0 +1,387 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       960
+   Number of degrees of freedom: 3075
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 1025
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+0.0000e+00      2.1265e-01              2.1265e-04         0.0000e+00         0.0000e+00      1.9874e+00              1.9874e+00         0.0000e+00         0.0000e+00           5.0000e-01 
+   Number of active cells:       1323
+   Number of degrees of freedom: 4299
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 1433
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+0.0000e+00      1.9794e-01              1.9794e-04         0.0000e+00         0.0000e+00      2.0021e+00              2.0021e+00         0.0000e+00         0.0000e+00           5.0000e-01 
+   Number of active cells:       2055
+   Number of degrees of freedom: 6753
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 2251
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+0.0000e+00      1.9983e-01              1.9983e-04         0.0000e+00         0.0000e+00      2.0002e+00              2.0002e+00         0.0000e+00         0.0000e+00           5.0000e-01 
+   Number of active cells:       3540
+   Number of degrees of freedom: 11709
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 3903
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+0.0000e+00      1.9990e-01              1.9990e-04         0.0000e+00         0.0000e+00      2.0001e+00              2.0001e+00         0.0000e+00         0.0000e+00           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 1        Time: 0.08     Time step: 0.08     CFL: 0       
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+8.0000e-02      1.9990e-01              1.9990e-04         8.5913e-11         2.7038e-08      2.0001e+00              2.0001e+00        -6.9607e-08        -3.1862e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 2        Time: 0.224    Time step: 0.144    CFL: 0.116391
+*******************************************************************************
+   Number of active cells:       2952
+   Number of degrees of freedom: 9942
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 3314
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.2400e-01      1.9995e-01              1.9995e-04         9.4122e-12         7.1104e-08      2.0000e+00              2.0000e+00         1.0087e-07        -7.5020e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 3        Time: 0.464    Time step: 0.24     CFL: 0.36762 
+*******************************************************************************
+   Number of active cells:       3825
+   Number of degrees of freedom: 12600
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 4200
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+4.6400e-01      2.0001e-01              2.0001e-04        -1.6539e-11         8.7146e-08      2.0000e+00              2.0000e+00         1.6882e-07        -9.2152e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 4        Time: 0.591961 Time step: 0.127961 CFL: 1.40668 
+*******************************************************************************
+   Number of active cells:       4383
+   Number of degrees of freedom: 14298
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 4766
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+5.9196e-01      2.0003e-01              2.0003e-04         1.4714e-10         7.5834e-08      2.0000e+00              2.0000e+00         1.8253e-07        -8.1875e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 5        Time: 0.710382 Time step: 0.118421 CFL: 0.810421
+*******************************************************************************
+   Number of active cells:       4713
+   Number of degrees of freedom: 15330
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5110
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+7.1038e-01      2.0005e-01              2.0005e-04         2.1469e-10         5.5896e-08      2.0000e+00              2.0000e+00         1.9729e-07        -5.9709e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 6        Time: 0.802307 Time step: 0.091925 CFL: 0.966175
+*******************************************************************************
+   Number of active cells:       4791
+   Number of degrees of freedom: 15570
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5190
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+8.0231e-01      2.0006e-01              2.0006e-04         1.1334e-10         3.0564e-08      1.9999e+00              1.9999e+00         1.6626e-07        -3.3801e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 7        Time: 0.912617 Time step: 0.11031  CFL: 0.563587
+*******************************************************************************
+   Number of active cells:       4803
+   Number of degrees of freedom: 15603
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5201
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+9.1262e-01      2.0007e-01              2.0007e-04         5.0944e-09        -9.6232e-10      1.9999e+00              1.9999e+00         1.4516e-07        -1.3698e-06           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 8        Time: 1.04206  Time step: 0.129444 CFL: 0.639139
+*******************************************************************************
+   Number of active cells:       4848
+   Number of degrees of freedom: 15678
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5226
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.0421e+00      2.0008e-01              2.0008e-04         5.0609e-09        -3.4988e-08      1.9999e+00              1.9999e+00         7.6268e-08         3.1970e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 9        Time: 1.18269  Time step: 0.14063  CFL: 0.690341
+*******************************************************************************
+   Number of active cells:       5097
+   Number of degrees of freedom: 16461
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5487
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.1827e+00      2.0010e-01              2.0010e-04         4.9199e-09        -5.8541e-08      1.9999e+00              1.9999e+00         1.0829e-07         5.6551e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 10       Time: 1.34202  Time step: 0.159324 CFL: 0.661998
+*******************************************************************************
+   Number of active cells:       5283
+   Number of degrees of freedom: 17028
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5676
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.3420e+00      2.0012e-01              2.0012e-04         4.7270e-09        -6.7500e-08      1.9999e+00              1.9999e+00         1.2600e-07         6.5816e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 11       Time: 1.53313  Time step: 0.191117 CFL: 0.625237
+*******************************************************************************
+   Number of active cells:       5331
+   Number of degrees of freedom: 17169
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5723
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.5331e+00      2.0014e-01              2.0014e-04         4.3782e-09        -5.5487e-08      1.9999e+00              1.9999e+00         1.4369e-07         5.3794e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 12       Time: 1.76247  Time step: 0.22934  CFL: 0.433042
+*******************************************************************************
+   Number of active cells:       5355
+   Number of degrees of freedom: 17238
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5746
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.7625e+00      2.0016e-01              2.0016e-04         3.9601e-09        -8.4693e-09      1.9998e+00              1.9998e+00         1.8923e-07         6.2176e-06           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 13       Time: 2.03768  Time step: 0.275208 CFL: 0.462054
+*******************************************************************************
+   Number of active cells:       5355
+   Number of degrees of freedom: 17226
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5742
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.0377e+00      2.0019e-01              2.0019e-04         3.1288e-09         4.7713e-08      1.9998e+00              1.9998e+00         1.8741e-07        -4.9972e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 14       Time: 2.19665  Time step: 0.158965 CFL: 1.29844 
+*******************************************************************************
+   Number of active cells:       5358
+   Number of degrees of freedom: 17268
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5756
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.1966e+00      2.0020e-01              2.0020e-04         3.1847e-09         6.3994e-08      1.9998e+00              1.9998e+00         1.8002e-07        -6.6220e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 15       Time: 2.32254  Time step: 0.125897 CFL: 0.946993
+*******************************************************************************
+   Number of active cells:       5379
+   Number of degrees of freedom: 17322
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5774
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.3225e+00      2.0021e-01              2.0021e-04         3.0360e-09         6.6223e-08      1.9998e+00              1.9998e+00         1.8445e-07        -6.8493e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 16       Time: 2.42856  Time step: 0.106016 CFL: 0.890648
+*******************************************************************************
+   Number of active cells:       5460
+   Number of degrees of freedom: 17565
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5855
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.4286e+00      2.0023e-01              2.0023e-04         3.2360e-09         6.0578e-08      1.9998e+00              1.9998e+00         2.0863e-07        -6.3084e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 17       Time: 2.53052  Time step: 0.101959 CFL: 0.779841
+*******************************************************************************
+   Number of active cells:       5529
+   Number of degrees of freedom: 17757
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5919
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.5305e+00      2.0024e-01              2.0024e-04         2.9368e-09         4.7598e-08      1.9998e+00              1.9998e+00         2.3097e-07        -4.9779e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 18       Time: 2.63191  Time step: 0.101391 CFL: 0.754198
+*******************************************************************************
+   Number of active cells:       5493
+   Number of degrees of freedom: 17658
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5886
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.6319e+00      2.0025e-01              2.0025e-04         2.6029e-09         2.8067e-08      1.9997e+00              1.9997e+00         2.3961e-07        -2.9829e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 19       Time: 2.73604  Time step: 0.104134 CFL: 0.730245
+*******************************************************************************
+   Number of active cells:       5481
+   Number of degrees of freedom: 17601
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5867
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.7360e+00      2.0026e-01              2.0026e-04         2.6224e-09         7.0881e-09      1.9997e+00              1.9997e+00         2.4995e-07        -9.1374e-06           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 20       Time: 2.84488  Time step: 0.108841 CFL: 0.717568
+*******************************************************************************
+   Number of active cells:       5505
+   Number of degrees of freedom: 17661
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5887
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.8449e+00      2.0028e-01              2.0028e-04         2.5658e-09        -1.3442e-08      1.9997e+00              1.9997e+00         2.5179e-07         1.1597e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 21       Time: 2.95899  Time step: 0.114102 CFL: 0.715417
+*******************************************************************************
+   Number of active cells:       5505
+   Number of degrees of freedom: 17679
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5893
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.9590e+00      2.0029e-01              2.0029e-04         2.5110e-09        -3.2278e-08      1.9997e+00              1.9997e+00         2.3664e-07         3.0399e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 22       Time: 3.08251  Time step: 0.123524 CFL: 0.692793
+*******************************************************************************
+   Number of active cells:       5574
+   Number of degrees of freedom: 17886
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 5962
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+3.0825e+00      2.0031e-01              2.0031e-04         2.3423e-09        -4.4107e-08      1.9997e+00              1.9997e+00         2.3965e-07         4.2501e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 23       Time: 3.22631  Time step: 0.143797 CFL: 0.644263
+*******************************************************************************
+   Number of active cells:       5619
+   Number of degrees of freedom: 18000
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 6000
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+3.2263e+00      2.0032e-01              2.0032e-04         2.2542e-09        -4.6228e-08      1.9997e+00              1.9997e+00         2.3655e-07         4.4454e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 24       Time: 3.39886  Time step: 0.172557 CFL: 0.556027
+*******************************************************************************
+   Number of active cells:       5730
+   Number of degrees of freedom: 18354
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 6118
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+3.3989e+00      2.0033e-01              2.0033e-04         2.1450e-09        -3.3694e-08      1.9997e+00              1.9997e+00         2.3173e-07         3.2149e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 25       Time: 3.6      Time step: 0.201136 CFL: 0.315783
+*******************************************************************************
+   Number of active cells:       5682
+   Number of degrees of freedom: 18222
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 6074
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+3.6000e+00      2.0035e-01              2.0035e-04         2.1670e-09        -5.5574e-09      1.9996e+00              1.9996e+00         2.2293e-07         3.7573e-06           5.0000e-01 

--- a/applications_tests/lethe-fluid/vof-velocity-extrapolation.output
+++ b/applications_tests/lethe-fluid/vof-velocity-extrapolation.output
@@ -9,36 +9,36 @@ VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
 0.0000e+00      2.1265e-01              2.1265e-04         0.0000e+00         0.0000e+00      1.9874e+00              1.9874e+00         0.0000e+00         0.0000e+00           5.0000e-01 
-   Number of active cells:       1323
-   Number of degrees of freedom: 4299
+   Number of active cells:       1335
+   Number of degrees of freedom: 4335
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 1433
+   Number of VOF degrees of freedom: 1445
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
 0.0000e+00      1.9794e-01              1.9794e-04         0.0000e+00         0.0000e+00      2.0021e+00              2.0021e+00         0.0000e+00         0.0000e+00           5.0000e-01 
-   Number of active cells:       2055
-   Number of degrees of freedom: 6753
+   Number of active cells:       2088
+   Number of degrees of freedom: 6849
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 2251
+   Number of VOF degrees of freedom: 2283
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-0.0000e+00      1.9983e-01              1.9983e-04         0.0000e+00         0.0000e+00      2.0002e+00              2.0002e+00         0.0000e+00         0.0000e+00           5.0000e-01 
-   Number of active cells:       3540
-   Number of degrees of freedom: 11709
+0.0000e+00      1.9976e-01              1.9976e-04         0.0000e+00         0.0000e+00      2.0002e+00              2.0002e+00         0.0000e+00         0.0000e+00           5.0000e-01 
+   Number of active cells:       3639
+   Number of degrees of freedom: 12003
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 3903
+   Number of VOF degrees of freedom: 4001
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-0.0000e+00      1.9990e-01              1.9990e-04         0.0000e+00         0.0000e+00      2.0001e+00              2.0001e+00         0.0000e+00         0.0000e+00           5.0000e-01 
+0.0000e+00      1.9987e-01              1.9987e-04         0.0000e+00         0.0000e+00      2.0001e+00              2.0001e+00         0.0000e+00         0.0000e+00           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 1        Time: 0.08     Time step: 0.08     CFL: 0       
@@ -48,340 +48,466 @@ Transient iteration: 1        Time: 0.08     Time step: 0.08     CFL: 0
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-8.0000e-02      1.9990e-01              1.9990e-04         8.5913e-11         2.7038e-08      2.0001e+00              2.0001e+00        -6.9607e-08        -3.1862e-05           5.0000e-01 
+8.0000e-02      1.9987e-01              1.9987e-04         2.8265e-13         2.7313e-08      2.0001e+00              2.0001e+00        -2.3839e-12        -3.2036e-05           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 2        Time: 0.224    Time step: 0.144    CFL: 0.116391
+Transient iteration: 2        Time: 0.224    Time step: 0.144    CFL: 0.116798
 *******************************************************************************
-   Number of active cells:       2952
-   Number of degrees of freedom: 9942
+   Number of active cells:       3012
+   Number of degrees of freedom: 10113
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 3314
+   Number of VOF degrees of freedom: 3371
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.2400e-01      1.9995e-01              1.9995e-04         9.4122e-12         7.1104e-08      2.0000e+00              2.0000e+00         1.0087e-07        -7.5020e-05           5.0000e-01 
+2.2400e-01      1.9992e-01              1.9992e-04         8.1457e-13         7.2007e-08      2.0001e+00              2.0001e+00         1.5189e-09        -7.5365e-05           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 3        Time: 0.464    Time step: 0.24     CFL: 0.36762 
+Transient iteration: 3        Time: 0.464    Time step: 0.24     CFL: 0.371812
 *******************************************************************************
-   Number of active cells:       3825
-   Number of degrees of freedom: 12600
+   Number of active cells:       4758
+   Number of degrees of freedom: 15447
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 4200
+   Number of VOF degrees of freedom: 5149
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-4.6400e-01      2.0001e-01              2.0001e-04        -1.6539e-11         8.7146e-08      2.0000e+00              2.0000e+00         1.6882e-07        -9.2152e-05           5.0000e-01 
+4.6400e-01      1.9998e-01              1.9998e-04         1.2909e-12         8.8388e-08      2.0000e+00              2.0000e+00         1.7588e-09        -9.2643e-05           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 4        Time: 0.591961 Time step: 0.127961 CFL: 1.40668 
+Transient iteration: 4        Time: 0.591991 Time step: 0.127991 CFL: 1.40635 
 *******************************************************************************
-   Number of active cells:       4383
-   Number of degrees of freedom: 14298
+   Number of active cells:       5880
+   Number of degrees of freedom: 18825
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 4766
+   Number of VOF degrees of freedom: 6275
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-5.9196e-01      2.0003e-01              2.0003e-04         1.4714e-10         7.5834e-08      2.0000e+00              2.0000e+00         1.8253e-07        -8.1875e-05           5.0000e-01 
+5.9199e-01      2.0000e-01              2.0000e-04         1.2595e-12         7.9565e-08      2.0000e+00              2.0000e+00         1.8354e-09        -8.2143e-05           5.0000e-01 
 
-*******************************************************************************
-Transient iteration: 5        Time: 0.710382 Time step: 0.118421 CFL: 0.810421
-*******************************************************************************
-   Number of active cells:       4713
-   Number of degrees of freedom: 15330
+********************************************************************************
+Transient iteration: 5        Time: 0.686682 Time step: 0.0946906 CFL: 1.01376 
+********************************************************************************
+   Number of active cells:       6384
+   Number of degrees of freedom: 20445
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5110
+   Number of VOF degrees of freedom: 6815
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-7.1038e-01      2.0005e-01              2.0005e-04         2.1469e-10         5.5896e-08      2.0000e+00              2.0000e+00         1.9729e-07        -5.9709e-05           5.0000e-01 
+6.8668e-01      2.0001e-01              2.0001e-04         1.2066e-12         6.3486e-08      2.0000e+00              2.0000e+00         1.8305e-09        -6.5926e-05           5.0000e-01 
 
-*******************************************************************************
-Transient iteration: 6        Time: 0.802307 Time step: 0.091925 CFL: 0.966175
-*******************************************************************************
-   Number of active cells:       4791
-   Number of degrees of freedom: 15570
+********************************************************************************
+Transient iteration: 6        Time: 0.762932 Time step: 0.0762504 CFL: 0.931379
+********************************************************************************
+   Number of active cells:       6471
+   Number of degrees of freedom: 20727
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5190
+   Number of VOF degrees of freedom: 6909
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-8.0231e-01      2.0006e-01              2.0006e-04         1.1334e-10         3.0564e-08      1.9999e+00              1.9999e+00         1.6626e-07        -3.3801e-05           5.0000e-01 
+7.6293e-01      2.0003e-01              2.0003e-04         2.4943e-13         4.4493e-08      2.0000e+00              2.0000e+00         1.7318e-09        -4.6595e-05           5.0000e-01 
 
-*******************************************************************************
-Transient iteration: 7        Time: 0.912617 Time step: 0.11031  CFL: 0.563587
-*******************************************************************************
-   Number of active cells:       4803
-   Number of degrees of freedom: 15603
+********************************************************************************
+Transient iteration: 7        Time: 0.83659  Time step: 0.0736575 CFL: 0.776401
+********************************************************************************
+   Number of active cells:       6498
+   Number of degrees of freedom: 20742
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5201
+   Number of VOF degrees of freedom: 6914
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-9.1262e-01      2.0007e-01              2.0007e-04         5.0944e-09        -9.6232e-10      1.9999e+00              1.9999e+00         1.4516e-07        -1.3698e-06           5.0000e-01 
+8.3659e-01      2.0004e-01              2.0004e-04         1.0034e-11         2.2733e-08      2.0000e+00              2.0000e+00         1.6767e-09        -2.4365e-05           5.0000e-01 
 
-*******************************************************************************
-Transient iteration: 8        Time: 1.04206  Time step: 0.129444 CFL: 0.639139
-*******************************************************************************
-   Number of active cells:       4848
-   Number of degrees of freedom: 15678
+********************************************************************************
+Transient iteration: 8        Time: 0.908906 Time step: 0.0723167 CFL: 0.763906
+********************************************************************************
+   Number of active cells:       6612
+   Number of degrees of freedom: 21138
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5226
+   Number of VOF degrees of freedom: 7046
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.0421e+00      2.0008e-01              2.0008e-04         5.0609e-09        -3.4988e-08      1.9999e+00              1.9999e+00         7.6268e-08         3.1970e-05           5.0000e-01 
+9.0891e-01      2.0004e-01              2.0004e-04         1.0969e-11         1.4700e-09      2.0000e+00              2.0000e+00         1.6126e-09        -3.4898e-06           5.0000e-01 
 
-*******************************************************************************
-Transient iteration: 9        Time: 1.18269  Time step: 0.14063  CFL: 0.690341
-*******************************************************************************
-   Number of active cells:       5097
-   Number of degrees of freedom: 16461
+********************************************************************************
+Transient iteration: 9        Time: 0.980977 Time step: 0.0720703 CFL: 0.752564
+********************************************************************************
+   Number of active cells:       6783
+   Number of degrees of freedom: 21672
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5487
+   Number of VOF degrees of freedom: 7224
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.1827e+00      2.0010e-01              2.0010e-04         4.9199e-09        -5.8541e-08      1.9999e+00              1.9999e+00         1.0829e-07         5.6551e-05           5.0000e-01 
+9.8098e-01      2.0005e-01              2.0005e-04         1.0579e-11        -1.7937e-08      1.9999e+00              1.9999e+00         9.3035e-10         1.5999e-05           5.0000e-01 
 
-*******************************************************************************
-Transient iteration: 10       Time: 1.34202  Time step: 0.159324 CFL: 0.661998
-*******************************************************************************
-   Number of active cells:       5283
-   Number of degrees of freedom: 17028
+********************************************************************************
+Transient iteration: 10       Time: 1.05296  Time step: 0.0719876 CFL: 0.750861
+********************************************************************************
+   Number of active cells:       6753
+   Number of degrees of freedom: 21570
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5676
+   Number of VOF degrees of freedom: 7190
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.3420e+00      2.0012e-01              2.0012e-04         4.7270e-09        -6.7500e-08      1.9999e+00              1.9999e+00         1.2600e-07         6.5816e-05           5.0000e-01 
+1.0530e+00      2.0006e-01              2.0006e-04         1.0485e-11        -3.5330e-08      1.9999e+00              1.9999e+00         1.2980e-09         3.3527e-05           5.0000e-01 
 
-*******************************************************************************
-Transient iteration: 11       Time: 1.53313  Time step: 0.191117 CFL: 0.625237
-*******************************************************************************
-   Number of active cells:       5331
-   Number of degrees of freedom: 17169
+********************************************************************************
+Transient iteration: 11       Time: 1.12583  Time step: 0.0728706 CFL: 0.740912
+********************************************************************************
+   Number of active cells:       6915
+   Number of degrees of freedom: 22056
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5723
+   Number of VOF degrees of freedom: 7352
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.5331e+00      2.0014e-01              2.0014e-04         4.3782e-09        -5.5487e-08      1.9999e+00              1.9999e+00         1.4369e-07         5.3794e-05           5.0000e-01 
+1.1258e+00      2.0007e-01              2.0007e-04         1.0181e-11        -4.9494e-08      1.9999e+00              1.9999e+00         6.7993e-10         4.7301e-05           5.0000e-01 
 
-*******************************************************************************
-Transient iteration: 12       Time: 1.76247  Time step: 0.22934  CFL: 0.433042
-*******************************************************************************
-   Number of active cells:       5355
-   Number of degrees of freedom: 17238
+********************************************************************************
+Transient iteration: 12       Time: 1.20046  Time step: 0.0746289 CFL: 0.732329
+********************************************************************************
+   Number of active cells:       6993
+   Number of degrees of freedom: 22368
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5746
+   Number of VOF degrees of freedom: 7456
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.7625e+00      2.0016e-01              2.0016e-04         3.9601e-09        -8.4693e-09      1.9998e+00              1.9998e+00         1.8923e-07         6.2176e-06           5.0000e-01 
+1.2005e+00      2.0008e-01              2.0008e-04         1.0012e-11        -5.9049e-08      1.9999e+00              1.9999e+00         1.4236e-09         5.7001e-05           5.0000e-01 
 
-*******************************************************************************
-Transient iteration: 13       Time: 2.03768  Time step: 0.275208 CFL: 0.462054
-*******************************************************************************
-   Number of active cells:       5355
-   Number of degrees of freedom: 17226
+********************************************************************************
+Transient iteration: 13       Time: 1.27888  Time step: 0.0784145 CFL: 0.713792
+********************************************************************************
+   Number of active cells:       7125
+   Number of degrees of freedom: 22698
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5742
+   Number of VOF degrees of freedom: 7566
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.0377e+00      2.0019e-01              2.0019e-04         3.1288e-09         4.7713e-08      1.9998e+00              1.9998e+00         1.8741e-07        -4.9972e-05           5.0000e-01 
+1.2789e+00      2.0009e-01              2.0009e-04         9.5207e-12        -6.5072e-08      1.9999e+00              1.9999e+00         1.0882e-09         6.2578e-05           5.0000e-01 
 
-*******************************************************************************
-Transient iteration: 14       Time: 2.19665  Time step: 0.158965 CFL: 1.29844 
-*******************************************************************************
-   Number of active cells:       5358
-   Number of degrees of freedom: 17268
+********************************************************************************
+Transient iteration: 14       Time: 1.36234  Time step: 0.0834645 CFL: 0.704621
+********************************************************************************
+   Number of active cells:       7194
+   Number of degrees of freedom: 22905
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5756
+   Number of VOF degrees of freedom: 7635
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.1966e+00      2.0020e-01              2.0020e-04         3.1847e-09         6.3994e-08      1.9998e+00              1.9998e+00         1.8002e-07        -6.6220e-05           5.0000e-01 
+1.3623e+00      2.0010e-01              2.0010e-04         9.3959e-12        -6.6081e-08      1.9999e+00              1.9999e+00         2.0041e-09         6.3667e-05           5.0000e-01 
 
-*******************************************************************************
-Transient iteration: 15       Time: 2.32254  Time step: 0.125897 CFL: 0.946993
-*******************************************************************************
-   Number of active cells:       5379
-   Number of degrees of freedom: 17322
+********************************************************************************
+Transient iteration: 15       Time: 1.45514  Time step: 0.0927953 CFL: 0.674586
+********************************************************************************
+   Number of active cells:       7302
+   Number of degrees of freedom: 23217
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5774
+   Number of VOF degrees of freedom: 7739
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.3225e+00      2.0021e-01              2.0021e-04         3.0360e-09         6.6223e-08      1.9998e+00              1.9998e+00         1.8445e-07        -6.8493e-05           5.0000e-01 
+1.4551e+00      2.0011e-01              2.0011e-04         8.9229e-12        -6.2672e-08      1.9999e+00              1.9999e+00         2.0185e-09         5.9891e-05           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 16       Time: 2.42856  Time step: 0.106016 CFL: 0.890648
+Transient iteration: 16       Time: 1.56201  Time step: 0.106868 CFL: 0.65124 
 *******************************************************************************
-   Number of active cells:       5460
-   Number of degrees of freedom: 17565
+   Number of active cells:       7380
+   Number of degrees of freedom: 23445
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5855
+   Number of VOF degrees of freedom: 7815
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.4286e+00      2.0023e-01              2.0023e-04         3.2360e-09         6.0578e-08      1.9998e+00              1.9998e+00         2.0863e-07        -6.3084e-05           5.0000e-01 
+1.5620e+00      2.0012e-01              2.0012e-04         8.6506e-12        -5.1519e-08      1.9999e+00              1.9999e+00         2.0077e-09         4.8469e-05           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 17       Time: 2.53052  Time step: 0.101959 CFL: 0.779841
+Transient iteration: 17       Time: 1.69025  Time step: 0.128241 CFL: 0.576382
 *******************************************************************************
-   Number of active cells:       5529
-   Number of degrees of freedom: 17757
+   Number of active cells:       7413
+   Number of degrees of freedom: 23520
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5919
+   Number of VOF degrees of freedom: 7840
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.5305e+00      2.0024e-01              2.0024e-04         2.9368e-09         4.7598e-08      1.9998e+00              1.9998e+00         2.3097e-07        -4.9779e-05           5.0000e-01 
+1.6902e+00      2.0014e-01              2.0014e-04         8.3661e-12        -2.7784e-08      1.9999e+00              1.9999e+00         1.7124e-09         2.4680e-05           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 18       Time: 2.63191  Time step: 0.101391 CFL: 0.754198
+Transient iteration: 18       Time: 1.84414  Time step: 0.153889 CFL: 0.377555
 *******************************************************************************
-   Number of active cells:       5493
-   Number of degrees of freedom: 17658
+   Number of active cells:       7599
+   Number of degrees of freedom: 24126
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5886
+   Number of VOF degrees of freedom: 8042
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.6319e+00      2.0025e-01              2.0025e-04         2.6029e-09         2.8067e-08      1.9997e+00              1.9997e+00         2.3961e-07        -2.9829e-05           5.0000e-01 
+1.8441e+00      2.0015e-01              2.0015e-04         8.0991e-12         8.1730e-09      1.9998e+00              1.9998e+00         1.6315e-09        -1.0868e-05           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 19       Time: 2.73604  Time step: 0.104134 CFL: 0.730245
+Transient iteration: 19       Time: 2.0288   Time step: 0.184667 CFL: 0.40342 
 *******************************************************************************
-   Number of active cells:       5481
-   Number of degrees of freedom: 17601
+   Number of active cells:       7572
+   Number of degrees of freedom: 23982
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5867
+   Number of VOF degrees of freedom: 7994
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.7360e+00      2.0026e-01              2.0026e-04         2.6224e-09         7.0881e-09      1.9997e+00              1.9997e+00         2.4995e-07        -9.1374e-06           5.0000e-01 
+2.0288e+00      2.0017e-01              2.0017e-04         7.3351e-12         4.3247e-08      1.9998e+00              1.9998e+00         1.5646e-09        -4.5579e-05           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 20       Time: 2.84488  Time step: 0.108841 CFL: 0.717568
+Transient iteration: 20       Time: 2.19606  Time step: 0.167259 CFL: 0.828061
 *******************************************************************************
-   Number of active cells:       5505
-   Number of degrees of freedom: 17661
+   Number of active cells:       7554
+   Number of degrees of freedom: 23955
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5887
+   Number of VOF degrees of freedom: 7985
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.8449e+00      2.0028e-01              2.0028e-04         2.5658e-09        -1.3442e-08      1.9997e+00              1.9997e+00         2.5179e-07         1.1597e-05           5.0000e-01 
+2.1961e+00      2.0019e-01              2.0019e-04         6.9400e-12         6.0104e-08      1.9998e+00              1.9998e+00         1.8899e-10        -6.2159e-05           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 21       Time: 2.95899  Time step: 0.114102 CFL: 0.715417
+Transient iteration: 21       Time: 2.32037  Time step: 0.124304 CFL: 1.00917 
 *******************************************************************************
-   Number of active cells:       5505
-   Number of degrees of freedom: 17679
+   Number of active cells:       7464
+   Number of degrees of freedom: 23733
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5893
+   Number of VOF degrees of freedom: 7911
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.9590e+00      2.0029e-01              2.0029e-04         2.5110e-09        -3.2278e-08      1.9997e+00              1.9997e+00         2.3664e-07         3.0399e-05           5.0000e-01 
+2.3204e+00      2.0020e-01              2.0020e-04         6.5202e-12         6.2447e-08      1.9998e+00              1.9998e+00        -5.1409e-12        -6.4539e-05           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 22       Time: 3.08251  Time step: 0.123524 CFL: 0.692793
+Transient iteration: 22       Time: 2.42607  Time step: 0.105702 CFL: 0.881989
 *******************************************************************************
-   Number of active cells:       5574
-   Number of degrees of freedom: 17886
+   Number of active cells:       7326
+   Number of degrees of freedom: 23319
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5962
+   Number of VOF degrees of freedom: 7773
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-3.0825e+00      2.0031e-01              2.0031e-04         2.3423e-09        -4.4107e-08      1.9997e+00              1.9997e+00         2.3965e-07         4.2501e-05           5.0000e-01 
+2.4261e+00      2.0022e-01              2.0022e-04         6.2533e-12         5.6775e-08      1.9998e+00              1.9998e+00        -7.6378e-11        -5.9175e-05           5.0000e-01 
 
-*******************************************************************************
-Transient iteration: 23       Time: 3.22631  Time step: 0.143797 CFL: 0.644263
-*******************************************************************************
-   Number of active cells:       5619
-   Number of degrees of freedom: 18000
+********************************************************************************
+Transient iteration: 23       Time: 2.52138  Time step: 0.0953169 CFL: 0.831713
+********************************************************************************
+   Number of active cells:       7170
+   Number of degrees of freedom: 22797
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 6000
+   Number of VOF degrees of freedom: 7599
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-3.2263e+00      2.0032e-01              2.0032e-04         2.2542e-09        -4.6228e-08      1.9997e+00              1.9997e+00         2.3655e-07         4.4454e-05           5.0000e-01 
+2.5214e+00      2.0023e-01              2.0023e-04         6.1501e-12         4.4575e-08      1.9998e+00              1.9998e+00        -2.3640e-10        -4.6652e-05           5.0000e-01 
 
-*******************************************************************************
-Transient iteration: 24       Time: 3.39886  Time step: 0.172557 CFL: 0.556027
-*******************************************************************************
-   Number of active cells:       5730
-   Number of degrees of freedom: 18354
+********************************************************************************
+Transient iteration: 24       Time: 2.61106  Time step: 0.0896765 CFL: 0.797174
+********************************************************************************
+   Number of active cells:       7233
+   Number of degrees of freedom: 23022
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 6118
+   Number of VOF degrees of freedom: 7674
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-3.3989e+00      2.0033e-01              2.0033e-04         2.1450e-09        -3.3694e-08      1.9997e+00              1.9997e+00         2.3173e-07         3.2149e-05           5.0000e-01 
+2.6111e+00      2.0024e-01              2.0024e-04         5.1552e-12         2.8068e-08      1.9998e+00              1.9998e+00        -2.7095e-10        -2.9944e-05           5.0000e-01 
 
-*******************************************************************************
-Transient iteration: 25       Time: 3.6      Time step: 0.201136 CFL: 0.315783
-*******************************************************************************
-   Number of active cells:       5682
-   Number of degrees of freedom: 18222
+********************************************************************************
+Transient iteration: 25       Time: 2.6984   Time step: 0.0873366 CFL: 0.770094
+********************************************************************************
+   Number of active cells:       7161
+   Number of degrees of freedom: 22791
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 6074
+   Number of VOF degrees of freedom: 7597
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-3.6000e+00      2.0035e-01              2.0035e-04         2.1670e-09        -5.5574e-09      1.9996e+00              1.9996e+00         2.2293e-07         3.7573e-06           5.0000e-01 
+2.6984e+00      2.0024e-01              2.0024e-04        -2.1811e-11         1.1140e-08      1.9998e+00              1.9998e+00        -3.3421e-10        -1.3288e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 26       Time: 2.78513  Time step: 0.0867327 CFL: 0.755222
+********************************************************************************
+   Number of active cells:       7227
+   Number of degrees of freedom: 23043
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 7681
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.7851e+00      2.0025e-01              2.0025e-04        -1.3023e-11        -4.4843e-09      1.9997e+00              1.9997e+00        -3.6548e-10         2.3298e-06           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 27       Time: 2.87198  Time step: 0.0868526 CFL: 0.748964
+********************************************************************************
+   Number of active cells:       7164
+   Number of degrees of freedom: 22818
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 7606
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.8720e+00      2.0026e-01              2.0026e-04        -6.1154e-11        -1.8783e-08      1.9997e+00              1.9997e+00        -4.6409e-10         1.7067e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 28       Time: 2.95966  Time step: 0.087681 CFL: 0.742915
+*******************************************************************************
+   Number of active cells:       7176
+   Number of degrees of freedom: 22842
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 7614
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.9597e+00      2.0027e-01              2.0027e-04        -5.4174e-11        -3.1047e-08      1.9997e+00              1.9997e+00         1.7755e-09         2.9460e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 29       Time: 3.04984  Time step: 0.0901801 CFL: 0.729215
+********************************************************************************
+   Number of active cells:       7188
+   Number of degrees of freedom: 22848
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 7616
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+3.0498e+00      2.0028e-01              2.0028e-04        -1.0033e-10        -3.9163e-08      1.9997e+00              1.9997e+00         1.3500e-09         3.7132e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 30       Time: 3.14547  Time step: 0.0956303 CFL: 0.707256
+********************************************************************************
+   Number of active cells:       7236
+   Number of degrees of freedom: 23061
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 7687
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+3.1455e+00      2.0029e-01              2.0029e-04        -9.3053e-11        -4.2336e-08      1.9997e+00              1.9997e+00         1.4691e-09         4.0327e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 31       Time: 3.25055  Time step: 0.105072 CFL: 0.682606
+*******************************************************************************
+   Number of active cells:       7320
+   Number of degrees of freedom: 23244
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 7748
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+3.2505e+00      2.0030e-01              2.0030e-04        -1.3490e-10        -4.0661e-08      1.9997e+00              1.9997e+00         1.3912e-09         3.8162e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 32       Time: 3.37279  Time step: 0.122248 CFL: 0.644622
+*******************************************************************************
+   Number of active cells:       7542
+   Number of degrees of freedom: 23952
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 7984
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+3.3728e+00      2.0031e-01              2.0031e-04        -1.2647e-10        -3.2357e-08      1.9997e+00              1.9997e+00         1.7962e-09         3.0312e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 33       Time: 3.51949  Time step: 0.146698 CFL: 0.572368
+*******************************************************************************
+   Number of active cells:       7575
+   Number of degrees of freedom: 23997
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 7999
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+3.5195e+00      2.0032e-01              2.0032e-04        -1.5924e-10        -1.6050e-08      1.9997e+00              1.9997e+00         1.7002e-09         1.3997e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 34       Time: 3.6      Time step: 0.080508 CFL: 0.372727
+*******************************************************************************
+   Number of active cells:       7590
+   Number of degrees of freedom: 24060
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 8020
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+3.6000e+00      2.0033e-01              2.0033e-04        -1.6027e-10        -4.8015e-09      1.9997e+00              1.9997e+00         1.6701e-09         2.8795e-06           5.0000e-01 

--- a/applications_tests/lethe-fluid/vof-velocity-extrapolation.output
+++ b/applications_tests/lethe-fluid/vof-velocity-extrapolation.output
@@ -1,14 +1,34 @@
 Running on 1 MPI rank(s)...
-   Number of active cells:       3840
-   Number of degrees of freedom: 11907
+   Number of active cells:       240
+   Number of degrees of freedom: 819
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 3969
+   Number of VOF degrees of freedom: 273
+Initial refinement in box - Step  1 of 4
+   Number of active cells:       360
+   Number of degrees of freedom: 1245
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 415
+Initial refinement in box - Step  2 of 4
+   Number of active cells:       600
+   Number of degrees of freedom: 2091
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 697
+Initial refinement in box - Step  3 of 4
+   Number of active cells:       1500
+   Number of degrees of freedom: 5046
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 1682
+Initial refinement in box - Step  4 of 4
+   Number of active cells:       4260
+   Number of degrees of freedom: 13827
+   Volume of triangulation:      2.2
+   Number of VOF degrees of freedom: 4609
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-0.0000e+00      1.9794e-01              1.9794e-04         0.0000e+00         0.0000e+00      2.0021e+00              2.0021e+00         0.0000e+00         0.0000e+00           5.0000e-01 
+0.0000e+00      1.9987e-01              1.9987e-04         0.0000e+00         0.0000e+00      2.0001e+00              2.0001e+00         0.0000e+00         0.0000e+00           5.0000e-01 
 
 *******************************************************************************
 Transient iteration: 1        Time: 0.04     Time step: 0.04     CFL: 0       
@@ -18,144 +38,204 @@ Transient iteration: 1        Time: 0.04     Time step: 0.04     CFL: 0
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-4.0000e-02      1.9794e-01              1.9794e-04        -2.5245e-12        -9.7048e-09      2.0021e+00              2.0021e+00        -2.4408e-10        -1.3564e-04           5.0000e-01 
+4.0000e-02      1.9987e-01              1.9987e-04        -3.1030e-14         1.4660e-08      2.0001e+00              2.0001e+00        -2.9289e-11        -1.7340e-05           5.0000e-01 
 
 ********************************************************************************
-Transient iteration: 2        Time: 0.106    Time step: 0.066    CFL: 0.0310268
-********************************************************************************
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.0600e-01      1.9827e-01              1.9827e-04        -1.9854e-12         2.2301e-08      2.0017e+00              2.0017e+00        -3.7955e-10        -1.9592e-04           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 3        Time: 0.216    Time step: 0.11     CFL: 0.119669
-*******************************************************************************
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.1600e-01      1.9881e-01              1.9881e-04        -4.7158e-12         6.9971e-08      2.0012e+00              2.0012e+00        -5.6011e-10        -2.3937e-04           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 4        Time: 0.337    Time step: 0.121    CFL: 0.313141
-*******************************************************************************
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-3.3700e-01      1.9929e-01              1.9929e-04         1.2314e-12         6.6207e-08      2.0007e+00              2.0007e+00        -6.6593e-10        -2.4909e-04           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 5        Time: 0.464933 Time step: 0.127933 CFL: 0.472903
-*******************************************************************************
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-4.6493e-01      1.9977e-01              1.9977e-04         4.7484e-13         4.7140e-08      2.0002e+00              2.0002e+00        -6.5520e-10        -2.1618e-04           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 6        Time: 0.574502 Time step: 0.109569 CFL: 0.583801
-*******************************************************************************
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-5.7450e-01      2.0014e-01              2.0014e-04        -2.3632e-13         6.1528e-09      1.9999e+00              1.9999e+00        -4.5702e-10        -1.5694e-04           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 7        Time: 0.681588 Time step: 0.107086 CFL: 0.511595
-*******************************************************************************
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-6.8159e-01      2.0044e-01              2.0044e-04        -7.0493e-13        -3.7768e-08      1.9996e+00              1.9996e+00        -3.3333e-10        -1.1440e-04           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 8        Time: 0.791616 Time step: 0.110028 CFL: 0.486631
-*******************************************************************************
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-7.9162e-01      2.0075e-01              2.0075e-04        -3.7288e-13        -6.7834e-08      1.9993e+00              1.9993e+00        -2.1474e-10        -8.1847e-05           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 9        Time: 0.905909 Time step: 0.114293 CFL: 0.48134 
-*******************************************************************************
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-9.0591e-01      2.0107e-01              2.0107e-04        -4.0651e-13        -9.1604e-08      1.9989e+00              1.9989e+00        -1.0600e-10        -5.6932e-05           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 10       Time: 1.02391  Time step: 0.118001 CFL: 0.484289
-*******************************************************************************
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.0239e+00      2.0139e-01              2.0139e-04        -3.7330e-13        -1.0722e-07      1.9986e+00              1.9986e+00        -1.3293e-11        -3.9969e-05           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 11       Time: 1.14629  Time step: 0.122379 CFL: 0.482112
-*******************************************************************************
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.1463e+00      2.0171e-01              2.0171e-04        -4.5173e-13        -9.2846e-08      1.9983e+00              1.9983e+00        -2.0910e-11        -5.5927e-05           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 12       Time: 1.27608  Time step: 0.129795 CFL: 0.471431
-*******************************************************************************
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.2761e+00      2.0204e-01              2.0204e-04        -2.3396e-13        -6.1410e-08      1.9980e+00              1.9980e+00        -7.0466e-13        -8.8987e-05           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 13       Time: 1.41743  Time step: 0.141347 CFL: 0.459137
-*******************************************************************************
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.4174e+00      2.0239e-01              2.0239e-04         7.6336e-14        -3.7186e-08      1.9976e+00              1.9976e+00         6.3807e-11        -1.0919e-04           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 14       Time: 1.57291  Time step: 0.155482 CFL: 0.451335
-*******************************************************************************
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.5729e+00      2.0276e-01              2.0276e-04         2.8826e-13        -3.0845e-08      1.9972e+00              1.9972e+00         1.1356e-10        -1.1371e-04           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 15       Time: 1.6      Time step: 0.0270864 CFL: 0.445791
+Transient iteration: 2        Time: 0.106    Time step: 0.066    CFL: 0.0369272
 ********************************************************************************
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.6000e+00      2.0282e-01              2.0282e-04         3.0611e-13        -1.8519e-08      1.9972e+00              1.9972e+00         1.2182e-10        -1.0596e-04           5.0000e-01 
+1.0600e-01      1.9990e-01              1.9990e-04        -2.4156e-13         3.8128e-08      2.0001e+00              2.0001e+00        -9.6494e-12        -4.0945e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 3        Time: 0.216    Time step: 0.11     CFL: 0.145606
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.1600e-01      1.9992e-01              1.9992e-04        -1.0417e-13         6.9311e-08      2.0001e+00              2.0001e+00        -1.3987e-11        -7.2104e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 4        Time: 0.319419 Time step: 0.103419 CFL: 0.425454
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+3.1942e-01      1.9995e-01              1.9995e-04        -1.8238e-13         8.7204e-08      2.0001e+00              2.0001e+00        -3.8486e-11        -9.0071e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 5        Time: 0.40004  Time step: 0.0806207 CFL: 0.513114
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+4.0004e-01      1.9996e-01              1.9996e-04        -1.1569e-13         9.1623e-08      2.0000e+00              2.0000e+00        -1.0732e-10        -9.4146e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 6        Time: 0.472086 Time step: 0.0720464 CFL: 0.447604
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+4.7209e-01      1.9997e-01              1.9997e-04        -2.2912e-13         9.0081e-08      2.0000e+00              2.0000e+00        -1.0363e-10        -9.2378e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 7        Time: 0.539958 Time step: 0.0678721 CFL: 0.424601
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+5.3996e-01      1.9998e-01              1.9998e-04        -2.7025e-13         8.5070e-08      2.0000e+00              2.0000e+00        -7.4462e-11        -8.7449e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 8        Time: 0.605071 Time step: 0.0651127 CFL: 0.416952
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+6.0507e-01      1.9999e-01              1.9999e-04        -3.1038e-13         7.7094e-08      2.0000e+00              2.0000e+00        -4.8331e-11        -7.9586e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 9        Time: 0.668539 Time step: 0.0634678 CFL: 0.410367
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+6.6854e-01      2.0000e-01              2.0000e-04        -3.3306e-13         6.5963e-08      2.0000e+00              2.0000e+00        -3.4578e-11        -6.8487e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 10       Time: 0.731211 Time step: 0.0626719 CFL: 0.40508 
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+7.3121e-01      2.0001e-01              2.0001e-04        -2.9537e-13         5.1570e-08      2.0000e+00              2.0000e+00         3.6556e-11        -5.3926e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 11       Time: 0.79412  Time step: 0.0629094 CFL: 0.39849 
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+7.9412e-01      2.0002e-01              2.0002e-04        -2.7759e-13         3.4236e-08      2.0000e+00              2.0000e+00         1.4058e-11        -3.6145e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 12       Time: 0.858447 Time step: 0.0643273 CFL: 0.391183
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+8.5845e-01      2.0003e-01              2.0003e-04        -3.5079e-13         1.5348e-08      2.0000e+00              2.0000e+00        -4.5207e-11        -1.7124e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 13       Time: 0.924811 Time step: 0.0663637 CFL: 0.387725
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+9.2481e-01      2.0004e-01              2.0004e-04        -3.2757e-13        -3.6794e-09      2.0000e+00              2.0000e+00        -3.5455e-11         1.7348e-06           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 14       Time: 0.993555 Time step: 0.0687442 CFL: 0.386149
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+9.9356e-01      2.0005e-01              2.0005e-04        -3.4098e-13        -2.2412e-08      2.0000e+00              2.0000e+00        -7.6380e-12         2.0330e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 15       Time: 1.06493  Time step: 0.0713699 CFL: 0.385284
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.0649e+00      2.0006e-01              2.0006e-04        -3.3210e-13        -3.9323e-08      1.9999e+00              1.9999e+00         7.2483e-11         3.7438e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 16       Time: 1.14021  Time step: 0.0752821 CFL: 0.379213
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.1402e+00      2.0006e-01              2.0006e-04        -2.7817e-13        -5.3011e-08      1.9999e+00              1.9999e+00         1.2905e-10         5.1210e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 17       Time: 1.22222  Time step: 0.0820177 CFL: 0.367151
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.2222e+00      2.0007e-01              2.0007e-04        -2.7639e-13        -6.2552e-08      1.9999e+00              1.9999e+00         2.3240e-10         6.0681e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 18       Time: 1.31244  Time step: 0.0902194 CFL: 0.351978
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.3124e+00      2.0009e-01              2.0009e-04        -2.5787e-13        -6.7010e-08      1.9999e+00              1.9999e+00         2.7160e-10         6.5009e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 19       Time: 1.41169  Time step: 0.0992414 CFL: 0.329891
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.4117e+00      2.0010e-01              2.0010e-04        -2.1862e-13        -6.5808e-08      1.9999e+00              1.9999e+00         2.9976e-10         6.3667e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 20       Time: 1.52085  Time step: 0.109165 CFL: 0.309595
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.5209e+00      2.0011e-01              2.0011e-04        -1.1213e-13        -5.7131e-08      1.9999e+00              1.9999e+00         3.3410e-10         5.4998e-05           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 21       Time: 1.6      Time step: 0.0791487 CFL: 0.262858
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.6000e+00      2.0012e-01              2.0012e-04        -2.4791e-13        -4.5479e-08      1.9999e+00              1.9999e+00         3.8017e-10         4.3296e-05           5.0000e-01 

--- a/applications_tests/lethe-fluid/vof-velocity-extrapolation.output
+++ b/applications_tests/lethe-fluid/vof-velocity-extrapolation.output
@@ -1,513 +1,161 @@
 Running on 1 MPI rank(s)...
-   Number of active cells:       960
-   Number of degrees of freedom: 3075
+   Number of active cells:       3840
+   Number of degrees of freedom: 11907
    Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 1025
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-0.0000e+00      2.1265e-01              2.1265e-04         0.0000e+00         0.0000e+00      1.9874e+00              1.9874e+00         0.0000e+00         0.0000e+00           5.0000e-01 
-   Number of active cells:       1335
-   Number of degrees of freedom: 4335
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 1445
+   Number of VOF degrees of freedom: 3969
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
 0.0000e+00      1.9794e-01              1.9794e-04         0.0000e+00         0.0000e+00      2.0021e+00              2.0021e+00         0.0000e+00         0.0000e+00           5.0000e-01 
-   Number of active cells:       2088
-   Number of degrees of freedom: 6849
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 2283
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-0.0000e+00      1.9976e-01              1.9976e-04         0.0000e+00         0.0000e+00      2.0002e+00              2.0002e+00         0.0000e+00         0.0000e+00           5.0000e-01 
-   Number of active cells:       3639
-   Number of degrees of freedom: 12003
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 4001
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-0.0000e+00      1.9987e-01              1.9987e-04         0.0000e+00         0.0000e+00      2.0001e+00              2.0001e+00         0.0000e+00         0.0000e+00           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 1        Time: 0.08     Time step: 0.08     CFL: 0       
+Transient iteration: 1        Time: 0.04     Time step: 0.04     CFL: 0       
 *******************************************************************************
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-8.0000e-02      1.9987e-01              1.9987e-04         2.8265e-13         2.7313e-08      2.0001e+00              2.0001e+00        -2.3839e-12        -3.2036e-05           5.0000e-01 
+4.0000e-02      1.9794e-01              1.9794e-04        -2.5245e-12        -9.7048e-09      2.0021e+00              2.0021e+00        -2.4408e-10        -1.3564e-04           5.0000e-01 
+
+********************************************************************************
+Transient iteration: 2        Time: 0.106    Time step: 0.066    CFL: 0.0310268
+********************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.0600e-01      1.9827e-01              1.9827e-04        -1.9854e-12         2.2301e-08      2.0017e+00              2.0017e+00        -3.7955e-10        -1.9592e-04           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 2        Time: 0.224    Time step: 0.144    CFL: 0.116798
+Transient iteration: 3        Time: 0.216    Time step: 0.11     CFL: 0.119669
 *******************************************************************************
-   Number of active cells:       3012
-   Number of degrees of freedom: 10113
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 3371
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.2400e-01      1.9992e-01              1.9992e-04         8.1457e-13         7.2007e-08      2.0001e+00              2.0001e+00         1.5189e-09        -7.5365e-05           5.0000e-01 
+2.1600e-01      1.9881e-01              1.9881e-04        -4.7158e-12         6.9971e-08      2.0012e+00              2.0012e+00        -5.6011e-10        -2.3937e-04           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 3        Time: 0.464    Time step: 0.24     CFL: 0.371812
+Transient iteration: 4        Time: 0.337    Time step: 0.121    CFL: 0.313141
 *******************************************************************************
-   Number of active cells:       4758
-   Number of degrees of freedom: 15447
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 5149
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-4.6400e-01      1.9998e-01              1.9998e-04         1.2909e-12         8.8388e-08      2.0000e+00              2.0000e+00         1.7588e-09        -9.2643e-05           5.0000e-01 
+3.3700e-01      1.9929e-01              1.9929e-04         1.2314e-12         6.6207e-08      2.0007e+00              2.0007e+00        -6.6593e-10        -2.4909e-04           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 4        Time: 0.591991 Time step: 0.127991 CFL: 1.40635 
+Transient iteration: 5        Time: 0.464933 Time step: 0.127933 CFL: 0.472903
 *******************************************************************************
-   Number of active cells:       5880
-   Number of degrees of freedom: 18825
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 6275
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-5.9199e-01      2.0000e-01              2.0000e-04         1.2595e-12         7.9565e-08      2.0000e+00              2.0000e+00         1.8354e-09        -8.2143e-05           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 5        Time: 0.686682 Time step: 0.0946906 CFL: 1.01376 
-********************************************************************************
-   Number of active cells:       6384
-   Number of degrees of freedom: 20445
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 6815
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-6.8668e-01      2.0001e-01              2.0001e-04         1.2066e-12         6.3486e-08      2.0000e+00              2.0000e+00         1.8305e-09        -6.5926e-05           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 6        Time: 0.762932 Time step: 0.0762504 CFL: 0.931379
-********************************************************************************
-   Number of active cells:       6471
-   Number of degrees of freedom: 20727
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 6909
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-7.6293e-01      2.0003e-01              2.0003e-04         2.4943e-13         4.4493e-08      2.0000e+00              2.0000e+00         1.7318e-09        -4.6595e-05           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 7        Time: 0.83659  Time step: 0.0736575 CFL: 0.776401
-********************************************************************************
-   Number of active cells:       6498
-   Number of degrees of freedom: 20742
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 6914
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-8.3659e-01      2.0004e-01              2.0004e-04         1.0034e-11         2.2733e-08      2.0000e+00              2.0000e+00         1.6767e-09        -2.4365e-05           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 8        Time: 0.908906 Time step: 0.0723167 CFL: 0.763906
-********************************************************************************
-   Number of active cells:       6612
-   Number of degrees of freedom: 21138
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7046
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-9.0891e-01      2.0004e-01              2.0004e-04         1.0969e-11         1.4700e-09      2.0000e+00              2.0000e+00         1.6126e-09        -3.4898e-06           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 9        Time: 0.980977 Time step: 0.0720703 CFL: 0.752564
-********************************************************************************
-   Number of active cells:       6783
-   Number of degrees of freedom: 21672
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7224
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-9.8098e-01      2.0005e-01              2.0005e-04         1.0579e-11        -1.7937e-08      1.9999e+00              1.9999e+00         9.3035e-10         1.5999e-05           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 10       Time: 1.05296  Time step: 0.0719876 CFL: 0.750861
-********************************************************************************
-   Number of active cells:       6753
-   Number of degrees of freedom: 21570
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7190
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.0530e+00      2.0006e-01              2.0006e-04         1.0485e-11        -3.5330e-08      1.9999e+00              1.9999e+00         1.2980e-09         3.3527e-05           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 11       Time: 1.12583  Time step: 0.0728706 CFL: 0.740912
-********************************************************************************
-   Number of active cells:       6915
-   Number of degrees of freedom: 22056
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7352
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.1258e+00      2.0007e-01              2.0007e-04         1.0181e-11        -4.9494e-08      1.9999e+00              1.9999e+00         6.7993e-10         4.7301e-05           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 12       Time: 1.20046  Time step: 0.0746289 CFL: 0.732329
-********************************************************************************
-   Number of active cells:       6993
-   Number of degrees of freedom: 22368
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7456
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.2005e+00      2.0008e-01              2.0008e-04         1.0012e-11        -5.9049e-08      1.9999e+00              1.9999e+00         1.4236e-09         5.7001e-05           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 13       Time: 1.27888  Time step: 0.0784145 CFL: 0.713792
-********************************************************************************
-   Number of active cells:       7125
-   Number of degrees of freedom: 22698
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7566
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.2789e+00      2.0009e-01              2.0009e-04         9.5207e-12        -6.5072e-08      1.9999e+00              1.9999e+00         1.0882e-09         6.2578e-05           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 14       Time: 1.36234  Time step: 0.0834645 CFL: 0.704621
-********************************************************************************
-   Number of active cells:       7194
-   Number of degrees of freedom: 22905
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7635
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.3623e+00      2.0010e-01              2.0010e-04         9.3959e-12        -6.6081e-08      1.9999e+00              1.9999e+00         2.0041e-09         6.3667e-05           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 15       Time: 1.45514  Time step: 0.0927953 CFL: 0.674586
-********************************************************************************
-   Number of active cells:       7302
-   Number of degrees of freedom: 23217
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7739
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.4551e+00      2.0011e-01              2.0011e-04         8.9229e-12        -6.2672e-08      1.9999e+00              1.9999e+00         2.0185e-09         5.9891e-05           5.0000e-01 
+4.6493e-01      1.9977e-01              1.9977e-04         4.7484e-13         4.7140e-08      2.0002e+00              2.0002e+00        -6.5520e-10        -2.1618e-04           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 16       Time: 1.56201  Time step: 0.106868 CFL: 0.65124 
+Transient iteration: 6        Time: 0.574502 Time step: 0.109569 CFL: 0.583801
 *******************************************************************************
-   Number of active cells:       7380
-   Number of degrees of freedom: 23445
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7815
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.5620e+00      2.0012e-01              2.0012e-04         8.6506e-12        -5.1519e-08      1.9999e+00              1.9999e+00         2.0077e-09         4.8469e-05           5.0000e-01 
+5.7450e-01      2.0014e-01              2.0014e-04        -2.3632e-13         6.1528e-09      1.9999e+00              1.9999e+00        -4.5702e-10        -1.5694e-04           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 17       Time: 1.69025  Time step: 0.128241 CFL: 0.576382
+Transient iteration: 7        Time: 0.681588 Time step: 0.107086 CFL: 0.511595
 *******************************************************************************
-   Number of active cells:       7413
-   Number of degrees of freedom: 23520
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7840
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.6902e+00      2.0014e-01              2.0014e-04         8.3661e-12        -2.7784e-08      1.9999e+00              1.9999e+00         1.7124e-09         2.4680e-05           5.0000e-01 
+6.8159e-01      2.0044e-01              2.0044e-04        -7.0493e-13        -3.7768e-08      1.9996e+00              1.9996e+00        -3.3333e-10        -1.1440e-04           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 18       Time: 1.84414  Time step: 0.153889 CFL: 0.377555
+Transient iteration: 8        Time: 0.791616 Time step: 0.110028 CFL: 0.486631
 *******************************************************************************
-   Number of active cells:       7599
-   Number of degrees of freedom: 24126
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 8042
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.8441e+00      2.0015e-01              2.0015e-04         8.0991e-12         8.1730e-09      1.9998e+00              1.9998e+00         1.6315e-09        -1.0868e-05           5.0000e-01 
+7.9162e-01      2.0075e-01              2.0075e-04        -3.7288e-13        -6.7834e-08      1.9993e+00              1.9993e+00        -2.1474e-10        -8.1847e-05           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 19       Time: 2.0288   Time step: 0.184667 CFL: 0.40342 
+Transient iteration: 9        Time: 0.905909 Time step: 0.114293 CFL: 0.48134 
 *******************************************************************************
-   Number of active cells:       7572
-   Number of degrees of freedom: 23982
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7994
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.0288e+00      2.0017e-01              2.0017e-04         7.3351e-12         4.3247e-08      1.9998e+00              1.9998e+00         1.5646e-09        -4.5579e-05           5.0000e-01 
+9.0591e-01      2.0107e-01              2.0107e-04        -4.0651e-13        -9.1604e-08      1.9989e+00              1.9989e+00        -1.0600e-10        -5.6932e-05           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 20       Time: 2.19606  Time step: 0.167259 CFL: 0.828061
+Transient iteration: 10       Time: 1.02391  Time step: 0.118001 CFL: 0.484289
 *******************************************************************************
-   Number of active cells:       7554
-   Number of degrees of freedom: 23955
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7985
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.1961e+00      2.0019e-01              2.0019e-04         6.9400e-12         6.0104e-08      1.9998e+00              1.9998e+00         1.8899e-10        -6.2159e-05           5.0000e-01 
+1.0239e+00      2.0139e-01              2.0139e-04        -3.7330e-13        -1.0722e-07      1.9986e+00              1.9986e+00        -1.3293e-11        -3.9969e-05           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 21       Time: 2.32037  Time step: 0.124304 CFL: 1.00917 
+Transient iteration: 11       Time: 1.14629  Time step: 0.122379 CFL: 0.482112
 *******************************************************************************
-   Number of active cells:       7464
-   Number of degrees of freedom: 23733
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7911
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.3204e+00      2.0020e-01              2.0020e-04         6.5202e-12         6.2447e-08      1.9998e+00              1.9998e+00        -5.1409e-12        -6.4539e-05           5.0000e-01 
+1.1463e+00      2.0171e-01              2.0171e-04        -4.5173e-13        -9.2846e-08      1.9983e+00              1.9983e+00        -2.0910e-11        -5.5927e-05           5.0000e-01 
 
 *******************************************************************************
-Transient iteration: 22       Time: 2.42607  Time step: 0.105702 CFL: 0.881989
+Transient iteration: 12       Time: 1.27608  Time step: 0.129795 CFL: 0.471431
 *******************************************************************************
-   Number of active cells:       7326
-   Number of degrees of freedom: 23319
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7773
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.4261e+00      2.0022e-01              2.0022e-04         6.2533e-12         5.6775e-08      1.9998e+00              1.9998e+00        -7.6378e-11        -5.9175e-05           5.0000e-01 
+1.2761e+00      2.0204e-01              2.0204e-04        -2.3396e-13        -6.1410e-08      1.9980e+00              1.9980e+00        -7.0466e-13        -8.8987e-05           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 13       Time: 1.41743  Time step: 0.141347 CFL: 0.459137
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.4174e+00      2.0239e-01              2.0239e-04         7.6336e-14        -3.7186e-08      1.9976e+00              1.9976e+00         6.3807e-11        -1.0919e-04           5.0000e-01 
+
+*******************************************************************************
+Transient iteration: 14       Time: 1.57291  Time step: 0.155482 CFL: 0.451335
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.5729e+00      2.0276e-01              2.0276e-04         2.8826e-13        -3.0845e-08      1.9972e+00              1.9972e+00         1.1356e-10        -1.1371e-04           5.0000e-01 
 
 ********************************************************************************
-Transient iteration: 23       Time: 2.52138  Time step: 0.0953169 CFL: 0.831713
+Transient iteration: 15       Time: 1.6      Time step: 0.0270864 CFL: 0.445791
 ********************************************************************************
-   Number of active cells:       7170
-   Number of degrees of freedom: 22797
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7599
 
 ----------------------
 VOF Mass Conservation
 ----------------------
    time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.5214e+00      2.0023e-01              2.0023e-04         6.1501e-12         4.4575e-08      1.9998e+00              1.9998e+00        -2.3640e-10        -4.6652e-05           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 24       Time: 2.61106  Time step: 0.0896765 CFL: 0.797174
-********************************************************************************
-   Number of active cells:       7233
-   Number of degrees of freedom: 23022
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7674
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.6111e+00      2.0024e-01              2.0024e-04         5.1552e-12         2.8068e-08      1.9998e+00              1.9998e+00        -2.7095e-10        -2.9944e-05           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 25       Time: 2.6984   Time step: 0.0873366 CFL: 0.770094
-********************************************************************************
-   Number of active cells:       7161
-   Number of degrees of freedom: 22791
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7597
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.6984e+00      2.0024e-01              2.0024e-04        -2.1811e-11         1.1140e-08      1.9998e+00              1.9998e+00        -3.3421e-10        -1.3288e-05           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 26       Time: 2.78513  Time step: 0.0867327 CFL: 0.755222
-********************************************************************************
-   Number of active cells:       7227
-   Number of degrees of freedom: 23043
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7681
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.7851e+00      2.0025e-01              2.0025e-04        -1.3023e-11        -4.4843e-09      1.9997e+00              1.9997e+00        -3.6548e-10         2.3298e-06           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 27       Time: 2.87198  Time step: 0.0868526 CFL: 0.748964
-********************************************************************************
-   Number of active cells:       7164
-   Number of degrees of freedom: 22818
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7606
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.8720e+00      2.0026e-01              2.0026e-04        -6.1154e-11        -1.8783e-08      1.9997e+00              1.9997e+00        -4.6409e-10         1.7067e-05           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 28       Time: 2.95966  Time step: 0.087681 CFL: 0.742915
-*******************************************************************************
-   Number of active cells:       7176
-   Number of degrees of freedom: 22842
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7614
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.9597e+00      2.0027e-01              2.0027e-04        -5.4174e-11        -3.1047e-08      1.9997e+00              1.9997e+00         1.7755e-09         2.9460e-05           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 29       Time: 3.04984  Time step: 0.0901801 CFL: 0.729215
-********************************************************************************
-   Number of active cells:       7188
-   Number of degrees of freedom: 22848
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7616
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-3.0498e+00      2.0028e-01              2.0028e-04        -1.0033e-10        -3.9163e-08      1.9997e+00              1.9997e+00         1.3500e-09         3.7132e-05           5.0000e-01 
-
-********************************************************************************
-Transient iteration: 30       Time: 3.14547  Time step: 0.0956303 CFL: 0.707256
-********************************************************************************
-   Number of active cells:       7236
-   Number of degrees of freedom: 23061
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7687
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-3.1455e+00      2.0029e-01              2.0029e-04        -9.3053e-11        -4.2336e-08      1.9997e+00              1.9997e+00         1.4691e-09         4.0327e-05           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 31       Time: 3.25055  Time step: 0.105072 CFL: 0.682606
-*******************************************************************************
-   Number of active cells:       7320
-   Number of degrees of freedom: 23244
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7748
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-3.2505e+00      2.0030e-01              2.0030e-04        -1.3490e-10        -4.0661e-08      1.9997e+00              1.9997e+00         1.3912e-09         3.8162e-05           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 32       Time: 3.37279  Time step: 0.122248 CFL: 0.644622
-*******************************************************************************
-   Number of active cells:       7542
-   Number of degrees of freedom: 23952
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7984
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-3.3728e+00      2.0031e-01              2.0031e-04        -1.2647e-10        -3.2357e-08      1.9997e+00              1.9997e+00         1.7962e-09         3.0312e-05           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 33       Time: 3.51949  Time step: 0.146698 CFL: 0.572368
-*******************************************************************************
-   Number of active cells:       7575
-   Number of degrees of freedom: 23997
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 7999
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-3.5195e+00      2.0032e-01              2.0032e-04        -1.5924e-10        -1.6050e-08      1.9997e+00              1.9997e+00         1.7002e-09         1.3997e-05           5.0000e-01 
-
-*******************************************************************************
-Transient iteration: 34       Time: 3.6      Time step: 0.080508 CFL: 0.372727
-*******************************************************************************
-   Number of active cells:       7590
-   Number of degrees of freedom: 24060
-   Volume of triangulation:      2.2
-   Number of VOF degrees of freedom: 8020
-
-----------------------
-VOF Mass Conservation
-----------------------
-   time    surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-3.6000e+00      2.0033e-01              2.0033e-04        -1.6027e-10        -4.8015e-09      1.9997e+00              1.9997e+00         1.6701e-09         2.8795e-06           5.0000e-01 
+1.6000e+00      2.0282e-01              2.0282e-04         3.0611e-13        -1.8519e-08      1.9972e+00              1.9972e+00         1.2182e-10        -1.0596e-04           5.0000e-01 

--- a/applications_tests/lethe-fluid/vof-velocity-extrapolation.prm
+++ b/applications_tests/lethe-fluid/vof-velocity-extrapolation.prm
@@ -1,0 +1,172 @@
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method                       = bdf2
+  set time end                     = 3.6
+  set time step                    = 0.2
+  set adapt                        = true
+  set max cfl                      = 0.75
+  set output name                  = vof-velocity-extrapolation
+  set output frequency             = 0
+  set adaptative time step scaling = 1.2
+end
+
+#---------------------------------------------------
+# Initial Condition
+#---------------------------------------------------
+
+subsection initial conditions
+  subsection VOF
+    set Function expression = if (y<=(0.01*sin(3.1416*(x+0.5))), min(0.5-(y-0.01*sin(3.1416*(x+0.5)))/0.0025,1), max(0.5-(y-0.01*sin(3.1416*(x+0.5)))/0.0025,0))
+  end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  set number of fluids = 2
+  subsection fluid 0
+    set density             = 0.001
+    set kinematic viscosity = 0.001
+  end
+  subsection fluid 1
+    set density             = 1
+    set kinematic viscosity = 0.005
+  end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = subdivided_hyper_rectangle
+  set grid arguments     = 5, 3 : -1, -1 : 1, 0.1 : true
+  set initial refinement = 3
+end
+
+#---------------------------------------------------
+# Mesh Adaptation
+#---------------------------------------------------
+
+subsection mesh adaptation
+  set type                     = kelly
+  set variable                 = phase
+  set fraction type            = fraction
+  set max refinement level     = 6
+  set min refinement level     = 3
+  set frequency                = 1
+  set fraction refinement      = 0.99
+  set fraction coarsening      = 0.01
+  set initial refinement steps = 3
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+
+subsection multiphysics
+  set VOF = true
+end
+
+#---------------------------------------------------
+# VOF
+#---------------------------------------------------
+
+subsection VOF
+  subsection phase filtration
+    set type = tanh
+    set beta = 20
+  end
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions
+  set number = 3
+  subsection bc 0
+    set id                 = 0
+    set type               = periodic
+    set periodic_id        = 1
+    set periodic_direction = 0
+  end
+  subsection bc 1
+    set id   = 2
+    set type = slip
+  end
+  subsection bc 2
+    set id   = 3
+    set type = slip
+  end
+end
+
+#---------------------------------------------------
+# Post-processing
+#---------------------------------------------------
+
+subsection post-processing
+  set verbosity                    = verbose
+  set calculate average velocities = true
+end
+
+#---------------------------------------------------
+# Source term
+#---------------------------------------------------
+
+subsection source term
+  subsection fluid dynamics
+    set Function expression = 0 ; -1 ; 0
+  end
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection fluid dynamics
+    set verbosity      = quiet
+    set tolerance      = 1e-8
+    set max iterations = 10
+  end
+  subsection VOF
+    set verbosity      = quiet
+    set tolerance      = 1e-8
+    set max iterations = 10
+  end
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection fluid dynamics
+    set verbosity          = quiet
+    set max krylov vectors = 100
+    set max iters          = 100
+    set relative residual  = 1e-5
+    set minimum residual   = 1e-9
+    set preconditioner     = amg
+  end
+  subsection VOF
+    set verbosity          = quiet
+    set max krylov vectors = 100
+    set max iters          = 100
+    set relative residual  = 1e-5
+    set minimum residual   = 1e-9
+    set preconditioner     = amg
+  end
+end

--- a/applications_tests/lethe-fluid/vof-velocity-extrapolation.prm
+++ b/applications_tests/lethe-fluid/vof-velocity-extrapolation.prm
@@ -8,14 +8,13 @@ set dimension = 2
 #---------------------------------------------------
 
 subsection simulation control
-  set method                       = bdf2
-  set time end                     = 1.6
-  set time step                    = 0.1
-  set adapt                        = true
-  set max cfl                      = 0.4
-  set output name                  = vof-velocity-extrapolation
-  set output frequency             = 0
-  set adaptative time step scaling = 1.1
+  set method           = bdf2
+  set time end         = 1.6
+  set time step        = 0.1
+  set adapt            = true
+  set max cfl          = 0.4
+  set output name      = vof-velocity-extrapolation
+  set output frequency = 0
 end
 
 #---------------------------------------------------
@@ -113,6 +112,7 @@ end
 #---------------------------------------------------
 # Post-processing
 #---------------------------------------------------
+
 subsection post-processing
   set verbosity                    = verbose
   set calculate average velocities = true
@@ -151,19 +151,15 @@ end
 
 subsection linear solver
   subsection fluid dynamics
-    set verbosity          = quiet
-    set max krylov vectors = 100
-    set max iters          = 100
-    set relative residual  = 1e-5
-    set minimum residual   = 1e-9
-    set preconditioner     = amg
+    set verbosity         = quiet
+    set relative residual = 1e-5
+    set minimum residual  = 1e-9
+    set preconditioner    = amg
   end
   subsection VOF
-    set verbosity          = quiet
-    set max krylov vectors = 100
-    set max iters          = 100
-    set relative residual  = 1e-5
-    set minimum residual   = 1e-9
-    set preconditioner     = amg
+    set verbosity         = quiet
+    set relative residual = 1e-5
+    set minimum residual  = 1e-9
+    set preconditioner    = amg
   end
 end

--- a/applications_tests/lethe-fluid/vof-velocity-extrapolation.prm
+++ b/applications_tests/lethe-fluid/vof-velocity-extrapolation.prm
@@ -12,7 +12,7 @@ subsection simulation control
   set time end                     = 1.6
   set time step                    = 0.1
   set adapt                        = true
-  set max cfl                      = 0.5
+  set max cfl                      = 0.4
   set output name                  = vof-velocity-extrapolation
   set output frequency             = 0
   set adaptative time step scaling = 1.1
@@ -52,6 +52,20 @@ subsection mesh
   set type               = dealii
   set grid type          = subdivided_hyper_rectangle
   set grid arguments     = 5, 3 : -1, -1 : 1, 0.1 : true
+  set initial refinement = 2
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection box refinement
+  subsection mesh
+    set type               = dealii
+    set grid type          = hyper_rectangle
+    set grid arguments     = -1, -0.02 : 1, 0.02 : true
+    set initial refinement = 0
+  end
   set initial refinement = 4
 end
 

--- a/applications_tests/lethe-fluid/vof-velocity-extrapolation.prm
+++ b/applications_tests/lethe-fluid/vof-velocity-extrapolation.prm
@@ -119,7 +119,7 @@ subsection post-processing
 end
 
 #---------------------------------------------------
-# Source term
+# Source Term
 #---------------------------------------------------
 
 subsection source term

--- a/applications_tests/lethe-fluid/vof-velocity-extrapolation.prm
+++ b/applications_tests/lethe-fluid/vof-velocity-extrapolation.prm
@@ -9,13 +9,13 @@ set dimension = 2
 
 subsection simulation control
   set method                       = bdf2
-  set time end                     = 3.6
-  set time step                    = 0.2
+  set time end                     = 1.6
+  set time step                    = 0.1
   set adapt                        = true
-  set max cfl                      = 0.75
+  set max cfl                      = 0.5
   set output name                  = vof-velocity-extrapolation
   set output frequency             = 0
-  set adaptative time step scaling = 1.2
+  set adaptative time step scaling = 1.1
 end
 
 #---------------------------------------------------
@@ -52,23 +52,7 @@ subsection mesh
   set type               = dealii
   set grid type          = subdivided_hyper_rectangle
   set grid arguments     = 5, 3 : -1, -1 : 1, 0.1 : true
-  set initial refinement = 3
-end
-
-#---------------------------------------------------
-# Mesh Adaptation
-#---------------------------------------------------
-
-subsection mesh adaptation
-  set type                     = kelly
-  set variable                 = phase
-  set fraction type            = fraction
-  set max refinement level     = 6
-  set min refinement level     = 3
-  set frequency                = 1
-  set fraction refinement      = 0.99
-  set fraction coarsening      = 0.01
-  set initial refinement steps = 3
+  set initial refinement = 4
 end
 
 #---------------------------------------------------
@@ -115,7 +99,6 @@ end
 #---------------------------------------------------
 # Post-processing
 #---------------------------------------------------
-
 subsection post-processing
   set verbosity                    = verbose
   set calculate average velocities = true

--- a/applications_tests/lethe-fluid/vof-velocity-extrapolation.prm
+++ b/applications_tests/lethe-fluid/vof-velocity-extrapolation.prm
@@ -56,7 +56,7 @@ subsection mesh
 end
 
 #---------------------------------------------------
-# Mesh
+# Box Refinement
 #---------------------------------------------------
 
 subsection box refinement

--- a/include/core/bdf.h
+++ b/include/core/bdf.h
@@ -124,8 +124,8 @@ number_of_previous_solutions(
 }
 
 /**
- * @brief Extrapolate vector of solution to time_vector[0] using previous
- * solution times and previous solution.
+ * @brief Extrapolates vector of solution to time_vector[0] using previous
+ * solution times and previous solutions.
  *
  * @tparam DataType Type of the variable being extrapolated (e.g. double,
  * Tensor<1,dim>)
@@ -133,14 +133,14 @@ number_of_previous_solutions(
  * @param[in] time_vector Vector of times. The solution will be extrapolated to
  * time 0. It should be of size @p number_of_previous_solutions+1.
  *
- * @param[in] solution_vector Vector of solutions. The solution will be
+ * @param[in] solution_vector Vector of solution. The solution will be
  * extrapolated to index 0. It should be at least of size @p
  * number_of_previous_solutions.
  *
  * @param[in] number_of_previous_solutions Number of previous solutions used
  * to extrapolate.
  *
- * @param[out]  extrapolated_solution Vector of extrapolated solutions.
+ * @param[out] extrapolated_solution Vector of extrapolated solution.
  */
 
 template <typename DataType>
@@ -159,7 +159,7 @@ bdf_extrapolate(const std::vector<double>                &time_vector,
       return;
     }
 
-  // Otherwise we extrapolate with a Lagrange polynomial
+  // Otherwise, we extrapolate with a Lagrange polynomial
   for (unsigned int q = 0; q < extrapolated_solution.size(); ++q)
     {
       // Set extrapolated solution to zero
@@ -169,14 +169,14 @@ bdf_extrapolate(const std::vector<double>                &time_vector,
       for (unsigned int p = 0; p < number_of_previous_solutions; ++p)
         {
           // Factor is the weight of the previous solution fixed by the Lagrange
-          // Polynomial
+          // polynomial
           double factor = 1;
           for (unsigned int k = 0; k < number_of_previous_solutions; ++k)
             {
               if (p != k)
                 {
                   // The time vector also contains the time of the solution to
-                  // be extrapoled to, hence the +1
+                  // be extrapolated to, hence the +1
                   factor *= (time_vector[0] - time_vector[k + 1]) /
                             (time_vector[p + 1] - time_vector[k + 1]);
                 }

--- a/include/core/bdf.h
+++ b/include/core/bdf.h
@@ -124,7 +124,7 @@ number_of_previous_solutions(
 }
 
 /**
- * @brief Extrapolates vector of solution to time_vector[0] using previous
+ * @brief Extrapolate vector of solution to time_vector[0] using previous
  * solution times and previous solutions.
  *
  * @tparam DataType Type of the variable being extrapolated (e.g. double,

--- a/include/solvers/vof_scratch_data.h
+++ b/include/solvers/vof_scratch_data.h
@@ -244,28 +244,28 @@ public:
           previous_solutions[p], this->previous_velocity_values[p]);
       }
 
-    if (!ale.enabled())
-      return;
-
-    // ALE enabled, so extract the ALE velocity and subtract it from the
-    // velocity obtained from the fluid dynamics
-    Tensor<1, dim>                                  velocity_ale;
-    std::shared_ptr<Functions::ParsedFunction<dim>> velocity_ale_function =
-      ale.velocity;
-    Vector<double> velocity_ale_vector(dim);
-
-    for (unsigned int q = 0; q < n_q_points; ++q)
+    if (ale.enabled())
       {
-        velocity_ale_function->vector_value(quadrature_points[q],
-                                            velocity_ale_vector);
-        for (unsigned int d = 0; d < dim; ++d)
-          velocity_ale[d] = velocity_ale_vector[d];
+        // ALE enabled, so extract the ALE velocity and subtract it from the
+        // velocity obtained from the fluid dynamics
+        Tensor<1, dim>                                  velocity_ale;
+        std::shared_ptr<Functions::ParsedFunction<dim>> velocity_ale_function =
+          ale.velocity;
+        Vector<double> velocity_ale_vector(dim);
 
-        velocity_values[q] -= velocity_ale;
-
-        for (unsigned int p = 0; p < previous_solutions.size(); ++p)
+        for (unsigned int q = 0; q < n_q_points; ++q)
           {
-            this->previous_velocity_values[p][q] -= velocity_ale;
+            velocity_ale_function->vector_value(quadrature_points[q],
+                                                velocity_ale_vector);
+            for (unsigned int d = 0; d < dim; ++d)
+              velocity_ale[d] = velocity_ale_vector[d];
+
+            velocity_values[q] -= velocity_ale;
+
+            for (unsigned int p = 0; p < previous_solutions.size(); ++p)
+              {
+                this->previous_velocity_values[p][q] -= velocity_ale;
+              }
           }
       }
 

--- a/include/solvers/vof_scratch_data.h
+++ b/include/solvers/vof_scratch_data.h
@@ -278,9 +278,9 @@ public:
         std::vector<double> time_vector =
           this->simulation_control->get_simulation_times();
         bdf_extrapolate(time_vector,
-                        previous_velocity_values,
+                        this->previous_velocity_values,
                         number_of_previous_solutions(method),
-                        velocity_values);
+                        this->velocity_values);
       }
   }
 

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -245,7 +245,7 @@ VolumeOfFluid<dim>::assemble_local_system_rhs(
 
   if (multiphysics->fluid_dynamics_is_block())
     {
-      // Check if the post processed variable needs to be calculated with the
+      // Check if the post-processed variable needs to be calculated with the
       // average velocity profile or the fluid solution.
       if (this->simulation_parameters.initial_condition->type ==
             Parameters::InitialConditionType::average_velocity_profile &&
@@ -273,7 +273,7 @@ VolumeOfFluid<dim>::assemble_local_system_rhs(
     }
   else
     {
-      // Check if the post processed variable needs to be calculated with the
+      // Check if the post-processed variable needs to be calculated with the
       // average velocity profile or the fluid solution.
       if (this->simulation_parameters.initial_condition->type ==
             Parameters::InitialConditionType::average_velocity_profile &&
@@ -320,8 +320,6 @@ VolumeOfFluid<dim>::copy_local_rhs_to_global_rhs(
                                               copy_data.local_dof_indices,
                                               this->system_rhs);
 }
-
-
 
 template <int dim>
 void

--- a/source/solvers/vof_assemblers.cc
+++ b/source/solvers/vof_assemblers.cc
@@ -33,7 +33,7 @@ VOFAssemblerCore<dim>::assemble_matrix(VOFScratchData<dim>       &scratch_data,
   auto &strong_jacobian_vec = copy_data.strong_jacobian;
   auto &local_matrix        = copy_data.local_matrix;
 
-  // assembling local matrix and right hand side
+  // Assemble local matrix and right-hand side
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
       // Gather into local variables the relevant fields
@@ -85,8 +85,8 @@ VOFAssemblerCore<dim>::assemble_matrix(VOFScratchData<dim>       &scratch_data,
 
       // Calculation of the GLS stabilization parameter. The
       // stabilization parameter used is different if the simulation is
-      // steady or unsteady. In the unsteady case it includes the value
-      // of the time-step. Hypothesis : advection dominated problem
+      // steady or unsteady. In the unsteady case, it includes the value
+      // of the time-step. Hypothesis: advection dominated problem
       // (Pe>3) [Bochev et al., Stability of the SUPG finite element
       // method for transient advection-diffusion problems, CMAME 2004]
       const double tau =
@@ -182,7 +182,7 @@ VOFAssemblerCore<dim>::assemble_rhs(VOFScratchData<dim>       &scratch_data,
   auto &strong_residual_vec = copy_data.strong_residual;
   auto &local_rhs           = copy_data.local_rhs;
 
-  // assembling local matrix and right hand side
+  // Assemble local matrix and right-hand side
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
       // Gather into local variables the relevant fields
@@ -214,7 +214,7 @@ VOFAssemblerCore<dim>::assemble_rhs(VOFScratchData<dim>       &scratch_data,
       const double vdcdd =
         (0.5 * h * h) * velocity.norm() * phase_gradient_norm;
 
-      // We  remove the diffusion aligned with the velocity
+      // We remove the diffusion aligned with the velocity
       // as is done in the original article. In Tezduyar 2003, this is denoted
       // s.
       Tensor<1, dim> velocity_unit_vector =
@@ -232,8 +232,8 @@ VOFAssemblerCore<dim>::assemble_rhs(VOFScratchData<dim>       &scratch_data,
 
       // Calculation of the GLS stabilization parameter. The
       // stabilization parameter used is different if the simulation is
-      // steady or unsteady. In the unsteady case it includes the value
-      // of the time-step. Hypothesis : advection dominated problem
+      // steady or unsteady. In the unsteady case, it includes the value
+      // of the time-step. Hypothesis: advection dominated problem
       // (Pe>3) [Bochev et al., Stability of the SUPG finite element
       // method for transient advection-diffusion problems, CMAME 2004]
       const double tau =

--- a/source/solvers/vof_assemblers.cc
+++ b/source/solvers/vof_assemblers.cc
@@ -258,7 +258,6 @@ VOFAssemblerCore<dim>::assemble_rhs(VOFScratchData<dim>       &scratch_data,
           const auto phi_phase_i      = scratch_data.phi[q][i];
           const auto grad_phi_phase_i = scratch_data.grad_phi[q][i];
 
-
           // rhs for: u * grad(phase) + phase * grad(u) - diffusivity *
           // laplacian(phase) = 0
           local_rhs(i) -= (phi_phase_i * velocity * phase_gradient +
@@ -368,11 +367,8 @@ VOFAssemblerBDF<dim>::assemble_rhs(VOFScratchData<dim>       &scratch_data,
     {
       phase_value[0] = scratch_data.present_phase_values[q];
 
-
       for (unsigned int p = 0; p < number_of_previous_solutions(method); ++p)
         phase_value[p + 1] = scratch_data.previous_phase_values[p][q];
-
-
 
       for (unsigned int p = 0; p < number_of_previous_solutions(method) + 1;
            ++p)


### PR DESCRIPTION
### Description

A bug in the VOF auxiliary physics was discovered when rerunning the gravity wave example.  In the PR #994, BDF extrapolation of the velocity vector field in the VOF auxiliary physic was moved to the scratch data. However, the implementation was bypassed by an "if" condition. 

### Solution

This bug is fixed with this PR, and an application test was added to ensure that the feature remains intact with future implementations.

### Testing
The new application test: `applications_tests/lethe-fluid/vof-velocity-extrapolation.prm`


### Miscellaneous (will be removed when merged)

A deal.ii version dependency when using kelly mesh refinement on the phase fraction with the BDF velocity extrapolation in VOF has been noticed, an issue will be opened to investigate this further. (issue #1288)

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge