### PR TITLE
Fix bugs: changing time step after restart and tracer tanh model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 
 - MAJOR The time step in the simulation control class is no longer modified by default to be exactly the end time of the simulation. Moreover, the time step is no longer modified to output Paraview files at certain times, therefore, the time output for transient simulations was refactored. [#1336](https://github.com/chaos-polymtl/lethe/pull/1341)
-- 
+-
 ### Added
 
 - MINOR Added bubble detachment in liquid shear flow example to the documentation [#1334](https://github.com/chaos-polymtl/lethe/pull/1334)
+
+## [Master] - 2024-11-07
+
+### Fix
+
+- MINOR Time step can now be changed after a restart if adaptive time stepping is disabled. [#1343](https://github.com/chaos-polymtl/lethe/pull/1343)
+- MINOR Application of the immersed solid tanh diffusivity model is now faster thanks to using optimizations from the Shape class. [#1343](https://github.com/chaos-polymtl/lethe/pull/1343)
 
 ## [Master] - 2024-11-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Master] - 2024-11-18
 
-### Fix
+### Fixed
 
 - MINOR Time step can now be changed after a restart if adaptive time stepping is disabled. [#1343](https://github.com/chaos-polymtl/lethe/pull/1343)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2024-11-18
+
+### Fix
+
+- MINOR Time step can now be changed after a restart if adaptive time stepping is disabled. [#1343](https://github.com/chaos-polymtl/lethe/pull/1343)
+
+- MINOR Application of the immersed solid tanh diffusivity model is now faster thanks to using optimizations from the Shape class. [#1343](https://github.com/chaos-polymtl/lethe/pull/1343)
+
 ## [Master] - 2024-11-11
 
 ### Changed
@@ -12,14 +20,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - MINOR Added bubble detachment in liquid shear flow example to the documentation [#1334](https://github.com/chaos-polymtl/lethe/pull/1334)
-
-## [Master] - 2024-11-07
-
-### Fix
-
-- MINOR Time step can now be changed after a restart if adaptive time stepping is disabled. [#1343](https://github.com/chaos-polymtl/lethe/pull/1343)
-
-- MINOR Application of the immersed solid tanh diffusivity model is now faster thanks to using optimizations from the Shape class. [#1343](https://github.com/chaos-polymtl/lethe/pull/1343)
 
 ## [Master] - 2024-11-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fix
 
 - MINOR Time step can now be changed after a restart if adaptive time stepping is disabled. [#1343](https://github.com/chaos-polymtl/lethe/pull/1343)
+
 - MINOR Application of the immersed solid tanh diffusivity model is now faster thanks to using optimizations from the Shape class. [#1343](https://github.com/chaos-polymtl/lethe/pull/1343)
 
 ## [Master] - 2024-11-04

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -141,7 +141,7 @@ public:
    * from which it draws it's arguments. This structure is not kept internally.
    * This means that require information is copied from the struct to the class.
    *
-   * @param param Structure of the parameters for the simulation control
+   * @param[in] param Structure of the parameters for the simulation control
    *
    **/
 
@@ -169,7 +169,8 @@ public:
   /**
    * @brief Add a time step and stores the previous one in a list.
    *
-   *  @param p_timestep the new value of the time step for the present iteration.
+   *  @param[in] p_timestep the new value of the time step for the present
+   *iteration.
    **/
   void
   add_time_step(double p_timestep);
@@ -229,7 +230,7 @@ public:
   /**
    * @brief print_progress Function that prints the current progress status of the simulation
    *
-   * @param pcout the ConditionalOSStream that is use to write
+   * @param[in] pcout the ConditionalOSStream that is use to write
    */
   virtual void
   print_progression(const ConditionalOStream &pcout) = 0;
@@ -289,7 +290,7 @@ public:
   /**
    * @brief Set the value of the CFL condition
    *
-   * @param p_CFL Value of the CFL condition calculated by the solver.
+   * @param[in] p_CFL Value of the CFL condition calculated by the solver.
    */
 
   void
@@ -302,7 +303,7 @@ public:
   /**
    * @brief Manually force the value of the time step for the present iteration
    *
-   * @param new_time_step The new value of the time step.
+   * @param[in] new_time_step The new value of the time step.
    * This time step is appended to the time step history
    */
   void
@@ -316,7 +317,7 @@ public:
    * @brief Suggest the value of the time step for the next iteration. Note that
    * for adaptative simulations this time step may be altered
    *
-   * @param new_time_step The new value of the time step.
+   * @param[in] new_time_step The new value of the time step.
    * This time step is not added to the time step vector
    */
   void
@@ -330,7 +331,7 @@ public:
    * @brief Provide the value of the residual at the beginning
    * of the iteration to the simulation controller
    *
-   * @param new_residual Value of the residual at the beginning
+   * @param[in] new_residual Value of the residual at the beginning
    * of an adjoint time-stepping time step
    */
   void
@@ -455,7 +456,7 @@ public:
   /**
    * @brief Save the simulation control information from the checkpoint file and updates the time step vector, the CFL value, the time and the iteration number.
    *
-   * @param prefix The prefix of the checkpoint of the simulation
+   * @param[in] prefix The prefix of the checkpoint of the simulation
    */
   virtual void
   save(const std::string &prefix);
@@ -463,7 +464,7 @@ public:
   /**
    * @brief Reads the simulation control information from the checkpoint file and updates the time step vector, the CFL value, the time and the iteration number.
    *
-   * @param prefix The prefix of the checkpoint of the simulation
+   * @param[in] prefix The prefix of the checkpoint of the simulation
    */
   virtual void
   read(const std::string &prefix);
@@ -471,7 +472,7 @@ public:
   /**
    * @brief Reads and returns the simulation control information from the checkpoint file filename without updating the simulation control information.
    *
-   * @param prefix The prefix of the checkpoint of the simulation
+   * @param[in] prefix The prefix of the checkpoint of the simulation
    *
    * @return A vector containing the last checkpointed file and time step.
    */
@@ -540,9 +541,10 @@ public:
   integrate() override;
 
   /**
-   * @brief Reads the simulation control information from the checkpoint file and updates the time step vector, the CFL value, the time and the iteration number.
+   * @brief Reads the simulation control information and updates the time integration variables. Allows to change time
+   * step if adaptive time stepping is disabled.
    *
-   * @param prefix The prefix of the checkpoint of the simulation
+   * @param[in] prefix The prefix of the checkpoint of the simulation
    */
   void
   read(const std::string &prefix) override;

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -540,6 +540,15 @@ public:
   integrate() override;
 
   /**
+   * @brief Reads the simulation control information from the checkpoint file and updates the time step vector, the CFL value, the time and the iteration number.
+   *
+   * @param prefix The prefix of the checkpoint of the simulation
+   */
+  void
+  read(const std::string &prefix) override;
+
+
+  /**
    * @brief Ends the simulation when the end time is reached
    */
   virtual bool

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -541,16 +541,6 @@ public:
   integrate() override;
 
   /**
-   * @brief Reads the simulation control information and updates the time integration variables. Allows to change time
-   * step if adaptive time stepping is disabled.
-   *
-   * @param[in] prefix The prefix of the checkpoint of the simulation
-   */
-  void
-  read(const std::string &prefix) override;
-
-
-  /**
    * @brief Ends the simulation when the end time is reached
    */
   virtual bool
@@ -576,7 +566,8 @@ public:
   /**
    * @brief Reads the simulation control information from the checkpoint file and
    * updates the time step vector, the CFL value, the time, the iteration number
-   * and the index of the output times vector if time control is used.
+   * and the index of the output times vector if time control is used. Allows to
+   * change time step if adaptive time stepping is disabled.
    *
    * @param prefix The prefix of the checkpoint of the simulation
    */

--- a/include/core/tracer_diffusivity_model.h
+++ b/include/core/tracer_diffusivity_model.h
@@ -162,14 +162,14 @@ public:
 
     const std::vector<double> &levelset_vec = field_vectors.at(field::levelset);
 
-    const unsigned int n_values = levelset_vec.size();
+    const unsigned int n_values = property_vector.size();
 
     Assert(n_values == levelset_vec.size(),
            SizeOfFields(n_values, levelset_vec.size()));
 
     for (unsigned int i = 0; i < n_values; ++i)
       {
-        double levelset = levelset_vec[i];
+        const double levelset = levelset_vec[i];
         property_vector[i] =
           tracer_diffusivity_inside +
           delta_diffusivity * (0.5 + 0.5 * tanh(levelset / thickness));

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -556,18 +556,18 @@ public:
   get_projected_phase_fraction_gradient_dof_handler();
 
   /**
-   * @brief Request immersed solid signed distance function
+   * @brief Request immersed solid shape
    */
   Shape<dim> *
-  get_immersed_solid_signed_distance_function();
+  get_immersed_solid_shape();
 
   /**
-   * @brief Share immersed solid signed distance function
+   * @brief Share immersed solid shape
    *
-   * @param function The immersed solid signed distance function
+   * @param shape The immersed solid shape
    */
   void
-  set_immersed_solid_signed_distance_function(Shape<dim> *function);
+  set_immersed_solid_shape(Shape<dim> *shape);
 
   /**
    * @brief Request the previous solutions of a given physics
@@ -913,8 +913,8 @@ private:
   // solver.
   GlobalVectorType *reynolds_stress_solutions;
 
-  // Immersed solid signed distance function to be used by auxiliary physics
-  Shape<dim> *immersed_solid_signed_distance_function;
+  // Immersed solid shape to be used by auxiliary physics
+  Shape<dim> *immersed_solid_shape;
 
   // past (minus 1) solution
   std::map<PhysicsID, GlobalVectorType *>      physics_solutions_m1;

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -558,7 +558,7 @@ public:
   /**
    * @brief Request immersed solid signed distance function
    */
-  Function<dim> *
+  Shape<dim> *
   get_immersed_solid_signed_distance_function();
 
   /**
@@ -567,7 +567,7 @@ public:
    * @param function The immersed solid signed distance function
    */
   void
-  set_immersed_solid_signed_distance_function(Function<dim> *function);
+  set_immersed_solid_signed_distance_function(Shape<dim> *function);
 
   /**
    * @brief Request the previous solutions of a given physics
@@ -914,7 +914,7 @@ private:
   GlobalVectorType *reynolds_stress_solutions;
 
   // Immersed solid signed distance function to be used by auxiliary physics
-  Function<dim> *immersed_solid_signed_distance_function;
+  Shape<dim> *immersed_solid_signed_distance_function;
 
   // past (minus 1) solution
   std::map<PhysicsID, GlobalVectorType *>      physics_solutions_m1;

--- a/include/solvers/multiphysics_interface.h
+++ b/include/solvers/multiphysics_interface.h
@@ -564,7 +564,7 @@ public:
   /**
    * @brief Share immersed solid shape
    *
-   * @param shape The immersed solid shape
+   * @param[in] shape The immersed solid shape
    */
   void
   set_immersed_solid_shape(Shape<dim> *shape);

--- a/include/solvers/tracer_scratch_data.h
+++ b/include/solvers/tracer_scratch_data.h
@@ -159,7 +159,7 @@ public:
          const VectorType                                     &current_solution,
          const std::vector<VectorType> &previous_solutions,
          const Function<dim>           *source_function,
-         const Function<dim>           *levelset_function)
+         Shape<dim>                    *levelset_function)
   {
     this->fe_values_tracer.reinit(cell);
 
@@ -176,6 +176,10 @@ public:
             "Levelset function is required for tracer assembly, but the level set function is a nullptr"));
 
         levelset_function->value_list(quadrature_points, sdf_values);
+        for (unsigned int q = 0; q < n_q_points; q++)
+          sdf_values[q] =
+            levelset_function->value_with_cell_guess(quadrature_points[q],
+                                                     cell);
       }
 
     // Compute cell diameter

--- a/include/solvers/tracer_scratch_data.h
+++ b/include/solvers/tracer_scratch_data.h
@@ -175,7 +175,6 @@ public:
           ExcMessage(
             "Levelset function is required for tracer assembly, but the level set function is a nullptr"));
 
-        levelset_function->value_list(quadrature_points, sdf_values);
         for (unsigned int q = 0; q < n_q_points; q++)
           sdf_values[q] =
             levelset_function->value_with_cell_guess(quadrature_points[q],

--- a/include/solvers/tracer_scratch_data.h
+++ b/include/solvers/tracer_scratch_data.h
@@ -215,12 +215,12 @@ public:
     const typename DoFHandler<dim>::active_cell_iterator &cell,
     Shape<dim>                                           *immersed_solid_shape)
   {
-    this->fe_values_tracer.reinit(cell);
-
-    quadrature_points = this->fe_values_tracer.get_quadrature_points();
-
     if (properties_manager.field_is_required(field::levelset))
       {
+        this->fe_values_tracer.reinit(cell);
+
+        quadrature_points = this->fe_values_tracer.get_quadrature_points();
+
         Assert(
           immersed_solid_shape != nullptr,
           ExcMessage(
@@ -233,9 +233,10 @@ public:
       }
   }
 
-  /** @brief Reinitializes the signed distance vector of the scratch.
+  /** @brief Reinitializes the signed distance vector of the scratch for a given face.
    *
    * @param[in] cell The cell over which the assembly is being carried.
+   * @param[in] face_no The face index associated with the cell
    * @param[in] immersed_solid_shape The shape describing the particles (if
    * there are any).
    */
@@ -245,11 +246,12 @@ public:
     const unsigned int                                   &face_no,
     Shape<dim>                                           *immersed_solid_shape)
   {
-    fe_interface_values_tracer.reinit(cell, face_no);
-    face_quadrature_points = fe_interface_values_tracer.get_quadrature_points();
-
     if (properties_manager.field_is_required(field::levelset))
       {
+        fe_interface_values_tracer.reinit(cell, face_no);
+        face_quadrature_points =
+          fe_interface_values_tracer.get_quadrature_points();
+
         Assert(
           immersed_solid_shape != nullptr,
           ExcMessage(
@@ -277,7 +279,6 @@ public:
    * @param drift_velocity Function to calculate the drift velocity
    *
    */
-
   template <typename VectorType>
   void
   reinit_velocity(
@@ -345,10 +346,6 @@ public:
    * neighboring cell
    *
    * @param[in] current_solution The present value of the solution.
-   *
-   * @param[in] immersed_solid_shape Shape used for the calculation of the
-   * level set. This is used for the calculation of the physical properties.
-   * (if there are any).
    */
   template <typename VectorType>
   void
@@ -403,10 +400,6 @@ public:
    *
    * @param[in] current_solution The present value of the solution.
    * there are any).
-   *
-   * @param[in] immersed_solid_shape Shape used for the calculation of the level
-   * set. This is used for the calculation of the physical properties. there are
-   * any).
    */
   template <typename VectorType>
   void
@@ -511,9 +504,10 @@ public:
     // BB note : Array could be pre-allocated
     tracer_diffusivity_face.resize(face_quadrature_points.size());
 
-    // If the trace diffusivity depends on the level set, take this into account
+    // If the tracer diffusivity depends on the level set, take this into
+    // account
     if (properties_manager.field_is_required(field::levelset))
-      set_field_vector(field::levelset, sdf_face_values, fields);
+      set_field_vector(field::levelset, sdf_values, fields);
 
 
     diffusivity_model->vector_value(fields, tracer_diffusivity_face);
@@ -573,9 +567,8 @@ public:
   // Bool that defines if the selected face is a dirichlet/outlet boundary
   unsigned int boundary_index;
 
-  // Immersed solid shape (signed distance) function
+  // Immersed solid shape (signed distance function)
   std::vector<double> sdf_values;
-  std::vector<double> sdf_face_values;
 
 
   // Source term

--- a/include/solvers/tracer_scratch_data.h
+++ b/include/solvers/tracer_scratch_data.h
@@ -150,7 +150,7 @@ public:
    *
    * @param[in] source_function The function describing the tracer source term.
    *
-   * @param[in] levelset_function The function describing the particles (if
+   * @param[in] immersed_solid_shape The shape describing the particles (if
    * there are any).
    */
   template <typename VectorType>
@@ -159,7 +159,7 @@ public:
          const VectorType                                     &current_solution,
          const std::vector<VectorType> &previous_solutions,
          const Function<dim>           *source_function,
-         Shape<dim>                    *levelset_function)
+         Shape<dim>                    *immersed_solid_shape)
   {
     this->fe_values_tracer.reinit(cell);
 
@@ -171,14 +171,14 @@ public:
     if (properties_manager.field_is_required(field::levelset))
       {
         Assert(
-          levelset_function != nullptr,
+          immersed_solid_shape != nullptr,
           ExcMessage(
-            "Levelset function is required for tracer assembly, but the level set function is a nullptr"));
+            "Shape is required for tracer assembly, but the shape is a nullptr"));
 
         for (unsigned int q = 0; q < n_q_points; q++)
           sdf_values[q] =
-            levelset_function->value_with_cell_guess(quadrature_points[q],
-                                                     cell);
+            immersed_solid_shape->value_with_cell_guess(quadrature_points[q],
+                                                        cell);
       }
 
     // Compute cell diameter
@@ -306,7 +306,7 @@ public:
    *
    * @param[in] current_solution The present value of the solution.
    *
-   * @param[in] levelset_function Function used for the calculation of the
+   * @param[in] immersed_solid_shape Shape used for the calculation of the
    * level set. This is used for the calculation of the physical properties.
    * (if there are any).
    */
@@ -320,7 +320,7 @@ public:
     const unsigned int                                   &neigh_face_no,
     const unsigned int                                   &neigh_sub_face_no,
     const VectorType                                     &current_solution,
-    const Function<dim>                                  *levelset_function)
+    const Function<dim>                                  *immersed_solid_shape)
   {
     fe_interface_values_tracer.reinit(
       cell, face_no, sub_face_no, neigh_cell, neigh_face_no, neigh_sub_face_no);
@@ -357,11 +357,12 @@ public:
     if (properties_manager.field_is_required(field::levelset))
       {
         Assert(
-          levelset_function != nullptr,
+          immersed_solid_shape != nullptr,
           ExcMessage(
-            "Levelset function is required for tracer assembly, but the level set function is a nullptr"));
+            "Shape is required for tracer assembly, but the shape is a nullptr"));
 
-        levelset_function->value_list(face_quadrature_points, sdf_face_values);
+        immersed_solid_shape->value_list(face_quadrature_points,
+                                         sdf_face_values);
       }
   }
 
@@ -375,7 +376,7 @@ public:
    * @param[in] current_solution The present value of the solution.
    * there are any).
    *
-   * @param[in] levelset_function Function used for the calculation of the level
+   * @param[in] immersed_solid_shape Shape used for the calculation of the level
    * set. This is used for the calculation of the physical properties. there are
    * any).
    */
@@ -386,7 +387,7 @@ public:
     const unsigned int                                   &face_no,
     const unsigned int                                   &boundary_index,
     const VectorType                                     &current_solution,
-    const Function<dim>                                  *levelset_function)
+    Shape<dim>                                           *immersed_solid_shape)
   {
     fe_interface_values_tracer.reinit(cell, face_no);
     const FEFaceValuesBase<dim> &fe_face =
@@ -410,11 +411,12 @@ public:
     if (properties_manager.field_is_required(field::levelset))
       {
         Assert(
-          levelset_function != nullptr,
+          immersed_solid_shape != nullptr,
           ExcMessage(
-            "Levelset function is required for tracer assembly, but the level set function is a nullptr"));
+            "Shape is required for tracer assembly, but the shape is a nullptr"));
 
-        levelset_function->value_list(face_quadrature_points, sdf_face_values);
+        immersed_solid_shape->value_list(face_quadrature_points,
+                                         sdf_face_values);
       }
   }
 
@@ -555,7 +557,7 @@ public:
   // Bool that defines if the selected face is a dirichlet/outlet boundary
   unsigned int boundary_index;
 
-  // Solid signed distance function
+  // Immersed solid shape (signed distance) function
   std::vector<double> sdf_values;
   std::vector<double> sdf_face_values;
 

--- a/include/solvers/tracer_scratch_data.h
+++ b/include/solvers/tracer_scratch_data.h
@@ -320,7 +320,7 @@ public:
     const unsigned int                                   &neigh_face_no,
     const unsigned int                                   &neigh_sub_face_no,
     const VectorType                                     &current_solution,
-    const Function<dim>                                  *immersed_solid_shape)
+    Shape<dim>                                           *immersed_solid_shape)
   {
     fe_interface_values_tracer.reinit(
       cell, face_no, sub_face_no, neigh_cell, neigh_face_no, neigh_sub_face_no);
@@ -361,8 +361,10 @@ public:
           ExcMessage(
             "Shape is required for tracer assembly, but the shape is a nullptr"));
 
-        immersed_solid_shape->value_list(face_quadrature_points,
-                                         sdf_face_values);
+        unsigned int n_face_q_points = face_quadrature_points.size();
+        for (unsigned int q = 0; q < n_face_q_points; q++)
+          sdf_values[q] = immersed_solid_shape->value_with_cell_guess(
+            face_quadrature_points[q], cell);
       }
   }
 
@@ -415,8 +417,10 @@ public:
           ExcMessage(
             "Shape is required for tracer assembly, but the shape is a nullptr"));
 
-        immersed_solid_shape->value_list(face_quadrature_points,
-                                         sdf_face_values);
+        unsigned int n_face_q_points = face_quadrature_points.size();
+        for (unsigned int q = 0; q < n_face_q_points; q++)
+          sdf_values[q] = immersed_solid_shape->value_with_cell_guess(
+            face_quadrature_points[q], cell);
       }
   }
 

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -265,6 +265,18 @@ SimulationControlTransient::integrate()
     return false;
 }
 
+void
+SimulationControlTransient::read(const std::string &prefix)
+{
+  SimulationControl::read(prefix);
+
+  // Fix the time step to the new provided value.
+  // We understand that users providing this value when adaptive time stepping
+  // is not enabled means a time step change is the desired effect.
+  if (!adapt)
+    set_current_time_step(initial_time_step);
+}
+
 bool
 SimulationControlTransient::is_at_end()
 {

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -265,18 +265,6 @@ SimulationControlTransient::integrate()
     return false;
 }
 
-void
-SimulationControlTransient::read(const std::string &prefix)
-{
-  SimulationControl::read(prefix);
-
-  // Fix the time step to the new provided value.
-  // We understand that users providing this value when adaptive time stepping
-  // is not enabled means a time step change is the desired effect.
-  if (!adapt)
-    set_current_time_step(initial_time_step);
-}
-
 bool
 SimulationControlTransient::is_at_end()
 {
@@ -451,6 +439,12 @@ SimulationControlTransient::read(const std::string &prefix)
         }
       input >> buffer >> output_times_counter;
     }
+
+  if (!adapt)
+    // Fix the time step to the new provided value.
+    // We understand that users providing this value when adaptive time stepping
+    // is not enabled means a time step change is the desired effect.
+    set_current_time_step(initial_time_step);
 }
 
 SimulationControlTransientDEM::SimulationControlTransientDEM(

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -809,8 +809,7 @@ FluidDynamicsSharp<dim>::define_particles()
     }
   combined_shapes =
     std::make_shared<CompositeShape<dim>>(all_shapes, Point<dim>(), Point<3>());
-  this->multiphysics->set_immersed_solid_signed_distance_function(
-    &(*combined_shapes));
+  this->multiphysics->set_immersed_solid_shape(&(*combined_shapes));
 }
 
 
@@ -4866,8 +4865,7 @@ FluidDynamicsSharp<dim>::solve()
                                                    *this->mapping);
           ib_dem.update_contact_candidates();
 
-          this->multiphysics->set_immersed_solid_signed_distance_function(
-            &(*combined_shapes));
+          this->multiphysics->set_immersed_solid_shape(&(*combined_shapes));
           this->iterate();
         }
       else
@@ -4887,8 +4885,7 @@ FluidDynamicsSharp<dim>::solve()
                 0)
             ib_dem.update_contact_candidates();
 
-          this->multiphysics->set_immersed_solid_signed_distance_function(
-            &(*combined_shapes));
+          this->multiphysics->set_immersed_solid_shape(&(*combined_shapes));
 
           // add initialization
           this->iterate();

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -4864,8 +4864,6 @@ FluidDynamicsSharp<dim>::solve()
                                                    *this->face_quadrature,
                                                    *this->mapping);
           ib_dem.update_contact_candidates();
-
-          this->multiphysics->set_immersed_solid_shape(&(*combined_shapes));
           this->iterate();
         }
       else
@@ -4884,8 +4882,6 @@ FluidDynamicsSharp<dim>::solve()
                     ->contact_search_frequency ==
                 0)
             ib_dem.update_contact_candidates();
-
-          this->multiphysics->set_immersed_solid_shape(&(*combined_shapes));
 
           // add initialization
           this->iterate();

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -4865,6 +4865,9 @@ FluidDynamicsSharp<dim>::solve()
                                                    *this->face_quadrature,
                                                    *this->mapping);
           ib_dem.update_contact_candidates();
+
+          this->multiphysics->set_immersed_solid_signed_distance_function(
+            &(*combined_shapes));
           this->iterate();
         }
       else
@@ -4884,6 +4887,8 @@ FluidDynamicsSharp<dim>::solve()
                 0)
             ib_dem.update_contact_candidates();
 
+          this->multiphysics->set_immersed_solid_signed_distance_function(
+            &(*combined_shapes));
 
           // add initialization
           this->iterate();

--- a/source/solvers/multiphysics_interface.cc
+++ b/source/solvers/multiphysics_interface.cc
@@ -221,19 +221,18 @@ MultiphysicsInterface<dim>::get_projected_phase_fraction_gradient_dof_handler()
 
 template <int dim>
 Shape<dim> *
-MultiphysicsInterface<dim>::get_immersed_solid_signed_distance_function()
+MultiphysicsInterface<dim>::get_immersed_solid_shape()
 {
   // This pointer is also used to check if an immersed boundary solid method is
   // being used, depending on whether the pointer is assigned.
-  return immersed_solid_signed_distance_function;
+  return immersed_solid_shape;
 }
 
 template <int dim>
 void
-MultiphysicsInterface<dim>::set_immersed_solid_signed_distance_function(
-  Shape<dim> *function)
+MultiphysicsInterface<dim>::set_immersed_solid_shape(Shape<dim> *shape)
 {
-  immersed_solid_signed_distance_function = function;
+  immersed_solid_shape = shape;
 }
 
 template <int dim>

--- a/source/solvers/multiphysics_interface.cc
+++ b/source/solvers/multiphysics_interface.cc
@@ -220,7 +220,7 @@ MultiphysicsInterface<dim>::get_projected_phase_fraction_gradient_dof_handler()
 }
 
 template <int dim>
-Function<dim> *
+Shape<dim> *
 MultiphysicsInterface<dim>::get_immersed_solid_signed_distance_function()
 {
   // This pointer is also used to check if an immersed boundary solid method is
@@ -231,7 +231,7 @@ MultiphysicsInterface<dim>::get_immersed_solid_signed_distance_function()
 template <int dim>
 void
 MultiphysicsInterface<dim>::set_immersed_solid_signed_distance_function(
-  Function<dim> *function)
+  Shape<dim> *function)
 {
   immersed_solid_signed_distance_function = function;
 }

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -256,8 +256,10 @@ Tracer<dim>::assemble_local_system_matrix(
   scratch_data.reinit(cell,
                       this->evaluation_point,
                       this->previous_solutions,
-                      &(*simulation_parameters.source_term.tracer_source),
-                      &(*this->multiphysics->get_immersed_solid_shape()));
+                      &(*simulation_parameters.source_term.tracer_source));
+
+  scratch_data.reinit_signed_distance(
+    cell, &(*this->multiphysics->get_immersed_solid_shape()));
 
   const DoFHandler<dim> *dof_handler_fluid =
     multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);
@@ -537,8 +539,10 @@ Tracer<dim>::assemble_local_system_rhs(
   scratch_data.reinit(cell,
                       this->evaluation_point,
                       this->previous_solutions,
-                      &(*source_term),
-                      (this->multiphysics->get_immersed_solid_shape()));
+                      &(*source_term));
+
+  scratch_data.reinit_signed_distance(
+    cell, &(*this->multiphysics->get_immersed_solid_shape()));
 
   const DoFHandler<dim> *dof_handler_fluid =
     multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -144,12 +144,13 @@ Tracer<dim>::assemble_system_matrix_dg()
         StabilizedDGMethodsCopyData                          &copy_data) {
       const auto boundary_index = cell->face(face_no)->boundary_id();
 
-      scratch_data.reinit_boundary_face(
-        cell,
-        face_no,
-        boundary_index,
-        this->evaluation_point,
-        this->multiphysics->get_immersed_solid_shape());
+      scratch_data.reinit_boundary_face(cell,
+                                        face_no,
+                                        boundary_index,
+                                        this->evaluation_point);
+
+      scratch_data.reinit_signed_distance_at_face(
+        cell, face_no, this->multiphysics->get_immersed_solid_shape());
 
       // Gather velocity information at the face to properly advect
       const DoFHandler<dim> *dof_handler_fluid =
@@ -177,15 +178,16 @@ Tracer<dim>::assemble_system_matrix_dg()
         const unsigned int                                   &neigh_sub_face_no,
         TracerScratchData<dim>                               &scratch_data,
         StabilizedDGMethodsCopyData                          &copy_data) {
-      scratch_data.reinit_internal_face(
-        cell,
-        face_no,
-        sub_face_no,
-        neigh_cell,
-        neigh_face_no,
-        neigh_sub_face_no,
-        this->evaluation_point,
-        this->multiphysics->get_immersed_solid_shape());
+      scratch_data.reinit_internal_face(cell,
+                                        face_no,
+                                        sub_face_no,
+                                        neigh_cell,
+                                        neigh_face_no,
+                                        neigh_sub_face_no,
+                                        this->evaluation_point);
+
+      scratch_data.reinit_signed_distance_at_face(
+        cell, face_no, this->multiphysics->get_immersed_solid_shape());
 
       // Pad copy_data memory for the internal faces elementary matrices
       // BB note : Array could be pre-allocated
@@ -428,12 +430,13 @@ Tracer<dim>::assemble_system_rhs_dg()
       // Identify which boundary condition corresponds to the boundary id.
       const auto boundary_index = cell->face(face_no)->boundary_id();
 
-      scratch_data.reinit_boundary_face(
-        cell,
-        face_no,
-        boundary_index,
-        this->evaluation_point,
-        this->multiphysics->get_immersed_solid_shape());
+      scratch_data.reinit_boundary_face(cell,
+                                        face_no,
+                                        boundary_index,
+                                        this->evaluation_point);
+
+      scratch_data.reinit_signed_distance_at_face(
+        cell, face_no, this->multiphysics->get_immersed_solid_shape());
 
       // Gather velocity information at the face to properly advect
       // First gather the dof handler for the fluid dynamics
@@ -463,15 +466,16 @@ Tracer<dim>::assemble_system_rhs_dg()
         StabilizedDGMethodsCopyData                          &copy_data)
 
   {
-    scratch_data.reinit_internal_face(
-      cell,
-      face_no,
-      sub_face_no,
-      neigh_cell,
-      neigh_face_no,
-      neigh_sub_face_no,
-      this->evaluation_point,
-      this->multiphysics->get_immersed_solid_shape());
+    scratch_data.reinit_internal_face(cell,
+                                      face_no,
+                                      sub_face_no,
+                                      neigh_cell,
+                                      neigh_face_no,
+                                      neigh_sub_face_no,
+                                      this->evaluation_point);
+
+    scratch_data.reinit_signed_distance_at_face(
+      cell, face_no, this->multiphysics->get_immersed_solid_shape());
 
     copy_data.face_data.emplace_back();
     auto &copy_data_face = copy_data.face_data.back();

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -149,7 +149,7 @@ Tracer<dim>::assemble_system_matrix_dg()
         face_no,
         boundary_index,
         this->evaluation_point,
-        this->multiphysics->get_immersed_solid_signed_distance_function());
+        this->multiphysics->get_immersed_solid_shape());
 
       // Gather velocity information at the face to properly advect
       const DoFHandler<dim> *dof_handler_fluid =
@@ -185,7 +185,7 @@ Tracer<dim>::assemble_system_matrix_dg()
         neigh_face_no,
         neigh_sub_face_no,
         this->evaluation_point,
-        this->multiphysics->get_immersed_solid_signed_distance_function());
+        this->multiphysics->get_immersed_solid_shape());
 
       // Pad copy_data memory for the internal faces elementary matrices
       // BB note : Array could be pre-allocated
@@ -253,12 +253,11 @@ Tracer<dim>::assemble_local_system_matrix(
   if (!cell->is_locally_owned())
     return;
 
-  scratch_data.reinit(
-    cell,
-    this->evaluation_point,
-    this->previous_solutions,
-    &(*simulation_parameters.source_term.tracer_source),
-    &(*this->multiphysics->get_immersed_solid_signed_distance_function()));
+  scratch_data.reinit(cell,
+                      this->evaluation_point,
+                      this->previous_solutions,
+                      &(*simulation_parameters.source_term.tracer_source),
+                      &(*this->multiphysics->get_immersed_solid_shape()));
 
   const DoFHandler<dim> *dof_handler_fluid =
     multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);
@@ -432,7 +431,7 @@ Tracer<dim>::assemble_system_rhs_dg()
         face_no,
         boundary_index,
         this->evaluation_point,
-        this->multiphysics->get_immersed_solid_signed_distance_function());
+        this->multiphysics->get_immersed_solid_shape());
 
       // Gather velocity information at the face to properly advect
       // First gather the dof handler for the fluid dynamics
@@ -470,7 +469,7 @@ Tracer<dim>::assemble_system_rhs_dg()
       neigh_face_no,
       neigh_sub_face_no,
       this->evaluation_point,
-      this->multiphysics->get_immersed_solid_signed_distance_function());
+      this->multiphysics->get_immersed_solid_shape());
 
     copy_data.face_data.emplace_back();
     auto &copy_data_face = copy_data.face_data.back();
@@ -535,12 +534,11 @@ Tracer<dim>::assemble_local_system_rhs(
   auto source_term = simulation_parameters.source_term.tracer_source;
   source_term->set_time(simulation_control->get_current_time());
 
-  scratch_data.reinit(
-    cell,
-    this->evaluation_point,
-    this->previous_solutions,
-    &(*source_term),
-    (this->multiphysics->get_immersed_solid_signed_distance_function()));
+  scratch_data.reinit(cell,
+                      this->evaluation_point,
+                      this->previous_solutions,
+                      &(*source_term),
+                      (this->multiphysics->get_immersed_solid_shape()));
 
   const DoFHandler<dim> *dof_handler_fluid =
     multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);
@@ -943,8 +941,7 @@ Tracer<dim>::postprocess_tracer_flow_rate(const VectorType &current_solution_fd)
                                                               n_q_points_face));
                       face_quadrature_points =
                         fe_face_values_tracer.get_quadrature_points();
-                      this->multiphysics
-                        ->get_immersed_solid_signed_distance_function()
+                      this->multiphysics->get_immersed_solid_shape()
                         ->value_list(face_quadrature_points, levelset_values);
                       set_field_vector(field::levelset,
                                        levelset_values,


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

There were two issues that appeared when using the tracer physics with an immersed solid:
- Evaluation of the diffusivity model `immersed solid tanh` was too costly
- Changing the `time step` after restarting was impossible

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

### Solution

- The diffusivity model now uses the optimizations from the Shape class, that allow to evaluate the distance using a cell guess; this makes RBF and composite distance evaluations magnitudes faster.
- Time step change after a restart is now allowed when `adapt==false`. This behavior is not allowed when `adapt==true`, as then we desire a continuity in time step evolution. When using fixed time step though, users who change the value after a restart apparently aim for this behavior.

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->

### Testing

All tests still pass.

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

### Documentation

No change needed.
<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge