### PR TITLE
fix algebraic reinitialization output issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2025-02-14
+
+### Fixed
+
+- MINOR When outputting vtu files from the algebraic reinitialization process, the PVDHandler was cumulating vtu files of previous reinitialization processes. This is now fixed by clearing the `times_and_names` vector of the PVDHandler object when setting the initial condition. []()
+
 ## [Master] - 2025-02-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- MINOR When outputting vtu files from the algebraic reinitialization process, the PVDHandler was cumulating vtu files of previous reinitialization processes. This is now fixed by clearing the `times_and_names` vector of the PVDHandler object when setting the initial condition. []()
+- MINOR When outputting vtu files from the algebraic reinitialization process, the PVDHandler was accumulating vtu files of previous reinitialization processes. This is now fixed by clearing the `times_and_names` vector of the PVDHandler object when setting the initial condition. [#1423](https://github.com/chaos-polymtl/lethe/pull/1423)
 
 ## [Master] - 2025-02-13
 

--- a/source/solvers/vof_algebraic_interface_reinitialization.cc
+++ b/source/solvers/vof_algebraic_interface_reinitialization.cc
@@ -187,7 +187,10 @@ VOFAlgebraicInterfaceReinitialization<dim>::set_initial_conditions()
   // Initial condition
   if (this->simulation_parameters.multiphysics.vof_parameters
         .algebraic_interface_reinitialization.output_reinitialization_steps)
-    write_output_results(0);
+    {
+      this->pvdhandler.times_and_names.clear();
+      write_output_results(0);
+    }
 }
 
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

When outputting vtu files from the algebraic reinitialization process, the PVDHandler was accumulating vtu files of previous reinitialization processes. 

### Solution

This is now fixed by clearing the `times_and_names` vector of the PVDHandler object when setting the initial condition.

### Testing

Tested by running the Rayleigh-Taylor example with the feature enabled.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge