### PR TITLE
Add missing flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-10-16
+
+### Fixed
+
+- MINOR Added missing flag to update quadrature points for the FEFaceValues of the tracer physics. [#1323](https://github.com/chaos-polymtl/lethe/pull/1323)
+
 ## [Master] - 2024-10-15
 
 ### Added

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -588,7 +588,8 @@ Tracer<dim>::postprocess_tracer_flow_rate(const VectorType &current_solution_fd)
                                           *this->face_quadrature,
                                           update_values | update_gradients |
                                             update_JxW_values |
-                                            update_normal_vectors);
+                                            update_normal_vectors |
+                                            update_quadrature_points);
 
   // Initialize fluid dynamics information
   const DoFHandler<dim> *dof_handler_fd =


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->


### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->
There was a missing flag to update the quadrature points for the FEValuesFace for the tracer, used for post-processing the tracer flow rate.

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->
The flag is added.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->
All tests still pass.

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->
No change required.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge