### PR TITLE
Test without void fraction bounding

### DIFF
--- a/applications_tests/lethe-fluid-vans/beetstra_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/beetstra_packed_bed.mpirun=1.output
@@ -14,83 +14,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 39.51026265 Pa
-Total pressure drop: 39.51026262 Pa
-Global continuity equation error: 1.110028982e-11 s^-1
-Max local continuity error: 7.080155431e-08 s^-1
-
-***********************************************************************************
-Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2159401507
-***********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 24.90024085 Pa
-Total pressure drop: 24.90050029 Pa
-Global continuity equation error: 5.707618624e-12 s^-1
-Max local continuity error: 7.04881985e-08 s^-1
-
-***********************************************************************************
-Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2163068229
-***********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 25.27622171 Pa
-Total pressure drop: 25.27596104 Pa
-Global continuity equation error: -1.024629594e-11 s^-1
-Max local continuity error: 7.164605484e-08 s^-1
-
-***********************************************************************************
-Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2182049239
-***********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 24.84073606 Pa
-Total pressure drop: 24.84099567 Pa
-Global continuity equation error: 9.565252946e-11 s^-1
-Max local continuity error: 7.123555053e-08 s^-1
-
-********************************************************************************
-Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2162116
-********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 25.27570798 Pa
-Total pressure drop: 25.27544744 Pa
-Global continuity equation error: -3.791452742e-13 s^-1
-Max local continuity error: 7.206746429e-08 s^-1
-
-***********************************************************************************
-Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2182505625
-***********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 24.84052913 Pa
-Total pressure drop: 24.84078888 Pa
-Global continuity equation error: -1.293908526e-11 s^-1
-Max local continuity error: 7.151241291e-08 s^-1
+Pressure drop: 39.51000872 Pa
+Total pressure drop: 39.5100087 Pa
+Global continuity equation error: 1.120197899e-11 s^-1
+Max local continuity error: 7.07974292e-08 s^-1
 
 **********************************************************************************
-Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.216229825
+Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.215937582
 **********************************************************************************
 --------------
 Void Fraction
@@ -98,13 +28,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 25.27561654 Pa
-Total pressure drop: 25.27535601 Pa
-Global continuity equation error: 1.975697396e-12 s^-1
-Max local continuity error: 7.226789626e-08 s^-1
+Pressure drop: 25.08253436 Pa
+Total pressure drop: 25.08253453 Pa
+Global continuity equation error: 6.170069157e-12 s^-1
+Max local continuity error: 7.082078693e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2182649663
+Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2173205911
 ***********************************************************************************
 --------------
 Void Fraction
@@ -112,13 +42,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 24.84046673 Pa
-Total pressure drop: 24.84072643 Pa
-Global continuity equation error: -8.443132749e-12 s^-1
-Max local continuity error: 7.166699863e-08 s^-1
+Pressure drop: 25.05839364 Pa
+Total pressure drop: 25.05839396 Pa
+Global continuity equation error: 7.159880384e-12 s^-1
+Max local continuity error: 7.131088194e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2162404941
+Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2171872842
 ***********************************************************************************
 --------------
 Void Fraction
@@ -126,13 +56,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 25.27554968 Pa
-Total pressure drop: 25.27528911 Pa
-Global continuity equation error: -9.914317608e-11 s^-1
-Max local continuity error: 7.239247839e-08 s^-1
+Pressure drop: 25.05802561 Pa
+Total pressure drop: 25.05802602 Pa
+Global continuity equation error: -4.014524408e-12 s^-1
+Max local continuity error: 7.15687695e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2182733758
+Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2172227449
 ***********************************************************************************
 --------------
 Void Fraction
@@ -140,7 +70,77 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 24.84045295 Pa
-Total pressure drop: 24.8407125 Pa
-Global continuity equation error: -6.935356746e-12 s^-1
-Max local continuity error: 7.177049671e-08 s^-1
+Pressure drop: 25.05791153 Pa
+Total pressure drop: 25.057912 Pa
+Global continuity equation error: -4.503037243e-12 s^-1
+Max local continuity error: 7.17308361e-08 s^-1
+
+***********************************************************************************
+Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2172327141
+***********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 25.05784662 Pa
+Total pressure drop: 25.0578471 Pa
+Global continuity equation error: 1.33308492e-12 s^-1
+Max local continuity error: 7.184484025e-08 s^-1
+
+***********************************************************************************
+Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2172410001
+***********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 25.0578068 Pa
+Total pressure drop: 25.05780726 Pa
+Global continuity equation error: 2.400140794e-12 s^-1
+Max local continuity error: 7.193093048e-08 s^-1
+
+***********************************************************************************
+Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2172469994
+***********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 25.05780979 Pa
+Total pressure drop: 25.05781022 Pa
+Global continuity equation error: -1.940344358e-11 s^-1
+Max local continuity error: 7.199949346e-08 s^-1
+
+***********************************************************************************
+Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2172518144
+***********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 25.05781196 Pa
+Total pressure drop: 25.05781232 Pa
+Global continuity equation error: -2.88153726e-12 s^-1
+Max local continuity error: 7.205559915e-08 s^-1
+
+***********************************************************************************
+Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2172556835
+***********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 25.05781135 Pa
+Total pressure drop: 25.05781159 Pa
+Global continuity equation error: 4.127957936e-11 s^-1
+Max local continuity error: 7.210291423e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/beetstra_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/beetstra_packed_bed.prm
@@ -79,9 +79,6 @@ subsection void fraction
   set read dem            = true
   set dem file name       = dem
   set l2 smoothing factor = 0.000005
-  set bound void fraction = true
-  set l2 lower bound      = 0
-  set l2 upper bound      = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/dallavalle_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/dallavalle_packed_bed.mpirun=1.output
@@ -14,13 +14,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.6512609 Pa
-Total pressure drop: 21.65126036 Pa
-Global continuity equation error: 2.440787446e-11 s^-1
-Max local continuity error: 7.296562332e-08 s^-1
+Pressure drop: 21.65123788 Pa
+Total pressure drop: 21.65123734 Pa
+Global continuity equation error: 2.457689607e-11 s^-1
+Max local continuity error: 7.2960348e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2258360816
+Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2258298836
 ***********************************************************************************
 --------------
 Void Fraction
@@ -28,13 +28,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 8.304814244 Pa
-Total pressure drop: 8.305073094 Pa
-Global continuity equation error: 6.582929091e-12 s^-1
-Max local continuity error: 7.151017135e-08 s^-1
+Pressure drop: 8.410078687 Pa
+Total pressure drop: 8.410078235 Pa
+Global continuity equation error: 3.173051397e-11 s^-1
+Max local continuity error: 7.183317584e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2199507506
+Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2209766134
 ***********************************************************************************
 --------------
 Void Fraction
@@ -42,13 +42,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 8.54590016 Pa
-Total pressure drop: 8.545638747 Pa
-Global continuity equation error: -5.323487163e-12 s^-1
-Max local continuity error: 7.264484654e-08 s^-1
+Pressure drop: 8.388673046 Pa
+Total pressure drop: 8.388672637 Pa
+Global continuity equation error: -1.258618875e-11 s^-1
+Max local continuity error: 7.231774942e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2221991367
+Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2211546365
 ***********************************************************************************
 --------------
 Void Fraction
@@ -56,13 +56,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 8.230897331 Pa
-Total pressure drop: 8.231156192 Pa
-Global continuity equation error: 2.117781974e-11 s^-1
-Max local continuity error: 7.224697792e-08 s^-1
+Pressure drop: 8.387935233 Pa
+Total pressure drop: 8.387934832 Pa
+Global continuity equation error: -5.938460722e-12 s^-1
+Max local continuity error: 7.257063958e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2201763168
+Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2212138916
 ***********************************************************************************
 --------------
 Void Fraction
@@ -70,13 +70,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 8.54489009 Pa
-Total pressure drop: 8.5446287 Pa
-Global continuity equation error: -1.583893026e-11 s^-1
-Max local continuity error: 7.304719609e-08 s^-1
+Pressure drop: 8.387685153 Pa
+Total pressure drop: 8.387684745 Pa
+Global continuity equation error: 1.187420527e-11 s^-1
+Max local continuity error: 7.271893653e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2222891827
+Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2212440396
 ***********************************************************************************
 --------------
 Void Fraction
@@ -84,13 +84,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 8.230521662 Pa
-Total pressure drop: 8.230780542 Pa
-Global continuity equation error: -7.908612306e-12 s^-1
-Max local continuity error: 7.249373904e-08 s^-1
+Pressure drop: 8.387554626 Pa
+Total pressure drop: 8.387554223 Pa
+Global continuity equation error: -3.212446144e-12 s^-1
+Max local continuity error: 7.281659995e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2202262097
+Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2212636215
 ***********************************************************************************
 --------------
 Void Fraction
@@ -98,27 +98,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 8.544693213 Pa
-Total pressure drop: 8.544431789 Pa
-Global continuity equation error: 8.289624313e-13 s^-1
-Max local continuity error: 7.321512623e-08 s^-1
-
-**********************************************************************************
-Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.222323341
-**********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 8.230393783 Pa
-Total pressure drop: 8.230652609 Pa
-Global continuity equation error: -7.548890741e-14 s^-1
-Max local continuity error: 7.261714524e-08 s^-1
+Pressure drop: 8.387478528 Pa
+Total pressure drop: 8.387478106 Pa
+Global continuity equation error: -2.359620654e-12 s^-1
+Max local continuity error: 7.288653581e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2202516783
+Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2212779426
 ***********************************************************************************
 --------------
 Void Fraction
@@ -126,13 +112,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 8.544600396 Pa
-Total pressure drop: 8.544338902 Pa
-Global continuity equation error: 6.407416402e-13 s^-1
-Max local continuity error: 7.331080894e-08 s^-1
+Pressure drop: 8.387426409 Pa
+Total pressure drop: 8.387425956 Pa
+Global continuity equation error: 7.474925512e-13 s^-1
+Max local continuity error: 7.293974599e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2223434543
+Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2212890551
 ***********************************************************************************
 --------------
 Void Fraction
@@ -140,7 +126,21 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 8.230330842 Pa
-Total pressure drop: 8.230589572 Pa
-Global continuity equation error: 1.086688352e-11 s^-1
-Max local continuity error: 7.269440429e-08 s^-1
+Pressure drop: 8.387389502 Pa
+Total pressure drop: 8.387389006 Pa
+Global continuity equation error: 3.797211003e-12 s^-1
+Max local continuity error: 7.298207337e-08 s^-1
+
+***********************************************************************************
+Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2212979991
+***********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 8.387387179 Pa
+Total pressure drop: 8.387386647 Pa
+Global continuity equation error: -1.444193764e-11 s^-1
+Max local continuity error: 7.301713178e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/dallavalle_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/dallavalle_packed_bed.prm
@@ -79,9 +79,6 @@ subsection void fraction
   set read dem            = true
   set dem file name       = dem
   set l2 smoothing factor = 0.000005
-  set bound void fraction = true
-  set l2 lower bound      = 0
-  set l2 upper bound      = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/difelice_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/difelice_packed_bed.mpirun=1.output
@@ -14,55 +14,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 28.20321227 Pa
-Total pressure drop: 28.20321223 Pa
-Global continuity equation error: -6.509539985e-12 s^-1
-Max local continuity error: 7.194912132e-08 s^-1
-
-***********************************************************************************
-Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2160314739
-***********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 20.7275789 Pa
-Total pressure drop: 20.7278382 Pa
-Global continuity equation error: -3.150229335e-11 s^-1
-Max local continuity error: 7.081086813e-08 s^-1
-
-***********************************************************************************
-Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2155214319
-***********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 21.05038208 Pa
-Total pressure drop: 21.05012121 Pa
-Global continuity equation error: -6.347860002e-11 s^-1
-Max local continuity error: 7.220398968e-08 s^-1
-
-***********************************************************************************
-Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2175647396
-***********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 20.65365059 Pa
-Total pressure drop: 20.65391002 Pa
-Global continuity equation error: -2.302411999e-12 s^-1
-Max local continuity error: 7.183677853e-08 s^-1
+Pressure drop: 28.20310068 Pa
+Total pressure drop: 28.20310065 Pa
+Global continuity equation error: -5.862276984e-12 s^-1
+Max local continuity error: 7.194439068e-08 s^-1
 
 **********************************************************************************
-Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.215582625
+Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.216028522
 **********************************************************************************
 --------------
 Void Fraction
@@ -70,13 +28,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.04974879 Pa
-Total pressure drop: 21.04948797 Pa
-Global continuity equation error: 1.226523858e-11 s^-1
-Max local continuity error: 7.266673368e-08 s^-1
+Pressure drop: 20.89052788 Pa
+Total pressure drop: 20.89052791 Pa
+Global continuity equation error: -3.236179822e-11 s^-1
+Max local continuity error: 7.114259309e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2176153247
+Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2165324721
 ***********************************************************************************
 --------------
 Void Fraction
@@ -84,13 +42,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 20.6534192 Pa
-Total pressure drop: 20.65367867 Pa
-Global continuity equation error: -4.317110254e-12 s^-1
-Max local continuity error: 7.211393038e-08 s^-1
+Pressure drop: 20.85200734 Pa
+Total pressure drop: 20.8520074 Pa
+Global continuity equation error: 2.682442527e-11 s^-1
+Max local continuity error: 7.187096824e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2156070393
+Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2165518695
 ***********************************************************************************
 --------------
 Void Fraction
@@ -98,13 +56,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.04962679 Pa
-Total pressure drop: 21.04936596 Pa
-Global continuity equation error: 1.524625751e-12 s^-1
-Max local continuity error: 7.286054965e-08 s^-1
+Pressure drop: 20.85151899 Pa
+Total pressure drop: 20.85151914 Pa
+Global continuity equation error: -6.901038232e-12 s^-1
+Max local continuity error: 7.216726633e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2176334555
+Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2165886954
 ***********************************************************************************
 --------------
 Void Fraction
@@ -112,13 +70,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 20.65334791 Pa
-Total pressure drop: 20.65360731 Pa
-Global continuity equation error: -1.665942793e-12 s^-1
-Max local continuity error: 7.225998482e-08 s^-1
+Pressure drop: 20.85137619 Pa
+Total pressure drop: 20.85137637 Pa
+Global continuity equation error: -2.725993713e-12 s^-1
+Max local continuity error: 7.23321167e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2156203528
+Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2166025314
 ***********************************************************************************
 --------------
 Void Fraction
@@ -126,13 +84,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.0495736 Pa
-Total pressure drop: 21.04931268 Pa
-Global continuity equation error: 4.575213329e-13 s^-1
-Max local continuity error: 7.297632743e-08 s^-1
+Pressure drop: 20.85129805 Pa
+Total pressure drop: 20.85129824 Pa
+Global continuity equation error: 3.634893963e-12 s^-1
+Max local continuity error: 7.244360578e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2176438924
+Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2166130171
 ***********************************************************************************
 --------------
 Void Fraction
@@ -140,7 +98,49 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 20.65331762 Pa
-Total pressure drop: 20.6535769 Pa
-Global continuity equation error: -2.25593521e-11 s^-1
-Max local continuity error: 7.235513554e-08 s^-1
+Pressure drop: 20.85125203 Pa
+Total pressure drop: 20.85125219 Pa
+Global continuity equation error: 2.929211206e-12 s^-1
+Max local continuity error: 7.252554626e-08 s^-1
+
+***********************************************************************************
+Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2166205255
+***********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 20.85122413 Pa
+Total pressure drop: 20.85122425 Pa
+Global continuity equation error: 3.759907302e-12 s^-1
+Max local continuity error: 7.258938757e-08 s^-1
+
+***********************************************************************************
+Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2166263206
+***********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 20.85122583 Pa
+Total pressure drop: 20.85122591 Pa
+Global continuity equation error: -2.617287611e-11 s^-1
+Max local continuity error: 7.264135522e-08 s^-1
+
+***********************************************************************************
+Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2166310487
+***********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 20.85122722 Pa
+Total pressure drop: 20.85122721 Pa
+Global continuity equation error: -8.395697593e-12 s^-1
+Max local continuity error: 7.268463149e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/difelice_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/difelice_packed_bed.prm
@@ -79,9 +79,6 @@ subsection void fraction
   set read dem            = true
   set dem file name       = dem
   set l2 smoothing factor = 0.000005
-  set bound void fraction = true
-  set l2 lower bound      = 0
-  set l2 upper bound      = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/gidaspow_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/gidaspow_packed_bed.mpirun=1.output
@@ -14,13 +14,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 58.68924128 Pa
-Total pressure drop: 58.68924145 Pa
-Global continuity equation error: -6.851257479e-13 s^-1
-Max local continuity error: 6.876447462e-08 s^-1
+Pressure drop: 58.68875313 Pa
+Total pressure drop: 58.6887533 Pa
+Global continuity equation error: -6.85032922e-13 s^-1
+Max local continuity error: 6.876064389e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2098217929
+Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2098195863
 ***********************************************************************************
 --------------
 Void Fraction
@@ -28,13 +28,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 54.25754731 Pa
-Total pressure drop: 54.25780711 Pa
-Global continuity equation error: 3.195119305e-12 s^-1
-Max local continuity error: 6.715989433e-08 s^-1
+Pressure drop: 54.57663737 Pa
+Total pressure drop: 54.57663791 Pa
+Global continuity equation error: 6.117778629e-12 s^-1
+Max local continuity error: 6.750397279e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2118257176
+Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2128205323
 ***********************************************************************************
 --------------
 Void Fraction
@@ -42,13 +42,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 54.80583664 Pa
-Total pressure drop: 54.80557642 Pa
-Global continuity equation error: -1.094046973e-11 s^-1
-Max local continuity error: 6.838971736e-08 s^-1
+Pressure drop: 54.49168036 Pa
+Total pressure drop: 54.49168116 Pa
+Global continuity equation error: -5.172565362e-11 s^-1
+Max local continuity error: 6.803815337e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2130229126
+Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2120331687
 ***********************************************************************************
 --------------
 Void Fraction
@@ -56,13 +56,27 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 54.17884689 Pa
-Total pressure drop: 54.17910704 Pa
-Global continuity equation error: 8.37887892e-12 s^-1
-Max local continuity error: 6.799504687e-08 s^-1
+Pressure drop: 54.49164288 Pa
+Total pressure drop: 54.49164378 Pa
+Global continuity equation error: -3.160360661e-14 s^-1
+Max local continuity error: 6.834589337e-08 s^-1
+
+**********************************************************************************
+Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.212179018
+**********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 54.49165099 Pa
+Total pressure drop: 54.49165193 Pa
+Global continuity equation error: 1.416037349e-11 s^-1
+Max local continuity error: 6.852867837e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2111972264
+Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2121589096
 ***********************************************************************************
 --------------
 Void Fraction
@@ -70,13 +84,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 54.80554278 Pa
-Total pressure drop: 54.80528275 Pa
-Global continuity equation error: -1.039091921e-11 s^-1
-Max local continuity error: 6.888143895e-08 s^-1
+Pressure drop: 54.49167813 Pa
+Total pressure drop: 54.49167909 Pa
+Global continuity equation error: -7.508727664e-12 s^-1
+Max local continuity error: 6.865809898e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2131462283
+Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2121656727
 ***********************************************************************************
 --------------
 Void Fraction
@@ -84,13 +98,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 54.17892146 Pa
-Total pressure drop: 54.17918167 Pa
-Global continuity equation error: 1.763526123e-11 s^-1
-Max local continuity error: 6.830829933e-08 s^-1
+Pressure drop: 54.49168662 Pa
+Total pressure drop: 54.49168758 Pa
+Global continuity equation error: -6.23563145e-11 s^-1
+Max local continuity error: 6.875562129e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2111845923
+Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2121668056
 ***********************************************************************************
 --------------
 Void Fraction
@@ -98,13 +112,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 54.80564313 Pa
-Total pressure drop: 54.80538307 Pa
-Global continuity equation error: -9.282119391e-12 s^-1
-Max local continuity error: 6.910868883e-08 s^-1
+Pressure drop: 54.4917038 Pa
+Total pressure drop: 54.49170469 Pa
+Global continuity equation error: -8.81888568e-11 s^-1
+Max local continuity error: 6.883289947e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2131542861
+Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2121683105
 ***********************************************************************************
 --------------
 Void Fraction
@@ -112,13 +126,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 54.17901948 Pa
-Total pressure drop: 54.17927957 Pa
-Global continuity equation error: 1.579314956e-11 s^-1
-Max local continuity error: 6.848319469e-08 s^-1
+Pressure drop: 54.49171521 Pa
+Total pressure drop: 54.49171603 Pa
+Global continuity equation error: -1.317702507e-10 s^-1
+Max local continuity error: 6.889644249e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2111874772
+Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2121693897
 ***********************************************************************************
 --------------
 Void Fraction
@@ -126,21 +140,7 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 54.80576092 Pa
-Total pressure drop: 54.80550068 Pa
-Global continuity equation error: -8.069980675e-12 s^-1
-Max local continuity error: 6.925011169e-08 s^-1
-
-***********************************************************************************
-Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2131572154
-***********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 54.17911989 Pa
-Total pressure drop: 54.17937976 Pa
-Global continuity equation error: 1.465087369e-11 s^-1
-Max local continuity error: 6.860048328e-08 s^-1
+Pressure drop: 54.491731 Pa
+Total pressure drop: 54.49173171 Pa
+Global continuity equation error: -1.505333851e-10 s^-1
+Max local continuity error: 6.895007826e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/gidaspow_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/gidaspow_packed_bed.prm
@@ -79,9 +79,6 @@ subsection void fraction
   set read dem            = true
   set dem file name       = dem
   set l2 smoothing factor = 0.000005
-  set bound void fraction = true
-  set l2 lower bound      = 0
-  set l2 upper bound      = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/kochhill_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/kochhill_packed_bed.mpirun=1.output
@@ -14,13 +14,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 39.22231712 Pa
-Total pressure drop: 39.22231707 Pa
-Global continuity equation error: -5.19026644e-13 s^-1
-Max local continuity error: 7.083660952e-08 s^-1
+Pressure drop: 39.22206618 Pa
+Total pressure drop: 39.22206613 Pa
+Global continuity equation error: -5.102614019e-13 s^-1
+Max local continuity error: 7.083245406e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2158483285
+Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2158457584
 ***********************************************************************************
 --------------
 Void Fraction
@@ -28,13 +28,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 24.46781633 Pa
-Total pressure drop: 24.46807571 Pa
-Global continuity equation error: 6.088782813e-12 s^-1
-Max local continuity error: 7.060721352e-08 s^-1
+Pressure drop: 24.64815947 Pa
+Total pressure drop: 24.64815957 Pa
+Global continuity equation error: 5.682101949e-12 s^-1
+Max local continuity error: 7.093922659e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2146286962
+Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2156347503
 ***********************************************************************************
 --------------
 Void Fraction
@@ -42,13 +42,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 24.85069318 Pa
-Total pressure drop: 24.85043241 Pa
-Global continuity equation error: -7.221607026e-12 s^-1
-Max local continuity error: 7.178679713e-08 s^-1
+Pressure drop: 24.62736663 Pa
+Total pressure drop: 24.62736684 Pa
+Global continuity equation error: 8.242956872e-12 s^-1
+Max local continuity error: 7.145361724e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2167063767
+Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2156937839
 ***********************************************************************************
 --------------
 Void Fraction
@@ -56,13 +56,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 24.40426485 Pa
-Total pressure drop: 24.40452442 Pa
-Global continuity equation error: -1.402660147e-11 s^-1
-Max local continuity error: 7.138682368e-08 s^-1
+Pressure drop: 24.62702014 Pa
+Total pressure drop: 24.62702044 Pa
+Global continuity equation error: 1.904484962e-12 s^-1
+Max local continuity error: 7.171789108e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2147068698
+Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2157133327
 ***********************************************************************************
 --------------
 Void Fraction
@@ -70,13 +70,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 24.85021933 Pa
-Total pressure drop: 24.84995868 Pa
-Global continuity equation error: -1.973355699e-11 s^-1
-Max local continuity error: 7.221698109e-08 s^-1
+Pressure drop: 24.62689537 Pa
+Total pressure drop: 24.6268957 Pa
+Global continuity equation error: 5.342768685e-13 s^-1
+Max local continuity error: 7.18822481e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2167391285
+Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2157260589
 ***********************************************************************************
 --------------
 Void Fraction
@@ -84,13 +84,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 24.40407613 Pa
-Total pressure drop: 24.40433574 Pa
-Global continuity equation error: -1.271239186e-11 s^-1
-Max local continuity error: 7.16664335e-08 s^-1
+Pressure drop: 24.62682994 Pa
+Total pressure drop: 24.62683027 Pa
+Global continuity equation error: -3.012407106e-12 s^-1
+Max local continuity error: 7.199668682e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2147284502
+Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2157348611
 ***********************************************************************************
 --------------
 Void Fraction
@@ -98,13 +98,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 24.85011837 Pa
-Total pressure drop: 24.84985767 Pa
-Global continuity equation error: 5.892249425e-12 s^-1
-Max local continuity error: 7.241753981e-08 s^-1
+Pressure drop: 24.62679226 Pa
+Total pressure drop: 24.62679255 Pa
+Global continuity equation error: 1.209680786e-12 s^-1
+Max local continuity error: 7.20825017e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2167545528
+Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2157413934
 ***********************************************************************************
 --------------
 Void Fraction
@@ -112,13 +112,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 24.40401229 Pa
-Total pressure drop: 24.40427181 Pa
-Global continuity equation error: -8.641926273e-12 s^-1
-Max local continuity error: 7.182020389e-08 s^-1
+Pressure drop: 24.62679466 Pa
+Total pressure drop: 24.62679492 Pa
+Global continuity equation error: -3.291504448e-11 s^-1
+Max local continuity error: 7.215049374e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2147400383
+Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2157465949
 ***********************************************************************************
 --------------
 Void Fraction
@@ -126,13 +126,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 24.85008066 Pa
-Total pressure drop: 24.84981983 Pa
-Global continuity equation error: 9.53722363e-12 s^-1
-Max local continuity error: 7.254093562e-08 s^-1
+Pressure drop: 24.62679723 Pa
+Total pressure drop: 24.62679741 Pa
+Global continuity equation error: -1.238087448e-11 s^-1
+Max local continuity error: 7.220595448e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2167637691
+Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2157507603
 ***********************************************************************************
 --------------
 Void Fraction
@@ -140,7 +140,7 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 24.40399022 Pa
-Total pressure drop: 24.40424957 Pa
-Global continuity equation error: -7.398956995e-12 s^-1
-Max local continuity error: 7.192240241e-08 s^-1
+Pressure drop: 24.62679602 Pa
+Total pressure drop: 24.62679607 Pa
+Global continuity equation error: 3.31098785e-11 s^-1
+Max local continuity error: 7.225261174e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/kochhill_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/kochhill_packed_bed.prm
@@ -79,9 +79,6 @@ subsection void fraction
   set read dem            = true
   set dem file name       = dem
   set l2 smoothing factor = 0.000005
-  set bound void fraction = true
-  set l2 lower bound      = 0
-  set l2 upper bound      = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/pcm_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/pcm_packed_bed.mpirun=1.output
@@ -14,13 +14,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 28.50048139 Pa
-Total pressure drop: 28.50048132 Pa
-Global continuity equation error: -1.456602341e-12 s^-1
-Max local continuity error: 7.154380835e-08 s^-1
+Pressure drop: 28.50036484 Pa
+Total pressure drop: 28.50036478 Pa
+Global continuity equation error: -1.158034117e-11 s^-1
+Max local continuity error: 7.153917193e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2187788891
+Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2187757266
 ***********************************************************************************
 --------------
 Void Fraction
@@ -28,13 +28,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.372732 Pa
-Total pressure drop: 21.37299134 Pa
-Global continuity equation error: -1.331198603e-11 s^-1
-Max local continuity error: 7.072441603e-08 s^-1
+Pressure drop: 21.53867054 Pa
+Total pressure drop: 21.53867061 Pa
+Global continuity equation error: -1.344364859e-11 s^-1
+Max local continuity error: 7.105641738e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2151962038
+Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2162044152
 ***********************************************************************************
 --------------
 Void Fraction
@@ -42,13 +42,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.6997947 Pa
-Total pressure drop: 21.69953386 Pa
-Global continuity equation error: -4.680276932e-11 s^-1
-Max local continuity error: 7.219023715e-08 s^-1
+Pressure drop: 21.4993733 Pa
+Total pressure drop: 21.49937339 Pa
+Global continuity equation error: 5.647629218e-11 s^-1
+Max local continuity error: 7.185712863e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2176564509
+Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2166420679
 ***********************************************************************************
 --------------
 Void Fraction
@@ -56,27 +56,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.29909628 Pa
-Total pressure drop: 21.29935575 Pa
-Global continuity equation error: -2.17779376e-12 s^-1
-Max local continuity error: 7.181414192e-08 s^-1
-
-**********************************************************************************
-Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.215619905
-**********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 21.69926182 Pa
-Total pressure drop: 21.69900105 Pa
-Global continuity equation error: 3.812701489e-12 s^-1
-Max local continuity error: 7.26422221e-08 s^-1
+Pressure drop: 21.49899157 Pa
+Total pressure drop: 21.49899175 Pa
+Global continuity equation error: 1.245275965e-11 s^-1
+Max local continuity error: 7.214489424e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2176618386
+Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2166275438
 ***********************************************************************************
 --------------
 Void Fraction
@@ -84,13 +70,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.29886986 Pa
-Total pressure drop: 21.29912936 Pa
-Global continuity equation error: -4.01634157e-12 s^-1
-Max local continuity error: 7.208725491e-08 s^-1
+Pressure drop: 21.49884567 Pa
+Total pressure drop: 21.49884589 Pa
+Global continuity equation error: 1.149576323e-12 s^-1
+Max local continuity error: 7.230741885e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2156494146
+Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2166474265
 ***********************************************************************************
 --------------
 Void Fraction
@@ -98,27 +84,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.69915103 Pa
-Total pressure drop: 21.69889024 Pa
-Global continuity equation error: 1.667000784e-12 s^-1
-Max local continuity error: 7.283348273e-08 s^-1
-
-**********************************************************************************
-Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.217679059
-**********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 21.29880548 Pa
-Total pressure drop: 21.29906493 Pa
-Global continuity equation error: -1.340232369e-11 s^-1
-Max local continuity error: 7.223199701e-08 s^-1
+Pressure drop: 21.49877571 Pa
+Total pressure drop: 21.49877593 Pa
+Global continuity equation error: 7.650214127e-12 s^-1
+Max local continuity error: 7.241721265e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2156626207
+Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2166570251
 ***********************************************************************************
 --------------
 Void Fraction
@@ -126,13 +98,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.69911194 Pa
-Total pressure drop: 21.69885105 Pa
-Global continuity equation error: 1.241300641e-12 s^-1
-Max local continuity error: 7.294867241e-08 s^-1
+Pressure drop: 21.49873306 Pa
+Total pressure drop: 21.49873327 Pa
+Global continuity equation error: 4.297443511e-12 s^-1
+Max local continuity error: 7.249827569e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2176893821
+Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2166645146
 ***********************************************************************************
 --------------
 Void Fraction
@@ -140,7 +112,35 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.29877044 Pa
-Total pressure drop: 21.29902979 Pa
-Global continuity equation error: -6.555267286e-11 s^-1
-Max local continuity error: 7.232691867e-08 s^-1
+Pressure drop: 21.49870828 Pa
+Total pressure drop: 21.49870844 Pa
+Global continuity equation error: 4.531514819e-12 s^-1
+Max local continuity error: 7.25616744e-08 s^-1
+
+***********************************************************************************
+Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2166702088
+***********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 21.49871001 Pa
+Total pressure drop: 21.49871013 Pa
+Global continuity equation error: -2.605560241e-11 s^-1
+Max local continuity error: 7.26134409e-08 s^-1
+
+***********************************************************************************
+Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2166748449
+***********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 21.49871184 Pa
+Total pressure drop: 21.49871187 Pa
+Global continuity equation error: -1.20237519e-11 s^-1
+Max local continuity error: 7.265668985e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/pcm_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/pcm_packed_bed.prm
@@ -79,9 +79,6 @@ subsection void fraction
   set read dem            = true
   set dem file name       = dem
   set l2 smoothing factor = 0.000005
-  set bound void fraction = true
-  set l2 lower bound      = 0
-  set l2 upper bound      = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/qcm_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/qcm_packed_bed.mpirun=1.output
@@ -14,21 +14,21 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 31.34193636 Pa
-Total pressure drop: 31.34200705 Pa
-Global continuity equation error: -1.01375152e-07 s^-1
-Max local continuity error: 2.840085777e-07 s^-1
+Pressure drop: 31.37371467 Pa
+Total pressure drop: 31.37378932 Pa
+Global continuity equation error: -1.070664719e-07 s^-1
+Max local continuity error: 2.833515481e-07 s^-1
 
-***********************************************************************************
-Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2927092027
-***********************************************************************************
+**********************************************************************************
+Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.287355379
+**********************************************************************************
 --------------
 Void Fraction
 --------------
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 29.31457418 Pa
-Total pressure drop: 29.31998825 Pa
-Global continuity equation error: -4.240971946e-08 s^-1
-Max local continuity error: 2.504426567e-07 s^-1
+Pressure drop: 30.09633205 Pa
+Total pressure drop: 30.09633288 Pa
+Global continuity equation error: -2.765823563e-09 s^-1
+Max local continuity error: 2.484639949e-07 s^-1

--- a/applications_tests/lethe-fluid-vans/qcm_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/qcm_packed_bed.prm
@@ -80,9 +80,6 @@ subsection void fraction
   set read dem                     = true
   set dem file name                = dem
   set l2 smoothing factor          = 0
-  set bound void fraction          = true
-  set l2 lower bound               = 0
-  set l2 upper bound               = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/rong_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/rong_packed_bed.mpirun=1.output
@@ -14,13 +14,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 28.50048139 Pa
-Total pressure drop: 28.50048132 Pa
-Global continuity equation error: -1.456602341e-12 s^-1
-Max local continuity error: 7.154380835e-08 s^-1
+Pressure drop: 28.50036484 Pa
+Total pressure drop: 28.50036478 Pa
+Global continuity equation error: -1.158034117e-11 s^-1
+Max local continuity error: 7.153917193e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2187788891
+Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2187757266
 ***********************************************************************************
 --------------
 Void Fraction
@@ -28,13 +28,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.372732 Pa
-Total pressure drop: 21.37299134 Pa
-Global continuity equation error: -1.331198603e-11 s^-1
-Max local continuity error: 7.072441603e-08 s^-1
+Pressure drop: 21.53867054 Pa
+Total pressure drop: 21.53867061 Pa
+Global continuity equation error: -1.344364859e-11 s^-1
+Max local continuity error: 7.105641738e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2151962038
+Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2162044152
 ***********************************************************************************
 --------------
 Void Fraction
@@ -42,13 +42,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.6997947 Pa
-Total pressure drop: 21.69953386 Pa
-Global continuity equation error: -4.680276932e-11 s^-1
-Max local continuity error: 7.219023715e-08 s^-1
+Pressure drop: 21.4993733 Pa
+Total pressure drop: 21.49937339 Pa
+Global continuity equation error: 5.647629218e-11 s^-1
+Max local continuity error: 7.185712863e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2176564509
+Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2166420679
 ***********************************************************************************
 --------------
 Void Fraction
@@ -56,27 +56,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.29909628 Pa
-Total pressure drop: 21.29935575 Pa
-Global continuity equation error: -2.17779376e-12 s^-1
-Max local continuity error: 7.181414192e-08 s^-1
-
-**********************************************************************************
-Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.215619905
-**********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 21.69926182 Pa
-Total pressure drop: 21.69900105 Pa
-Global continuity equation error: 3.812701489e-12 s^-1
-Max local continuity error: 7.26422221e-08 s^-1
+Pressure drop: 21.49899157 Pa
+Total pressure drop: 21.49899175 Pa
+Global continuity equation error: 1.245275965e-11 s^-1
+Max local continuity error: 7.214489424e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2176618386
+Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2166275438
 ***********************************************************************************
 --------------
 Void Fraction
@@ -84,13 +70,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.29886986 Pa
-Total pressure drop: 21.29912936 Pa
-Global continuity equation error: -4.01634157e-12 s^-1
-Max local continuity error: 7.208725491e-08 s^-1
+Pressure drop: 21.49884567 Pa
+Total pressure drop: 21.49884589 Pa
+Global continuity equation error: 1.149576323e-12 s^-1
+Max local continuity error: 7.230741885e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2156494146
+Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2166474265
 ***********************************************************************************
 --------------
 Void Fraction
@@ -98,27 +84,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.69915103 Pa
-Total pressure drop: 21.69889024 Pa
-Global continuity equation error: 1.667000784e-12 s^-1
-Max local continuity error: 7.283348273e-08 s^-1
-
-**********************************************************************************
-Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.217679059
-**********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 21.29880548 Pa
-Total pressure drop: 21.29906493 Pa
-Global continuity equation error: -1.340232369e-11 s^-1
-Max local continuity error: 7.223199701e-08 s^-1
+Pressure drop: 21.49877571 Pa
+Total pressure drop: 21.49877593 Pa
+Global continuity equation error: 7.650214127e-12 s^-1
+Max local continuity error: 7.241721265e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2156626207
+Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2166570251
 ***********************************************************************************
 --------------
 Void Fraction
@@ -126,13 +98,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.69911194 Pa
-Total pressure drop: 21.69885105 Pa
-Global continuity equation error: 1.241300641e-12 s^-1
-Max local continuity error: 7.294867241e-08 s^-1
+Pressure drop: 21.49873306 Pa
+Total pressure drop: 21.49873327 Pa
+Global continuity equation error: 4.297443511e-12 s^-1
+Max local continuity error: 7.249827569e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2176893821
+Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2166645146
 ***********************************************************************************
 --------------
 Void Fraction
@@ -140,7 +112,35 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.29877044 Pa
-Total pressure drop: 21.29902979 Pa
-Global continuity equation error: -6.555267286e-11 s^-1
-Max local continuity error: 7.232691867e-08 s^-1
+Pressure drop: 21.49870828 Pa
+Total pressure drop: 21.49870844 Pa
+Global continuity equation error: 4.531514819e-12 s^-1
+Max local continuity error: 7.25616744e-08 s^-1
+
+***********************************************************************************
+Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2166702088
+***********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 21.49871001 Pa
+Total pressure drop: 21.49871013 Pa
+Global continuity equation error: -2.605560241e-11 s^-1
+Max local continuity error: 7.26134409e-08 s^-1
+
+***********************************************************************************
+Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2166748449
+***********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 21.49871184 Pa
+Total pressure drop: 21.49871187 Pa
+Global continuity equation error: -1.20237519e-11 s^-1
+Max local continuity error: 7.265668985e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/rong_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/rong_packed_bed.prm
@@ -79,9 +79,6 @@ subsection void fraction
   set read dem            = true
   set dem file name       = dem
   set l2 smoothing factor = 0.000005
-  set bound void fraction = true
-  set l2 lower bound      = 0
-  set l2 upper bound      = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/spm_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/spm_packed_bed.mpirun=1.output
@@ -14,13 +14,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 28.50507105 Pa
-Total pressure drop: 28.50507104 Pa
-Global continuity equation error: -3.178749291e-13 s^-1
-Max local continuity error: 7.065849394e-08 s^-1
+Pressure drop: 28.50495762 Pa
+Total pressure drop: 28.50495762 Pa
+Global continuity equation error: -2.38730577e-12 s^-1
+Max local continuity error: 7.065394937e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2187522913
+Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2187490081
 ***********************************************************************************
 --------------
 Void Fraction
@@ -28,13 +28,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.3864869 Pa
-Total pressure drop: 21.38674567 Pa
-Global continuity equation error: -4.892541262e-12 s^-1
-Max local continuity error: 6.959736831e-08 s^-1
+Pressure drop: 21.55222435 Pa
+Total pressure drop: 21.55222443 Pa
+Global continuity equation error: -3.996275986e-12 s^-1
+Max local continuity error: 6.992588931e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2145274393
+Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2155321252
 ***********************************************************************************
 --------------
 Void Fraction
@@ -42,13 +42,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.71296368 Pa
-Total pressure drop: 21.71270346 Pa
-Global continuity equation error: -3.433676916e-11 s^-1
-Max local continuity error: 7.106059351e-08 s^-1
+Pressure drop: 21.51287222 Pa
+Total pressure drop: 21.51287234 Pa
+Global continuity equation error: 4.410729367e-11 s^-1
+Max local continuity error: 7.073110206e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2170233189
+Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2160120003
 ***********************************************************************************
 --------------
 Void Fraction
@@ -56,13 +56,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.3129029 Pa
-Total pressure drop: 21.31316182 Pa
-Global continuity equation error: -3.561749068e-12 s^-1
-Max local continuity error: 7.071107061e-08 s^-1
+Pressure drop: 21.51248439 Pa
+Total pressure drop: 21.51248461 Pa
+Global continuity equation error: 2.102972784e-12 s^-1
+Max local continuity error: 7.103842404e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2149843982
+Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2159891248
 ***********************************************************************************
 --------------
 Void Fraction
@@ -70,27 +70,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.71242579 Pa
-Total pressure drop: 21.71216564 Pa
-Global continuity equation error: 1.11221852e-11 s^-1
-Max local continuity error: 7.154474622e-08 s^-1
-
-**********************************************************************************
-Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.217019353
-**********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 21.31265521 Pa
-Total pressure drop: 21.31291419 Pa
-Global continuity equation error: -4.303366259e-12 s^-1
-Max local continuity error: 7.100609107e-08 s^-1
+Pressure drop: 21.51232768 Pa
+Total pressure drop: 21.51232795 Pa
+Global continuity equation error: -3.356090905e-12 s^-1
+Max local continuity error: 7.12134243e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2150115304
+Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2160079754
 ***********************************************************************************
 --------------
 Void Fraction
@@ -98,13 +84,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.71230093 Pa
-Total pressure drop: 21.71204081 Pa
-Global continuity equation error: 1.343271845e-12 s^-1
-Max local continuity error: 7.175235925e-08 s^-1
+Pressure drop: 21.51224991 Pa
+Total pressure drop: 21.51225019 Pa
+Global continuity equation error: 3.531710556e-12 s^-1
+Max local continuity error: 7.133248054e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2170342881
+Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2160162268
 ***********************************************************************************
 --------------
 Void Fraction
@@ -112,27 +98,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.31257889 Pa
-Total pressure drop: 21.31283784 Pa
-Global continuity equation error: -1.739145824e-11 s^-1
-Max local continuity error: 7.116350482e-08 s^-1
-
-**********************************************************************************
-Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.215023054
-**********************************************************************************
---------------
-Void Fraction
---------------
--------------------------------
-Volume-Averaged Fluid Dynamics
--------------------------------
-Pressure drop: 21.71225286 Pa
-Total pressure drop: 21.71199267 Pa
-Global continuity equation error: 6.557444561e-13 s^-1
-Max local continuity error: 7.187769522e-08 s^-1
+Pressure drop: 21.51220234 Pa
+Total pressure drop: 21.51220261 Pa
+Global continuity equation error: 2.375711776e-12 s^-1
+Max local continuity error: 7.142058335e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2170432698
+Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2160227874
 ***********************************************************************************
 --------------
 Void Fraction
@@ -140,7 +112,35 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.312548 Pa
-Total pressure drop: 21.31280685 Pa
-Global continuity equation error: -2.605257949e-11 s^-1
-Max local continuity error: 7.126688389e-08 s^-1
+Pressure drop: 21.51217342 Pa
+Total pressure drop: 21.51217366 Pa
+Global continuity equation error: 3.303283467e-12 s^-1
+Max local continuity error: 7.148956286e-08 s^-1
+
+***********************************************************************************
+Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2160277517
+***********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 21.51217517 Pa
+Total pressure drop: 21.51217539 Pa
+Global continuity equation error: -2.972021621e-11 s^-1
+Max local continuity error: 7.154594809e-08 s^-1
+
+***********************************************************************************
+Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2160318312
+***********************************************************************************
+--------------
+Void Fraction
+--------------
+-------------------------------
+Volume-Averaged Fluid Dynamics
+-------------------------------
+Pressure drop: 21.51217659 Pa
+Total pressure drop: 21.51217674 Pa
+Global continuity equation error: -1.290955376e-11 s^-1
+Max local continuity error: 7.159301305e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/spm_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/spm_packed_bed.prm
@@ -79,9 +79,6 @@ subsection void fraction
   set read dem            = true
   set dem file name       = dem
   set l2 smoothing factor = 0.000005
-  set bound void fraction = true
-  set l2 lower bound      = 0
-  set l2 upper bound      = 1
 end
 
 #---------------------------------------------------


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

As part of the current void fraction refactoring I wish to aim at deprecating the void fraction bounding after the refactoring is done. This requires modifying the test that currently use void fraction bounds. This PR updates the tests that use lethe-fluid-vans to not bound the void fraction. This is all it does, update the tests.

### Testing

Test results are updated.

### Documentation

Nothing to be done here

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge