### PR TITLE
Minor corrections in boundary conditions documentation

### DIFF
--- a/doc/source/parameters/cfd/boundary_conditions_cfd.rst
+++ b/doc/source/parameters/cfd/boundary_conditions_cfd.rst
@@ -14,14 +14,14 @@ This subsection defines the boundary conditions associated with fluid dynamics p
 
 .. math::
 
-  - \nu \nabla \mathbf{u} \cdot \mathbf{n} + p \mathcal{I} \cdot \mathbf{n} = - \beta (\mathbf{u}\cdot n)_{-} \mathbf{u}
+  \nu \nabla \mathbf{u} \cdot \mathbf{n} - p \mathcal{I} \cdot \mathbf{n} - \beta (\mathbf{u}\cdot \mathbf{n})_{-} \mathbf{u} = 0
 
 or in Einstein notation:
 
 .. math::
-    - \nu \partial_i u_j n_j  + p n_i = - \beta ( u_k n_k)_{-} u_i
+    \nu \partial_i u_j n_j  - p n_i - \beta ( u_k n_k)_{-} u_i = 0
 
-where :math:`\beta` is a constant  and :math:`(\mathbf{u}\cdot n)_{-}` is :math:`min (0,\mathbf{u}\cdot n)`. We refer the reader to the work of `Arndt et al 2015 <https://www.mathsim.eu/~darndt/files/ENUMATH_2015.pdf>`_  for more detail.
+where :math:`\beta` is a constant  and :math:`(\mathbf{u}\cdot \mathbf{n})_{-}` is :math:`\min (0,\mathbf{u}\cdot \mathbf{n})`. We refer the reader to the work of `Arndt et al 2015 <https://www.mathsim.eu/~darndt/files/ENUMATH_2015.pdf>`_  for more detail.
 
 * Finally, Lethe also supports not imposing a boundary condition on an ID. Not imposing a boundary condition is equivalent to the *do nothing* boundary condition (``none``), which results in a zero net traction on a boundary. This, in fact, imposes :math:`\int_{\Gamma}(-p\mathcal{I} + \mathbf{\tau}) \cdot \mathbf{n}=0` where :math:`p` is the pressure, :math:`\mathcal{I}` is the identity tensor, :math:`\mathbf{\tau}` is the deviatoric stress tensor  and :math:`\Gamma` is the boundary. 
 

--- a/doc/source/parameters/cfd/boundary_conditions_cfd.rst
+++ b/doc/source/parameters/cfd/boundary_conditions_cfd.rst
@@ -14,12 +14,12 @@ This subsection defines the boundary conditions associated with fluid dynamics p
 
 .. math::
 
-   \nu \nabla \mathbf{u} \cdot \mathbf{n} - p \mathcal{I} \cdot \mathbf{n} - \beta (\mathbf{u}\cdot n)_{-} \mathbf{u} = 0
+  - \nu \nabla \mathbf{u} \cdot \mathbf{n} + p \mathcal{I} \cdot \mathbf{n} = - \beta (\mathbf{u}\cdot n)_{-} \mathbf{u}
 
 or in Einstein notation:
 
 .. math::
-       \nu \partial_i u_j n_j  - p n_i - \beta ( u_k n_k)_{-} u_i = 0
+    - \nu \partial_i u_j n_j  + p n_i = - \beta ( u_k n_k)_{-} u_i
 
 where :math:`\beta` is a constant  and :math:`(\mathbf{u}\cdot n)_{-}` is :math:`min (0,\mathbf{u}\cdot n)`. We refer the reader to the work of `Arndt et al 2015 <https://www.mathsim.eu/~darndt/files/ENUMATH_2015.pdf>`_  for more detail.
 

--- a/doc/source/theory/multiphysics/fluid_dynamics/fem_formulation.rst
+++ b/doc/source/theory/multiphysics/fluid_dynamics/fem_formulation.rst
@@ -34,7 +34,7 @@ Because we want the pressure to be in :math:`\mathcal{L}^2` and the velocity to 
   &  - \int_{\Omega} \left( \partial_k \right) v_k p \mathrm{d}\Omega  
  + \nu \int_{\Omega} \left( \partial_l v_k \right) \left( \partial_l u_k  \right) \mathrm{d}\Omega  
  \\
-  &  + \int_{\Gamma} \left( v_k \right) \left( \partial_l u_k  +\delta_{lk} p \right) n_l \mathrm{d}\Gamma
+  &  + \int_{\Gamma} \left( v_k \right) \left(- \partial_l u_k  +\delta_{lk} p \right) n_l \mathrm{d}\Gamma
    =0
 
 where :math:`\delta_{lk}` is the Kronecker delta and :math:`n_l` is the outward pointing normal vector to a surface. Since we assume Dirichlet boundary conditions or zero stress  conditions 
@@ -42,7 +42,7 @@ on :math:`\Gamma`, this term may be discarded. Thus, when no boundary condition 
 
 .. math::
 
-    \int_{\Gamma} \left( v_k \right) \left( \partial_l u_k  +\delta_{lk} p \right) n_l \mathrm{d}\Gamma=0
+    \int_{\Gamma} \left( v_k \right) \left(- \partial_l u_k  +\delta_{lk} p \right) n_l \mathrm{d}\Gamma=0
 
 which can be seen as an outlet boundary condition where the normal stress is zero. In essence, this can be used to approximately impose an outlet boundary condition with a zero average pressure.
 This weak form is non-linear because of :math:`u_l \partial_l u_k` term. 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the content of this documentation
       Is it related to Lethe documentation (simulation parameters or theory guide) or in-code documentation? -->

There was a sign error in the boundary conditions of the FEM formulation in the theory guide. Also, the normal vector in the outlet boundary condition was not bold.

Code related list:
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master

Pull request related list:
- [X] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] The PR description is cleaned and ready for merge