### PR TITLE
Add change to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- MINOR The function get_properties_name() did not contain the pair corresponding to "volumetric_contribution". As consequence, the CFD-DEM vtu files would not have this property and would have an empty property instead. This PR adds this modification to the changelog as the addition of the property was pushed straight to master. The hash or the commit that pushes it to master is: 3dd817096cd2f5056902ace464e1aef9358c4ef8. []()
+- MINOR The function get_properties_name() did not contain the pair corresponding to "volumetric_contribution". As consequence, the CFD-DEM vtu files would not have this property and would have an empty property instead. This PR adds this modification to the changelog as the addition of the property was pushed straight to master. The hash or the commit that pushes it to master is: 3dd817096cd2f5056902ace464e1aef9358c4ef8. [#1430](https://github.com/chaos-polymtl/lethe/pull/1430)
 
 ## [Master] - 2025-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2025-02-24
+
+### Fixed
+
+- MINOR The function get_properties_name() did not contain the pair corresponding to "volumetric_contribution". As consequence, the CFD-DEM vtu files would not have this property and would have an empty property instead. This PR adds this modification to the changelog as the addition of the property was pushed straight to master. The hash or the commit that pushes it to master is: 3dd817096cd2f5056902ace464e1aef9358c4ef8. []()
+
 ## [Master] - 2025-02-22
 
 ### Added

--- a/source/core/dem_properties.cc
+++ b/source/core/dem_properties.cc
@@ -55,10 +55,8 @@ namespace DEM
           std::make_pair("fem_torque", 1);
         properties[PropertiesIndex::fem_torque_z] =
           std::make_pair("fem_torque", 1);
-
         properties[PropertiesIndex::volumetric_contribution] =
           std::make_pair("volumetric_contribution", 1);
-
         properties[PropertiesIndex::mass] = std::make_pair("mass", 1);
 
         return properties;


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

When running CFD-DEM simulations, the volumetric_contribution was not among the particle properties returned by ParticleProperties::get_properties_name(). Hence, it would not be present in the vtu file. Instead, an empty property was observed.

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->

The pair corresponding to the "volumetric_contribution" was added.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

All tests pass

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

N/A

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [ ] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge