### PR TITLE
Examples update for ball-packing and rectangular-hopper 

### DIFF
--- a/doc/source/examples/dem/packing-in-ball/packing-in-ball.rst
+++ b/doc/source/examples/dem/packing-in-ball/packing-in-ball.rst
@@ -86,12 +86,12 @@ Gravitational acceleration has three components in three directions.
         set diameter                          = 0.005
         set number of particles               = 5000
         set density particles                 = 2000
-        set young modulus particles           = 10000000
+        set young modulus particles           = 1e7
         set poisson ratio particles           = 0.3
         set restitution coefficient particles = 0.75
         set friction coefficient particles    = 0.3
       end
-      set young modulus wall           = 10000000
+      set young modulus wall           = 1e7
       set poisson ratio wall           = 0.3
       set restitution coefficient wall = 0.75
       set friction coefficient wall    = 0.3
@@ -106,8 +106,8 @@ Model Parameters
     subsection model parameters
       subsection contact detection
         set contact detection method                = dynamic
-        set dynamic contact search size coefficient = 0.7
-        set neighborhood threshold                  = 1.5
+        set dynamic contact search size coefficient = 0.5
+        set neighborhood threshold                  = 1.4
       end
       set particle particle contact force method    = hertz_mindlin_limit_overlap
       set particle wall contact force method        = nonlinear

--- a/doc/source/examples/dem/rectangular-hopper/rectangular-hopper.rst
+++ b/doc/source/examples/dem/rectangular-hopper/rectangular-hopper.rst
@@ -80,12 +80,7 @@ An insertion box is defined inside and the top part of the hopper. The inserted 
       set insertion method                               = volume
       set inserted number of particles at each time step = 2910
       set insertion frequency                            = 25000
-      set insertion box minimum x                        = -0.1030
-      set insertion box minimum y                        = 0.10644
-      set insertion box minimum z                        = .00224
-      set insertion box maximum x                        = 0.1030
-      set insertion box maximum y                        = 0.16020
-      set insertion box maximum z                        = 0.03136
+      set insertion box points coordinates               = -0.06, 0.10644, .00224 : 0.06, 0.16020, 0.03136
       set insertion distance threshold                   = 1.5
       set insertion maximum offset                       = 0.1
       set insertion prn seed                             = 20
@@ -168,6 +163,7 @@ The time end of the simulation is 7.5 where most of the particles are discharged
       set output frequency = 1000
       set output path      = ./output/
       set output name      = hopper
+      set output boundaries = true
     end
 
 
@@ -341,10 +337,10 @@ Since the geometry of the mesh and the number of the particles are not the same,
 .. code-block:: text
 
     subsection insertion info
-        set insertion method                               = non_uniform
-        set inserted number of particles at each time step = 2910
+        set insertion method                               = volume
+        set inserted number of particles at each time step = 485
         set insertion frequency                            = 25000
-        set insertion box points coordinates               = -0.1030, 0.10644, 0.00224 : 0.1030,0.16020, 0.03136
+        set insertion box points coordinates               = -0.06, 0.10644, .00112 : 0.06, 0.16020, 0.00448
         set insertion distance threshold                   = 1.5
         set insertion maximum offset                       = 0.1
         set insertion prn seed                             = 20

--- a/examples/dem/3d-packing-in-ball/packing-in-ball.prm
+++ b/examples/dem/3d-packing-in-ball/packing-in-ball.prm
@@ -44,12 +44,12 @@ subsection lagrangian physical properties
     set diameter                          = 0.005
     set number of particles               = 5000
     set density particles                 = 2000
-    set young modulus particles           = 10000000
+    set young modulus particles           = 1e7
     set poisson ratio particles           = 0.3
     set restitution coefficient particles = 0.75
     set friction coefficient particles    = 0.3
   end
-  set young modulus wall           = 10000000
+  set young modulus wall           = 1e7
   set poisson ratio wall           = 0.3
   set restitution coefficient wall = 0.75
   set friction coefficient wall    = 0.3


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the content of the new example
       What are the motivations? 
       What is/are the feature(s) highlighted in this example? -->

Update of the .prm and .rst files of the ball-packing and rectangular-hopper examples for the Lethe 1.0 release. The rectangular hopper gave similar curves visually, but the mass flow rate is different than the one stated in the documentation (85.17 vs 84.94 & 90.12 vs 85.09 g/s). Nonetheless, I feel that those results are close enough that it is not necessary to change the example documentation for it. 

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] Lethe documentation is up to date
- [x] Copyright headers are present and up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] Links are added to parent .rst files
- [x] The example is following the [standard format](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#general-rules-and-format)

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge