### PR TITLE
For QCM, add parameters to control quadrature rule and number of quadrature points

### DIFF
--- a/include/fem-dem/parameters_cfd_dem.h
+++ b/include/fem-dem/parameters_cfd_dem.h
@@ -31,6 +31,12 @@ namespace Parameters
     spm  // The satellite point method (divided approach)
   };
 
+  enum class VoidFractionQCMRule
+  {
+    gauss, // Apply gauss quadrature rule (default)
+    gauss_lobatto
+  };
+
   enum class DragModel
   {
     difelice,
@@ -72,6 +78,8 @@ namespace Parameters
     unsigned int                   particle_refinement_factor;
     double                         qcm_sphere_diameter;
     bool                           qcm_sphere_equal_cell_volume;
+    VoidFractionQCMRule            qcm_quadrature_rule;
+    int                            qcm_n_quadrature_points;
   };
 
   struct CFDDEM

--- a/include/fem-dem/void_fraction.h
+++ b/include/fem-dem/void_fraction.h
@@ -133,9 +133,18 @@ public:
     else
       {
         // Usual case, for quad/hex meshes
-        fe         = std::make_shared<FE_Q<dim>>(fe_degree);
-        mapping    = std::make_shared<MappingQ<dim>>(fe->degree);
-        quadrature = std::make_shared<QGauss<dim>>(fe->degree + 1);
+        fe      = std::make_shared<FE_Q<dim>>(fe_degree);
+        mapping = std::make_shared<MappingQ<dim>>(fe->degree);
+        if (this->void_fraction_parameters->qcm_quadrature_rule ==
+            Parameters::VoidFractionQCMRule::gauss)
+          quadrature = std::make_shared<QGauss<dim>>(
+            this->void_fraction_parameters->qcm_n_quadrature_points);
+        else if (this->void_fraction_parameters->qcm_quadrature_rule ==
+                 Parameters::VoidFractionQCMRule::gauss_lobatto)
+          quadrature = std::make_shared<QGaussLobatto<dim>>(
+            this->void_fraction_parameters->qcm_n_quadrature_points);
+        else
+          quadrature = std::make_shared<QGauss<dim>>(fe->degree + 1);
       }
   }
 

--- a/source/fem-dem/parameters_cfd_dem.cc
+++ b/source/fem-dem/parameters_cfd_dem.cc
@@ -3,6 +3,8 @@
 
 #include <fem-dem/parameters_cfd_dem.h>
 
+#include <deal.II/base/patterns.h>
+
 namespace Parameters
 {
   template <int dim>
@@ -45,6 +47,16 @@ namespace Parameters
       "false",
       Patterns::Bool(),
       "Specify whether the virtual sphere has the same volume as the mesh element");
+    prm.declare_entry(
+      "quadrature rule",
+      "gauss",
+      Patterns::Selection("gauss|gauss-lobatto"),
+      "Choose which quadrature rule to follow when distributing quadrature points for the QCM void fraction scheme");
+    prm.declare_entry(
+      "n quadrature points",
+      "-1",
+      Patterns::Integer(),
+      "Number of quadrature points per cell used in the QCM void fraction scheme");
     prm.leave_subsection();
   }
 
@@ -63,7 +75,7 @@ namespace Parameters
     else if (op == "spm")
       mode = Parameters::VoidFractionMode::spm;
     else
-      throw(std::runtime_error("Invalid voidfraction model"));
+      throw(std::runtime_error("Invalid void fraction calculation scheme"));
     prm.enter_subsection("function");
     void_fraction.parse_parameters(prm);
     prm.leave_subsection();
@@ -74,6 +86,40 @@ namespace Parameters
     particle_refinement_factor = prm.get_integer("particle refinement factor");
     qcm_sphere_diameter        = prm.get_double("qcm sphere diameter");
     qcm_sphere_equal_cell_volume = prm.get_bool("qcm sphere equal cell volume");
+    const std::string qcm_quadrature_rule_op = prm.get("quadrature rule");
+
+    if (mode == Parameters::VoidFractionMode::qcm)
+      {
+        if (qcm_quadrature_rule_op == "gauss")
+          qcm_quadrature_rule = Parameters::VoidFractionQCMRule::gauss;
+        else if (qcm_quadrature_rule_op == "gauss-lobatto")
+          qcm_quadrature_rule = Parameters::VoidFractionQCMRule::gauss_lobatto;
+        else
+          throw(std::runtime_error(
+            "Invalid quadrature rule for QCM void fraction scheme. Options are 'gauss' or 'gauss-lobatto'"));
+      }
+
+    qcm_n_quadrature_points = prm.get_integer("n quadrature points");
+
+    if (qcm_quadrature_rule == Parameters::VoidFractionQCMRule::gauss)
+      {
+        // Ensure coherence with default
+        if (qcm_n_quadrature_points == -1)
+          qcm_n_quadrature_points = 2;
+        if (qcm_n_quadrature_points < 1)
+          throw(std::runtime_error(
+            "For the QCM void fraction scheme using Gauss ('gauss') quadrature rule, the minimum number of quadrature points is 1"));
+      }
+    else if (qcm_quadrature_rule ==
+             Parameters::VoidFractionQCMRule::gauss_lobatto)
+      {
+        // Ensure coherence with default
+        if (qcm_n_quadrature_points == -1)
+          qcm_n_quadrature_points = 3;
+        if (qcm_n_quadrature_points < 3)
+          throw(std::runtime_error(
+            "For the QCM void fraction scheme using Gauss-Lobatto ('gauss-lobatto') quadrature rule, the minimum number of quadrature points is 3"));
+      }
 
     prm.leave_subsection();
   }


### PR DESCRIPTION


<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the content of the new feature
       What are the motivations? 
       How is it integrated into the current code? -->

The QCM void fraction scheme in unresolved CFD-DEM used the Gauss rule to distribute the quadrature points over the cell. The number of quadrature points was fixed at 2 per dimension. In mesh independence studies, in which we want to preserve the sphere size across meshes, this could leave gaps between the QCM virtual spheres. The void fraction calculation would not account for particles in this uncovered region.

For this reason, we decided to improve the method's flexibility by adding two user-defined parameters, namely ``quadrature rule`` and ``n quadrature points``. The first controls the quadrature rule to be applied upon distributing the quadrature points, while the second allows for choosing the number of quadrature points per dimension. In this implementation, the available rules are Gauss and Gauss-Lobatto. We chose these two because the first respects the default of the solver and the latter places quadrature points at the boundaries of the cells.

### Testing

<!-- How has this been tested?
       What are the new test(s) and what feature(s)/parameter(s) does it test?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works?
       How will you ensure that it will continue to work in the future? -->

All previous tests pass. One new test was added to track the feature.

### Documentation

<!-- Does this new feature introduce new simulation parameters? If so, describe them. -->

The parameters were documented accordingly.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Copyright headers are present and up to date
- [ ] Lethe documentation is up to date
- [ ] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [ ] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge