### PR TITLE
Fix 2D output for DEM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2025-02-19
+
+### Fixed
+
+- MINOR The vtu output for 2D DEM and CFD-DEM simulations were not able to display the velocity and the angular velocity correctly. This is because the data is always 3D in the simulations even for 2D simulations. This has been fixed by always writing velocity and angular velocity as 3D vectors even for 2D simulations.[#1427](https://github.com/chaos-polymtl/lethe/pull/1427)
+
 ## [Master] - 2025-02-18
 
 ### Added

--- a/source/core/dem_properties.cc
+++ b/source/core/dem_properties.cc
@@ -19,10 +19,10 @@ namespace DEM
           PropertiesIndex::n_properties);
         properties[PropertiesIndex::type]    = std::make_pair("type", 1);
         properties[PropertiesIndex::dp]      = std::make_pair("diameter", 1);
-        properties[PropertiesIndex::v_x]     = std::make_pair("velocity", dim);
+        properties[PropertiesIndex::v_x]     = std::make_pair("velocity", 3);
         properties[PropertiesIndex::v_y]     = std::make_pair("velocity", 1);
         properties[PropertiesIndex::v_z]     = std::make_pair("velocity", 1);
-        properties[PropertiesIndex::omega_x] = std::make_pair("omega", dim);
+        properties[PropertiesIndex::omega_x] = std::make_pair("omega", 3);
         properties[PropertiesIndex::omega_y] = std::make_pair("omega", 1);
         properties[PropertiesIndex::omega_z] = std::make_pair("omega", 1);
         properties[PropertiesIndex::mass]    = std::make_pair("mass", 1);
@@ -37,20 +37,20 @@ namespace DEM
           PropertiesIndex::n_properties);
         properties[PropertiesIndex::type]    = std::make_pair("type", 1);
         properties[PropertiesIndex::dp]      = std::make_pair("diameter", 1);
-        properties[PropertiesIndex::v_x]     = std::make_pair("velocity", dim);
+        properties[PropertiesIndex::v_x]     = std::make_pair("velocity", 3);
         properties[PropertiesIndex::v_y]     = std::make_pair("velocity", 1);
         properties[PropertiesIndex::v_z]     = std::make_pair("velocity", 1);
-        properties[PropertiesIndex::omega_x] = std::make_pair("omega", dim);
+        properties[PropertiesIndex::omega_x] = std::make_pair("omega", 3);
         properties[PropertiesIndex::omega_y] = std::make_pair("omega", 1);
         properties[PropertiesIndex::omega_z] = std::make_pair("omega", 1);
         properties[PropertiesIndex::fem_force_x] =
-          std::make_pair("fem_force", dim);
+          std::make_pair("fem_force", 3);
         properties[PropertiesIndex::fem_force_y] =
           std::make_pair("fem_force", 1);
         properties[PropertiesIndex::fem_force_z] =
           std::make_pair("fem_force", 1);
         properties[PropertiesIndex::fem_torque_x] =
-          std::make_pair("fem_torque", dim);
+          std::make_pair("fem_torque", 3);
         properties[PropertiesIndex::fem_torque_y] =
           std::make_pair("fem_torque", 1);
         properties[PropertiesIndex::fem_torque_z] =

--- a/source/dem/visualization.cc
+++ b/source/dem/visualization.cc
@@ -34,7 +34,10 @@ Visualization<dim, PropertiesIndex>::build_patches(
       const unsigned n_components = properties[field_position].second;
 
       // Check to see if the property is a vector
-      if (n_components == dim)
+      // By default we assume that even 2D simulations have 3 components
+      // Since the velocity and the angular velocity are stored in 3D
+      // even for 2D simulations
+      if (n_components == 3)
         {
           // The proeprty is a vector, thus we set that the components
           // are part of a vector. Do not forget that since we added the ID


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

2D DEM simulation would not output the velocity and the angular velocity in VTU format correctly. This is because the velocity and the angular velocity are still stored as 3D vectors even in 2D simulation. This PR fixes the output for 2D DEM cases.


### Solution

The solution was to force all output vectors to be 3D by forcing 3 instead of using dim.

### Testing

A quick run of an example confirms that it works well.



Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge