### PR TITLE
Add verbosity to interface thickness in Cahn-Hilliard (and CHNS) solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- MINOR Added verbosity for the interface thickness in the CHNS solver. An application test was added to verify the feature resists to future changes made in the code. The documentation was updated to display the new feature in the Cahn-Hilliard section of the documentation. [#1274](https://github.com/chaos-polymtl/lethe/pull/1274)
+- MINOR Added verbosity for the interface thickness in the CHNS solver. An application test was added to verify the feature resists to future changes made in the code. The documentation was updated to display the new feature in the Cahn-Hilliard section of the documentation. [#1291](https://github.com/chaos-polymtl/lethe/pull/1291)
 
 ## [Master] - 2024-09-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- MINOR Added verbosity for the interface thickness in the CHNS solver. An application test was added to verify the feature resists to future changes made in the code. [#1274](https://github.com/chaos-polymtl/lethe/pull/1274)
+- MINOR Added verbosity for the interface thickness in the CHNS solver. An application test was added to verify the feature resists to future changes made in the code. The documentation was updated to display the new feature in the Cahn-Hilliard section of the documentation. [#1274](https://github.com/chaos-polymtl/lethe/pull/1274)
 
 ## [Master] - 2024-09-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MINOR Remove the GIFs from the repository to reduce its size. [#1289](https://github.com/chaos-polymtl/lethe/pull/1289)
 
+### Added
+
+- MINOR Added verbosity for the interface thickness in the CHNS solver. An application test was added to verify the feature resists to future changes made in the code. [#1274](https://github.com/chaos-polymtl/lethe/pull/1274)
+
 ## [Master] - 2024-09-24
 
 ### Added

--- a/applications_tests/lethe-fluid/cahn_hilliard_epsilon_verbosity.output
+++ b/applications_tests/lethe-fluid/cahn_hilliard_epsilon_verbosity.output
@@ -1,0 +1,17 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       4
+   Number of degrees of freedom: 27
+   Volume of triangulation:      4
+   Number of Cahn-Hilliard degrees of freedom: 18
+--------------
+Epsilon value
+--------------
+Epsilon value: 1.41421
+
+*****************************
+Steady iteration:        1/1
+*****************************
+--------------
+Epsilon value
+--------------
+Epsilon value: 1.41421

--- a/applications_tests/lethe-fluid/cahn_hilliard_epsilon_verbosity.prm
+++ b/applications_tests/lethe-fluid/cahn_hilliard_epsilon_verbosity.prm
@@ -1,0 +1,99 @@
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method           = steady
+  set output frequency = 0
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+
+subsection multiphysics
+  set cahn hilliard  = true
+  set fluid dynamics = false
+end
+
+#---------------------------------------------------
+# Cahn Hilliard
+#---------------------------------------------------
+
+subsection cahn hilliard
+  set potential smoothing coefficient = 0.0
+
+  subsection epsilon
+    set method    = automatic
+    set verbosity = verbose
+  end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = hyper_rectangle
+  set grid arguments     = -1,-1 : 1, 1 : true
+  set initial refinement = 1
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  set number of fluids = 2
+  subsection fluid 1
+    set density             = 1
+    set kinematic viscosity = 1
+  end
+  subsection fluid 0
+    set density             = 1
+    set kinematic viscosity = 1
+  end
+  set number of material interactions = 1 #by default it is set to 0
+  subsection material interaction 0
+    set type = fluid-fluid
+    subsection fluid-fluid interaction
+      set surface tension coefficient = 0
+    end
+  end
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions
+  set number = 0
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection cahn hilliard
+    set verbosity = quiet
+    set tolerance = 1e-1
+  end
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection cahn hilliard
+    set verbosity        = quiet
+    set minimum residual = 1e-3
+  end
+end

--- a/applications_tests/lethe-fluid/cahn_hilliard_epsilon_verbosity.prm
+++ b/applications_tests/lethe-fluid/cahn_hilliard_epsilon_verbosity.prm
@@ -27,7 +27,6 @@ end
 
 subsection cahn hilliard
   set potential smoothing coefficient = 0.0
-
   subsection epsilon
     set method    = automatic
     set verbosity = verbose
@@ -50,22 +49,8 @@ end
 #---------------------------------------------------
 
 subsection physical properties
-  set number of fluids = 2
-  subsection fluid 1
-    set density             = 1
-    set kinematic viscosity = 1
-  end
-  subsection fluid 0
-    set density             = 1
-    set kinematic viscosity = 1
-  end
-  set number of material interactions = 1 #by default it is set to 0
-  subsection material interaction 0
-    set type = fluid-fluid
-    subsection fluid-fluid interaction
-      set surface tension coefficient = 0
-    end
-  end
+  set number of fluids                = 2
+  set number of material interactions = 1
 end
 
 #---------------------------------------------------

--- a/doc/source/parameters/cfd/cahn_hilliard.rst
+++ b/doc/source/parameters/cfd/cahn_hilliard.rst
@@ -50,7 +50,7 @@ The default values of the Cahn-Hilliard parameters are given in the text box bel
  
   * ``verbosity``: enables the display of the interface thickness values in the terminal. This does not affect the printing of output  fils. Choices are ``quiet`` (default, no output) or ``verbose`` (output at every iteration).
 
-  * ``method``: sets the method for the computation of epsilon. The first choice is ``automatic``: the interface thickness is determined automatically using the minimum cell diameter obtained by the deal.ii ``minimum_cell_diameter`` `method <https://www.dealii.org/current/doxygen/deal.II/namespaceGridTools.html#a47c293eff2ec7ce4b90ba08b35d1f2e2>`_. The other choice is ``manual``: allows the user to define the interface thickness by hand by setting the desired value in ``value``.
+  * ``method``: sets the method for the computation of epsilon. The first choice is ``automatic``: the interface thickness is determined automatically using the minimum cell diameter obtained by the deal.ii ``minimum_cell_diameter`` `method <https://www.dealii.org/current/doxygen/deal.II/namespaceGridTools.html#a47c293eff2ec7ce4b90ba08b35d1f2e2>`_. The other choice is ``manual``: allows the user to define the interface thickness by hand by setting the desired value with ``value``.
   
 .. attention::
      The ``mobility model`` and ``mobility constant`` must be set in the :doc:`physical_properties` section.

--- a/doc/source/parameters/cfd/cahn_hilliard.rst
+++ b/doc/source/parameters/cfd/cahn_hilliard.rst
@@ -46,11 +46,11 @@ The default values of the Cahn-Hilliard parameters are given in the text box bel
   
 * ``potential smoothing coefficient``: defines the :math:`\xi` parameter in the equations above. Its value should be increased if the potential presents excessive oscillations (in advective problems for instance).
 
-* ``epsilon``: defines the :math:`\epsilon` parameter.
+* ``epsilon``: defines the :math:`\epsilon` parameter. The reader is refered to the :doc:`../../../theory/multiphase/cfd/cahn-hilliard` section for additional details about this parameter.
  
   * ``verbosity``: enables the display of the interface thickness values in the terminal. This does not affect the printing of output  fils. Choices are ``quiet`` (default, no output) or ``verbose`` (output at every iteration).
 
-  * ``method``: sets the method for the computation of epsilon. The first choice is ``automatic``: the interface thickness is determined automatically using the minimum cell diameter obtained by the deal.ii ``minimum_cell_diameter`` `method <https://www.dealii.org/current/doxygen/deal.II/namespaceGridTools.html#a47c293eff2ec7ce4b90ba08b35d1f2e2>`_. The other choice is ``manual``: allows the user to define the interface thickness by hand by setting the desired value with ``value``.
+  * ``method``: sets the method for the computation of epsilon. The first choice is ``automatic``: the interface thickness is determined automatically using the minimum cell diameter obtained by the deal.ii ``minimum_cell_diameter`` `method <https://www.dealii.org/current/doxygen/deal.II/namespaceGridTools.html#a47c293eff2ec7ce4b90ba08b35d1f2e2>`_. The other choice is ``manual``: allows the user to define the interface thickness by hand by setting the desired value with ``value``. 
   
 .. attention::
      The ``mobility model`` and ``mobility constant`` must be set in the :doc:`physical_properties` section.

--- a/doc/source/parameters/cfd/cahn_hilliard.rst
+++ b/doc/source/parameters/cfd/cahn_hilliard.rst
@@ -38,7 +38,7 @@ The default values of the Cahn-Hilliard parameters are given in the text box bel
     set potential smoothing coefficient = 1
 
     subsection epsilon
-      set verbosity = verbose
+      set verbosity = quiet
       set method    = automatic
       set value     = 1
     end

--- a/doc/source/parameters/cfd/cahn_hilliard.rst
+++ b/doc/source/parameters/cfd/cahn_hilliard.rst
@@ -38,14 +38,19 @@ The default values of the Cahn-Hilliard parameters are given in the text box bel
     set potential smoothing coefficient = 1
 
     subsection epsilon
-      set method = automatic
-      set value  = 1
+      set verbosity = verbose
+      set method    = automatic
+      set value     = 1
     end
   end
   
 * ``potential smoothing coefficient``: defines the :math:`\xi` parameter in the equations above. Its value should be increased if the potential presents excessive oscillations (in advective problems for instance).
 
-* ``epsilon``: defines the :math:`\epsilon` parameter. It can either be user-defined or determined automatically for each cell. For the latter, epsilon is equal to two times the characteristic length of the cell (:math:`h`). The choices are ``automatic`` (default) or ``manual``.
+* ``epsilon``: defines the :math:`\epsilon` parameter.
+ 
+  * ``verbosity``: enables the display of the interface thickness values in the terminal. This does not affect the printing of output  fils. Choices are ``quiet`` (default, no output) or ``verbose`` (output at every iteration).
 
+  * ``method``: sets the method for the computation of epsilon. The first choice is ``automatic``: the interface thickness is determined automatically using the minimum cell diameter obtained by the deal.ii ``minimum_cell_diameter`` `method <https://www.dealii.org/current/doxygen/deal.II/namespaceGridTools.html#a47c293eff2ec7ce4b90ba08b35d1f2e2>`_. The other choice is ``manual``: allows the user to define the interface thickness by hand by setting the desired value in ``value``.
+  
 .. attention::
      The ``mobility model`` and ``mobility constant`` must be set in the :doc:`physical_properties` section.

--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -63,9 +63,15 @@ namespace Parameters
     manual
   };
 
+    /**
+   * @brief Verbosity options for the epsilon parameter.
+*/
   enum class EpsilonVerbosity
   {
+      /// Epsilon related information will not be displayed on terminal
     quiet,
+      /// Epsilon value will be displayed on terminal for every steady and
+      /// transient iteration.
     verbose
   };
 

--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -63,6 +63,12 @@ namespace Parameters
     manual
   };
 
+  enum class EpsilonVerbosity
+  {
+    quiet,
+    verbose
+  };
+
 
   /**
    * @brief CahnHilliard_PhaseFilter - Defines the parameters for the phase filtration of CahnHilliard physics
@@ -207,6 +213,9 @@ namespace Parameters
 
     // Epsilon set strategy (automatic|manual)
     Parameters::EpsilonSetMethod epsilon_set_method;
+
+    // Epsilon verbosity
+    Parameters::EpsilonVerbosity epsilon_verbosity;
 
     // Epsilon value in the Cahn-Hilliard equations
     double epsilon;

--- a/include/core/parameters_multiphysics.h
+++ b/include/core/parameters_multiphysics.h
@@ -63,15 +63,15 @@ namespace Parameters
     manual
   };
 
-    /**
+  /**
    * @brief Verbosity options for the epsilon parameter.
-*/
+   */
   enum class EpsilonVerbosity
   {
-      /// Epsilon related information will not be displayed on terminal
+    /// Epsilon related information will not be displayed on terminal
     quiet,
-      /// Epsilon value will be displayed on terminal for every steady and
-      /// transient iteration.
+    /// Epsilon value will be displayed on terminal for every steady and
+    /// transient iteration.
     verbose
   };
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -57,6 +57,8 @@ DeclException3(ParameterStrictlyGreaterThanError,
                << ". However, it should be strictly greater than " << arg3
                << ".");
 
+//DeclException
+
 namespace Parameters
 {
   SizeOfSubsections

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -57,7 +57,7 @@ DeclException3(ParameterStrictlyGreaterThanError,
                << ". However, it should be strictly greater than " << arg3
                << ".");
 
-//DeclException
+// DeclException
 
 namespace Parameters
 {

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -570,7 +570,7 @@ Parameters::CahnHilliard::parse_parameters(ParameterHandler    &prm,
             Parameters::EpsilonVerbosity::verbose;
         }
       else
-        throw(std::runtime_error("Invalid epsilon verbosity. "
+        AssertThrow(false,ExcMessage("Invalid epsilon verbosity. "
                                  "Options are 'quiet' or 'verbose'."));
 
       epsilon = prm.get_double("value");

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -524,7 +524,7 @@ Parameters::CahnHilliard::declare_parameters(ParameterHandler &prm)
         "verbosity",
         "quiet",
         Patterns::Selection("quiet|verbose"),
-        "Display the value of epsilon for each time iteration is set to verbose");
+        "Display the value of epsilon for each time iteration if set to verbose");
     }
     prm.leave_subsection();
   }

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -570,8 +570,9 @@ Parameters::CahnHilliard::parse_parameters(ParameterHandler    &prm,
             Parameters::EpsilonVerbosity::verbose;
         }
       else
-        AssertThrow(false,ExcMessage("Invalid epsilon verbosity. "
-                                 "Options are 'quiet' or 'verbose'."));
+        AssertThrow(false,
+                    ExcMessage("Invalid epsilon verbosity. "
+                               "Options are 'quiet' or 'verbose'."));
 
       epsilon = prm.get_double("value");
       epsilon *= dimensions.cahn_hilliard_epsilon_scaling;

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -519,6 +519,12 @@ Parameters::CahnHilliard::declare_parameters(ParameterHandler &prm)
         "1.0",
         Patterns::Double(),
         "Parameter linked to the interface thickness. Should always be bigger than the characteristic size of the smallest element");
+
+      prm.declare_entry(
+        "verbosity",
+        "quiet",
+        Patterns::Selection("quiet|verbose"),
+        "Display the value of epsilon for each time iteration is set to verbose");
     }
     prm.leave_subsection();
   }
@@ -552,6 +558,20 @@ Parameters::CahnHilliard::parse_parameters(ParameterHandler    &prm,
       else
         throw(std::runtime_error("Invalid epsilon setting strategy. "
                                  "Options are 'automatic' or 'manual'."));
+
+      const std::string op_epsilon_verbosity = prm.get("verbosity");
+      if (op_epsilon_verbosity == "quiet")
+        {
+          CahnHilliard::epsilon_verbosity = Parameters::EpsilonVerbosity::quiet;
+        }
+      else if (op_epsilon_verbosity == "verbose")
+        {
+          CahnHilliard::epsilon_verbosity =
+            Parameters::EpsilonVerbosity::verbose;
+        }
+      else
+        throw(std::runtime_error("Invalid epsilon verbosity. "
+                                 "Options are 'quiet' or 'verbose'."));
 
       epsilon = prm.get_double("value");
       epsilon *= dimensions.cahn_hilliard_epsilon_scaling;

--- a/source/solvers/cahn_hilliard.cc
+++ b/source/solvers/cahn_hilliard.cc
@@ -695,6 +695,14 @@ CahnHilliard<dim>::postprocess(bool first_iteration)
         }
     }
 
+  if (simulation_parameters.multiphysics.cahn_hilliard_parameters
+        .epsilon_verbosity == Parameters::EpsilonVerbosity::verbose)
+    {
+      double epsilon = GridTools::minimal_cell_diameter(*triangulation);
+      announce_string(this->pcout, "Epsilon value");
+      this->pcout << "Epsilon value: " << epsilon << std::endl;
+    }
+
   if (simulation_parameters.post_processing.calculate_phase_statistics)
     {
       calculate_phase_statistics();


### PR DESCRIPTION
### Description

It is often useful for the user to know the exact value of the interface thickness when it is determined automatically. Hence a verbosity parameter was added to the interface thickness parameter to display it at every iteration and make sure it remains coherent with the problem under study.
### Testing

An application test was added to make sure any future change to the code do not break the interface thickness computation (whether in deal.ii or lethe)

### Documentation
This pull requests adds a new parameter in the Cahn-Hilliard subsection of the .prm file. The documentation was modified accordingly and also made clearer.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Lethe documentation is up to date
- [x] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] The PR description is cleaned and ready for merge