### PR TITLE
RPT examples review (parameters-tuning and fem-reconstruction)

### DIFF
--- a/doc/source/examples/rpt/tuning-parameters-with-nomad/tuning-parameters-with-nomad.rst
+++ b/doc/source/examples/rpt/tuning-parameters-with-nomad/tuning-parameters-with-nomad.rst
@@ -113,7 +113,7 @@ As seen in the previous example (:doc:`../photon-count-calculation-in-a-cylindri
       set verbosity                        = quiet
       set export counts                    = false
       set counts file                      = run.csv
-      set monte carlo iteration            = 10000
+      set monte carlo iteration            = 100000
       set random number seed               = 0
       set reactor height                   = 0.3
       set reactor radius                   = 0.4

--- a/examples/rpt/parameters-tuning/rpt_lethe_nomad.py
+++ b/examples/rpt/parameters-tuning/rpt_lethe_nomad.py
@@ -43,7 +43,7 @@ with open(tmp_lethe_parameter_file, "w") as file:  # Write .prm with new paramet
     file.write("\n".join(filestr))
 
 # Call rpt_3d executable
-os.system("rpt_3d " + tmp_lethe_parameter_file)
+os.system("lethe-rpt-3d " + tmp_lethe_parameter_file)
 
 # Delete temporary parameter files
 os.remove(tmp_lethe_parameter_file)

--- a/examples/rpt/particle-fem-reconstruction/particle-fem-reconstruction-post-processing.py
+++ b/examples/rpt/particle-fem-reconstruction/particle-fem-reconstruction-post-processing.py
@@ -1,0 +1,34 @@
+"""
+IMPORTS
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+import pandas as pd
+
+"""
+MAIN
+"""
+
+# Read data
+found_positions = pd.read_csv("found_positions.csv", header=1).values 
+real_positions = np.loadtxt("real-positions.txt", skiprows=1)
+
+# Extract X and Y coordinates
+found_x, found_y = found_positions[:, 0], found_positions[:, 1]
+real_x, real_y = real_positions[:, 0], real_positions[:, 1]
+
+"""
+PLOTS
+"""
+
+plt.figure(figsize=(6, 6))
+plt.scatter(real_x, real_y, c='red', label='Experimental position', s=10, alpha=0.8)
+plt.scatter(found_x, found_y, c='black', label='Reconstructed position', s=10, alpha=0.8)
+
+plt.xlabel("X (m)")
+plt.ylabel("Y (m)")
+plt.legend(loc="upper center", bbox_to_anchor=(0.5, 1.1), ncol=2)
+plt.axis('equal') # ensures the grid is square
+
+plt.show()


### PR DESCRIPTION
- Modified the exacutable rpt_3d -> lethe-rpt-3d in the python file responsible for launching the lethe code
- Changed the  monte carlo iteration count in the doc to match the one in the prm files

- Forgot to create a new branch so I will do two examples in a single PR. Added a post-processing script to particle-fem-reconstruction example. 