### PR TITLE
Add a checkbox in PR templates regarding the license in the header

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_bug-fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_bug-fix.md
@@ -34,6 +34,7 @@ See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing
 
 Code related list:
 - [ ] All in-code documentation related to this PR is up to date (Doxygen format)
+- [ ] If new files are added, the license is included in the header
 - [ ] Lethe documentation is up to date
 - [ ] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
 - [ ] The branch is rebased onto master

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_bug-fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_bug-fix.md
@@ -34,7 +34,7 @@ See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing
 
 Code related list:
 - [ ] All in-code documentation related to this PR is up to date (Doxygen format)
-- [ ] If new files are added, the license is included in the header
+- [ ] Copyright headers are present and up to date
 - [ ] Lethe documentation is up to date
 - [ ] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
 - [ ] The branch is rebased onto master

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_documentation.md
@@ -18,6 +18,7 @@ See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing
 
 Code related list:
 - [ ] All in-code documentation related to this PR is up to date (Doxygen format)
+- [ ] If new files are added, the license is included in the header
 - [ ] Lethe documentation is up to date
 - [ ] The branch is rebased onto master
 - [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_documentation.md
@@ -18,7 +18,7 @@ See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing
 
 Code related list:
 - [ ] All in-code documentation related to this PR is up to date (Doxygen format)
-- [ ] If new files are added, the license is included in the header
+- [ ] Copyright headers are present and up to date
 - [ ] Lethe documentation is up to date
 - [ ] The branch is rebased onto master
 - [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_example.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_example.md
@@ -19,7 +19,7 @@ See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing
 
 Code related list:
 - [ ] Lethe documentation is up to date
-- [ ] If new files are added, the license is included in the header
+- [ ] Copyright headers are present and up to date
 - [ ] The branch is rebased onto master
 - [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
 - [ ] Links are added to parent .rst files

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_example.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_example.md
@@ -19,6 +19,7 @@ See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing
 
 Code related list:
 - [ ] Lethe documentation is up to date
+- [ ] If new files are added, the license is included in the header
 - [ ] The branch is rebased onto master
 - [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
 - [ ] Links are added to parent .rst files

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_new-feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_new-feature.md
@@ -31,7 +31,7 @@ See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing
 
 Code related list:
 - [ ] All in-code documentation related to this PR is up to date (Doxygen format)
-- [ ] If new files are added, the license is included in the header
+- [ ] Copyright headers are present and up to date
 - [ ] Lethe documentation is up to date
 - [ ] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
 - [ ] The branch is rebased onto master

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_new-feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_new-feature.md
@@ -31,6 +31,7 @@ See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing
 
 Code related list:
 - [ ] All in-code documentation related to this PR is up to date (Doxygen format)
+- [ ] If new files are added, the license is included in the header
 - [ ] Lethe documentation is up to date
 - [ ] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
 - [ ] The branch is rebased onto master

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_refactoring.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_refactoring.md
@@ -29,7 +29,7 @@ See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing
 
 Code related list:
 - [ ] All in-code documentation related to this PR is up to date (Doxygen format)
-- [ ] If new files are added, the license is included in the header
+- [ ] Copyright headers are present and up to date
 - [ ] Lethe documentation is up to date
 - [ ] The branch is rebased onto master
 - [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template_refactoring.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template_refactoring.md
@@ -29,6 +29,7 @@ See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing
 
 Code related list:
 - [ ] All in-code documentation related to this PR is up to date (Doxygen format)
+- [ ] If new files are added, the license is included in the header
 - [ ] Lethe documentation is up to date
 - [ ] The branch is rebased onto master
 - [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the content of the new feature
       What are the motivations? 
       How is it integrated to the current code? -->

Since Lethe is relicensed, adding a checkbox to the Github PR templates would help ensure that new files have the proper header when added.

### Testing

Not applicable.

### Documentation

Not applicable.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Lethe documentation is up to date
- [x] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge