### PR TITLE
Use MGCoarseGridApplyOperator class in the multigrid preconditioners

### DIFF
--- a/include/solvers/fluid_dynamics_matrix_free.h
+++ b/include/solvers/fluid_dynamics_matrix_free.h
@@ -30,6 +30,12 @@ class PreconditionBase;
 template <typename VectorType, typename VectorTypePrecondition>
 class PreconditionAdapter;
 
+namespace dealii
+{
+  template <class VectorType, class PreconditionerType>
+  class MGCoarseGridApplyPreconditioner;
+}
+
 /**
  * @brief A geometric multigrid preconditioner compatible with the
  * matrix-free solver.

--- a/include/solvers/fluid_dynamics_matrix_free.h
+++ b/include/solvers/fluid_dynamics_matrix_free.h
@@ -43,7 +43,7 @@ class MFNavierStokesPreconditionGMG
   using MGNumber = double;
 #else
 #  if DEAL_II_VERSION_GTE(9, 7, 0)
-  using MGNumber = float;
+  using MGNumber              = float;
 #  else
   AssertThrow(
     false,
@@ -65,6 +65,16 @@ class MFNavierStokesPreconditionGMG
     PreconditionMG<dim, MGVectorType, LSTransferType>;
   using PreconditionerTypeGC =
     PreconditionMG<dim, MGVectorType, GCTransferType>;
+
+#if DEAL_II_VERSION_GTE(9, 7, 0)
+  using CoarseGridSolverApply = MGCoarseGridApplyOperator<
+    MGVectorType,
+    PreconditionAdapter<MGVectorType, TrilinosVectorType>>;
+#else
+  using CoarseGridSolverApply = MGCoarseGridApplyPreconditioner<
+    MGVectorType,
+    PreconditionAdapter<MGVectorType, TrilinosVectorType>>;
+#endif
 
 public:
   /**

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -491,17 +491,10 @@ namespace dealii
     /**
      * Reference to the preconditioner.
      */
-#if DEAL_II_VERSION_GTE(9, 7, 0)
-    ObserverPointer<
-      const PreconditionerType,
-      MGCoarseGridApplyPreconditioner<VectorType, PreconditionerType>>
-      preconditioner;
-#else
     SmartPointer<
       const PreconditionerType,
       MGCoarseGridApplyPreconditioner<VectorType, PreconditionerType>>
       preconditioner;
-#endif
   };
 
 

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -1576,9 +1576,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
     {
       setup_AMG();
 
-      this->mg_coarse = std::make_shared<MGCoarseGridApplyPreconditioner<
-        MGVectorType,
-        PreconditionAdapter<MGVectorType, TrilinosVectorType>>>(
+      this->mg_coarse = std::make_shared<CoarseGridSolverApply>(
         *this->coarse_grid_precondition);
     }
   else if (this->simulation_parameters.linear_solver
@@ -1588,9 +1586,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
     {
       setup_ILU();
 
-      this->mg_coarse = std::make_shared<MGCoarseGridApplyPreconditioner<
-        MGVectorType,
-        PreconditionAdapter<MGVectorType, TrilinosVectorType>>>(
+      this->mg_coarse = std::make_shared<CoarseGridSolverApply>(
         *this->coarse_grid_precondition);
     }
   else if (this->simulation_parameters.linear_solver
@@ -1614,9 +1610,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
         std::make_shared<PreconditionAdapter<MGVectorType, TrilinosVectorType>>(
           precondition_direct);
 
-      this->mg_coarse = std::make_shared<MGCoarseGridApplyPreconditioner<
-        MGVectorType,
-        PreconditionAdapter<MGVectorType, TrilinosVectorType>>>(
+      this->mg_coarse = std::make_shared<CoarseGridSolverApply>(
         *this->coarse_grid_precondition);
 #else
       AssertThrow(


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

This PR allows to use the wrapper class `MGCoarseGridApplyOperator` from deal.II in the multigrid preconditioners (introduced in https://github.com/dealii/dealii/commit/1d169fedf01590f6d872ade7ae464e9488d241cf). It was previously implemented locally as `MGCoarseGridApplyPreconditioner `in Lethe, however, since now it exists in deal.II, we introduce an alias that will change according to the deal.II version. The local class is not yet deleted from Lethe since we still support deal.II 9.6. 

### Testing

<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

All existent tests should pass without any change. 

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [X] If parameters are modified, the tests and the documentation of examples are up to date

Pull request related list:
- [X] No other PR is open related to this refactoring
- [X] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] The PR description is cleaned and ready for merge