### PR TITLE
Change default coarse grid solver for the geometric multigrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+
+## [Master] - 2024-10-16
+
+### Changed
+
+- MINOR Change default coarse grid solver to a direct solver for the geometric multigrid preconditioner in the matrix application. [#1322](https://github.com/chaos-polymtl/lethe/pull/1322)
+
 ## [Master] - 2024-10-15
 
 ### Added

--- a/applications_tests/lethe-fluid-matrix-free/couette_function_weak.prm
+++ b/applications_tests/lethe-fluid-matrix-free/couette_function_weak.prm
@@ -172,8 +172,5 @@ subsection linear solver
     set eig estimation smoothing range = 5
     set eig estimation cg n iterations = 5
     set eig estimation verbosity       = quiet
-
-    # Coarse-grid solver
-    set mg coarse grid solver = direct
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator.prm
@@ -162,9 +162,7 @@ subsection linear solver
     set max krylov vectors = 200
 
     #MG parameters
-    set mg verbosity       = quiet
-    set mg min level       = -1
-    set mg level min cells = -1
+    set mg verbosity = quiet
 
     #smoother
     set mg smoother iterations     = 10

--- a/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator.prm
@@ -175,17 +175,5 @@ subsection linear solver
     set eig estimation smoothing range = 5
     set eig estimation cg n iterations = 20
     set eig estimation verbosity       = quiet
-
-    #coarse-grid solver
-    set mg gmres preconditioner     = ilu
-    set mg gmres max iterations     = 500
-    set mg gmres tolerance          = 1e-12
-    set mg gmres reduce             = 1e-12
-    set mg gmres max krylov vectors = 500
-
-    #coarse-grid ILU preconditioner
-    set ilu preconditioner fill               = 1
-    set ilu preconditioner absolute tolerance = 1e-5
-    set ilu preconditioner relative tolerance = 1
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/cylinder_outlet_bc.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_outlet_bc.prm
@@ -171,8 +171,5 @@ subsection linear solver
     set eig estimation smoothing range = 5
     set eig estimation cg n iterations = 20
     set eig estimation verbosity       = quiet
-
-    # Coarse-grid solver
-    set mg coarse grid solver = direct
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/heat_transfer_high_pe_stab_gls.prm
+++ b/applications_tests/lethe-fluid-matrix-free/heat_transfer_high_pe_stab_gls.prm
@@ -137,15 +137,15 @@ end
 subsection boundary conditions heat transfer
   set number = 2
   subsection bc 0
-    set id    = 0
-    set type  = temperature
+    set id   = 0
+    set type = temperature
     subsection value
       set Function expression = 0
     end
   end
   subsection bc 1
-    set id    = 1
-    set type  = temperature
+    set id   = 1
+    set type = temperature
     subsection value
       set Function expression = 1
     end

--- a/applications_tests/lethe-fluid-matrix-free/mms2d_fe2_weak.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms2d_fe2_weak.prm
@@ -142,8 +142,5 @@ subsection linear solver
     set eig estimation smoothing range = 5
     set eig estimation cg n iterations = 5
     set eig estimation verbosity       = quiet
-
-    # Coarse-grid solver
-    set mg coarse grid solver = direct
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_gcmg.prm
@@ -118,9 +118,7 @@ subsection linear solver
     set verbosity         = quiet
 
     #MG parameters
-    set mg verbosity       = quiet
-    set mg min level       = -1
-    set mg level min cells = -1
+    set mg verbosity = quiet
 
     #smoother
     set mg smoother iterations = 10

--- a/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_gcmg.prm
@@ -125,22 +125,5 @@ subsection linear solver
     #smoother
     set mg smoother iterations = 10
     set mg smoother relaxation = 0.5
-
-    #coarse-grid solver
-    set mg gmres max iterations     = 2000
-    set mg gmres tolerance          = 1e-14
-    set mg gmres reduce             = 1e-4
-    set mg gmres max krylov vectors = 30
-    set mg gmres preconditioner     = amg
-
-    #coarse-grid AMG preconditioner
-    set amg aggregation threshold                 = 1e-14
-    set amg n cycles                              = 1
-    set amg w cycles                              = false
-    set amg smoother sweeps                       = 2
-    set amg smoother overlap                      = 1
-    set amg preconditioner ilu fill               = 1
-    set amg preconditioner ilu absolute tolerance = 1e-10
-    set amg preconditioner ilu relative tolerance = 1.00
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_lsmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_lsmg.prm
@@ -118,8 +118,6 @@ subsection linear solver
     set verbosity         = quiet
 
     #MG parameters
-    set mg verbosity       = quiet
-    set mg min level       = -1
-    set mg level min cells = -1
+    set mg verbosity = quiet
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_lsmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_lsmg.prm
@@ -121,26 +121,5 @@ subsection linear solver
     set mg verbosity       = quiet
     set mg min level       = -1
     set mg level min cells = -1
-
-    #smoother
-    set mg smoother iterations = 10
-    set mg smoother relaxation = 0.5
-
-    #coarse-grid solver
-    set mg gmres max iterations     = 2000
-    set mg gmres tolerance          = 1e-14
-    set mg gmres reduce             = 1e-4
-    set mg gmres max krylov vectors = 30
-    set mg gmres preconditioner     = amg
-
-    #coarse-grid AMG preconditioner
-    set amg aggregation threshold                 = 1e-14
-    set amg n cycles                              = 1
-    set amg w cycles                              = false
-    set amg smoother sweeps                       = 2
-    set amg smoother overlap                      = 1
-    set amg preconditioner ilu fill               = 1
-    set amg preconditioner ilu absolute tolerance = 1e-10
-    set amg preconditioner ilu relative tolerance = 1.00
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/taylor_couette_2d_local_ref.prm
+++ b/applications_tests/lethe-fluid-matrix-free/taylor_couette_2d_local_ref.prm
@@ -46,7 +46,7 @@ end
 
 subsection forces
   set verbosity        = quiet # Output force and torques in log <quiet|verbose>
-  set calculate torque = false  # Enable torque calculation
+  set calculate torque = false # Enable torque calculation
 end
 
 #---------------------------------------------------
@@ -140,9 +140,7 @@ subsection linear solver
     set verbosity         = quiet
 
     # MG parameters
-    set mg verbosity       = quiet
-    set mg min level       = 0
-    set mg level min cells = -1
+    set mg verbosity = quiet
 
     # Smoother
     set mg smoother iterations     = 10

--- a/applications_tests/lethe-fluid-matrix-free/taylor_couette_2d_local_ref.prm
+++ b/applications_tests/lethe-fluid-matrix-free/taylor_couette_2d_local_ref.prm
@@ -152,15 +152,5 @@ subsection linear solver
     set eig estimation smoothing range = 5
     set eig estimation cg n iterations = 10
     set eig estimation verbosity       = quiet
-
-    # Coarse-grid solver
-    set mg gmres max iterations         = 50
-    set mg gmres tolerance              = 1e-7
-    set mg gmres reduce                 = 1e-4
-    set mg gmres max krylov vectors     = 50
-    set mg gmres preconditioner         = ilu
-    set ilu preconditioner fill               = 0
-    set ilu preconditioner absolute tolerance = 1e-10
-    set ilu preconditioner relative tolerance = 1.00
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/turbulent_taylor_couette_restart.prm
+++ b/applications_tests/lethe-fluid-matrix-free/turbulent_taylor_couette_restart.prm
@@ -161,8 +161,5 @@ subsection linear solver
     set eig estimation smoothing range = 5
     set eig estimation cg n iterations = 20
     set eig estimation verbosity       = quiet
-
-    # Coarse-grid solver
-    set mg coarse grid solver = direct
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/turbulent_taylor_couette_restart.prm
+++ b/applications_tests/lethe-fluid-matrix-free/turbulent_taylor_couette_restart.prm
@@ -150,7 +150,6 @@ subsection linear solver
 
     # MG parameters
     set mg verbosity       = quiet
-    set mg min level       = -1
     set mg level min cells = 16
 
     # Smoother

--- a/doc/source/parameters/cfd/linear_solver_control.rst
+++ b/doc/source/parameters/cfd/linear_solver_control.rst
@@ -205,7 +205,7 @@ Different parameters for the main components of the two geometric multigrid algo
 .. code-block:: text
 
     # General MG parameters
-    set mg verbosity                   = quiet
+    set mg verbosity                   = verbose
     set mg min level                   = -1
     set mg level min cells             = -1
     set mg int level                   = -1
@@ -220,10 +220,10 @@ Different parameters for the main components of the two geometric multigrid algo
     # Eigenvalue estimation parameters
     set eig estimation smoothing range = 10
     set eig estimation cg n iterations = 10
-    set eig estimation verbosity       = quiet
+    set eig estimation verbosity       = verbose
 
     # Coarse-grid solver parameters
-    set mg coarse grid solver          = gmres
+    set mg coarse grid solver          = direct
     set mg coarse grid use fe q iso q1 = false
 
     # Parameters for GMRES as coarse grid solver

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2602,7 +2602,7 @@ namespace Parameters
                           "Choices are <quiet|verbose>.");
 
         prm.declare_entry("mg coarse grid solver",
-                          "gmres",
+                          "direct",
                           Patterns::Selection("gmres|amg|ilu|direct"),
                           "The coarse grid solver for lsmg or gcmg"
                           "Choices are <gmres|amg|ilu|direct>.");


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

This PR makes the direct solver the default coarse grid solver for the geometric multigrid alternatives in the matrix-free application. 

### Testing

<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

All the existent tests pass with this coarse-grid solver. The parameter files were cleaned and the coarse grid solver section removed. 
### Documentation

<!-- Does this refactor modify or have new simulation parameters? If so, describe them. -->

The default value was updated in the linear solver section of the documentation. 

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [X] No other PR is open related to this refactoring
- [X] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] The PR description is cleaned and ready for merge