### PR TITLE
3D ribbon mixer example review

### DIFF
--- a/doc/source/examples/incompressible-flow/3d-mixer-using-single-rotating-frame/3d-mixer-using-single-rotating-frame.rst
+++ b/doc/source/examples/incompressible-flow/3d-mixer-using-single-rotating-frame/3d-mixer-using-single-rotating-frame.rst
@@ -126,7 +126,7 @@ Mesh
 
     subsection mesh
         set type      = gmsh
-        set file name = diff-step-mesh.msh
+        set file name = ../diff-step-mesh.msh
         set simplex   = true
     end
 

--- a/examples/incompressible-flow/3d-ribbon-mixer-srf/Np_vs_Re/gather-torques.sh
+++ b/examples/incompressible-flow/3d-ribbon-mixer-srf/Np_vs_Re/gather-torques.sh
@@ -3,5 +3,5 @@ for i in $(cat case_index.txt) ;
 do 
 echo "Gathering $i"
 echo "-------------"
-tail -1 ./$i/output/torque.00.dat   >> gather.dat
+tail -1 ./$i/output/torque.01.dat   >> gather.dat
 done


### PR DESCRIPTION
- Modified mesh section in the doc.
- Modified the gather-torques because of the new boundary convention.
- ALSO, the experimental.dat file is missing and the reference is not in the doc. 