### PR TITLE
Bug when using multiple manifolds

### DIFF
--- a/include/core/manifolds.h
+++ b/include/core/manifolds.h
@@ -59,7 +59,7 @@ namespace Parameters
     void
     declareDefaultEntry(ParameterHandler &prm, unsigned int i_bc);
     void
-    declare_parameters(ParameterHandler &prm);
+    declare_parameters(ParameterHandler &prm, unsigned int subsection_max_size);
 
     void
     parse_parameters(ParameterHandler &prm);

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -32,6 +32,7 @@ namespace Parameters
   struct SizeOfSubsections
   {
     int boundary_conditions;
+    int manifolds;
   };
 
 

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -471,7 +471,11 @@ get_dimension(const std::string &file_name);
 
 /**
  * @brief Extract the maximum value between the number of boundary conditions and the number of manifolds from the file.
-This value is linked to the "number" string defined in the simulation parameter file. It provides an estimate for the amount of parameters or manifolds and is used to determine the size of the vectors that will store boundary conditions and manifold data. This feature will need to be monitored extensively in the future.
+This value is linked to the "number" string defined in the simulation parameter
+file. It provides an estimate for the amount of parameters or manifolds and is
+used to determine the size of the vectors that will store boundary conditions
+and manifold data. This feature will need to be monitored extensively in the
+future.
  * @param file_name The file name from which the number of boundary conditions
  * is read
  */

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -470,14 +470,13 @@ unsigned int
 get_dimension(const std::string &file_name);
 
 /**
- * @brief Extract the maximum number of boundary conditions from the file.
- * The number of boundary conditions is linked to the string "number" so
- * this feature will need to be monitored extensively in the future.
+ * @brief Extract the maximum value between the number of boundary conditions and the number of manifolds from the file.
+This value is linked to the "number" string defined in the simulation parameter file. It provides an estimate for the amount of parameters or manifolds and is used to determine the size of the vectors that will store boundary conditions and manifold data. This feature will need to be monitored extensively in the future.
  * @param file_name The file name from which the number of boundary conditions
  * is read
  */
 int
-get_max_number_of_boundary_conditions(const std::string &file_name);
+get_max_subsection_size(const std::string &file_name);
 
 /**
  * @brief Return the tensor corresponding to the @p value_string. If the

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -109,7 +109,7 @@ public:
     Parameters::DynamicFlowControl ::declare_parameters(prm);
     particlesParameters = std::make_shared<Parameters::IBParticles<dim>>();
     particlesParameters->declare_parameters(prm);
-    manifolds_parameters.declare_parameters(prm);
+    manifolds_parameters.declare_parameters(prm, size_of_subsections.manifolds);
 
     analytical_solution = new AnalyticalSolutions::AnalyticalSolution<dim>;
     analytical_solution->declare_parameters(prm);

--- a/source/core/manifolds.cc
+++ b/source/core/manifolds.cc
@@ -62,7 +62,8 @@ namespace Parameters
   }
 
   void
-  Manifolds::declare_parameters(ParameterHandler &prm, unsigned int subsection_max_size)
+  Manifolds::declare_parameters(ParameterHandler &prm,
+                                unsigned int      subsection_max_size)
   {
     manifold_point.resize(subsection_max_size);
     manifold_direction.resize(subsection_max_size);
@@ -119,8 +120,7 @@ attach_manifolds_to_triangulation(
           Point<spacedim> circle_center(
             value_string_to_tensor<spacedim>(manifolds.manifold_point[i]));
 
-          SphericalManifold<dim, spacedim> manifold_description(
-            circle_center);
+          SphericalManifold<dim, spacedim> manifold_description(circle_center);
           triangulation.set_manifold(manifolds.id[i], manifold_description);
         }
       else if (manifolds.types[i] ==
@@ -138,8 +138,8 @@ attach_manifolds_to_triangulation(
                 value_string_to_tensor<spacedim>(
                   manifolds.manifold_direction[i]));
 
-              CylindricalManifold<dim, spacedim>
-                manifold_description(cylinder_axis, point_on_axis);
+              CylindricalManifold<dim, spacedim> manifold_description(
+                cylinder_axis, point_on_axis);
               triangulation.set_manifold(manifolds.id[i], manifold_description);
             }
           else

--- a/source/core/manifolds.cc
+++ b/source/core/manifolds.cc
@@ -62,12 +62,11 @@ namespace Parameters
   }
 
   void
-  Manifolds::declare_parameters(ParameterHandler &prm)
+  Manifolds::declare_parameters(ParameterHandler &prm, unsigned int subsection_max_size)
   {
-    max_size = 14;
-    manifold_point.resize(max_size);
-    manifold_direction.resize(max_size);
-    cad_files.resize(max_size);
+    manifold_point.resize(subsection_max_size);
+    manifold_direction.resize(subsection_max_size);
+    cad_files.resize(subsection_max_size);
 
     prm.enter_subsection("manifolds");
     {
@@ -75,9 +74,9 @@ namespace Parameters
                         "0",
                         Patterns::Integer(),
                         "Number of boundary conditions");
-      id.resize(max_size);
-      types.resize(max_size);
-      for (unsigned int i = 0; i < max_size; i++)
+      id.resize(subsection_max_size);
+      types.resize(subsection_max_size);
+      for (unsigned int i = 0; i < subsection_max_size; i++)
         {
           prm.enter_subsection("manifold " + Utilities::int_to_string(i));
           declareDefaultEntry(prm, i);
@@ -120,7 +119,7 @@ attach_manifolds_to_triangulation(
           Point<spacedim> circle_center(
             value_string_to_tensor<spacedim>(manifolds.manifold_point[i]));
 
-          static const SphericalManifold<dim, spacedim> manifold_description(
+          SphericalManifold<dim, spacedim> manifold_description(
             circle_center);
           triangulation.set_manifold(manifolds.id[i], manifold_description);
         }
@@ -139,7 +138,7 @@ attach_manifolds_to_triangulation(
                 value_string_to_tensor<spacedim>(
                   manifolds.manifold_direction[i]));
 
-              static const CylindricalManifold<dim, spacedim>
+              CylindricalManifold<dim, spacedim>
                 manifold_description(cylinder_axis, point_on_axis);
               triangulation.set_manifold(manifolds.id[i], manifold_description);
             }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -68,9 +68,8 @@ namespace Parameters
   get_size_of_subsections(const std::string &file_name)
   {
     SizeOfSubsections sizes;
-    sizes.boundary_conditions =
-      get_max_subsection_size(file_name);
-    sizes.manifolds = get_max_subsection_size(file_name);
+    sizes.boundary_conditions = get_max_subsection_size(file_name);
+    sizes.manifolds           = get_max_subsection_size(file_name);
     return sizes;
   }
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -69,7 +69,8 @@ namespace Parameters
   {
     SizeOfSubsections sizes;
     sizes.boundary_conditions =
-      get_max_number_of_boundary_conditions(file_name);
+      get_max_subsection_size(file_name);
+    sizes.manifolds = get_max_subsection_size(file_name);
     return sizes;
   }
 

--- a/source/core/utilities.cc
+++ b/source/core/utilities.cc
@@ -684,7 +684,7 @@ get_dimension(const std::string &file_name)
 
 
 int
-get_max_number_of_boundary_conditions(const std::string &file_name)
+get_max_subsection_size(const std::string &file_name)
 {
   int max_number_of_boundary_conditions =
     get_max_value_of_parameter(file_name, "number");

--- a/tests/solvers/multiphysics_interface_01.cc
+++ b/tests/solvers/multiphysics_interface_01.cc
@@ -39,7 +39,8 @@ test()
   SimulationParameters<dim>     solver_parameters;
   ParameterHandler              dummy_handler;
   Parameters::SizeOfSubsections size_of_subsections;
-  size_of_subsections.boundary_conditions = 0;
+  size_of_subsections.boundary_conditions = 1;
+  size_of_subsections.manifolds           = 1;
 
   solver_parameters.declare(dummy_handler, size_of_subsections);
   solver_parameters.parse(dummy_handler);


### PR DESCRIPTION


<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

A bug was preventing the use of multiple manifolds. The variable describing the manifold was set as a static const but needed to be modified for every manifold. 

The maximum number of manifolds was also set to 14. To make it more flexible, the method used for the boundary conditions was modified to take the manifolds into account.

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->

removed the static const.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Copyright headers are present and up to date
- [ ] Lethe documentation is up to date
- [ ] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [ ] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge