### PR TITLE
Fix norm used in matrix for DCDD

### DIFF
--- a/source/solvers/tracer_assemblers.cc
+++ b/source/solvers/tracer_assemblers.cc
@@ -66,10 +66,14 @@ TracerAssemblerCore<dim>::assemble_matrix(TracerScratchData<dim> &scratch_data,
       const Tensor<2, dim> rr          = outer_product(r, r);
       const Tensor<2, dim> dcdd_factor = rr - k_corr;
 
-
-      const double d_vdcdd = order * (0.5 * h * h) *
-                             (velocity.norm() * velocity.norm()) *
-                             pow(tracer_gradient_for_dcdd_norm * h, order - 1);
+      // If the method is not steady, we use the previous gradient to calculate
+      // the DCDD schock capture term and consequently we do not need an
+      // estimation of the derivative of the vdcdd term.
+      const double d_vdcdd =
+        is_steady(method) ?
+          order * (0.5 * h * h) * (velocity.norm() * velocity.norm()) *
+            pow(tracer_gradient_for_dcdd_norm * h, order - 1) :
+          0;
 
 
 

--- a/source/solvers/tracer_assemblers.cc
+++ b/source/solvers/tracer_assemblers.cc
@@ -55,7 +55,7 @@ TracerAssemblerCore<dim>::assemble_matrix(TracerScratchData<dim> &scratch_data,
       const double order = scratch_data.fe_values_tracer.get_fe().degree;
 
       const double vdcdd = (0.5 * h) * (velocity.norm() * velocity.norm()) *
-                           pow(tracer_gradient.norm() * h, order);
+                           pow(tracer_gradient_for_dcdd.norm() * h, order);
 
       const double   tolerance = 1e-12;
       Tensor<1, dim> s         = velocity / (velocity.norm() + tolerance);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The tracer matrix assembler was using the current tracer gradient in the jacobian matrix but not in the residual for the calculation of the artifcial shock capture viscosity. This is very bad because the jacobian matrix becomes wrong and it is unclear if the solver will converge in this case. Furthermore, in the case of transient simulations, the solver was still trying to estimate the gradient of the vdcdd diffusivity, which is not meaningful because that gradient is zero since we are using the previous time step gradient.

### Solution

This PR fixes this issue by using the correct jacobian matrix implementation which uses the previous time step value of the gradient of the tracer for the DCDD calculation.


Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Lethe documentation is up to date
- [X] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [X] The branch is rebased onto master
- [X] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] If the fix is temporary, an issue is opened
- [X] The PR description is cleaned and ready for merge