### PR TITLE
Fix velocity average solution transfer adapt grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+
+## [Master] - 2025-02-28
+
+### Fixed
+
+- MINOR Simulation with dynamic mesh adaptation and the matrix-free solver could sometimes crash during the mesh adaptation stage due to the SolutionTransfer. This has been fixed by enabling averaging of the SolutionTransfer to reconcile incoherence between multiple cells. [#1436](https://github.com/chaos-polymtl/lethe/pull/1436)
+
+- MINOR Simulation with dynamic mesh adaptation and time-averaging of the velocity field carried out using the lethe-fluid-matrix-free solver would crash with a thrown error. This was caused by the fact that solution transfer with deal.II vector requires ghosted vectors whereas solution transfer with Trilinos vectors requires locally_owned vectors. This has been fixed by adding a const expression to adapt the behaviour depending on the vector type. [#1436](https://github.com/chaos-polymtl/lethe/pull/1436)
+
 ## [Master] - 2025-02-27
 
 ### Added

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -841,7 +841,7 @@ NavierStokesBase<dim, VectorType, DofsType>::box_refine_mesh(const bool restart)
 
       // Solution transfer objects for all the solutions
       parallel::distributed::SolutionTransfer<dim, VectorType>
-        solution_transfer(this->dof_handler);
+        solution_transfer(this->dof_handler, true);
       std::vector<parallel::distributed::SolutionTransfer<dim, VectorType>>
         previous_solutions_transfer;
       // Important to reserve to prevent pointer dangling
@@ -850,7 +850,7 @@ NavierStokesBase<dim, VectorType, DofsType>::box_refine_mesh(const bool restart)
         {
           previous_solutions_transfer.emplace_back(
             parallel::distributed::SolutionTransfer<dim, VectorType>(
-              this->dof_handler));
+              this->dof_handler, true));
           if constexpr (std::is_same_v<
                           VectorType,
                           LinearAlgebra::distributed::Vector<double>>)
@@ -860,11 +860,11 @@ NavierStokesBase<dim, VectorType, DofsType>::box_refine_mesh(const bool restart)
         }
 
       parallel::distributed::SolutionTransfer<dim, VectorType>
-        solution_transfer_m1(this->dof_handler);
+        solution_transfer_m1(this->dof_handler, true);
       parallel::distributed::SolutionTransfer<dim, VectorType>
-        solution_transfer_m2(this->dof_handler);
+        solution_transfer_m2(this->dof_handler, true);
       parallel::distributed::SolutionTransfer<dim, VectorType>
-        solution_transfer_m3(this->dof_handler);
+        solution_transfer_m3(this->dof_handler, true);
 
       if constexpr (std::is_same_v<VectorType,
                                    LinearAlgebra::distributed::Vector<double>>)
@@ -1094,7 +1094,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
 
   // Solution transfer objects for all the solutions
   parallel::distributed::SolutionTransfer<dim, VectorType> solution_transfer(
-    this->dof_handler);
+    this->dof_handler, true);
   std::vector<parallel::distributed::SolutionTransfer<dim, VectorType>>
     previous_solutions_transfer;
   // Important to reserve to prevent pointer dangling
@@ -1103,7 +1103,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
     {
       previous_solutions_transfer.emplace_back(
         parallel::distributed::SolutionTransfer<dim, VectorType>(
-          this->dof_handler));
+          this->dof_handler, true));
       if constexpr (std::is_same_v<VectorType,
                                    LinearAlgebra::distributed::Vector<double>>)
         previous_solutions[i].update_ghost_values();
@@ -1167,11 +1167,11 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_uniform()
 
   // Solution transfer objects for all the solutions
   parallel::distributed::SolutionTransfer<dim, VectorType> solution_transfer(
-    this->dof_handler);
+    this->dof_handler, true);
   parallel::distributed::SolutionTransfer<dim, VectorType> solution_transfer_m2(
-    this->dof_handler);
+    this->dof_handler, true);
   parallel::distributed::SolutionTransfer<dim, VectorType> solution_transfer_m3(
-    this->dof_handler);
+    this->dof_handler, true);
 
   if constexpr (std::is_same_v<VectorType,
                                LinearAlgebra::distributed::Vector<double>>)
@@ -1189,7 +1189,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_uniform()
     {
       previous_solutions_transfer.emplace_back(
         parallel::distributed::SolutionTransfer<dim, VectorType>(
-          this->dof_handler));
+          this->dof_handler, true));
 
       if constexpr (std::is_same_v<VectorType,
                                    LinearAlgebra::distributed::Vector<double>>)
@@ -2159,7 +2159,7 @@ NavierStokesBase<dim, VectorType, DofsType>::set_solution_from_checkpoint(
       x_system[i + 1] = &distributed_previous_solutions[i];
     }
   parallel::distributed::SolutionTransfer<dim, VectorType> system_trans_vectors(
-    this->dof_handler);
+    this->dof_handler, true);
 
   if (simulation_parameters.post_processing.calculate_average_velocities ||
       this->simulation_parameters.initial_condition->type ==
@@ -2804,7 +2804,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_checkpoint()
     }
 
   parallel::distributed::SolutionTransfer<dim, VectorType> system_trans_vectors(
-    this->dof_handler);
+    this->dof_handler, true);
   system_trans_vectors.prepare_for_serialization(sol_set_transfer);
 
   multiphysics->write_checkpoint();

--- a/source/solvers/postprocessing_velocities.cc
+++ b/source/solvers/postprocessing_velocities.cc
@@ -10,9 +10,9 @@
 template <int dim, typename VectorType, typename DofsType>
 AverageVelocities<dim, VectorType, DofsType>::AverageVelocities(
   DoFHandler<dim> &dof_handler)
-  : solution_transfer_sum_velocity_dt(dof_handler)
-  , solution_transfer_sum_reynolds_normal_stress_dt(dof_handler)
-  , solution_transfer_sum_reynolds_shear_stress_dt(dof_handler)
+  : solution_transfer_sum_velocity_dt(dof_handler, true)
+  , solution_transfer_sum_reynolds_normal_stress_dt(dof_handler, true)
+  , solution_transfer_sum_reynolds_shear_stress_dt(dof_handler, true)
   , total_time_for_average(0.0)
   , average_calculation(false)
 {}

--- a/source/solvers/postprocessing_velocities.cc
+++ b/source/solvers/postprocessing_velocities.cc
@@ -347,17 +347,40 @@ template <int dim, typename VectorType, typename DofsType>
 void
 AverageVelocities<dim, VectorType, DofsType>::post_mesh_adaptation()
 {
-  solution_transfer_sum_velocity_dt.interpolate(sum_velocity_dt);
-  solution_transfer_sum_reynolds_normal_stress_dt.interpolate(
-    sum_reynolds_normal_stress_dt);
-  solution_transfer_sum_reynolds_shear_stress_dt.interpolate(
-    sum_reynolds_shear_stress_dt);
+  if constexpr (std::is_same_v<VectorType,
+                               LinearAlgebra::distributed::Vector<double>>)
+    {
+      // When the vector are deal.II vectors, the solution transfer expects a
+      // vector with ghost entries
+      solution_transfer_sum_velocity_dt.interpolate(
+        sum_velocity_dt_with_ghost_cells);
+      solution_transfer_sum_reynolds_normal_stress_dt.interpolate(
+        sum_rns_dt_with_ghost_cells);
+      solution_transfer_sum_reynolds_shear_stress_dt.interpolate(
+        sum_rss_dt_with_ghost_cells);
+
+      sum_velocity_dt               = sum_velocity_dt_with_ghost_cells;
+      sum_reynolds_normal_stress_dt = sum_rns_dt_with_ghost_cells;
+      sum_reynolds_shear_stress_dt  = sum_rss_dt_with_ghost_cells;
+    }
+  else
+    {
+      // When the vectors are trilinos vectors, the solution transfer expects a
+      // locally_owned vector
+      solution_transfer_sum_velocity_dt.interpolate(sum_velocity_dt);
+      solution_transfer_sum_reynolds_normal_stress_dt.interpolate(
+        sum_reynolds_normal_stress_dt);
+      solution_transfer_sum_reynolds_shear_stress_dt.interpolate(
+        sum_reynolds_shear_stress_dt);
 
 
 
-  sum_velocity_dt_with_ghost_cells = sum_velocity_dt;
-  sum_rns_dt_with_ghost_cells      = sum_reynolds_normal_stress_dt;
-  sum_rss_dt_with_ghost_cells      = sum_reynolds_shear_stress_dt;
+      sum_velocity_dt_with_ghost_cells = sum_velocity_dt;
+      sum_rns_dt_with_ghost_cells      = sum_reynolds_normal_stress_dt;
+      sum_rss_dt_with_ghost_cells      = sum_reynolds_shear_stress_dt;
+    }
+
+
 
   update_average_velocities();
 }


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

Simulation with dynamic mesh adaptation and time-averaging of the velocity field carried out using the lethe-fluid-matrix-free solver would crash with a thrown error. This was caused by the fact that solution transfer with deal.II vector requires ghosted vectors whereas solution transfer with Trilinos vectors requires locally_owned vectors. 
This PR aims at solving this which also pointed out in issue #1434 . It will close this issue.

Furthermore, simulation with dynamic mesh adaptation and the matrix-free solver could sometimes crash during the mesh adaptation stage due to the SolutionTransfer. This has been fixed by enabling averaging of the SolutionTransfer to reconcile incoherence between multiple cells by having the average flag set to true. For most simulation this does not have an impact, but for some it will (esp. when grid is distorted). Thanks to @peterrum for pointing this out ot me.

### Solution

This has been fixed by adding a const expression to adapt the behaviour depending on the vector type

### Testing

Test has been added.
It breaks on master and works on this branch.

### Documentation

Nothing to document here.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge