### PR TITLE
Dem fix segfault solid surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [Master] - 2025-02-15
+## [Master] - 2025-02-18
+
+### Fixed
+
+- MAJOR Since [#1417](https://github.com/chaos-polymtl/lethe/pull/1417), the restart_moving_receptable test had a segfault at the end of the simulation in semi-reproducible ways. After using valgrind, it was found that the boost signal that was connecting the Insertion class and the triangulation was causing this segfault when the triangulation was destructed. This was because the Insertion class was destructed prior, but the boost signals were still connected. To solve this issue, the Insertion class now has a destructor that disconnect the boost signal before destructing the whole object. [#1425](https://github.com/chaos-polymtl/lethe/pull/1425)
+
+## [Master] - 2025-02-17
 
 ### Added
 

--- a/include/dem/insertion.h
+++ b/include/dem/insertion.h
@@ -59,6 +59,17 @@ public:
               &size_distribution_object_container,
             const parallel::distributed::Triangulation<dim> &triangulation,
             const DEMSolverParameters<dim>                  &dem_parameters);
+  /**
+   * @brief Carries out the destruction of the insertion class.
+   *
+   */
+  ~Insertion()
+  {
+    // This boost signal needs to be disconnected before being destroyed,
+    // otherwise a segfault could occur when the triangulation will be
+    // destroyed.
+    this->change_to_triangulation.disconnect();
+  };
 
   /**
    * @brief This function is overridden by the volume_insertion, plane_insertion,

--- a/include/fem-dem/ib_particles_dem.h
+++ b/include/fem-dem/ib_particles_dem.h
@@ -45,6 +45,7 @@ public:
     double       normal_overlap;
     double       normal_relative_velocity;
     Tensor<1, 3> tangential_overlap;
+    Tensor<1, 3> rolling_resistance_spring_torque;
     std::vector<Tensor<1, 3>>
       tangential_relative_velocity; // keep each step of RK4 in memory
   };

--- a/source/dem/particle_wall_jkr_force.cc
+++ b/source/dem/particle_wall_jkr_force.cc
@@ -404,7 +404,9 @@ ParticleWallJKRForce<dim, PropertiesIndex>::
                           contact_info.normal_overlap = 0;
                           for (int d = 0; d < dim; ++d)
                             {
-                              contact_info.tangential_overlap[d] = 0;
+                              contact_info.tangential_overlap[d] = 0.;
+                              contact_info.rolling_resistance_spring_torque[d] =
+                                0.;
                             }
                         }
                     }

--- a/source/dem/particle_wall_jkr_force.cc
+++ b/source/dem/particle_wall_jkr_force.cc
@@ -240,12 +240,9 @@ ParticleWallJKRForce<dim, PropertiesIndex>::
             }
           else
             {
-              contact_information.normal_overlap = 0;
-              for (int d = 0; d < dim; ++d)
-                {
-                  contact_information.tangential_overlap[d]               = 0;
-                  contact_information.rolling_resistance_spring_torque[d] = 0;
-                }
+              contact_information.normal_overlap = 0.;
+              contact_information.tangential_overlap.clear();
+              contact_information.rolling_resistance_spring_torque.clear();
             }
         }
     }
@@ -402,12 +399,8 @@ ParticleWallJKRForce<dim, PropertiesIndex>::
                       else
                         {
                           contact_info.normal_overlap = 0;
-                          for (int d = 0; d < dim; ++d)
-                            {
-                              contact_info.tangential_overlap[d] = 0.;
-                              contact_info.rolling_resistance_spring_torque[d] =
-                                0.;
-                            }
+                          contact_info.tangential_overlap.clear();
+                          contact_info.rolling_resistance_spring_torque.clear();
                         }
                     }
                   particle_counter++;

--- a/source/dem/particle_wall_linear_force.cc
+++ b/source/dem/particle_wall_linear_force.cc
@@ -383,7 +383,9 @@ ParticleWallLinearForce<dim, PropertiesIndex>::
                           contact_info.normal_overlap = 0;
                           for (int d = 0; d < dim; ++d)
                             {
-                              contact_info.tangential_overlap[d] = 0;
+                              contact_info.tangential_overlap[d] = 0.;
+                              contact_info.rolling_resistance_spring_torque[d] =
+                                0.;
                             }
                         }
                     }

--- a/source/dem/particle_wall_linear_force.cc
+++ b/source/dem/particle_wall_linear_force.cc
@@ -220,11 +220,9 @@ ParticleWallLinearForce<dim, PropertiesIndex>::
             }
           else
             {
-              for (int d = 0; d < dim; ++d)
-                {
-                  contact_information.tangential_overlap[d]               = 0;
-                  contact_information.rolling_resistance_spring_torque[d] = 0;
-                }
+              contact_information.normal_overlap = 0.;
+              contact_information.tangential_overlap.clear();
+              contact_information.rolling_resistance_spring_torque.clear();
             }
         }
     }
@@ -381,16 +379,12 @@ ParticleWallLinearForce<dim, PropertiesIndex>::
                       else
                         {
                           contact_info.normal_overlap = 0;
-                          for (int d = 0; d < dim; ++d)
-                            {
-                              contact_info.tangential_overlap[d] = 0.;
-                              contact_info.rolling_resistance_spring_torque[d] =
-                                0.;
-                            }
+                          contact_info.tangential_overlap.clear();
+                          contact_info.rolling_resistance_spring_torque.clear();
                         }
                     }
-                  particle_counter++;
                 }
+              particle_counter++;
             }
         }
     }

--- a/source/dem/particle_wall_nonlinear_force.cc
+++ b/source/dem/particle_wall_nonlinear_force.cc
@@ -225,12 +225,9 @@ ParticleWallNonLinearForce<dim, PropertiesIndex>::
             }
           else
             {
-              contact_information.normal_overlap = 0;
-              for (int d = 0; d < dim; ++d)
-                {
-                  contact_information.tangential_overlap[d]               = 0;
-                  contact_information.rolling_resistance_spring_torque[d] = 0;
-                }
+              contact_information.normal_overlap = 0.;
+              contact_information.tangential_overlap.clear();
+              contact_information.rolling_resistance_spring_torque.clear();
             }
         }
     }
@@ -388,12 +385,8 @@ ParticleWallNonLinearForce<dim, PropertiesIndex>::
                       else
                         {
                           contact_info.normal_overlap = 0;
-                          for (int d = 0; d < dim; ++d)
-                            {
-                              contact_info.tangential_overlap[d] = 0.;
-                              contact_info.rolling_resistance_spring_torque[d] =
-                                0.;
-                            }
+                          contact_info.tangential_overlap.clear();
+                          contact_info.rolling_resistance_spring_torque.clear();
                         }
                     }
                   particle_counter++;

--- a/source/dem/particle_wall_nonlinear_force.cc
+++ b/source/dem/particle_wall_nonlinear_force.cc
@@ -390,7 +390,9 @@ ParticleWallNonLinearForce<dim, PropertiesIndex>::
                           contact_info.normal_overlap = 0;
                           for (int d = 0; d < dim; ++d)
                             {
-                              contact_info.tangential_overlap[d] = 0;
+                              contact_info.tangential_overlap[d] = 0.;
+                              contact_info.rolling_resistance_spring_torque[d] =
+                                0.;
                             }
                         }
                     }

--- a/source/fem-dem/ib_particles_dem.cc
+++ b/source/fem-dem/ib_particles_dem.cc
@@ -135,7 +135,8 @@ IBParticlesDEM<dim>::calculate_pp_contact_force(
                 {
                   for (int d = 0; d < dim; ++d)
                     {
-                      contact_info.tangential_overlap[d] = 0;
+                      contact_info.tangential_overlap[d]               = 0.;
+                      contact_info.rolling_resistance_spring_torque[d] = 0.;
                     }
                   pp_contact_map[particle_one.particle_id]
                                 [particle_two.particle_id] = contact_info;
@@ -309,7 +310,8 @@ IBParticlesDEM<dim>::calculate_pp_contact_force(
                   // if the adjacent pair is not in contact anymore
                   for (int d = 0; d < dim; ++d)
                     {
-                      contact_info.tangential_overlap[d] = 0;
+                      contact_info.tangential_overlap[d]               = 0.;
+                      contact_info.rolling_resistance_spring_torque[d] = 0.;
                     }
                   pp_contact_map[particle_one.particle_id].erase(
                     particle_two.particle_id);
@@ -788,7 +790,8 @@ IBParticlesDEM<dim>::calculate_pw_contact_force(
                   // in contact with the wall anymore.
                   for (int d = 0; d < dim; ++d)
                     {
-                      contact_info.tangential_overlap[d] = 0;
+                      contact_info.tangential_overlap[d]               = 0.;
+                      contact_info.rolling_resistance_spring_torque[d] = 0.;
                     }
                 }
             }


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The moving_receptable_application test was segfaulting sometimes after #1417 on the CI. We think this is due to the clearing of the new tensor in the contact_info which should be cleared when there is no longer contact between particles. 

EDIT: The real cause of this segfault was the boost signal between the triangulation and the Insertion class that was still connected to the Insertion class when the triangulation was being destructed even though the Insertion class was already destructed prior. 

### Solution

Add the .clear() where it is needed. The new tensor had to be added to the IB_Particles contact_info for this to work.  

EDIT: A destructor was added to the Insertion class. This destructor disconnect the boost signal. 

### Testing

Run the CI many times to trigger the segfault before merging. 


### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge