### PR TITLE
Force chains, add the arbitrary rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fix
 
+- MINOR Force chains between local-ghost particle were being written multiple time when running in parallel. An arbitrary rule was added so that only one of the process is writing the force chain.[#1340](https://github.com/chaos-polymtl/lethe/pull/1340)
+
+
+### Fix
+
 - MINOR It was not possible to differentiate cohesive and repulsive forces with the force chains since the code was using the ".norm()" function. Now, the force chain calculation uses the scalar product between the normal force and the normal unit vector. [#1339](https://github.com/chaos-polymtl/lethe/pull/1339)
 
 ## [Master] - 2024-11-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fix
 
-- MINOR Force chains between local-ghost particle were being written multiple time when running in parallel. An arbitrary rule was added so that only one of the process is writing the force chain.[#1340](https://github.com/chaos-polymtl/lethe/pull/1340)
+- MINOR Force chains between local-ghost particle were being written multiple time when running in parallel. An arbitrary rule was added so that only one of the process is writing the force chain.[#1342](https://github.com/chaos-polymtl/lethe/pull/1342)
 
 
 ### Fix

--- a/include/dem/force_chains_visualization.h
+++ b/include/dem/force_chains_visualization.h
@@ -47,13 +47,19 @@ public:
    * @param[in] ghost_adjacent_particles Container of the contact pair
    * candidates information for calculation of the local-ghost particle-particle
    * contact forces.
+   * @param[out] vertices the vector of positions of touching particles.
+   * @param[out] normal_forces_vector the vector of normal forces between each
+   * touching particles.
    */
   virtual void
   calculate_force_chains(
     typename dem_data_structures<dim>::adjacent_particle_pairs
       &local_adjacent_particles,
     typename dem_data_structures<dim>::adjacent_particle_pairs
-      &ghost_adjacent_particles) = 0;
+                          &ghost_adjacent_particles,
+    std::vector<Point<3>> &vertices,
+    std::vector<double>   &normal_forces_vector) = 0;
+
   /**
    * @brief Output the force chains in VTU and PVTU files for each iteration and
    * a PVD file.
@@ -73,7 +79,11 @@ public:
                      const MPI_Comm                  mpi_communicator,
                      const std::string               folder,
                      const unsigned int              iter,
-                     const double                    time) = 0;
+                     const double                    time,
+                     typename dem_data_structures<dim>::adjacent_particle_pairs
+                       &local_adjacent_particles,
+                     typename dem_data_structures<dim>::adjacent_particle_pairs
+                       &ghost_adjacent_particles) = 0;
 };
 
 /**
@@ -116,13 +126,18 @@ public:
    * @param[in] ghost_adjacent_particles Container of the contact pair
    * candidates information for calculation of the local-ghost particle-particle
    * contact forces.
+   * @param[out] vertices the vector of positions of touching particles.
+   * @param[out] normal_forces_vector the vector of normal forces between each
+   * touching particles.
    */
   void
   calculate_force_chains(
     typename dem_data_structures<dim>::adjacent_particle_pairs
       &local_adjacent_particles,
     typename dem_data_structures<dim>::adjacent_particle_pairs
-      &ghost_adjacent_particles) override;
+                          &ghost_adjacent_particles,
+    std::vector<Point<3>> &vertices,
+    std::vector<double>   &normal_forces_vector) override;
 
   /**
    * @brief Output the force chains in VTU and PVTU files for each iteration and
@@ -136,6 +151,12 @@ public:
    * be saved.
    * @param[in] iter the iteration number associated with the file.
    * @param[in] time the time associated with the file.
+   * @param[in] local_adjacent_particles Container of the contact pair
+   * candidates information for calculation of the local particle-particle
+   * contact forces.
+   * @param[in] ghost_adjacent_particles Container of the contact pair
+   * candidates information for calculation of the local-ghost particle-particle
+   * contact forces.
    */
   void
   write_force_chains(const DEMSolverParameters<dim> &dem_parameters,
@@ -143,7 +164,11 @@ public:
                      const MPI_Comm                  mpi_communicator,
                      const std::string               folder,
                      const unsigned int              iter,
-                     const double                    time) override;
+                     const double                    time,
+                     typename dem_data_structures<dim>::adjacent_particle_pairs
+                       &local_adjacent_particles,
+                     typename dem_data_structures<dim>::adjacent_particle_pairs
+                       &ghost_adjacent_particles) override;
 
 private:
   /**
@@ -156,12 +181,17 @@ private:
    * @tparam force_model The particle-particle contact force model.
    * @param[in] adjacent_particles_list Container of the adjacent particles of a
    * particles.
+   * @param[out] vertices the vector of positions of touching particles.
+   * @param[out] normal_forces_vector the vector of normal forces between each
+   * touching particles.
    */
   template <ContactType contact_type>
   inline void
   execute_contact_calculation(
     typename DEM::dem_data_structures<dim>::particle_contact_info
-      &adjacent_particles_list)
+                          &adjacent_particles_list,
+    std::vector<Point<3>> &vertices,
+    std::vector<double>   &normal_forces_vector)
   {
     // No contact calculation if no adjacent particles
     if (adjacent_particles_list.empty())
@@ -330,15 +360,5 @@ private:
   void
   multi_general_cell(Triangulation<1, 3>         &tria,
                      const std::vector<Point<3>> &vertices);
-
-  /**
-   * @brief Vector of normal forces between each touching particles.
-   */
-  std::vector<double> normal_forces_vector;
-
-  /**
-   * @brief Vector of positions of touching particles.
-   */
-  std::vector<Point<3>> vertices;
 };
 #endif

--- a/include/dem/force_chains_visualization.h
+++ b/include/dem/force_chains_visualization.h
@@ -153,9 +153,11 @@ private:
    * particle-particle contact forces class, without the other contact types and
    * the update of the particles forces, torques and tangential overlap.
    *
+   * @tparam force_model The particle-particle contact force model.
    * @param[in] adjacent_particles_list Container of the adjacent particles of a
    * particles.
    */
+  template <ContactType contact_type>
   inline void
   execute_contact_calculation(
     typename DEM::dem_data_structures<dim>::particle_contact_info
@@ -193,6 +195,14 @@ private:
         // contact with particle 1
         auto particle_two            = contact_info.particle_two;
         auto particle_two_properties = particle_two->get_properties();
+
+        if constexpr (contact_type == ghost_particle_particle)
+          {
+            // We create an arbitrary rule so that forces between local-ghost
+            // particle are not written twice by each processor.
+            if (particle_one->get_id() < particle_two->get_id())
+              continue;
+          }
 
         // Get particle 2 location in dimension independent way
         Point<3> particle_two_location = this->get_location(particle_two);

--- a/include/dem/force_chains_visualization.h
+++ b/include/dem/force_chains_visualization.h
@@ -35,7 +35,7 @@ using namespace DEM;
 template <int dim>
 class ParticlesForceChainsBase
 {
-public:
+protected:
   /**
    * @brief Use a ParticleParticleContactForce object to calculate normal forces
    * between particles. Store normal forces and particles position in
@@ -60,6 +60,7 @@ public:
     std::vector<Point<3>> &vertices,
     std::vector<double>   &normal_forces_vector) = 0;
 
+public:
   /**
    * @brief Output the force chains in VTU and PVTU files for each iteration and
    * a PVD file.
@@ -115,30 +116,7 @@ public:
   virtual ~ParticlesForceChains()
   {}
 
-  /**
-   * @brief Calculate normal forces between all touching particles with
-   * ParticleParticleContactForce class' methods. Stock normal forces and
-   * particles position in vectors.
-   *
-   * @param[in] local_adjacent_particles Container of the contact pair
-   * candidates information for calculation of the local particle-particle
-   * contact forces.
-   * @param[in] ghost_adjacent_particles Container of the contact pair
-   * candidates information for calculation of the local-ghost particle-particle
-   * contact forces.
-   * @param[out] vertices the vector of positions of touching particles.
-   * @param[out] normal_forces_vector the vector of normal forces between each
-   * touching particles.
-   */
-  void
-  calculate_force_chains(
-    typename dem_data_structures<dim>::adjacent_particle_pairs
-      &local_adjacent_particles,
-    typename dem_data_structures<dim>::adjacent_particle_pairs
-                          &ghost_adjacent_particles,
-    std::vector<Point<3>> &vertices,
-    std::vector<double>   &normal_forces_vector) override;
-
+public:
   /**
    * @brief Output the force chains in VTU and PVTU files for each iteration and
    * a PVD file.
@@ -171,6 +149,30 @@ public:
                        &ghost_adjacent_particles) override;
 
 private:
+  /**
+   * @brief Calculate normal forces between all touching particles with
+   * ParticleParticleContactForce class' methods. Stock normal forces and
+   * particles position in vectors.
+   *
+   * @param[in] local_adjacent_particles Container of the contact pair
+   * candidates information for calculation of the local particle-particle
+   * contact forces.
+   * @param[in] ghost_adjacent_particles Container of the contact pair
+   * candidates information for calculation of the local-ghost particle-particle
+   * contact forces.
+   * @param[out] vertices the vector of positions of touching particles.
+   * @param[out] normal_forces_vector the vector of normal forces between each
+   * touching particles.
+   */
+  void
+  calculate_force_chains(
+    typename dem_data_structures<dim>::adjacent_particle_pairs
+      &local_adjacent_particles,
+    typename dem_data_structures<dim>::adjacent_particle_pairs
+                          &ghost_adjacent_particles,
+    std::vector<Point<3>> &vertices,
+    std::vector<double>   &normal_forces_vector) override;
+
   /**
    * @brief Execute the contact calculation step for the particle-particle
    * contact only for local-local and local-ghost contacts with no periodicity.

--- a/include/dem/force_chains_visualization.h
+++ b/include/dem/force_chains_visualization.h
@@ -235,12 +235,12 @@ private:
                                     particle_one_tangential_torque,
                                     particle_two_tangential_torque,
                                     rolling_resistance_torque);
-          }
 
-        vertices.push_back(particle_one_location);
-        vertices.push_back(particle_two_location);
-        normal_forces_vector.push_back(
-          scalar_product(normal_force, normal_unit_vector));
+            vertices.push_back(particle_one_location);
+            vertices.push_back(particle_two_location);
+            normal_forces_vector.push_back(
+              scalar_product(normal_force, normal_unit_vector));
+          }
       }
   }
 

--- a/include/dem/force_chains_visualization.h
+++ b/include/dem/force_chains_visualization.h
@@ -239,7 +239,7 @@ private:
 
         vertices.push_back(particle_one_location);
         vertices.push_back(particle_two_location);
-        force_normal.push_back(
+        normal_forces_vector.push_back(
           scalar_product(normal_force, normal_unit_vector));
       }
   }
@@ -334,7 +334,7 @@ private:
   /**
    * @brief Vector of normal forces between each touching particles.
    */
-  std::vector<double> force_normal;
+  std::vector<double> normal_forces_vector;
 
   /**
    * @brief Vector of positions of touching particles.

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -685,16 +685,15 @@ DEMSolver<dim>::write_output_results()
       // Force chains visualization
       particles_force_chains_object =
         set_force_chains_contact_force_model(parameters);
-      particles_force_chains_object->calculate_force_chains(
-        contact_manager.get_local_adjacent_particles(),
-        contact_manager.get_ghost_adjacent_particles());
       particles_force_chains_object->write_force_chains(
         parameters,
         particles_pvdhandler_force_chains,
         this->mpi_communicator,
         folder,
         iter,
-        time);
+        time,
+        contact_manager.get_local_adjacent_particles(),
+        contact_manager.get_ghost_adjacent_particles());
     }
 
   // Write all solid objects

--- a/source/dem/force_chains_visualization.cc
+++ b/source/dem/force_chains_visualization.cc
@@ -70,14 +70,16 @@ ParticlesForceChains<dim, contact_model, rolling_friction_model>::
   for (auto &&adjacent_particles_list :
        local_adjacent_particles | boost::adaptors::map_values)
     {
-      execute_contact_calculation(adjacent_particles_list);
+      execute_contact_calculation<ContactType::local_particle_particle>(
+        adjacent_particles_list);
     }
 
   // Calculate force for local-ghost particle pairs
   for (auto &&adjacent_particles_list :
        ghost_adjacent_particles | boost::adaptors::map_values)
     {
-      execute_contact_calculation(adjacent_particles_list);
+      execute_contact_calculation<ContactType::ghost_particle_particle>(
+        adjacent_particles_list);
     }
 }
 

--- a/source/dem/force_chains_visualization.cc
+++ b/source/dem/force_chains_visualization.cc
@@ -2,12 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/parameters_lagrangian.h>
-#include <core/tensors_and_points_dimension_manipulation.h>
 
 #include <dem/force_chains_visualization.h>
-#include <dem/particle_particle_contact_force.h>
 
-#include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/tria.h>
 
@@ -27,13 +24,7 @@ ParticlesForceChains<dim, contact_model, rolling_friction_model>::
   ParticlesForceChains(const DEMSolverParameters<dim> &dem_parameters_in)
   : ParticleParticleContactForce<dim, contact_model, rolling_friction_model>(
       dem_parameters_in)
-{
-  /*Initialize with a dummy normal force between two same points (0,0,0) to be
-  sure every core have someting to write. */
-  normal_forces_vector.emplace_back(0);
-  vertices.emplace_back(Point<3>(0, 0, 0));
-  vertices.emplace_back(Point<3>(0, 0, 0));
-}
+{}
 
 template <int                               dim,
           ParticleParticleContactForceModel contact_model,
@@ -54,16 +45,19 @@ ParticlesForceChains<dim, contact_model, rolling_friction_model>::
   tria.create_triangulation(vertices, cells, SubCellData());
 }
 
-template <int                               dim,
-          ParticleParticleContactForceModel contact_model,
-          RollingResistanceMethod           rolling_friction_model>
+template <
+  int                                                       dim,
+  Parameters::Lagrangian::ParticleParticleContactForceModel force_model,
+  Parameters::Lagrangian::RollingResistanceMethod rolling_friction_model>
 void
-ParticlesForceChains<dim, contact_model, rolling_friction_model>::
+ParticlesForceChains<dim, force_model, rolling_friction_model>::
   calculate_force_chains(
     typename dem_data_structures<dim>::adjacent_particle_pairs
       &local_adjacent_particles,
     typename dem_data_structures<dim>::adjacent_particle_pairs
-      &ghost_adjacent_particles)
+                          &ghost_adjacent_particles,
+    std::vector<Point<3>> &vertices,
+    std::vector<double>   &normal_forces_vector)
 {
   // Looping over local_adjacent_particles values with iterator
   // adjacent_particles_list
@@ -71,7 +65,7 @@ ParticlesForceChains<dim, contact_model, rolling_friction_model>::
        local_adjacent_particles | boost::adaptors::map_values)
     {
       execute_contact_calculation<ContactType::local_particle_particle>(
-        adjacent_particles_list);
+        adjacent_particles_list, vertices, normal_forces_vector);
     }
 
   // Calculate force for local-ghost particle pairs
@@ -79,7 +73,7 @@ ParticlesForceChains<dim, contact_model, rolling_friction_model>::
        ghost_adjacent_particles | boost::adaptors::map_values)
     {
       execute_contact_calculation<ContactType::ghost_particle_particle>(
-        adjacent_particles_list);
+        adjacent_particles_list, vertices, normal_forces_vector);
     }
 }
 
@@ -93,8 +87,21 @@ ParticlesForceChains<dim, contact_model, rolling_friction_model>::
                      MPI_Comm                        mpi_communicator,
                      const std::string               folder,
                      const unsigned int              iter,
-                     const double                    time)
+                     const double                    time,
+                     typename dem_data_structures<dim>::adjacent_particle_pairs
+                       &local_adjacent_particles,
+                     typename dem_data_structures<dim>::adjacent_particle_pairs
+                       &ghost_adjacent_particles)
 {
+  // Creating containers
+  std::vector<Point<3>> vertices;
+  std::vector<double>   normal_forces_vector;
+
+  this->calculate_force_chains(local_adjacent_particles,
+                               ghost_adjacent_particles,
+                               vertices,
+                               normal_forces_vector);
+
   Triangulation<1, 3> triangulation;
   multi_general_cell(triangulation, vertices);
   DoFHandler<1, 3> force_dh(triangulation);

--- a/source/dem/force_chains_visualization.cc
+++ b/source/dem/force_chains_visualization.cc
@@ -94,7 +94,7 @@ ParticlesForceChains<dim, contact_model, rolling_friction_model>::
                        &ghost_adjacent_particles)
 {
   // Creating containers
-  std::vector<Point<3>> vertices ={Point<3>(),Point<3>()};
+  std::vector<Point<3>> vertices             = {Point<3>(), Point<3>()};
   std::vector<double>   normal_forces_vector = {0.};
 
   this->calculate_force_chains(local_adjacent_particles,
@@ -138,7 +138,6 @@ ParticlesForceChains<dim, contact_model, rolling_friction_model>::
   pvd_handler.append(time, pvtu_filename);
   std::ofstream pvd_output(pvdPrefix.c_str());
   DataOutBase::write_pvd_record(pvd_output, pvd_handler.times_and_names);
-
 }
 
 // No resistance

--- a/source/dem/force_chains_visualization.cc
+++ b/source/dem/force_chains_visualization.cc
@@ -94,8 +94,8 @@ ParticlesForceChains<dim, contact_model, rolling_friction_model>::
                        &ghost_adjacent_particles)
 {
   // Creating containers
-  std::vector<Point<3>> vertices;
-  std::vector<double>   normal_forces_vector;
+  std::vector<Point<3>> vertices ={Point<3>(),Point<3>()};
+  std::vector<double>   normal_forces_vector = {0.};
 
   this->calculate_force_chains(local_adjacent_particles,
                                ghost_adjacent_particles,
@@ -108,7 +108,7 @@ ParticlesForceChains<dim, contact_model, rolling_friction_model>::
   DataOut<1, 3>    data_out;
   data_out.attach_dof_handler(force_dh);
 
-  Vector<float> force_values(triangulation.n_active_cells());
+  Vector<double> force_values(triangulation.n_active_cells());
   for (unsigned int i = 0; i < force_values.size(); ++i)
     {
       force_values[i] = normal_forces_vector[i];
@@ -139,9 +139,6 @@ ParticlesForceChains<dim, contact_model, rolling_friction_model>::
   std::ofstream pvd_output(pvdPrefix.c_str());
   DataOutBase::write_pvd_record(pvd_output, pvd_handler.times_and_names);
 
-  // Clear the containers for the next writing time step.
-  vertices.clear();
-  normal_forces_vector.clear();
 }
 
 // No resistance

--- a/source/dem/force_chains_visualization.cc
+++ b/source/dem/force_chains_visualization.cc
@@ -30,7 +30,7 @@ ParticlesForceChains<dim, contact_model, rolling_friction_model>::
 {
   /*Initialize with a dummy normal force between two same points (0,0,0) to be
   sure every core have someting to write. */
-  force_normal.emplace_back(0);
+  normal_forces_vector.emplace_back(0);
   vertices.emplace_back(Point<3>(0, 0, 0));
   vertices.emplace_back(Point<3>(0, 0, 0));
 }
@@ -104,7 +104,7 @@ ParticlesForceChains<dim, contact_model, rolling_friction_model>::
   Vector<float> force_values(triangulation.n_active_cells());
   for (unsigned int i = 0; i < force_values.size(); ++i)
     {
-      force_values[i] = force_normal[i];
+      force_values[i] = normal_forces_vector[i];
     }
   data_out.add_data_vector(force_values, "force");
   data_out.build_patches();
@@ -131,6 +131,10 @@ ParticlesForceChains<dim, contact_model, rolling_friction_model>::
   pvd_handler.append(time, pvtu_filename);
   std::ofstream pvd_output(pvdPrefix.c_str());
   DataOutBase::write_pvd_record(pvd_output, pvd_handler.times_and_names);
+
+  // Clear the containers for the next writing time step.
+  vertices.clear();
+  normal_forces_vector.clear();
 }
 
 // No resistance


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

Force chains between local-ghost particle were being duplicated since the arbitrary rule with particle ids was not implemented. 

### Solution

The `execute_contact_calculation` function in the `force_chain_visualization.h` file is templated with the contact type. Weh nwe are dealing with `ghost_particle_particle` contacts, we apply the rule.

### Testing

I could add a test, but I'm not sure what is the best way to do it. It would require two particles, being in two different subdomains. 

### Documentation
N/A

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [X] Lethe documentation is up to date
- [X] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [X] The branch is rebased onto master
- [X] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] If the fix is temporary, an issue is opened
- [X] The PR description is cleaned and ready for merge