### PR TITLE
Removed the useless parameter in the serialize and deserialize functions

### DIFF
--- a/include/dem/insertion.h
+++ b/include/dem/insertion.h
@@ -96,7 +96,7 @@ public:
    *
    */
   virtual void
-  serialize(boost::archive::text_oarchive &ar, const unsigned int) = 0;
+  serialize(boost::archive::text_oarchive &ar) = 0;
 
 
   /**
@@ -109,7 +109,7 @@ public:
    *
    */
   virtual void
-  deserialize(boost::archive::text_iarchive &ar, const unsigned int) = 0;
+  deserialize(boost::archive::text_iarchive &ar) = 0;
 
 protected:
   /**

--- a/include/dem/insertion_file.h
+++ b/include/dem/insertion_file.h
@@ -73,7 +73,7 @@ public:
    * @param ar Output archive where the attributes are stored.
    */
   virtual void
-  serialize(boost::archive::text_oarchive &ar, const unsigned int) override
+  serialize(boost::archive::text_oarchive &ar) override
   {
     ar &remaining_particles_of_each_type &current_inserting_particle_type
       &current_file_id;
@@ -86,7 +86,7 @@ public:
    *
    */
   virtual void
-  deserialize(boost::archive::text_iarchive &ar, const unsigned int) override
+  deserialize(boost::archive::text_iarchive &ar) override
   {
     ar &remaining_particles_of_each_type &current_inserting_particle_type
       &current_file_id;

--- a/include/dem/insertion_list.h
+++ b/include/dem/insertion_list.h
@@ -81,7 +81,7 @@ public:
    * @param ar Output archive where the attributes are stored.
    */
   virtual void
-  serialize(boost::archive::text_oarchive &ar, const unsigned int) override
+  serialize(boost::archive::text_oarchive &ar) override
   {
     ar &remaining_particles_of_each_type &current_inserting_particle_type;
   }
@@ -93,7 +93,7 @@ public:
    *
    */
   virtual void
-  deserialize(boost::archive::text_iarchive &ar, const unsigned int) override
+  deserialize(boost::archive::text_iarchive &ar) override
   {
     ar &remaining_particles_of_each_type &current_inserting_particle_type;
   }

--- a/include/dem/insertion_plane.h
+++ b/include/dem/insertion_plane.h
@@ -57,7 +57,7 @@ public:
    * @param ar Output archive where the attributes are stored.
    */
   virtual void
-  serialize(boost::archive::text_oarchive &ar, const unsigned int) override
+  serialize(boost::archive::text_oarchive &ar) override
   {
     ar &particles_of_each_type_remaining &current_inserting_particle_type;
   }
@@ -69,7 +69,7 @@ public:
    *
    */
   virtual void
-  deserialize(boost::archive::text_iarchive &ar, const unsigned int) override
+  deserialize(boost::archive::text_iarchive &ar) override
   {
     ar &particles_of_each_type_remaining &current_inserting_particle_type;
   }

--- a/include/dem/insertion_volume.h
+++ b/include/dem/insertion_volume.h
@@ -60,7 +60,7 @@ public:
    * @param ar Output archive where the attributes are stored.
    */
   virtual void
-  serialize(boost::archive::text_oarchive &ar, const unsigned int) override
+  serialize(boost::archive::text_oarchive &ar) override
   {
     ar &particles_of_each_type_remaining &current_inserting_particle_type;
   }
@@ -72,7 +72,7 @@ public:
    *
    */
   virtual void
-  deserialize(boost::archive::text_iarchive &ar, const unsigned int) override
+  deserialize(boost::archive::text_iarchive &ar) override
   {
     ar &particles_of_each_type_remaining &current_inserting_particle_type;
   }

--- a/source/dem/read_checkpoint.cc
+++ b/source/dem/read_checkpoint.cc
@@ -99,7 +99,7 @@ read_checkpoint(
   std::ifstream iss_insertion_obj(insertion_object_filename);
   boost::archive::text_iarchive ia_insertion_obj(iss_insertion_obj,
                                                  boost::archive::no_header);
-  insertion_object->deserialize(ia_insertion_obj, 0);
+  insertion_object->deserialize(ia_insertion_obj);
 
   // Load solid surfaces
   for (unsigned int i = 0; i < solid_surfaces.size(); ++i)

--- a/source/dem/write_checkpoint.cc
+++ b/source/dem/write_checkpoint.cc
@@ -66,7 +66,7 @@ write_checkpoint(
   std::ofstream oss_insertion_obj(insertion_object_filename);
   boost::archive::text_oarchive oa_insertion_obj(oss_insertion_obj,
                                                  boost::archive::no_header);
-  insertion_object->serialize(oa_insertion_obj, 0);
+  insertion_object->serialize(oa_insertion_obj);
 
   // Checkpoint the serial solid objects one by one
   for (unsigned int i = 0; i < solid_objects.size(); ++i)


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

This PR is related to issue https://github.com/chaos-polymtl/lethe/issues/1332 . Serialize and deserialize functions were using a useless const unsigned int parameter. This input parameter has been removed.

### Testing

No new test is added. This is just clean up. 

### Documentation

<!-- Does this refactor modify or have new simulation parameters? If so, describe them. -->
N/A

### Miscellaneous (will be removed when merged)


### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge