### PR TITLE
remove font specification for image magick

### DIFF
--- a/examples/dem/3d-rectangular-hopper/validate.sh
+++ b/examples/dem/3d-rectangular-hopper/validate.sh
@@ -71,7 +71,7 @@ cp $plots $folder
 cp $data $folder
 
 # Append the information to the report
-magick -density 300 -pointsize 12 -font Courier text:mass-and-discharge-rate.txt mass-and-discharge-rate.pdf
+magick -density 300 -pointsize 12 text:mass-and-discharge-rate.txt mass-and-discharge-rate.pdf
 
 magick -density 300  $output_root/report.pdf mass-and-discharge-rate.pdf $plots  -quality 100 $output_root/temporary.pdf
 cp $output_root/temporary.pdf $output_root/report.pdf


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

On some machines, the validation script can fail because the Courier font was not present in imagemagick. 

### Solution

This can be fixed by just not specifying a font. This fixes the issue and does not have any consequences.

