### PR TITLE
Installation instructions with faster cloning

### DIFF
--- a/doc/source/installation/apple_arm.rst
+++ b/doc/source/installation/apple_arm.rst
@@ -26,7 +26,7 @@ To install the dependencies (mpi, p4est, trilinos and METIS) all together using 
 
 Clone the candi git repository in a folder of your choice  (e.g. ``$HOME/software/``). You can edit the ``candi.cfg`` file if you want to force the installation of the deal.II master version instead of the current stable version by setting ``DEAL_II_VERSION=master`` on line 97. Under Apple ARM, we only recommend the installation of the required libraries, namely parmetis, trilinos and p4est.
 
-To ensure that the Lethe test suite works, deal.II must be configured with p4est version 2.3.6 which is the current default candi version of p4est. Otherwise, application tests which include restart files will fail.
+To ensure that the Lethe test suite works, deal.II must be configured with p4est version 2.3.6, the current default candi version of p4est. Otherwise, application tests that include restart files will fail.
 
 From the candi folder, the installation of candi can be launched using:
 

--- a/doc/source/installation/apple_arm.rst
+++ b/doc/source/installation/apple_arm.rst
@@ -26,7 +26,7 @@ To install the dependencies (mpi, p4est, trilinos and METIS) all together using 
 
 Clone the candi git repository in a folder of your choice  (e.g. ``$HOME/software/``). You can edit the ``candi.cfg`` file if you want to force the installation of the deal.II master version instead of the current stable version by setting ``DEAL_II_VERSION=master`` on line 97. Under Apple ARM, we only recommend the installation of the required libraries, namely parmetis, trilinos and p4est.
 
-To ensure that the Lethe test suite works, deal.II must be configured with p4est version 2.3.6. 
+To ensure that the Lethe test suite works, deal.II must be configured with p4est version 2.3.6 which is the current default candi version of p4est. Otherwise, application tests which include restart files will fail.
 
 From the candi folder, the installation of candi can be launched using:
 

--- a/doc/source/installation/apple_arm.rst
+++ b/doc/source/installation/apple_arm.rst
@@ -26,25 +26,7 @@ To install the dependencies (mpi, p4est, trilinos and METIS) all together using 
 
 Clone the candi git repository in a folder of your choice  (e.g. ``$HOME/software/``). You can edit the ``candi.cfg`` file if you want to force the installation of the deal.II master version instead of the current stable version by setting ``DEAL_II_VERSION=master`` on line 97. Under Apple ARM, we only recommend the installation of the required libraries, namely parmetis, trilinos and p4est.
 
-To ensure that the Lethe test suite works, deal.II must be configured with p4est version 2.3.6. In the subfolder ``deal.II-toolchain/packages/``, open the ``p4est.package`` file with a text editor and change the following lines:
-
-+--------+------------------------------------------------+-------------------------------------------------------------------------------+
-| line # | initial line                                   | changed line                                                                  |
-+========+================================================+===============================================================================+
-|     9  | ``VERSION=2.3.2``                              | ``#VERSION=2.3.2``                                                            |
-+--------+------------------------------------------------+-------------------------------------------------------------------------------+
-|     10 | ``CHECKSUM=076df9e...``                        | ``#CHECKSUM=076df9e...``                                                      |
-+--------+------------------------------------------------+-------------------------------------------------------------------------------+
-|     11 | ``CHECKSUM="${CHECKSUM} b41c8ef29ca...``       | ``#CHECKSUM="${CHECKSUM} b41c8ef29ca...``                                     |
-+--------+------------------------------------------------+-------------------------------------------------------------------------------+
-|     12 | ``CHECKSUM="${CHECKSUM} 0ea6e4806b6...``       | ``#CHECKSUM="${CHECKSUM} 0ea6e4806b6...``                                     |
-+--------+------------------------------------------------+-------------------------------------------------------------------------------+
-|     13 |                                                | .. code-block:: text                                                          |
-|        |                                                |   :class: copy-button                                                         |
-|        |                                                |                                                                               |
-|        |                                                |   VERSION=2.3.6                                                               |
-|        |                                                |   CHECKSUM=4b35d9cc374e3b05cd29c552070940124f04af8f8e5e01ff046e39833de5e153   |
-+--------+------------------------------------------------+-------------------------------------------------------------------------------+
+To ensure that the Lethe test suite works, deal.II must be configured with p4est version 2.3.6. 
 
 From the candi folder, the installation of candi can be launched using:
 
@@ -134,7 +116,7 @@ Clone lethe from the `official repository <https://github.com/chaos-polymtl/leth
 .. code-block:: text
   :class: copy-button
 
-  git clone https://github.com/chaos-polymtl/lethe 
+  git clone https://github.com/chaos-polymtl/lethe --single-branch
 
 Create a build folder at the same level as the lethe folder
 

--- a/doc/source/installation/digital_alliance.rst
+++ b/doc/source/installation/digital_alliance.rst
@@ -92,7 +92,7 @@ In the ``$HOME/lethe`` directory, download Lethe:
 .. code-block:: text
   :class: copy-button
 
-  git clone https://github.com/chaos-polymtl/lethe.git
+  git clone https://github.com/chaos-polymtl/lethe.git --single-branch
 
 To install Lethe in the ``$HOME/lethe/inst`` directory (applications will be in ``inst/bin``), run in the ``$HOME/lethe/build`` directory:
 

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -95,7 +95,7 @@ A dependency required by Lethe, and that deal.II needs to be compiled with, is m
 
 Other packages can be disabled by simply commenting out the lines (adding a ``#`` at the beginning of the lines)
 
-To ensure that the Lethe test suite works, deal.II must be configured with p4est version 2.3.6 which is the current default candi version of p4est. Otherwise, application tests which include restart files will fail.
+To ensure that the Lethe test suite works, deal.II must be configured with p4est version 2.3.6, the current default candi version of p4est. Otherwise, application tests that include restart files will fail.
 
 From the candi folder, the installation of candi can be launched using:
 

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -176,7 +176,7 @@ Lethe comes pre-packaged with an extensive test suit for all of its modules. It 
 where $numprocs can be the number of physical cores on your machine.
 
 .. warning:: 
-  The lethe test suites requires that deal.II be configured with p4est 2.3.6, otherwise the test which include restart files will fail.
+  The lethe test suites requires that deal.II be configured with p4est 2.3.6, otherwise the test that include restart files will fail.
 
 
 .. _install-deal.II-manually:

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -95,7 +95,7 @@ A dependency required by Lethe, and that deal.II needs to be compiled with, is m
 
 Other packages can be disabled by simply commenting out the lines (adding a ``#`` at the beginning of the lines)
 
-To ensure that the Lethe test suite works, deal.II must be configured with p4est version 2.3.6.
+To ensure that the Lethe test suite works, deal.II must be configured with p4est version 2.3.6 which is the current default candi version of p4est. Otherwise, application tests which include restart files will fail.
 
 From the candi folder, the installation of candi can be launched using:
 

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -95,25 +95,7 @@ A dependency required by Lethe, and that deal.II needs to be compiled with, is m
 
 Other packages can be disabled by simply commenting out the lines (adding a ``#`` at the beginning of the lines)
 
-To ensure that the Lethe test suite works, deal.II must be configured with p4est version 2.3.6. In the subfolder ``deal.II-toolchain/packages/``, open the ``p4est.package`` file with a text editor and change the following lines:
-
-+--------+------------------------------------------------+------------------------------------------------------------------------------+
-| line # | initial line                                   | changed line                                                                 |
-+========+================================================+==============================================================================+
-|     9  | ``VERSION=2.3.2``                              | ``#VERSION=2.3.2``                                                           |
-+--------+------------------------------------------------+------------------------------------------------------------------------------+
-|     10 | ``CHECKSUM=076df9e...``                        | ``#CHECKSUM=076df9e...``                                                     |
-+--------+------------------------------------------------+------------------------------------------------------------------------------+
-|     11 | ``CHECKSUM="${CHECKSUM} b41c8ef29ca...``       | ``#CHECKSUM="${CHECKSUM} b41c8ef29ca...``                                    |
-+--------+------------------------------------------------+------------------------------------------------------------------------------+
-|     12 | ``CHECKSUM="${CHECKSUM} 0ea6e4806b6...``       | ``#CHECKSUM="${CHECKSUM} 0ea6e4806b6...``                                    |
-+--------+------------------------------------------------+------------------------------------------------------------------------------+
-|     13 |                                                | .. code-block:: text                                                         |
-|        |                                                |   :class: copy-button                                                        |
-|        |                                                |                                                                              |
-|        |                                                |   VERSION=2.3.6                                                              |
-|        |                                                |   CHECKSUM=4b35d9cc374e3b05cd29c552070940124f04af8f8e5e01ff046e39833de5e153  |
-+--------+------------------------------------------------+------------------------------------------------------------------------------+
+To ensure that the Lethe test suite works, deal.II must be configured with p4est version 2.3.6.
 
 From the candi folder, the installation of candi can be launched using:
 
@@ -150,7 +132,7 @@ Clone Lethe from the `Lethe official repository <https://github.com/chaos-polymt
 .. code-block:: text
   :class: copy-button
 
-  git clone https://github.com/chaos-polymtl/lethe 
+  git clone https://github.com/chaos-polymtl/lethe --single-branch
 
 Create a build folder at the same level as the lethe folder
 
@@ -194,7 +176,7 @@ Lethe comes pre-packaged with an extensive test suit for all of its modules. It 
 where $numprocs can be the number of physical cores on your machine.
 
 .. warning:: 
-  The lethe test suites requires that deal.II be configured with p4est 2.2.1, otherwise the test which include restart files will fail.
+  The lethe test suites requires that deal.II be configured with p4est 2.3.6, otherwise the test which include restart files will fail.
 
 
 .. _install-deal.II-manually:

--- a/doc/source/installation/windows_wsl.rst
+++ b/doc/source/installation/windows_wsl.rst
@@ -231,7 +231,7 @@ Do not forget the ``.`` at the end of the command, which means "here".
   +--------+------------------------------------------------+-----------------------------------------------+
 
   * save and close
-  * To ensure that the Lethe test suite works, deal.II must be configured with p4est version 2.3.6 which is the current default candi version of p4est. Otherwise, application tests which include restart files will fail.
+  * To ensure that the Lethe test suite works, deal.II must be configured with p4est version 2.3.6, the current default candi version of p4est. Otherwise, application tests that include restart files will fail.
   
 6. |linux_shell| Still in the candi subfolder, run candi installation script:
 

--- a/doc/source/installation/windows_wsl.rst
+++ b/doc/source/installation/windows_wsl.rst
@@ -231,31 +231,7 @@ Do not forget the ``.`` at the end of the command, which means "here".
   +--------+------------------------------------------------+-----------------------------------------------+
 
   * save and close
-  * still in the subfolder ``deal.II-toolchain/packages/``, open the ``p4est.package`` file with notepad and change the following lines:
-
-  .. tip::
-    The prefix ``#`` is used to comment a line. Here we are commenting lines 9 to 12 and adding 2 new lines to change the p4est version.
-
-  +--------+------------------------------------------------+-------------------------------------------------------------------------------+
-  | line # | initial line                                   | changed line                                                                  |
-  +========+================================================+===============================================================================+
-  |     9  | ``VERSION=2.3.2``                              | ``#VERSION=2.3.2``                                                            |
-  +--------+------------------------------------------------+-------------------------------------------------------------------------------+
-  |     10 | ``CHECKSUM=076df9e...``                        | ``#CHECKSUM=076df9e...``                                                      |
-  +--------+------------------------------------------------+-------------------------------------------------------------------------------+
-  |     11 | ``CHECKSUM="${CHECKSUM} b41c8ef29ca...``       | ``#CHECKSUM="${CHECKSUM} b41c8ef29ca...``                                     |
-  +--------+------------------------------------------------+-------------------------------------------------------------------------------+
-  |     12 | ``CHECKSUM="${CHECKSUM} 0ea6e4806b6...``       | ``#CHECKSUM="${CHECKSUM} 0ea6e4806b6...``                                     |
-  +--------+------------------------------------------------+-------------------------------------------------------------------------------+
-  |     13 |                                                | .. code-block:: text                                                          |
-  |        |                                                |   :class: copy-button                                                         |
-  |        |                                                |                                                                               |
-  |        |                                                |   VERSION=2.3.6                                                               |
-  |        |                                                |   CHECKSUM=4b35d9cc374e3b05cd29c552070940124f04af8f8e5e01ff046e39833de5e153   |
-  +--------+------------------------------------------------+-------------------------------------------------------------------------------+
-
-  * save and close
-
+  
 6. |linux_shell| Still in the candi subfolder, run candi installation script:
 
 .. code-block:: text
@@ -327,7 +303,7 @@ After installation is complete, the folder structure will be:
   :class: copy-button
 
   cd lethe
-  git clone https://github.com/chaos-polymtl/lethe git
+  git clone https://github.com/chaos-polymtl/lethe --single-branch
 
 3. |linux_shell| Build lethe:
 
@@ -335,7 +311,7 @@ After installation is complete, the folder structure will be:
   :class: copy-button
 
   cd build
-  cmake ../git -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../inst/
+  cmake ../lethe -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../inst/
 
 4. |linux_shell| Compile lethe:
 

--- a/doc/source/installation/windows_wsl.rst
+++ b/doc/source/installation/windows_wsl.rst
@@ -231,6 +231,7 @@ Do not forget the ``.`` at the end of the command, which means "here".
   +--------+------------------------------------------------+-----------------------------------------------+
 
   * save and close
+  * To ensure that the Lethe test suite works, deal.II must be configured with p4est version 2.3.6 which is the current default candi version of p4est. Otherwise, application tests which include restart files will fail.
   
 6. |linux_shell| Still in the candi subfolder, run candi installation script:
 
@@ -240,7 +241,7 @@ Do not forget the ``.`` at the end of the command, which means "here".
   ./candi.sh -j$numprocs
 
 Where ``$numprocs`` corresponds to the number of processors used for the compilation:
-  * if you have less than 8Gb of RAM, use 1 to 2 procs: ``./candi.sh -j1`` or ``./candi.sh -j2``
+  * if you have less than 8Gb of RAM, use 2 procs: ``./candi.sh -j2``
   * if you have 16Gb of RAM and above, ``$numprocs`` can be the number of physical cores minus 1. For instance, for a computer with 6 physical cores: ``./candi.sh -j5``
 
 .. tip::


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The installation instructions using the git clone command without specifying that only the master branch needs to be pulled. This leads to people downloading the whole repository (800MB) vs the 120MB that would be sufficient for all their needs. Furthermore, the installation instructions mention that the p4est version of candi must be changed. This is not necessary anymore since candi is packaged by default with 2.3.6.

EDIT: The installation instructions also suggest using the package manager in ubuntu which is not a possibility right now since there are no 9.6 packages in ubuntu. I have fixed this part by commenting the code out and adding a warning.

I have changed the installation instructions to ensure that only the master branch is cloned with cloning. If someone needs other branches they can just check them out manually. Furthermore, I have removed the blocks about changing the version of p4est within candi.




Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planed, an issue is opened
- [x] The PR description is cleaned and ready for merge