### PR TITLE
Simplify the linear solver for the taylor-couette

### DIFF
--- a/examples/incompressible-flow/2d-taylor-couette/taylor-couette.prm
+++ b/examples/incompressible-flow/2d-taylor-couette/taylor-couette.prm
@@ -106,7 +106,7 @@ end
 #---------------------------------------------------
 
 subsection timer
-  set type               = iteration
+  set type = iteration
 end
 
 #---------------------------------------------------
@@ -128,10 +128,10 @@ end
 
 subsection linear solver
   subsection fluid dynamics
-    set method                                    = gmres
-    set relative residual                         = 1e-4
-    set minimum residual                          = 1e-11
-    set preconditioner                            = amg
-    set verbosity                                 = verbose
+    set method            = gmres
+    set relative residual = 1e-4
+    set minimum residual  = 1e-11
+    set preconditioner    = amg
+    set verbosity         = verbose
   end
 end

--- a/examples/incompressible-flow/2d-taylor-couette/taylor-couette.prm
+++ b/examples/incompressible-flow/2d-taylor-couette/taylor-couette.prm
@@ -102,6 +102,14 @@ subsection mesh adaptation
 end
 
 #---------------------------------------------------
+# Timer
+#---------------------------------------------------
+
+subsection timer
+  set type               = iteration
+end
+
+#---------------------------------------------------
 # Non-Linear Solver Control
 #---------------------------------------------------
 
@@ -121,18 +129,9 @@ end
 subsection linear solver
   subsection fluid dynamics
     set method                                    = gmres
-    set max iters                                 = 100
     set relative residual                         = 1e-4
     set minimum residual                          = 1e-11
     set preconditioner                            = amg
-    set amg preconditioner ilu fill               = 1
-    set amg preconditioner ilu absolute tolerance = 1e-10
-    set amg preconditioner ilu relative tolerance = 1.00
-    set amg aggregation threshold                 = 1e-14 # Aggregation
-    set amg n cycles                              = 1     # Number of AMG cycles
-    set amg w cycles                              = true  # W cycles, otherwise V cycles
-    set amg smoother sweeps                       = 2     # Sweeps
-    set amg smoother overlap                      = 1     # Overlap
     set verbosity                                 = verbose
   end
 end


### PR DESCRIPTION
### Description

The Taylor-Couette example is fine as-is. However, the linear solver could be made simpler. The default AMG parameters work just fine and are actually cheaper.


Code related list:
- [x] Lethe documentation is up to date
- [x] Copyright headers are present and up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] Links are added to parent .rst files
- [x] The example is following the [standard format](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#general-rules-and-format)

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planed, an issue is opened
- [x] The PR description is cleaned and ready for merge