### PR TITLE
Fix Lethe version in the main CMakeList

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ CONFIGURE_FILE(
   ${CMAKE_CURRENT_BINARY_DIR}/include/core/revision.h
 )
 
-project(lethe VERSION 0.1 LANGUAGES CXX)
+project(lethe VERSION 1.0 LANGUAGES CXX)
 
 # Check for deal.II features after the PROJECT call — but still as close
 # as possible to the FIND_PACKAGE call — so that the messages appear


### PR DESCRIPTION
The lethe version number in the main CMakeList still showed Version 0.1. This small PR changes this to adequately show version 1.0 until this is changed at the next release.
