### PR TITLE
Fix time frequency output in transient simulation control

### DIFF
--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -215,6 +215,7 @@ SimulationControlTransient::SimulationControlTransient(
   , adapt(param.adapt)
   , adaptative_time_step_scaling(param.adaptative_time_step_scaling)
   , max_dt(param.max_dt)
+  , time_last_output(0.)
   , output_time_frequency(param.output_time_frequency)
   , output_times_vector(param.output_times_vector)
   , output_times_counter(0)
@@ -302,6 +303,7 @@ SimulationControlTransient::calculate_time_step()
 bool
 SimulationControlTransient::is_output_iteration()
 {
+  std::cout << "Inside of output iteration!" << std::endl;
   // If iteration control the only options are to not print or at certain
   // frequency of iterations for the time interval given
   if (output_control == Parameters::SimulationControl::OutputControl::iteration)
@@ -324,13 +326,35 @@ SimulationControlTransient::is_output_iteration()
   // specific time interval):
   if (output_time_frequency != -1)
     {
+      std::cout << "Inside of output frequency!" << std::endl;
+
+      std::cout << "Current time: " << current_time << std::endl;
+
+      std::cout << "time_last_output: " << time_last_output << std::endl;
+
+      std::cout << "output_time_frequency: " << output_time_frequency
+                << std::endl;
+
+      bool result =
+        (((current_time - time_last_output) - output_time_frequency) >
+         (-1e-12 * output_time_frequency)) ?
+          "true" :
+          "false";
+      std::cout << "First condition: " << result << std::endl;
+
+      bool result_2 = (current_time >= output_time_interval[0]);
+      std::cout << "Second condition: " << result_2 << std::endl;
+
+      bool result_3 = (current_time <= output_time_interval[1]);
+      std::cout << "third condition: " << result_3 << std::endl;
+
       if ((current_time - time_last_output) - output_time_frequency >
             -1e-12 * output_time_frequency &&
           current_time >= output_time_interval[0] &&
           current_time <= output_time_interval[1])
         {
           time_last_output = current_time;
-
+          std::cout << "Inside of if!" << std::endl;
           return true;
         }
       else // if it does not match the time frequency we do not output

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -303,7 +303,6 @@ SimulationControlTransient::calculate_time_step()
 bool
 SimulationControlTransient::is_output_iteration()
 {
-  std::cout << "Inside of output iteration!" << std::endl;
   // If iteration control the only options are to not print or at certain
   // frequency of iterations for the time interval given
   if (output_control == Parameters::SimulationControl::OutputControl::iteration)
@@ -326,35 +325,12 @@ SimulationControlTransient::is_output_iteration()
   // specific time interval):
   if (output_time_frequency != -1)
     {
-      std::cout << "Inside of output frequency!" << std::endl;
-
-      std::cout << "Current time: " << current_time << std::endl;
-
-      std::cout << "time_last_output: " << time_last_output << std::endl;
-
-      std::cout << "output_time_frequency: " << output_time_frequency
-                << std::endl;
-
-      bool result =
-        (((current_time - time_last_output) - output_time_frequency) >
-         (-1e-12 * output_time_frequency)) ?
-          "true" :
-          "false";
-      std::cout << "First condition: " << result << std::endl;
-
-      bool result_2 = (current_time >= output_time_interval[0]);
-      std::cout << "Second condition: " << result_2 << std::endl;
-
-      bool result_3 = (current_time <= output_time_interval[1]);
-      std::cout << "third condition: " << result_3 << std::endl;
-
       if ((current_time - time_last_output) - output_time_frequency >
             -1e-12 * output_time_frequency &&
           current_time >= output_time_interval[0] &&
           current_time <= output_time_interval[1])
         {
           time_last_output = current_time;
-          std::cout << "Inside of if!" << std::endl;
           return true;
         }
       else // if it does not match the time frequency we do not output


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

The last output time variable was not being initialized correctly and affected the output of Paraview files when using time control and time frequency.

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->

The variable is initialized to zero in the constructor.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

All the tests should pass and the Rayleigh Benard Convection example works now with output time frequency (FYI @OresteMarquis). 

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

No documentation needs to be updated. 

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [X] Lethe documentation is up to date
- [X] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge