### PR TITLE
Fix typo in documentation for DEM parameters

### DIFF
--- a/doc/source/parameters/dem/model_parameters.rst
+++ b/doc/source/parameters/dem/model_parameters.rst
@@ -102,7 +102,7 @@ All contact force models are described in the :doc:`../../theory/multiphase/cfd_
 
 * ``particle particle contact force method`` controls the particle-particle contact force model. The following models are available in Lethe: ``hertz_mindlin_limit_overlap``, ``hertz_mindlin_limit_force``, ``hertz``, ``hertz_JKR``, ``DMT`` and ``linear``.
   
-* ``particle wall contact force method`` controls the particle-wall contact force model used. The following models are available: ``linear``, ``non-linear``, ``JKR`` and ``DMT``.
+* ``particle wall contact force method`` controls the particle-wall contact force model used. The following models are available: ``linear``, ``nonlinear``, ``JKR`` and ``DMT``.
 
 * ``dmt cut-off threshold`` controls the distance at witch the non contact forces are being negleted for the DMT cohesive force model.
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

There was a typo in the documentation, the `nonlinear` dem wall contact model was called `non-linear` at one location of the documentation. This PR fixes that.

This closes #1440 

