### PR TITLE
Update clang tidy CI

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           # Since dealii image doesn't include Node.js, we'll install it
           sudo apt-get install -y software-properties-common
-          sudo add-apt-repository ppa:ginggs/deal.ii-9.5.1-backports
+          sudo add-apt-repository ppa:ginggs/deal.ii-9.6.0-backports
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends nodejs \
             clang-12 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
+- MINOR The clang-tidy CI now uses deal.II 9.6.0 instead of deal.II 9.5.1 [#1410](https://github.com/chaos-polymtl/lethe/pull/1410)
+
+## [Master] - 2025-01-23
+
+### Changed
+
 - MINOR Update the installation instructions under WSL and Linux to use the deal.II 9.6.0 version instead of the 9.5.1 [#1409](https://github.com/chaos-polymtl/lethe/pull/1409)
 
 ## [Master] - 2025-01-20


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The clang tidy CI was still using deal.II 9.5.1 instead of 9.6. This is because the backports did not allow it.

### Testing

If the tidy works, everything is fine.


### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge