### PR TITLE
Changed the neighboring threshold of some application test

### DIFF
--- a/applications_tests/lethe-particles/pp_dmt_equilibrium.prm
+++ b/applications_tests/lethe-particles/pp_dmt_equilibrium.prm
@@ -28,7 +28,7 @@ subsection model parameters
   subsection contact detection
     set contact detection method                = dynamic
     set dynamic contact search size coefficient = 0.9
-    set neighborhood threshold                  = 20
+    set neighborhood threshold                  = 1.3
   end
   subsection load balancing
     set load balance method = none

--- a/applications_tests/lethe-particles/pp_jkr_equilibrium.prm
+++ b/applications_tests/lethe-particles/pp_jkr_equilibrium.prm
@@ -28,7 +28,7 @@ subsection model parameters
   subsection contact detection
     set contact detection method                = dynamic
     set dynamic contact search size coefficient = 0.9
-    set neighborhood threshold                  = 20
+    set neighborhood threshold                  = 1.3
   end
   subsection load balancing
     set load balance method = none

--- a/applications_tests/lethe-particles/pw_dmt_equilibrium.output
+++ b/applications_tests/lethe-particles/pw_dmt_equilibrium.output
@@ -16,10 +16,10 @@ This feature is useful in geometries with concave boundaries.
 Transient iteration: 10000    Time: 0.1      Time step: 1e-05
 *****************************************************************
 | Variable                     | Min        | Max         | Average    | Total      |
-| Contact list generation      | 0.0000e+00 | 1.0000e+00  | 1.0000e+00 | 1.0000e+00 |
-| Velocity magnitude           | 2.0555e-16 | 2.0555e-16  | 2.0555e-16 | 2.0555e-16 |
+| Contact list generation      | 0.0000e+00 | 3.0000e+00  | 3.0000e+00 | 3.0000e+00 |
+| Velocity magnitude           | 1.1486e-14 | 1.1486e-14  | 1.1486e-14 | 1.1486e-14 |
 | Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 |
-| Translational kinetic energy | 2.8758e-41 | 2.8758e-41  | 2.8758e-41 | 2.8758e-41 |
+| Translational kinetic energy | 8.9806e-38 | 8.9806e-38  | 8.9806e-38 | 8.9806e-38 |
 | Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 |
 id, type, dp, x, y, z
 0 0 0.00010 0.0000 0.0010 0.0010

--- a/applications_tests/lethe-particles/pw_dmt_equilibrium.prm
+++ b/applications_tests/lethe-particles/pw_dmt_equilibrium.prm
@@ -27,7 +27,7 @@ subsection model parameters
   subsection contact detection
     set contact detection method                = dynamic
     set dynamic contact search size coefficient = 0.9
-    set neighborhood threshold                  = 20
+    set neighborhood threshold                  = 1.3
   end
   subsection load balancing
     set load balance method = none

--- a/applications_tests/lethe-particles/pw_jkr_equilibrium.prm
+++ b/applications_tests/lethe-particles/pw_jkr_equilibrium.prm
@@ -27,7 +27,7 @@ subsection model parameters
   subsection contact detection
     set contact detection method                = dynamic
     set dynamic contact search size coefficient = 0.9
-    set neighborhood threshold                  = 20
+    set neighborhood threshold                  = 1.3
   end
   subsection load balancing
     set load balance method = none


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The neighboring threshold parameter used in some application tests was set at 20 when it is suppose to be in the range of 1.0 to 1.5 . 

### Solution

The parameter was set to 1.3 .

### Testing

The output of one test has changed.

### Documentation

N/A

### Miscellaneous (will be removed when merged)

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Copyright headers are present and up to date
- [ ] Lethe documentation is up to date
- [ ] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [ ] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge