### PR TITLE
Update deal.II version in the installation instruction to 9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2025-01-23
+
+### Changed
+
+- MINOR Update the installation instructions under WSL and Linux to use the deal.II 9.6.0 version instead of the 9.5.1 [#1409](https://github.com/chaos-polymtl/lethe/pull/1409)
+
 ## [Master] - 2025-01-20
 
 ### Changed

--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -34,7 +34,7 @@ In case you are using Ubuntu, you will need to `update the backports <https://la
 .. code-block:: text
   :class: copy-button
 
-  sudo add-apt-repository ppa:ginggs/deal.ii-9.5.1-backports
+  sudo add-apt-repository ppa:ginggs/deal.ii-9.6.0-backports
   sudo apt update
 
 A dependency required by Lethe, and that deal.II needs to be compiled with, is muParser:
@@ -58,11 +58,11 @@ To verify if the correct version of deal.II is installed, run:
 
   apt show libdeal.ii-dev
 
-This should output several information about the installed version. Everything worked as expected if ``deal.ii-9.5.1`` is output
+This should output several information about the installed version. Everything worked as expected if ``deal.ii-9.6.0`` is output
 
 .. note::
 
-  If the installed version is other than ``deal.ii-9.5.1``, follow `this link <https://github.com/dealii/dealii/wiki/Getting-deal.II>`_.
+  If the installed version is other than ``deal.ii-9.6.0``, follow `this link <https://github.com/dealii/dealii/wiki/Getting-deal.II>`_.
 
 
 .. _install-deal.II-candi:
@@ -265,12 +265,12 @@ The deal.II version supported by Lethe is updated and tested every week or so, s
 
 With Candi
 ~~~~~~~~~~~~~
-In the candi folder (for instance, ``/home/username/software/candi``), modify the ``candi.cfg`` to get the latest dealii version, by changing the ``DEAL_II_VERSION`` variable in the case of an official release with its number (e.g. ``v9.5.2``), or by changing it to ``master`` in the case of a development release. The ``candi.cfg`` file should contain on lines 96-97:
+In the candi folder (for instance, ``/home/username/software/candi``), modify the ``candi.cfg`` to get the latest dealii version, by changing the ``DEAL_II_VERSION`` variable in the case of an official release with its number (e.g. ``v9.6.0``), or by changing it to ``master`` in the case of a development release. The ``candi.cfg`` file should contain on lines 96-97:
 
 .. code-block:: text
   :class: copy-button
 
-  # Install the following deal.II version (choose master, v9.3.0, v9.2.0, ...)
+  # Install the following deal.II version (choose master, v9.6.0, ...)
   DEAL_II_VERSION=master
 
 Run the command ``./candi.sh`` to install the new version of dealii.

--- a/doc/source/installation/windows_wsl.rst
+++ b/doc/source/installation/windows_wsl.rst
@@ -97,12 +97,12 @@ Installing deal.II using apt (Step #1)
 
 This is done following `this procedure <https://www.dealii.org/download.html#:~:text=page%20for%20details.-,Linux%20distributions,-Arch%20Linux>`_.
 
-1. |linux_shell| In case you are using Ubuntu, you will need to `update the backports <https://launchpad.net/~ginggs/+archive/ubuntu/deal.ii-9.5.1-backports>`_:
+1. |linux_shell| In case you are using Ubuntu, you will need to `update the backports <https://launchpad.net/~ginggs/+archive/ubuntu/deal.ii-9.6.0-backports>`_:
 
 .. code-block:: text
   :class: copy-button
 
-  sudo add-apt-repository ppa:ginggs/deal.ii-9.5.1-backports
+  sudo add-apt-repository ppa:ginggs/deal.ii-9.6.0-backports
   sudo apt update
 
 2. |linux_shell| A dependency required by Lethe, and that deal.II needs to be compiled with, is muParser:
@@ -208,7 +208,7 @@ Do not forget the ``.`` at the end of the command, which means "here".
   +--------+------------------------------------------+----------------------------------------+
   |     86 | ``# PACKAGES="${PACKAGES} once:netcdf"`` | ``PACKAGES="${PACKAGES} once:netcdf"`` |
   +--------+------------------------------------------+----------------------------------------+
-  |     97 | ``DEAL_II_VERSION=v9.5.0``               | ``DEAL_II_VERSION=master``             |
+  |     97 | ``DEAL_II_VERSION=v9.6.0``               | ``DEAL_II_VERSION=master``             |
   +--------+------------------------------------------+----------------------------------------+
 
   * save and close


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The installation instructions under Linux and WSL were all based on deal.II 9.5.1. This was because the previous 9.6.0 backport had not been relreased at the time. This PR updates the installation instruction to use the new backport.


Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge