### PR TITLE
Replace the norm by the scalar product with the normal vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fix
 
-- MINOR The checkpoint files generated from the lethe-particles solver were now incompatible with the CFD-DEM solvers (lethe-fluid-particles and lethe-fluid-vans) since the prefix are now ending with a "_0" or "_1". The "read_dem" function now reads the ".checkpoint_controller" file at first. [#1327](https://github.com/chaos-polymtl/lethe/pull/1327)
+- MINOR The checkpoint files generated from the lethe-particles solver were now incompatible with the CFD-DEM solvers (lethe-fluid-particles and lethe-fluid-vans) since the prefix are now ending with a "_0" or "_1". The "read_dem" function now reads the ".checkpoint_controller" file at first. [#1338](https://github.com/chaos-polymtl/lethe/pull/1338)
 
 ## [Master] - 2024-10-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,17 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-11-03
+
+### Fix
+
+- MINOR It was not possible to differentiate cohesive and repulsive forces with the force chains since the code was using the ".norm()" function. Now, the force chain calculation uses the scalar product between the normal force and the normal unit vector. [#1339](https://github.com/chaos-polymtl/lethe/pull/1339)
+
 ## [Master] - 2024-11-02
 
 ### Fix
 
-- MINOR The checkpoint files generated from the lethe-particles solver were now incompatible with the CFD-DEM solvers (lethe-fluid-particles and lethe-fluid-vans) since the prefix are now ending with a "_0" or "_1". The "read_dem" function now reads the ".checkpoint_controller" file at first.
+- MINOR The checkpoint files generated from the lethe-particles solver were now incompatible with the CFD-DEM solvers (lethe-fluid-particles and lethe-fluid-vans) since the prefix are now ending with a "_0" or "_1". The "read_dem" function now reads the ".checkpoint_controller" file at first. [#1327](https://github.com/chaos-polymtl/lethe/pull/1327)
 
 ## [Master] - 2024-10-31
 

--- a/include/dem/force_chains_visualization.h
+++ b/include/dem/force_chains_visualization.h
@@ -229,7 +229,8 @@ private:
 
         vertices.push_back(particle_one_location);
         vertices.push_back(particle_two_location);
-        force_normal.push_back(sqrt(normal_force.norm()));
+        force_normal.push_back(
+          scalar_product(normal_force, normal_unit_vector));
       }
   }
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

Force chain calculation had two implementation errors.

First, the square root shouldn't be there. 

Second, using the norm is not allowing to see if a force calculation is cohesive or repulsive.  

### Solution

Using the scalar product with the unit normal vector, we can see is the force is positive or negative. 

### Testing

All test are succeeding.

### Documentation


### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [X] Lethe documentation is up to date
- [X] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [X] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] If the fix is temporary, an issue is opened
- [X] The PR description is cleaned and ready for merge