### PR TITLE
Remove colorized cylinder shell parameter

### DIFF
--- a/doc/source/parameters/cfd/mesh.rst
+++ b/doc/source/parameters/cfd/mesh.rst
@@ -6,13 +6,13 @@ This subsection provides information of the simulation geometry and its mesh. Th
 .. code-block:: text
 
   subsection mesh
-    # Type of mesh. Choices are <gmsh|dealii|cylinder|colorized_cylinder_shell|periodic_hills>
+    # Type of mesh. Choices are <gmsh|dealii|cylinder|periodic_hills>
     set type = dealii
 
     # GMSH file name
     set file name = none
 
-    # Grid arguments for dealii, cylinder, colorized_cylinder_shell and periodic_hills
+    # Grid arguments for dealii, cylinder and periodic_hills
     set grid type      = hyper_cube
     set grid arguments = -1 : 1 : false
 
@@ -57,7 +57,6 @@ This subsection provides information of the simulation geometry and its mesh. Th
     * ``gmsh``: if this type is chosen, a ``.msh`` file generated from GMSH can be used. In this case, the grid file name must be specified in the ``file name`` variable.
     * ``dealii``: if this type is chosen, the deal.II grid generator class can be used. For additional documentation on these grids, you can consult the deal.II documentation for the `GridGenerator <https://www.dealii.org/current/doxygen/deal.II/namespaceGridGenerator.html>`_ . The type of grid is specified by the ``grid type`` parameter and the arguments used for grid generation by the ``grid arguments`` parameter. 
     * ``periodic_hills``: if this type is chosen a mesh for the periodic hills CFD benchmark is created. For more details on this type of mesh and its grid arguments refer to :doc:`../../examples/incompressible-flow/3d-flow-over-periodic-hills/3d-flow-over-periodic-hills`.
-    * ``colorized_cylinder_shell``: if this type is chosen, the ``grid arguments`` must follow their `related deal.II documentation for a cylinder shell <https://www.dealii.org/current/doxygen/deal.II/namespaceGridGenerator.html#a760789a93b1e0fe7f5c2675c31b6f14f>`_. The only difference is that this cylinder shell is colorized with boundary ids. Boundary 0 is the inner cylinder, boundary 1 is the outer cylinder, boundary 2 is the bottom surface (z=0) and boundary 3 is the top surface (z=length).
     * ``cylinder``: if this type is chosen, the ``grid type`` must be chosen according to the following figure. The ``classic`` type is equivalent to a subdivided cylinder from deal.II and ``grid arguments`` must follow their `related deal.II documentation for a cylinder <https://www.dealii.org/current/doxygen/deal.II/namespaceGridGenerator.html#a95f6e6a7ae2fe3a862df035dd2cb4467>`_ and this applies to all cylinder grid types.
 
     .. warning::

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1327,8 +1327,7 @@ namespace Parameters
       gmsh,
       dealii,
       periodic_hills,
-      cylinder,
-      colorized_cylinder_shell
+      cylinder
     };
     Type type;
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2246,13 +2246,12 @@ namespace Parameters
   {
     prm.enter_subsection("mesh");
     {
-      prm.declare_entry(
-        "type",
-        "dealii",
-        Patterns::Selection(
-          "gmsh|dealii|periodic_hills|cylinder|colorized_cylinder_shell"),
-        "Type of mesh "
-        "Choices are <gmsh|dealii|periodic_hills|cylinder|colorized_cylinder_shell>.");
+      prm.declare_entry("type",
+                        "dealii",
+                        Patterns::Selection(
+                          "gmsh|dealii|periodic_hills|cylinder"),
+                        "Type of mesh "
+                        "Choices are <gmsh|dealii|periodic_hills|cylinder>.");
 
       prm.declare_entry("file name",
                         "none",
@@ -2363,8 +2362,6 @@ namespace Parameters
           type = Type::periodic_hills;
         else if (op == "cylinder")
           type = Type::cylinder;
-        else if (op == "colorized_cylinder_shell")
-          type = Type::colorized_cylinder_shell;
         else
           throw std::logic_error(
             "Error, invalid mesh type. Choices are gmsh and dealii");


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

The colorized cylinder shell parameter was still in the documentation and the parameters; however, we do not use it anymore, as the mesh was included in deal.II and the implementation was removed from Lethe.

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->

The parameter was completely removed from the documentation and the parameters class.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

No testing required, we were not using it anywhere. 

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] The PR description is cleaned and ready for merge