### PR TITLE
Fix specific heat model with bdf2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MINOR Application of the immersed solid tanh diffusivity model is now faster thanks to using optimizations from the Shape class. [#1343](https://github.com/chaos-polymtl/lethe/pull/1343)
 
+- MINOR The specific heat model in BDF2 was not protected against a division by zero (dH/dT). A tolerance is now added to the denominator (dH/(dT+tol)) to avoid this problem. [#1336](https://github.com/chaos-polymtl/lethe/pull/1336)
+
 ## [Master] - 2024-11-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MINOR Application of the immersed solid tanh diffusivity model is now faster thanks to using optimizations from the Shape class. [#1343](https://github.com/chaos-polymtl/lethe/pull/1343)
 
-- MINOR The specific heat model in BDF2 was not protected against a division by zero (dH/dT). A tolerance is now added to the denominator (dH/(dT+tol)) to avoid this problem. [#1336](https://github.com/chaos-polymtl/lethe/pull/1336)
-
+- MINOR The specific heat model in BDF2 was not protected against a division by zero (dH/dT). A tolerance is now added to the denominator (dH/(dT+tol)) to avoid this problem. [#1367](https://github.com/chaos-polymtl/lethe/pull/1367)
+ 
 ## [Master] - 2024-11-11
 
 ### Changed

--- a/include/core/specific_heat_model.h
+++ b/include/core/specific_heat_model.h
@@ -346,10 +346,10 @@ public:
             case Parameters::SimulationControl::TimeSteppingMethod::bdf2:
               {
                 // Clipping to ensure a minimal temperature difference
-                if (temperature > temperature_p2)
-                  temperature = std::max(temperature, temperature_p2 + 1e-6);
-                else
-                  temperature_p2 = std::max(temperature_p2, temperature + 1e-6);
+                // if (temperature > temperature_p2)
+                //   temperature = std::max(temperature, temperature_p2 + 1e-6);
+                // else
+                //   temperature_p2 = std::max(temperature_p2, temperature + 1e-6);
 
                 const double enthalpy_current = enthalpy(temperature);
                 const double enthalpy_p1      = enthalpy(temperature_p1);
@@ -360,7 +360,7 @@ public:
                 const double dT = bdf_coefs[0] * temperature +
                                   bdf_coefs[1] * temperature_p1 +
                                   bdf_coefs[2] * temperature_p2;
-                property_vector[i] = dH / dT;
+                property_vector[i] = dH / (dT + 1e-6);
                 break;
               }
 

--- a/include/core/specific_heat_model.h
+++ b/include/core/specific_heat_model.h
@@ -363,7 +363,7 @@ public:
                 const double dT = bdf_coefs[0] * temperature +
                                   bdf_coefs[1] * temperature_p1 +
                                   bdf_coefs[2] * temperature_p2;
-                property_vector[i] = dH / (dT + 1e-6);
+                property_vector[i] = dH / (dT + 1e-8);
                 break;
               }
 

--- a/include/core/specific_heat_model.h
+++ b/include/core/specific_heat_model.h
@@ -338,9 +338,9 @@ public:
                   bdf_coefs[0] * enthalpy_current + bdf_coefs[1] * enthalpy_p1;
                 const double dT =
                   bdf_coefs[0] * temperature + bdf_coefs[1] * temperature_p1;
-                  
-                // The division does not need a tolerance to avoid a division by 0 
-                // since the temperature is clipped 
+
+                // The division does not need a tolerance to avoid a division by
+                // 0 since the temperature is clipped
                 property_vector[i] = dH / dT;
 
                 break;

--- a/include/core/specific_heat_model.h
+++ b/include/core/specific_heat_model.h
@@ -338,6 +338,9 @@ public:
                   bdf_coefs[0] * enthalpy_current + bdf_coefs[1] * enthalpy_p1;
                 const double dT =
                   bdf_coefs[0] * temperature + bdf_coefs[1] * temperature_p1;
+                  
+                // The division does not need a tolerance to avoid a division by 0 
+                // since the temperature is clipped 
                 property_vector[i] = dH / dT;
 
                 break;
@@ -346,10 +349,10 @@ public:
             case Parameters::SimulationControl::TimeSteppingMethod::bdf2:
               {
                 // Clipping to ensure a minimal temperature difference
-                // if (temperature > temperature_p2)
-                //   temperature = std::max(temperature, temperature_p2 + 1e-6);
-                // else
-                //   temperature_p2 = std::max(temperature_p2, temperature + 1e-6);
+                if (temperature > temperature_p2)
+                  temperature = std::max(temperature, temperature_p2 + 1e-6);
+                else
+                  temperature_p2 = std::max(temperature_p2, temperature + 1e-6);
 
                 const double enthalpy_current = enthalpy(temperature);
                 const double enthalpy_p1      = enthalpy(temperature_p1);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The specific heat model in BDF2 was not protected against a division by zero (dH/dT)

### Solution

A tolerance is now added to the denominator (dH/(dT+tol)) to avoid this problem

### Testing

No change in the tests

### Documentation

No change in the documentation

### Miscellaneous (will be removed when merged)

I didn't add a new test because I think the current state of the cp model will probably change to be more robust in BDF2

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [ ] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge