### PR TITLE
Fix simulation restart when using averaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-09-30
+
+### Fixed
+
+- MINOR Simulations with time-averaging of the velocity fields could be unable to restart when the domain was very large due to the fact that the restart vectors were read into the wrong vectors (locally_owned instead of locally_relevant). This PR fixes this. This also ensures that Lethe is able to restart with a different core-count than what was used to generate the restart file. [#1300](https://github.com/chaos-polymtl/lethe/pull/1300)
+
 ## [Master] - 2024-09-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- MINOR Simulations with time-averaging of the velocity fields could be unable to restart when the domain was very large due to the fact that the restart vectors were read into the wrong vectors (locally_owned instead of locally_relevant). This PR fixes this. This also ensures that Lethe is able to restart with a different core-count than what was used to generate the restart file. [#1300](https://github.com/chaos-polymtl/lethe/pull/1300)
+- MINOR Simulations with time-averaging of the velocity fields were unable to restart when the domain was very large due to the fact that the restart vectors were read into the wrong vectors (locally_owned instead of locally_relevant). This PR fixes this. This also ensures that Lethe is able to restart with a different core-count than what was used to generate the restart file. [#1300](https://github.com/chaos-polymtl/lethe/pull/1300)
 
 ## [Master] - 2024-09-26
 

--- a/include/solvers/postprocessing_velocities.h
+++ b/include/solvers/postprocessing_velocities.h
@@ -138,7 +138,8 @@ public:
 
   /**
    * @brief Initialize all the important vectors for the average velocities and
-   * reynolds stresses calculation.
+   * reynolds stresses calculation. This includes the vector for the
+   * checkpoints.
    *
    * @param[in] locally_owned_dofs The owned dofs.
    *
@@ -156,23 +157,6 @@ public:
                      const DofsType     &locally_relevant_dofs,
                      const unsigned int &dofs_per_vertex,
                      const MPI_Comm     &mpi_communicator);
-
-  /**
-   * @brief Initialize all the sum vectors for the average velocities and reynolds
-   *  stresses storage.
-   *
-   * @param[in] locally_owned_dofs The owned dofs.
-   *
-   * @param[in] locally_owned_rs_components The owned Reynolds stress
-   * components.
-   *
-   * @param[in] mpi_communicator The communicator information.
-   */
-  void
-  initialize_checkpoint_vectors(const DofsType &locally_owned_dofs,
-                                const DofsType &locally_relevant_dofs,
-                                const MPI_Comm &mpi_communicator);
-
 
   /**
    * @brief Prepare average velocity object for dynamic mesh adaptation.

--- a/include/solvers/postprocessing_velocities.h
+++ b/include/solvers/postprocessing_velocities.h
@@ -206,6 +206,22 @@ public:
   std::vector<VectorType *>
   read(const std::string &prefix);
 
+
+  /**
+   * @brief Sanitize the average velocity object after a checkpoint has been read by
+   * resetting all of the locally_owned vectors using the locally_relevant
+   * vectors. This is necessary because only the locally_relevant_vectors are
+   * saved, but the calculation routines expect that the content of the
+   * locally_owned vectors match that of the locally_relevant vectors.
+   */
+  void
+  sanitize_after_restart()
+  {
+    sum_velocity_dt               = sum_velocity_dt_with_ghost_cells;
+    sum_reynolds_normal_stress_dt = sum_rns_dt_with_ghost_cells;
+    sum_reynolds_shear_stress_dt  = sum_rss_dt_with_ghost_cells;
+  }
+
 private:
   /**
    * @brief Inverse for total time for averaging.

--- a/source/solvers/fluid_dynamics_block.cc
+++ b/source/solvers/fluid_dynamics_block.cc
@@ -776,14 +776,6 @@ FluidDynamicsBlock<dim>::setup_dofs_fd()
         this->locally_relevant_dofs,
         this->fe->n_dofs_per_vertex(),
         this->mpi_communicator);
-
-      if (this->simulation_parameters.restart_parameters.checkpoint)
-        {
-          this->average_velocities->initialize_checkpoint_vectors(
-            this->locally_owned_dofs,
-            this->locally_relevant_dofs,
-            this->mpi_communicator);
-        }
     }
 
 

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -144,14 +144,6 @@ FluidDynamicsMatrixBased<dim>::setup_dofs_fd()
         this->locally_relevant_dofs,
         this->fe->n_dofs_per_vertex(),
         this->mpi_communicator);
-
-      if (this->simulation_parameters.restart_parameters.checkpoint)
-        {
-          this->average_velocities->initialize_checkpoint_vectors(
-            this->locally_owned_dofs,
-            this->locally_relevant_dofs,
-            this->mpi_communicator);
-        }
     }
 
   double global_volume =

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -2185,14 +2185,6 @@ FluidDynamicsMatrixFree<dim>::setup_dofs_fd()
       this->multiphysics_average_velocities.reinit(this->locally_owned_dofs,
                                                    this->locally_relevant_dofs,
                                                    this->mpi_communicator);
-
-      if (this->simulation_parameters.restart_parameters.checkpoint)
-        {
-          this->average_velocities->initialize_checkpoint_vectors(
-            this->locally_owned_dofs,
-            this->locally_relevant_dofs,
-            this->mpi_communicator);
-        }
     }
 
   double global_volume =

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1907,7 +1907,10 @@ NavierStokesBase<dim, VectorType, DofsType>::set_solution_from_checkpoint(
       previous_solutions[i] = distributed_previous_solutions[i];
     }
 
-  this->average_velocities->sanitize_after_restart();
+  if (simulation_parameters.post_processing.calculate_average_velocities ||
+      this->simulation_parameters.initial_condition->type ==
+        Parameters::InitialConditionType::average_velocity_profile)
+    this->average_velocities->sanitize_after_restart();
 }
 
 template <int dim, typename VectorType, typename DofsType>

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1906,6 +1906,8 @@ NavierStokesBase<dim, VectorType, DofsType>::set_solution_from_checkpoint(
     {
       previous_solutions[i] = distributed_previous_solutions[i];
     }
+
+  this->average_velocities->sanitize_after_restart();
 }
 
 template <int dim, typename VectorType, typename DofsType>

--- a/source/solvers/postprocessing_velocities.cc
+++ b/source/solvers/postprocessing_velocities.cc
@@ -396,9 +396,9 @@ std::vector<VectorType *>
 AverageVelocities<dim, VectorType, DofsType>::read(const std::string &prefix)
 {
   std::vector<VectorType *> sum_vectors;
-  sum_vectors.push_back(&sum_velocity_dt);
-  sum_vectors.push_back(&sum_reynolds_normal_stress_dt);
-  sum_vectors.push_back(&sum_reynolds_shear_stress_dt);
+  sum_vectors.push_back(&sum_velocity_dt_with_ghost_cells);
+  sum_vectors.push_back(&sum_rns_dt_with_ghost_cells);
+  sum_vectors.push_back(&sum_rss_dt_with_ghost_cells);
 
 
   std::string   filename = prefix + ".averagevelocities";

--- a/source/solvers/postprocessing_velocities.cc
+++ b/source/solvers/postprocessing_velocities.cc
@@ -310,6 +310,18 @@ AverageVelocities<dim, VectorType, DofsType>::initialize_vectors(
   sum_reynolds_shear_stress_dt.reinit(locally_owned_dofs, mpi_communicator);
   reynolds_shear_stresses.reinit(locally_owned_dofs, mpi_communicator);
   get_rss.reinit(locally_owned_dofs, locally_relevant_dofs, mpi_communicator);
+
+  // Initializing vector with locally_relevant_dofs because writing checkpoint
+  // needs to read ghost cells.
+  sum_velocity_dt_with_ghost_cells.reinit(locally_owned_dofs,
+                                          locally_relevant_dofs,
+                                          mpi_communicator);
+  sum_rns_dt_with_ghost_cells.reinit(locally_owned_dofs,
+                                     locally_relevant_dofs,
+                                     mpi_communicator);
+  sum_rss_dt_with_ghost_cells.reinit(locally_owned_dofs,
+                                     locally_relevant_dofs,
+                                     mpi_communicator);
 }
 
 template <int dim, typename VectorType, typename DofsType>
@@ -344,26 +356,6 @@ AverageVelocities<dim, VectorType, DofsType>::post_mesh_adaptation()
   sum_rss_dt_with_ghost_cells      = sum_reynolds_shear_stress_dt;
 
   update_average_velocities();
-}
-
-template <int dim, typename VectorType, typename DofsType>
-void
-AverageVelocities<dim, VectorType, DofsType>::initialize_checkpoint_vectors(
-  const DofsType &locally_owned_dofs,
-  const DofsType &locally_relevant_dofs,
-  const MPI_Comm &mpi_communicator)
-{
-  // Initializing vector with locally_relevant_dofs because writing checkpoint
-  // needs to read ghost cells.
-  sum_velocity_dt_with_ghost_cells.reinit(locally_owned_dofs,
-                                          locally_relevant_dofs,
-                                          mpi_communicator);
-  sum_rns_dt_with_ghost_cells.reinit(locally_owned_dofs,
-                                     locally_relevant_dofs,
-                                     mpi_communicator);
-  sum_rss_dt_with_ghost_cells.reinit(locally_owned_dofs,
-                                     locally_relevant_dofs,
-                                     mpi_communicator);
 }
 
 template <int dim, typename VectorType, typename DofsType>


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

There was an issue where simulation restarts would crash on large parallel simulation when the time-averaging of the velocity was enabled. This issue was caused by the fact that the vectors that were checkpointed were the locally_relevant solutions but the restart was reading into the locally_owned solutions.

### Solution

I have fixed this by reading the restart into the locally_relevant solutions. However, I had to add a function to manually sanitize the time_averaging operator because the locally_owned vectors were now empty.

### Testing

This should not affect any of the current test results. I do not know if it is necessary to add a new tests since restart tests are cumbersome. @lpsaavedra what do you think?

### Documentation

No changes to documentation.

### Miscellaneous (will be removed when merged)


### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Lethe documentation is up to date
- [X] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [X] The branch is rebased onto master
- [X] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] If the fix is temporary, an issue is opened
- [X] The PR description is cleaned and ready for merge