### PR TITLE
Fix typo and broken link

### DIFF
--- a/doc/source/examples/dem/oblique-wall-impact/oblique-wall-impact.rst
+++ b/doc/source/examples/dem/oblique-wall-impact/oblique-wall-impact.rst
@@ -13,7 +13,7 @@ Features
 - Postprocessing using `Python <https://www.python.org/>`_, `PyVista <https://docs.pyvista.org/>`_, `lethe_pyvista_tools <https://github.com/chaos-polymtl/lethe/tree/master/contrib/postprocessing>`_
 
 ----------------------------
-Files Used in This Example
+Files Used in this Example
 ----------------------------
 
 All files mentioned below are located in the example's folder (``examples/dem/3d-oblique-wall-impact``).
@@ -147,7 +147,7 @@ A Python post-processing code called ``oblique_wall_impact_postprocessing.py`` i
 
 .. important::
 
-    You need to ensure that ``lethe_pyvista_tools`` is working on your machine. Click `here <../../../tools/postprocessing/postprocessing.html>`_ for details.
+    You need to ensure that ``lethe_pyvista_tools`` is working on your machine. Click `here <../../../tools/postprocessing/postprocessing_pyvista.html>`_ for details.
 
 A figure will be generated which compares the simulation results with the experimental data.
 


### PR DESCRIPTION

### Description

The oblique wall example works fine but it had a broken link when referencing lethe_pyvista_tool and a typo in the text. I fixed those.


Code related list:
- [x] Lethe documentation is up to date
- [x] Copyright headers are present and up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] Links are added to parent .rst files
- [x] The example is following the [standard format](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#general-rules-and-format)

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge