### PR TITLE
Move boundary conditions of all fluid dynamics solvers to base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-10-09
+
+### Changed
+
+- MAJOR The boundary conditions for the fluid dynamics applications: matrix-based, matrix-free and block applications are now implemented only in the NavierStokesBase class. [#1313](https://github.com/chaos-polymtl/lethe/pull/1313)
+
 ## [Master] - 2024-10-04
 
 ### Changed

--- a/include/solvers/fluid_dynamics_matrix_based.h
+++ b/include/solvers/fluid_dynamics_matrix_based.h
@@ -103,12 +103,6 @@ protected:
   setup_preconditioner() override;
 
   /**
-   * @brief Define the zero constraints used to solve the problem.
-   */
-  void
-  define_zero_constraints();
-
-  /**
    * @brief Define the zero constraints used to solved the problem that change
    * with other physics' solutions.
    *

--- a/include/solvers/fluid_dynamics_matrix_based.h
+++ b/include/solvers/fluid_dynamics_matrix_based.h
@@ -54,12 +54,6 @@ protected:
   setup_dofs_fd() override;
 
   /**
-   * @brief update non zero constraint if the boundary is time-dependent
-   */
-  void
-  update_boundary_conditions();
-
-  /**
    * @brief Sets the initial condition for the solver
    *
    * If the simulation is restarted from a checkpoint, the initial solution

--- a/include/solvers/fluid_dynamics_matrix_based.h
+++ b/include/solvers/fluid_dynamics_matrix_based.h
@@ -103,12 +103,6 @@ protected:
   setup_preconditioner() override;
 
   /**
-   * @brief Define the non-zero constraints used to solve the problem.
-   */
-  void
-  define_non_zero_constraints();
-
-  /**
    * @brief Define the zero constraints used to solve the problem.
    */
   void

--- a/include/solvers/fluid_dynamics_matrix_free.h
+++ b/include/solvers/fluid_dynamics_matrix_free.h
@@ -313,12 +313,6 @@ protected:
   setup_dofs_fd() override;
 
   /**
-   * @brief Update non zero constraints if the boundary is time dependent.
-   */
-  void
-  update_boundary_conditions();
-
-  /**
    * @brief Set the initial conditions for the solver. If the simulation is
    * restarted from a checkpoint, the initial solution setting is bypassed
    * and the checkpoint is instead read.

--- a/include/solvers/fluid_dynamics_matrix_free.h
+++ b/include/solvers/fluid_dynamics_matrix_free.h
@@ -371,12 +371,6 @@ protected:
   calculate_time_derivative_previous_solutions();
 
   /**
-   * @brief Define the non-zero constraints used to solve the problem.
-   */
-  void
-  define_non_zero_constraints();
-
-  /**
    * @brief Define the zero constraints used to solve the problem.
    */
   void

--- a/include/solvers/fluid_dynamics_matrix_free.h
+++ b/include/solvers/fluid_dynamics_matrix_free.h
@@ -371,12 +371,6 @@ protected:
   calculate_time_derivative_previous_solutions();
 
   /**
-   * @brief Define the zero constraints used to solve the problem.
-   */
-  void
-  define_zero_constraints();
-
-  /**
    * @brief Set up appropriate preconditioner.
    *
    */

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -395,6 +395,18 @@ protected:
   set_nodal_values();
 
   /**
+   * @brief Define the non-zero constraints used to solve the problem.
+   */
+  void
+  define_non_zero_constraints();
+
+  /**
+   * @brief Define the zero constraints used to solve the problem.
+   */
+  void
+  define_zero_constraints_global();
+
+  /**
    * @brief Check if a specifique boundary condition exist
    * @param bc, the boundary type that we want to check if it exists
    */

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -404,7 +404,7 @@ protected:
    * @brief Define the zero constraints used to solve the problem.
    */
   void
-  define_zero_constraints_global();
+  define_zero_constraints();
 
   /**
    * @brief Check if a specifique boundary condition exist

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -407,6 +407,13 @@ protected:
   define_zero_constraints();
 
   /**
+   * @brief Update non-zero constraints if the boundary is time dependent.
+   * Note: not implemented for the block fluid dynamics application.
+   */
+  void
+  update_boundary_conditions();
+
+  /**
    * @brief Check if a specifique boundary condition exist
    * @param bc, the boundary type that we want to check if it exists
    */

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -82,7 +82,7 @@ FluidDynamicsMatrixBased<dim>::setup_dofs_fd()
   this->define_non_zero_constraints();
 
   // Zero constraints
-  define_zero_constraints();
+  this->define_zero_constraints();
 
   this->present_solution.reinit(this->locally_owned_dofs,
                                 this->locally_relevant_dofs,
@@ -201,85 +201,6 @@ FluidDynamicsMatrixBased<dim>::update_boundary_conditions()
   auto &nonzero_constraints = this->nonzero_constraints;
   nonzero_constraints.distribute(this->local_evaluation_point);
   this->present_solution = this->local_evaluation_point;
-}
-
-template <int dim>
-void
-FluidDynamicsMatrixBased<dim>::define_zero_constraints()
-{
-  FEValuesExtractors::Vector velocities(0);
-  FEValuesExtractors::Scalar pressure(dim);
-  this->zero_constraints.clear();
-  this->locally_relevant_dofs =
-    DoFTools::extract_locally_relevant_dofs(this->dof_handler);
-  this->zero_constraints.reinit(this->locally_relevant_dofs);
-
-  DoFTools::make_hanging_node_constraints(this->dof_handler,
-                                          this->zero_constraints);
-
-  for (unsigned int i_bc = 0;
-       i_bc < this->simulation_parameters.boundary_conditions.size;
-       ++i_bc)
-    {
-      if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-          BoundaryConditions::BoundaryType::slip)
-        {
-          std::set<types::boundary_id> no_normal_flux_boundaries;
-          no_normal_flux_boundaries.insert(
-            this->simulation_parameters.boundary_conditions.id[i_bc]);
-          VectorTools::compute_no_normal_flux_constraints(
-            this->dof_handler,
-            0,
-            no_normal_flux_boundaries,
-            this->zero_constraints,
-            *this->mapping);
-        }
-      else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-               BoundaryConditions::BoundaryType::periodic)
-        {
-          DoFTools::make_periodicity_constraints(
-            this->dof_handler,
-            this->simulation_parameters.boundary_conditions.id[i_bc],
-            this->simulation_parameters.boundary_conditions.periodic_id[i_bc],
-            this->simulation_parameters.boundary_conditions
-              .periodic_direction[i_bc],
-            this->zero_constraints);
-        }
-      else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-               BoundaryConditions::BoundaryType::pressure)
-        {
-          /*do nothing*/
-        }
-      else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-               BoundaryConditions::BoundaryType::function_weak)
-        {
-          /*do nothing*/
-        }
-      else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-               BoundaryConditions::BoundaryType::partial_slip)
-        {
-          /*do nothing*/
-        }
-      else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-               BoundaryConditions::BoundaryType::outlet)
-        {
-          /*do nothing*/
-        }
-      else
-        {
-          VectorTools::interpolate_boundary_values(
-            *this->mapping,
-            this->dof_handler,
-            this->simulation_parameters.boundary_conditions.id[i_bc],
-            dealii::Functions::ZeroFunction<dim>(dim + 1),
-            this->zero_constraints,
-            this->fe->component_mask(velocities));
-        }
-    }
-
-  this->establish_solid_domain(false);
-
-  this->zero_constraints.close();
 }
 
 template <int dim>

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -79,7 +79,7 @@ FluidDynamicsMatrixBased<dim>::setup_dofs_fd()
   FEValuesExtractors::Vector velocities(0);
 
   // Non Zero constraints
-  define_non_zero_constraints();
+  this->define_non_zero_constraints();
 
   // Zero constraints
   define_zero_constraints();
@@ -196,99 +196,11 @@ FluidDynamicsMatrixBased<dim>::update_boundary_conditions()
       this->simulation_parameters.boundary_conditions.bcPressureFunction[i_bc]
         .p.set_time(time);
     }
-  define_non_zero_constraints();
+  this->define_non_zero_constraints();
   // Distribute constraints
   auto &nonzero_constraints = this->nonzero_constraints;
   nonzero_constraints.distribute(this->local_evaluation_point);
   this->present_solution = this->local_evaluation_point;
-}
-
-template <int dim>
-void
-FluidDynamicsMatrixBased<dim>::define_non_zero_constraints()
-{
-  double time = this->simulation_control->get_current_time();
-  FEValuesExtractors::Vector velocities(0);
-  FEValuesExtractors::Scalar pressure(dim);
-  // Non-zero constraints
-  auto &nonzero_constraints = this->get_nonzero_constraints();
-  {
-    nonzero_constraints.clear();
-    nonzero_constraints.reinit(this->locally_relevant_dofs);
-
-    DoFTools::make_hanging_node_constraints(this->dof_handler,
-                                            nonzero_constraints);
-    for (unsigned int i_bc = 0;
-         i_bc < this->simulation_parameters.boundary_conditions.size;
-         ++i_bc)
-      {
-        if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-            BoundaryConditions::BoundaryType::noslip)
-          {
-            VectorTools::interpolate_boundary_values(
-              *this->mapping,
-              this->dof_handler,
-              this->simulation_parameters.boundary_conditions.id[i_bc],
-              dealii::Functions::ZeroFunction<dim>(dim + 1),
-              nonzero_constraints,
-              this->fe->component_mask(velocities));
-          }
-        else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-                 BoundaryConditions::BoundaryType::slip)
-          {
-            std::set<types::boundary_id> no_normal_flux_boundaries;
-            no_normal_flux_boundaries.insert(
-              this->simulation_parameters.boundary_conditions.id[i_bc]);
-            VectorTools::compute_no_normal_flux_constraints(
-              this->dof_handler,
-              0,
-              no_normal_flux_boundaries,
-              nonzero_constraints,
-              *this->mapping);
-          }
-        else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-                 BoundaryConditions::BoundaryType::function)
-          {
-            this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
-              .u.set_time(time);
-            this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
-              .v.set_time(time);
-            this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
-              .w.set_time(time);
-            VectorTools::interpolate_boundary_values(
-              *this->mapping,
-              this->dof_handler,
-              this->simulation_parameters.boundary_conditions.id[i_bc],
-              NavierStokesFunctionDefined<dim>(
-                &this->simulation_parameters.boundary_conditions
-                   .bcFunctions[i_bc]
-                   .u,
-                &this->simulation_parameters.boundary_conditions
-                   .bcFunctions[i_bc]
-                   .v,
-                &this->simulation_parameters.boundary_conditions
-                   .bcFunctions[i_bc]
-                   .w),
-              nonzero_constraints,
-              this->fe->component_mask(velocities));
-          }
-        else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-                 BoundaryConditions::BoundaryType::periodic)
-          {
-            DoFTools::make_periodicity_constraints(
-              this->dof_handler,
-              this->simulation_parameters.boundary_conditions.id[i_bc],
-              this->simulation_parameters.boundary_conditions.periodic_id[i_bc],
-              this->simulation_parameters.boundary_conditions
-                .periodic_direction[i_bc],
-              nonzero_constraints);
-          }
-      }
-  }
-
-  this->establish_solid_domain(true);
-
-  nonzero_constraints.close();
 }
 
 template <int dim>

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -171,40 +171,6 @@ FluidDynamicsMatrixBased<dim>::update_multiphysics_time_average_solution()
 
 template <int dim>
 void
-FluidDynamicsMatrixBased<dim>::update_boundary_conditions()
-{
-  if (!this->simulation_parameters.boundary_conditions.time_dependent)
-    return;
-
-  // We can never assume in the code anywhere that the local_evaluation_point is
-  // at the right value its value must always be reinitialized from the present
-  // solution. This may appear trivial, but this is extremely important when we
-  // are checkpointing. Trust me future Bruno.
-  this->local_evaluation_point = this->present_solution;
-
-  double time = this->simulation_control->get_current_time();
-  for (unsigned int i_bc = 0;
-       i_bc < this->simulation_parameters.boundary_conditions.size;
-       ++i_bc)
-    {
-      this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
-        .u.set_time(time);
-      this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
-        .v.set_time(time);
-      this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
-        .w.set_time(time);
-      this->simulation_parameters.boundary_conditions.bcPressureFunction[i_bc]
-        .p.set_time(time);
-    }
-  this->define_non_zero_constraints();
-  // Distribute constraints
-  auto &nonzero_constraints = this->nonzero_constraints;
-  nonzero_constraints.distribute(this->local_evaluation_point);
-  this->present_solution = this->local_evaluation_point;
-}
-
-template <int dim>
-void
 FluidDynamicsMatrixBased<dim>::define_dynamic_zero_constraints()
 {
   if (!this->simulation_parameters.constrain_solid_domain.enable)

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -2120,7 +2120,7 @@ FluidDynamicsMatrixFree<dim>::setup_dofs_fd()
     DoFTools::extract_locally_relevant_dofs(this->dof_handler);
 
   // Non Zero constraints
-  define_non_zero_constraints();
+  this->define_non_zero_constraints();
 
   // Zero constraints
   define_zero_constraints();
@@ -2233,7 +2233,7 @@ FluidDynamicsMatrixFree<dim>::update_boundary_conditions()
       this->simulation_parameters.boundary_conditions.bcPressureFunction[i_bc]
         .p.set_time(time);
     }
-  define_non_zero_constraints();
+  this->define_non_zero_constraints();
   // Distribute constraints
   auto &nonzero_constraints = this->nonzero_constraints;
   nonzero_constraints.distribute(this->local_evaluation_point);
@@ -2711,96 +2711,6 @@ FluidDynamicsMatrixFree<dim>::update_solutions_for_multiphysics()
   this->multiphysics->set_previous_solutions(PhysicsID::fluid_dynamics,
                                              &this->previous_solutions);
 #endif
-}
-
-template <int dim>
-void
-FluidDynamicsMatrixFree<dim>::define_non_zero_constraints()
-{
-  double time = this->simulation_control->get_current_time();
-  FEValuesExtractors::Vector velocities(0);
-  FEValuesExtractors::Scalar pressure(dim);
-  // Non-zero constraints
-  auto &nonzero_constraints = this->get_nonzero_constraints();
-  {
-    nonzero_constraints.clear();
-    nonzero_constraints.reinit(this->locally_relevant_dofs);
-
-    DoFTools::make_hanging_node_constraints(this->dof_handler,
-                                            nonzero_constraints);
-    for (unsigned int i_bc = 0;
-         i_bc < this->simulation_parameters.boundary_conditions.size;
-         ++i_bc)
-      {
-        if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-            BoundaryConditions::BoundaryType::noslip)
-          {
-            VectorTools::interpolate_boundary_values(
-              *this->mapping,
-              this->dof_handler,
-              this->simulation_parameters.boundary_conditions.id[i_bc],
-              dealii::Functions::ZeroFunction<dim>(dim + 1),
-              nonzero_constraints,
-              this->fe->component_mask(velocities));
-          }
-        else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-                 BoundaryConditions::BoundaryType::slip)
-          {
-            std::set<types::boundary_id> no_normal_flux_boundaries;
-            no_normal_flux_boundaries.insert(
-              this->simulation_parameters.boundary_conditions.id[i_bc]);
-            VectorTools::compute_no_normal_flux_constraints(
-              this->dof_handler,
-              0,
-              no_normal_flux_boundaries,
-              nonzero_constraints,
-              *this->mapping);
-          }
-        else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-                 BoundaryConditions::BoundaryType::function)
-          {
-            this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
-              .u.set_time(time);
-            this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
-              .v.set_time(time);
-            this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
-              .w.set_time(time);
-            VectorTools::interpolate_boundary_values(
-              *this->mapping,
-              this->dof_handler,
-              this->simulation_parameters.boundary_conditions.id[i_bc],
-              NavierStokesFunctionDefined<dim>(
-                &this->simulation_parameters.boundary_conditions
-                   .bcFunctions[i_bc]
-                   .u,
-                &this->simulation_parameters.boundary_conditions
-                   .bcFunctions[i_bc]
-                   .v,
-                &this->simulation_parameters.boundary_conditions
-                   .bcFunctions[i_bc]
-                   .w),
-              nonzero_constraints,
-              this->fe->component_mask(velocities));
-          }
-        else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-                 BoundaryConditions::BoundaryType::periodic)
-          {
-            DoFTools::make_periodicity_constraints(
-              this->dof_handler,
-              this->simulation_parameters.boundary_conditions.id[i_bc],
-              this->simulation_parameters.boundary_conditions.periodic_id[i_bc],
-              this->simulation_parameters.boundary_conditions
-                .periodic_direction[i_bc],
-              nonzero_constraints);
-          }
-      }
-  }
-
-
-
-  this->establish_solid_domain(true);
-
-  nonzero_constraints.close();
 }
 
 template <int dim>

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -2032,7 +2032,7 @@ FluidDynamicsMatrixFree<dim>::solve()
         this->forcing_function->set_time(
           this->simulation_control->get_current_time());
 
-      update_boundary_conditions();
+      this->update_boundary_conditions();
       this->multiphysics->update_boundary_conditions();
 
       this->simulation_control->print_progression(this->pcout);
@@ -2223,40 +2223,6 @@ FluidDynamicsMatrixFree<dim>::setup_dofs_fd()
   // apart from fluid dynamics are enabled.
   if (this->multiphysics->get_active_physics().size() > 1)
     update_solutions_for_multiphysics();
-}
-
-template <int dim>
-void
-FluidDynamicsMatrixFree<dim>::update_boundary_conditions()
-{
-  if (!this->simulation_parameters.boundary_conditions.time_dependent)
-    return;
-
-  // We can never assume in the code anywhere that the local_evaluation_point is
-  // at the right value its value must always be reinitialized from the present
-  // solution. This may appear trivial, but this is extremely important when we
-  // are checkpointing. Trust me future Bruno.
-  this->local_evaluation_point = this->present_solution;
-
-  double time = this->simulation_control->get_current_time();
-  for (unsigned int i_bc = 0;
-       i_bc < this->simulation_parameters.boundary_conditions.size;
-       ++i_bc)
-    {
-      this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
-        .u.set_time(time);
-      this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
-        .v.set_time(time);
-      this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
-        .w.set_time(time);
-      this->simulation_parameters.boundary_conditions.bcPressureFunction[i_bc]
-        .p.set_time(time);
-    }
-  this->define_non_zero_constraints();
-  // Distribute constraints
-  auto &nonzero_constraints = this->nonzero_constraints;
-  nonzero_constraints.distribute(this->local_evaluation_point);
-  this->present_solution = this->local_evaluation_point;
 }
 
 template <int dim>

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1718,6 +1718,194 @@ NavierStokesBase<dim, VectorType, DofsType>::set_nodal_values()
     }
 }
 
+template <int dim, typename VectorType, typename DofsType>
+void
+NavierStokesBase<dim, VectorType, DofsType>::
+  define_non_zero_constraints()
+{
+  double time = this->simulation_control->get_current_time();
+  FEValuesExtractors::Vector velocities(0);
+  FEValuesExtractors::Scalar pressure(dim);
+
+  // Non-zero constraints
+  auto &nonzero_constraints = this->get_nonzero_constraints();
+  nonzero_constraints.clear();
+
+  if constexpr (std::is_same_v<VectorType, GlobalBlockVectorType>)
+    {
+      std::vector<unsigned int> block_component(dim + 1, 0);
+      block_component[dim] = 1;
+      DoFRenumbering::component_wise(this->dof_handler, block_component);
+      std::vector<types::global_dof_index> dofs_per_block =
+        DoFTools::count_dofs_per_fe_block(this->dof_handler, block_component);
+
+      unsigned int dof_u = dofs_per_block[0];
+      unsigned int dof_p = dofs_per_block[1];
+
+      IndexSet locally_relevant_dofs_acquisition;
+      locally_relevant_dofs_acquisition =
+        DoFTools::extract_locally_relevant_dofs(this->dof_handler);
+      this->locally_relevant_dofs.resize(2);
+      this->locally_relevant_dofs[0] =
+        locally_relevant_dofs_acquisition.get_view(0, dof_u);
+      this->locally_relevant_dofs[1] =
+        locally_relevant_dofs_acquisition.get_view(dof_u, dof_u + dof_p);
+      nonzero_constraints.reinit(locally_relevant_dofs_acquisition);
+    }
+  else
+    {
+      nonzero_constraints.reinit(this->locally_relevant_dofs);
+    }
+
+  DoFTools::make_hanging_node_constraints(this->dof_handler,
+                                          nonzero_constraints);
+  for (unsigned int i_bc = 0;
+       i_bc < this->simulation_parameters.boundary_conditions.size;
+       ++i_bc)
+    {
+      if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+          BoundaryConditions::BoundaryType::noslip)
+        {
+          VectorTools::interpolate_boundary_values(
+            *this->mapping,
+            this->dof_handler,
+            this->simulation_parameters.boundary_conditions.id[i_bc],
+            dealii::Functions::ZeroFunction<dim>(dim + 1),
+            nonzero_constraints,
+            this->fe->component_mask(velocities));
+        }
+      else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+               BoundaryConditions::BoundaryType::slip)
+        {
+          std::set<types::boundary_id> no_normal_flux_boundaries;
+          no_normal_flux_boundaries.insert(
+            this->simulation_parameters.boundary_conditions.id[i_bc]);
+          VectorTools::compute_no_normal_flux_constraints(
+            this->dof_handler,
+            0,
+            no_normal_flux_boundaries,
+            nonzero_constraints,
+            *this->mapping);
+        }
+      else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+               BoundaryConditions::BoundaryType::function)
+        {
+          this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
+            .u.set_time(time);
+          this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
+            .v.set_time(time);
+          this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
+            .w.set_time(time);
+          VectorTools::interpolate_boundary_values(
+            *this->mapping,
+            this->dof_handler,
+            this->simulation_parameters.boundary_conditions.id[i_bc],
+            NavierStokesFunctionDefined<dim>(
+              &this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
+                 .u,
+              &this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
+                 .v,
+              &this->simulation_parameters.boundary_conditions.bcFunctions[i_bc]
+                 .w),
+            nonzero_constraints,
+            this->fe->component_mask(velocities));
+        }
+      else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+               BoundaryConditions::BoundaryType::periodic)
+        {
+          DoFTools::make_periodicity_constraints(
+            this->dof_handler,
+            this->simulation_parameters.boundary_conditions.id[i_bc],
+            this->simulation_parameters.boundary_conditions.periodic_id[i_bc],
+            this->simulation_parameters.boundary_conditions
+              .periodic_direction[i_bc],
+            nonzero_constraints);
+        }
+    }
+
+  this->establish_solid_domain(true);
+
+  nonzero_constraints.close();
+}
+
+template <int dim, typename VectorType, typename DofsType>
+void
+NavierStokesBase<dim, VectorType, DofsType>::define_zero_constraints_global()
+{
+  // FEValuesExtractors::Vector velocities(0);
+  // FEValuesExtractors::Scalar pressure(dim);
+  // this->zero_constraints.clear();
+  // this->locally_relevant_dofs =
+  //   DoFTools::extract_locally_relevant_dofs(this->dof_handler);
+  // this->zero_constraints.reinit(this->locally_relevant_dofs);
+
+  // DoFTools::make_hanging_node_constraints(this->dof_handler,
+  //                                         this->zero_constraints);
+
+  // for (unsigned int i_bc = 0;
+  //      i_bc < this->simulation_parameters.boundary_conditions.size;
+  //      ++i_bc)
+  //   {
+  //     if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+  //         BoundaryConditions::BoundaryType::slip)
+  //       {
+  //         std::set<types::boundary_id> no_normal_flux_boundaries;
+  //         no_normal_flux_boundaries.insert(
+  //           this->simulation_parameters.boundary_conditions.id[i_bc]);
+  //         VectorTools::compute_no_normal_flux_constraints(
+  //           this->dof_handler,
+  //           0,
+  //           no_normal_flux_boundaries,
+  //           this->zero_constraints,
+  //           *this->mapping);
+  //       }
+  //     else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+  //              BoundaryConditions::BoundaryType::periodic)
+  //       {
+  //         DoFTools::make_periodicity_constraints(
+  //           this->dof_handler,
+  //           this->simulation_parameters.boundary_conditions.id[i_bc],
+  //           this->simulation_parameters.boundary_conditions.periodic_id[i_bc],
+  //           this->simulation_parameters.boundary_conditions
+  //             .periodic_direction[i_bc],
+  //           this->zero_constraints);
+  //       }
+  //     else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+  //              BoundaryConditions::BoundaryType::pressure)
+  //       {
+  //         /*do nothing*/
+  //       }
+  //     else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+  //              BoundaryConditions::BoundaryType::function_weak)
+  //       {
+  //         /*do nothing*/
+  //       }
+  //     else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+  //              BoundaryConditions::BoundaryType::partial_slip)
+  //       {
+  //         /*do nothing*/
+  //       }
+  //     else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+  //              BoundaryConditions::BoundaryType::outlet)
+  //       {
+  //         /*do nothing*/
+  //       }
+  //     else
+  //       {
+  //         VectorTools::interpolate_boundary_values(
+  //           *this->mapping,
+  //           this->dof_handler,
+  //           this->simulation_parameters.boundary_conditions.id[i_bc],
+  //           dealii::Functions::ZeroFunction<dim>(dim + 1),
+  //           this->zero_constraints,
+  //           this->fe->component_mask(velocities));
+  //       }
+  //   }
+
+  // this->establish_solid_domain(false);
+
+  // this->zero_constraints.close();
+}
 
 template <int dim, typename VectorType, typename DofsType>
 void

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1720,8 +1720,7 @@ NavierStokesBase<dim, VectorType, DofsType>::set_nodal_values()
 
 template <int dim, typename VectorType, typename DofsType>
 void
-NavierStokesBase<dim, VectorType, DofsType>::
-  define_non_zero_constraints()
+NavierStokesBase<dim, VectorType, DofsType>::define_non_zero_constraints()
 {
   double time = this->simulation_control->get_current_time();
   FEValuesExtractors::Vector velocities(0);
@@ -1830,81 +1829,110 @@ NavierStokesBase<dim, VectorType, DofsType>::
 
 template <int dim, typename VectorType, typename DofsType>
 void
-NavierStokesBase<dim, VectorType, DofsType>::define_zero_constraints_global()
+NavierStokesBase<dim, VectorType, DofsType>::define_zero_constraints()
 {
-  // FEValuesExtractors::Vector velocities(0);
-  // FEValuesExtractors::Scalar pressure(dim);
-  // this->zero_constraints.clear();
-  // this->locally_relevant_dofs =
-  //   DoFTools::extract_locally_relevant_dofs(this->dof_handler);
-  // this->zero_constraints.reinit(this->locally_relevant_dofs);
+  FEValuesExtractors::Vector velocities(0);
+  FEValuesExtractors::Scalar pressure(dim);
+  this->zero_constraints.clear();
 
-  // DoFTools::make_hanging_node_constraints(this->dof_handler,
-  //                                         this->zero_constraints);
+  if constexpr (std::is_same_v<VectorType, GlobalBlockVectorType>)
+    {
+      std::vector<unsigned int> block_component(dim + 1, 0);
+      block_component[dim] = 1;
+      DoFRenumbering::component_wise(this->dof_handler, block_component);
+      std::vector<types::global_dof_index> dofs_per_block =
+        DoFTools::count_dofs_per_fe_block(this->dof_handler, block_component);
 
-  // for (unsigned int i_bc = 0;
-  //      i_bc < this->simulation_parameters.boundary_conditions.size;
-  //      ++i_bc)
-  //   {
-  //     if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-  //         BoundaryConditions::BoundaryType::slip)
-  //       {
-  //         std::set<types::boundary_id> no_normal_flux_boundaries;
-  //         no_normal_flux_boundaries.insert(
-  //           this->simulation_parameters.boundary_conditions.id[i_bc]);
-  //         VectorTools::compute_no_normal_flux_constraints(
-  //           this->dof_handler,
-  //           0,
-  //           no_normal_flux_boundaries,
-  //           this->zero_constraints,
-  //           *this->mapping);
-  //       }
-  //     else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-  //              BoundaryConditions::BoundaryType::periodic)
-  //       {
-  //         DoFTools::make_periodicity_constraints(
-  //           this->dof_handler,
-  //           this->simulation_parameters.boundary_conditions.id[i_bc],
-  //           this->simulation_parameters.boundary_conditions.periodic_id[i_bc],
-  //           this->simulation_parameters.boundary_conditions
-  //             .periodic_direction[i_bc],
-  //           this->zero_constraints);
-  //       }
-  //     else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-  //              BoundaryConditions::BoundaryType::pressure)
-  //       {
-  //         /*do nothing*/
-  //       }
-  //     else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-  //              BoundaryConditions::BoundaryType::function_weak)
-  //       {
-  //         /*do nothing*/
-  //       }
-  //     else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-  //              BoundaryConditions::BoundaryType::partial_slip)
-  //       {
-  //         /*do nothing*/
-  //       }
-  //     else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
-  //              BoundaryConditions::BoundaryType::outlet)
-  //       {
-  //         /*do nothing*/
-  //       }
-  //     else
-  //       {
-  //         VectorTools::interpolate_boundary_values(
-  //           *this->mapping,
-  //           this->dof_handler,
-  //           this->simulation_parameters.boundary_conditions.id[i_bc],
-  //           dealii::Functions::ZeroFunction<dim>(dim + 1),
-  //           this->zero_constraints,
-  //           this->fe->component_mask(velocities));
-  //       }
-  //   }
+      unsigned int dof_u = dofs_per_block[0];
+      unsigned int dof_p = dofs_per_block[1];
 
-  // this->establish_solid_domain(false);
+      IndexSet locally_relevant_dofs_acquisition;
+      locally_relevant_dofs_acquisition =
+        DoFTools::extract_locally_relevant_dofs(this->dof_handler);
+      this->locally_relevant_dofs.resize(2);
+      this->locally_relevant_dofs[0] =
+        locally_relevant_dofs_acquisition.get_view(0, dof_u);
+      this->locally_relevant_dofs[1] =
+        locally_relevant_dofs_acquisition.get_view(dof_u, dof_u + dof_p);
+      this->zero_constraints.reinit(locally_relevant_dofs_acquisition);
+    }
+  else
+    {
+      this->locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(this->dof_handler);
+      this->zero_constraints.reinit(this->locally_relevant_dofs);
+    }
 
-  // this->zero_constraints.close();
+  DoFTools::make_hanging_node_constraints(this->dof_handler,
+                                          this->zero_constraints);
+
+  for (unsigned int i_bc = 0;
+       i_bc < this->simulation_parameters.boundary_conditions.size;
+       ++i_bc)
+    {
+      if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+          BoundaryConditions::BoundaryType::slip)
+        {
+          std::set<types::boundary_id> no_normal_flux_boundaries;
+          no_normal_flux_boundaries.insert(
+            this->simulation_parameters.boundary_conditions.id[i_bc]);
+          VectorTools::compute_no_normal_flux_constraints(
+            this->dof_handler,
+            0,
+            no_normal_flux_boundaries,
+            this->zero_constraints,
+            *this->mapping);
+        }
+      else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+               BoundaryConditions::BoundaryType::periodic)
+        {
+          DoFTools::make_periodicity_constraints(
+            this->dof_handler,
+            this->simulation_parameters.boundary_conditions.id[i_bc],
+            this->simulation_parameters.boundary_conditions.periodic_id[i_bc],
+            this->simulation_parameters.boundary_conditions
+              .periodic_direction[i_bc],
+            this->zero_constraints);
+        }
+      else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+               BoundaryConditions::BoundaryType::pressure)
+        {
+          /*The pressure boundary condition is implemented in the matrix-based
+           * assemblers*/
+        }
+      else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+               BoundaryConditions::BoundaryType::function_weak)
+        {
+          /*The function weak boundary condition is implemented in the
+           * matrix-based assemblers and the matrix-free operators*/
+        }
+      else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+               BoundaryConditions::BoundaryType::partial_slip)
+        {
+          /*The partial slip boundary condition is implemented in the
+           * matrix-based assemblers*/
+        }
+      else if (this->simulation_parameters.boundary_conditions.type[i_bc] ==
+               BoundaryConditions::BoundaryType::outlet)
+        {
+          /*The directional do-nothing boundary condition is implemented
+           * in the matrix-based assemblers and the matrix-free operators*/
+        }
+      else
+        {
+          VectorTools::interpolate_boundary_values(
+            *this->mapping,
+            this->dof_handler,
+            this->simulation_parameters.boundary_conditions.id[i_bc],
+            dealii::Functions::ZeroFunction<dim>(dim + 1),
+            this->zero_constraints,
+            this->fe->component_mask(velocities));
+        }
+    }
+
+  this->establish_solid_domain(false);
+
+  this->zero_constraints.close();
 }
 
 template <int dim, typename VectorType, typename DofsType>


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

As mentioned in  #1303, the constraints of the matrix free application are now mature enough to have only one common implementation for the three fluid dynamics applications: matrix-based, matrix-free and block applications. Therefore, the three main functions related to boundary conditions are now in only one place in the base class, i.e., `NavierStokesBase`.  

### Testing

<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

No additional tests are included. All the existent tests pass for the three fluid dynamics applications. 

### Documentation

<!-- Does this refactor modify or have new simulation parameters? If so, describe them. -->

No documentation required for this. 

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

Appropriate asserts were added in the block and matrix-free implementations to avoid the user from specifying boundary conditions in the parameter file that are not implemented.  

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [X] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] The PR description is cleaned and ready for merge