### PR TITLE
Update TGV example in documentation

### DIFF
--- a/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
+++ b/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
@@ -189,7 +189,7 @@ Since this is a transient problem, the linear solver can be relatively simple. W
     subsection fluid dynamics
       set verbosity                             = verbose
       set method                                = gmres
-      set max iters                             = 200
+      set max iters                             = 100
       set max krylov vectors                    = 200
       set relative residual                     = 1e-4
       set minimum residual                      = 1e-7
@@ -223,15 +223,17 @@ The ``lethe-fluid-matrix-free`` has significantly more parameters for its linear
 
   subsection linear solver
     subsection fluid dynamics
-      set method            = gmres
-      set max iters         = 100
-      set relative residual = 1e-4
-      set minimum residual  = 1e-7
-      set preconditioner    = gcmg
-      set verbosity         = verbose
+      set verbosity          = verbose
+      set method             = gmres
+      set max iters          = 100
+      set max krylov vectors = 200
+      set relative residual  = 1e-4
+      set minimum residual   = 1e-7
+      set preconditioner     = gcmg
       
       # MG parameters
-      set mg verbosity = quiet
+      set mg verbosity                   = quiet
+      set mg enable hessians in jacobian = false
 
       # Smoother
       set mg smoother iterations     = 5
@@ -239,7 +241,7 @@ The ``lethe-fluid-matrix-free`` has significantly more parameters for its linear
 
       # Eigenvalue estimation parameters
       set eig estimation smoothing range = 5
-      set eig estimation cg n iterations = 10
+      set eig estimation cg n iterations = 20
       set eig estimation verbosity       = quiet
 
       # Coarse-grid solver

--- a/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
+++ b/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
@@ -247,7 +247,7 @@ The ``lethe-fluid-matrix-free`` has significantly more parameters for its linear
     end
   end
 
-We set ``mg verbosity = quiet`` to prevent logging of the multigrid parameters during the simulation.  The ``smoother``, ``Eigenvalue estimation parameters`` and ``coarse-grid solver`` subsections are explained in the **Theory Guide** (under construction).
+We set ``mg verbosity = quiet`` to prevent logging of the multigrid parameters during the simulation.  The ``smoother``, ``Eigenvalue estimation parameters`` and ``coarse-grid solver`` subsections are explained in the :doc:`../../../parameters/cfd/linear_solver_control` section.
 
 ----------------------
 Running the Simulation
@@ -340,7 +340,7 @@ Possibilities for Extension
 
 - This case is very interesting to postprocess. Try to postprocess this case using other quantities (vorticity, q-criterion) and use the results to generate interesting animations. Feel free to share them with us!
 
-- This case can also be used to experiment with adaptive time step. In the simulation control section add ``adapt = true`` and ``set max cfl = 1``, similar results should be obtained but with significantly less iterations as larger time steps are taken. To postprocess the results use an additional script given in the example folder in a similar way as the one for fixed time step (``calculate_dissipation_rate_constant_cfl.py``). You can also increase the CFL limit and see what happens!
+- This case can also be used to experiment with adaptive time step. In the simulation control section add ``adapt = true`` and ``set max cfl = 1``, similar results should be obtained but with significantly less iterations as larger time steps are taken. To postprocess the results use the additional script ``calculate_dissipation_rate_constant_cfl.py`` given in the same folder to calculate the kinetic energy rate. 
 
 
 ------------

--- a/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
+++ b/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
@@ -10,7 +10,7 @@ Features
 ---------
 
 - Solvers: ``lethe-fluid`` (with Q2-Q2) or  ``lethe-fluid-matrix-free`` (with Q2-Q2 or Q3-Q3)
-- Transient problem using ``bdf3`` time integrator
+- Transient problem using ``bdf2`` time integrator
 - Displays the calculation of enstrophy and total kinetic energy
 
 
@@ -148,12 +148,12 @@ To monitor the kinetic energy and the enstrophy, we set both calculation to ``tr
 Simulation Control
 ~~~~~~~~~~~~~~~~~~
 
-The ``simulation control`` subsection controls the flow of the simulation. To maximize the temporal accuracy of the simulation, we use a third order ``bdf3`` scheme. Results are written every 2 time-steps. To ensure a more adequate visualization of the high-order elements, we set ``subdivision = 3``. This will allow Paraview to render the high-order solutions with more fidelity.
+The ``simulation control`` subsection controls the flow of the simulation. To maximize the temporal accuracy of the simulation, we use a second order ``bdf2`` scheme. Results are written every 2 time-steps. To ensure a more adequate visualization of the high-order elements, we set ``subdivision = 3``. This will allow Paraview to render the high-order solutions with more fidelity.
 
 .. code-block:: text
 
   subsection simulation control
-    set method            = bdf3
+    set method            = bdf2
     set time step         = 0.05 
     set time end          = 20  
     set output frequency  = 2    

--- a/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
+++ b/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
@@ -39,8 +39,7 @@ The three velocity components :math:`[u_x,u_y,u_z]^T` and the pressure :math:`p`
   u_{z} &= 0 \\
   p &=  \frac{1}{16}*\left[\cos(2x)+\cos(2y)\right]\left[\cos(2z)+2\right]
 
-In this case, the vortex, which is initially 2D, will decay by generating smaller 3D turbulent structures (vortex tubes, rings and sheets). This decay can be monitored through the total kinetic energy of the system. Since the simulation domain is periodic, it can be demontrated that the time derative of the total kinetic energy :math:`E_\mathrm{k}` is directly related to the enstrophy :math:`\mathcal{E}` such that:
-
+In this case, the vortex, which is initially 2D, will decay by generating smaller 3D turbulent structures (vortex tubes, rings and sheets). This decay can be monitored through the total kinetic energy of the system. Since the simulation domain is periodic, it can be demonstrated that the time derative of the total kinetic energy :math:`E_\mathrm{k}` is directly related to the enstrophy :math:`\mathcal{E}` such that:
 
 
 .. math::
@@ -70,7 +69,7 @@ The ``mesh`` subsection specifies the computational grid:
     set initial refinement = 5 
   end
 
-The ``type`` specifies the mesh format used. We use the ``hyper_cube`` mesh generated from the deal.II `GridGenerator <https://www.dealii.org/current/doxygen/deal.II/namespaceGridGenerator.html>`_ . We set ``colorize = true`` to be able to adequately set-up the periodic boundary conditions.
+The ``type`` specifies the mesh format used. We use the ``hyper_cube`` mesh generated from the deal.II `GridGenerator <https://www.dealii.org/current/doxygen/deal.II/namespaceGridGenerator.html>`_ . We set ``colorize = true`` (the last parameter of the grid arguments) to assign boundary condition ids to each of the walls of the cube.
 
 
 The last parameter specifies the ``initial refinement`` of the grid. Indicating an ``initial refinement = 5`` implies that the initial mesh is refined 5 times. In 3D, each cell is divided by 8 per refinement. Consequently, the final grid is made of 32768 cells.
@@ -104,7 +103,7 @@ The ``boundary conditions`` subsection establishes the constraints on different 
     end
   end
 
-First, the ``number`` of boundary conditions to be applied must be specified. For each boundary condition, the ``id`` of the boundary as well as its ``type`` must be specified. All boundaries are ``periodic``. The ``x-`` (id=0) is periodic with the ``x+`` boundary (id=1), the ``y-`` (id=2) is periodic with the ``y+`` boundary (id=3) and so on and so forth. For each periodic boundary condition, the periodic direction must be specified. A periodic direction of ``0`` implies that the normal direction of the wall is the :math:`\mathbf{e}_x` vector, ``1`` implies that it's the :math:`\mathbf{e}_y`.
+First, the ``number`` of boundary conditions to be applied must be specified. For each boundary condition, the ``id`` of the boundary as well as its ``type`` must be specified. All boundaries are ``periodic``. The ``x-`` boundary (id=0) is periodic with the ``x+`` boundary (id=1), the ``y-`` boundary (id=2) is periodic with the ``y+`` boundary (id=3) and so on and so forth. For each periodic boundary condition, the periodic direction must be specified. A periodic direction of ``0`` implies that the normal direction of the wall is the :math:`\mathbf{e}_x` vector, ``1`` implies that it's the :math:`\mathbf{e}_y`.
 
 Physical Properties
 ~~~~~~~~~~~~~~~~~~~
@@ -124,7 +123,7 @@ The Reynolds number of 1600 is set solely using the kinematic viscosity since th
 FEM Interpolation
 ~~~~~~~~~~~~~~~~~
 
-The results obtained for the Taylor-Green vortex are highly dependent on the numerical dissipation that occurs within the CFD scheme. Generally, high-order methods outperform traditional second-order accurate methods for this type of flow. In the present case, we will investigate the usage of both second and third degree polynomial.
+The results obtained for the Taylor-Green vortex are highly dependent on the numerical dissipation that occurs within the CFD scheme. Generally, high-order methods outperform traditional second-order accurate methods for this type of flow. In the present case, we will investigate the usage of both second and third degree polynomials.
 
 .. code-block:: text
 
@@ -156,12 +155,10 @@ The ``simulation control`` subsection controls the flow of the simulation. To ma
   subsection simulation control
     set method            = bdf3
     set time step         = 0.05 
-    set number mesh adapt = 0    
     set time end          = 20  
     set output frequency  = 2    
     set subdivision       = 3
   end
-
 
 
 Matrix-based - Non-linear Solver 
@@ -195,9 +192,10 @@ Since this is a transient problem, the linear solver can be relatively simple. W
       set max iters                             = 200
       set max krylov vectors                    = 200
       set relative residual                     = 1e-4
-      set minimum residual                      = 1e-12
+      set minimum residual                      = 1e-7
+      set preconditioner                        = ilu
       set ilu preconditioner fill               = 0
-      set ilu preconditioner absolute tolerance = 1e-12
+      set ilu preconditioner absolute tolerance = 1e-10
       set ilu preconditioner relative tolerance = 1.00
     end
   end
@@ -230,40 +228,26 @@ The ``lethe-fluid-matrix-free`` has significantly more parameters for its linear
       set relative residual = 1e-4
       set minimum residual  = 1e-7
       set preconditioner    = gcmg
-      set verbosity         = verbos
+      set verbosity         = verbose
       
       # MG parameters
-      set mg verbosity       = quiet
-      set mg min level       = -1
-      set mg level min cells = 16
+      set mg verbosity = quiet
 
       # Smoother
-      set mg smoother iterations     = 10
+      set mg smoother iterations     = 5
       set mg smoother eig estimation = true
-      
+
       # Eigenvalue estimation parameters
       set eig estimation smoothing range = 5
-      set eig estimation cg n iterations = 20
-      set eig estimation verbosity       = verbose
+      set eig estimation cg n iterations = 10
+      set eig estimation verbosity       = quiet
 
       # Coarse-grid solver
-      set mg coarse grid solver                 = gmres
-      set mg gmres max iterations               = 2000
-      set mg gmres tolerance                    = 1e-7
-      set mg gmres reduce                       = 1e-4
-      set mg gmres max krylov vectors           = 30
-      set mg gmres preconditioner               = ilu
-      set ilu preconditioner fill               = 1
-      set ilu preconditioner absolute tolerance = 1e-10
-      set ilu preconditioner relative tolerance = 1.00
+      set mg coarse grid solver = direct
     end
   end
 
-We set ``mg verbosity = quiet`` to prevent logging of the multigrid parameters during the simulation. Setting ``mg min level = -1`` ensures that the ``mg level min cells = 16`` parameter is used to determine the coarsest level. It is important to ensure that the Taylor-Green vortex has sufficient cells on the coarsest level since periodic boundary conditions are used. Indeed, using a coarsest level with a single cell can lead to a problematic situation where too few degrees of freedom are available on the coarsest level.
-
-The ``smoother``, ``Eigenvalue estimation parameters`` and ``coarse-grid solver`` subsections are explained in the **Theory Guide** (under construction).
-
-
+We set ``mg verbosity = quiet`` to prevent logging of the multigrid parameters during the simulation.  The ``smoother``, ``Eigenvalue estimation parameters`` and ``coarse-grid solver`` subsections are explained in the **Theory Guide** (under construction).
 
 ----------------------
 Running the Simulation
@@ -304,14 +288,14 @@ Using the ``enstrophy.dat`` and ``kinetic_energy.dat`` files generated by Lethe,
 .. code-block:: text
   :class: copy-button
 
-  python3 calculate_dissipation_rate.py -i kinetic_energy.dat -o output.dat
+  python3 calculate_dissipation_rate.py -i output/kinetic_energy.dat
 
 Then, by invoking the second script present in the example, a plot comparing the kinetic energy decay with the enstrophy is generated:
 
 .. code-block:: text
   :class: copy-button
 
-  python3 plot_dissipation_rate.py -ke kinetic_energy_decay.dat -ens enstrophy.dat -v 0.000625
+  python3 plot_dissipation_rate.py -ke ke_rate.dat -ens output/enstrophy.dat -v 0.000625
 
 .. tip::
  
@@ -355,6 +339,8 @@ Possibilities for Extension
 ----------------------------
 
 - This case is very interesting to postprocess. Try to postprocess this case using other quantities (vorticity, q-criterion) and use the results to generate interesting animations. Feel free to share them with us!
+
+- This case can also be used to experiment with adaptive time step. In the simulation control section add ``adapt = true`` and ``set max cfl = 1``, similar results should be obtained but with significantly less iterations as larger time steps are taken. To postprocess the results use an additional script given in the example folder in a similar way as the one for fixed time step (``calculate_dissipation_rate_constant_cfl.py``). You can also increase the CFL limit and see what happens!
 
 
 ------------

--- a/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
+++ b/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
@@ -34,10 +34,10 @@ The three velocity components :math:`[u_x,u_y,u_z]^T` and the pressure :math:`p`
 
 .. math::
 
-  u_{x} &= \sin(x)*\cos(y)*\cos(z) \\
-  u_{y} &= -\cos(x)*\sin(y)*\cos(z)\\
+  u_{x} &= \sin(x)\cos(y)\cos(z) \\
+  u_{y} &= -\cos(x)\sin(y)\cos(z)\\
   u_{z} &= 0 \\
-  p &=  \frac{1}{16}*\left[\cos(2x)+\cos(2y)\right]\left[\cos(2z)+2\right]
+  p &=  \frac{1}{16}\left[\cos(2x)+\cos(2y)\right]\left[\cos(2z)+2\right]
 
 In this case, the vortex, which is initially 2D, will decay by generating smaller 3D turbulent structures (vortex tubes, rings and sheets). This decay can be monitored through the total kinetic energy of the system. Since the simulation domain is periodic, it can be demonstrated that the time derative of the total kinetic energy :math:`E_\mathrm{k}` is directly related to the enstrophy :math:`\mathcal{E}` such that:
 

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-based.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-based.prm
@@ -11,14 +11,13 @@ set dimension = 3
 #---------------------------------------------------
 
 subsection simulation control
-  set method            = bdf3
-  set time step         = 0.05 
-  set number mesh adapt = 0    
-  set time end          = 20   
-  set output name       = tgv  
-  set output frequency  = 2    
-  set output path       = ./output/
-  set subdivision       = 3
+  set method           = bdf3
+  set time step        = 0.05
+  set time end         = 20
+  set output name      = tgv
+  set output frequency = 2
+  set output path      = ./output/
+  set subdivision      = 3
 end
 
 #---------------------------------------------------
@@ -35,7 +34,7 @@ end
 #---------------------------------------------------
 
 subsection timer
-  set type = iteration 
+  set type = iteration
 end
 
 #---------------------------------------------------
@@ -86,7 +85,7 @@ subsection mesh
   set type               = dealii
   set grid type          = hyper_cube
   set grid arguments     = -3.14159265359 : 3.14159265359 : true
-  set initial refinement = 5 
+  set initial refinement = 5
 end
 
 # --------------------------------------------------
@@ -140,9 +139,10 @@ subsection linear solver
     set max iters                             = 200
     set max krylov vectors                    = 200
     set relative residual                     = 1e-4
-    set minimum residual                      = 1e-12
+    set minimum residual                      = 1e-7
+    set preconditioner                        = ilu
     set ilu preconditioner fill               = 0
-    set ilu preconditioner absolute tolerance = 1e-12
+    set ilu preconditioner absolute tolerance = 1e-10
     set ilu preconditioner relative tolerance = 1.00
   end
 end

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-based.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-based.prm
@@ -11,7 +11,7 @@ set dimension = 3
 #---------------------------------------------------
 
 subsection simulation control
-  set method           = bdf3
+  set method           = bdf2
   set time step        = 0.05
   set time end         = 20
   set output name      = tgv

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-based.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-based.prm
@@ -136,7 +136,7 @@ subsection linear solver
   subsection fluid dynamics
     set verbosity                             = verbose
     set method                                = gmres
-    set max iters                             = 200
+    set max iters                             = 100
     set max krylov vectors                    = 200
     set relative residual                     = 1e-4
     set minimum residual                      = 1e-7

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
@@ -11,14 +11,13 @@ set dimension = 3
 #---------------------------------------------------
 
 subsection simulation control
-  set method            = bdf3
-  set time step         = 0.05  
-  set number mesh adapt = 0     
-  set time end          = 20    
-  set output name       = tgv   
-  set output frequency  = 2      
-  set output path       = ./output/
-  set subdivision       = 3
+  set method           = bdf3
+  set time step        = 0.05
+  set time end         = 20
+  set output name      = tgv
+  set output frequency = 2
+  set output path      = ./output/
+  set subdivision      = 3
 end
 
 #---------------------------------------------------
@@ -35,7 +34,7 @@ end
 #---------------------------------------------------
 
 subsection timer
-  set type = iteration 
+  set type = iteration
 end
 
 #---------------------------------------------------
@@ -66,7 +65,7 @@ end
 
 subsection source term
   subsection fluid dynamics
-    set enable              = false
+    set enable = false
   end
 end
 
@@ -88,7 +87,7 @@ subsection mesh
   set type               = dealii
   set grid type          = hyper_cube
   set grid arguments     = -3.14159265359 : 3.14159265359 : true
-  set initial refinement = 5 
+  set initial refinement = 5
 end
 
 #---------------------------------------------------
@@ -123,8 +122,8 @@ end
 
 subsection non-linear solver
   subsection fluid dynamics
-    set tolerance      = 1e-3
-    set verbosity      = verbose
+    set tolerance = 1e-3
+    set verbosity = verbose
   end
 end
 
@@ -142,29 +141,18 @@ subsection linear solver
     set verbosity         = verbose
 
     # MG parameters
-    set mg verbosity       = verbose
-    set mg min level       = -1
-    set mg level min cells = 16
+    set mg verbosity = quiet
 
     # Smoother
-    set mg smoother iterations = 10
+    set mg smoother iterations     = 5
     set mg smoother eig estimation = true
 
     # Eigenvalue estimation parameters
     set eig estimation smoothing range = 5
     set eig estimation cg n iterations = 10
-    set eig estimation verbosity       = verbose
+    set eig estimation verbosity       = quiet
 
     # Coarse-grid solver
-    set mg coarse grid solver       = gmres
-    set mg gmres max iterations     = 2000
-    set mg gmres tolerance          = 1e-7
-    set mg gmres reduce             = 1e-4
-    set mg gmres max krylov vectors = 30
-    set mg gmres preconditioner     = ilu
-
-    set ilu preconditioner fill               = 1
-    set ilu preconditioner absolute tolerance = 1e-10
-    set ilu preconditioner relative tolerance = 1.00
+    set mg coarse grid solver = direct
   end
 end

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
@@ -11,7 +11,7 @@ set dimension = 3
 #---------------------------------------------------
 
 subsection simulation control
-  set method           = bdf3
+  set method           = bdf2
   set time step        = 0.05
   set time end         = 20
   set output name      = tgv

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
@@ -133,15 +133,17 @@ end
 
 subsection linear solver
   subsection fluid dynamics
-    set method            = gmres
-    set max iters         = 100
-    set relative residual = 1e-4
-    set minimum residual  = 1e-7
-    set preconditioner    = gcmg
-    set verbosity         = verbose
+    set verbosity          = verbose
+    set method             = gmres
+    set max iters          = 100
+    set max krylov vectors = 200
+    set relative residual  = 1e-4
+    set minimum residual   = 1e-7
+    set preconditioner     = gcmg
 
     # MG parameters
-    set mg verbosity = quiet
+    set mg verbosity                   = quiet
+    set mg enable hessians in jacobian = false
 
     # Smoother
     set mg smoother iterations     = 5
@@ -149,7 +151,7 @@ subsection linear solver
 
     # Eigenvalue estimation parameters
     set eig estimation smoothing range = 5
-    set eig estimation cg n iterations = 10
+    set eig estimation cg n iterations = 20
     set eig estimation verbosity       = quiet
 
     # Coarse-grid solver


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the content of the new example
       What are the motivations? 
       What is/are the feature(s) highlighted in this example? -->

This PR updates the parameters of both the matrix-based and matrix-free TGV simulations according to the findings in the matrix-free article. To summarize:

- BDF3 scheme was changed to BDF2.
- Linear solver parameters were already tuned for the article, so we updated tolerances, number of iterations and krylov vectors accordingly.
- The example was written with constant time step, which works well so it won't be changed. However, trying constant CFL was added as a suggestion and the script to calculate the kinetic energy rate for that case was already available in the example folder.

I do not think it is necessary to re run all the cases, so the part that talks about approximate times was left as it is.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] Lethe documentation is up to date
- [X] Copyright headers are present and up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [X] Links are added to parent .rst files
- [X] The example is following the [standard format](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#general-rules-and-format)

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge