### PR TITLE
Fix mesh adaptation controller parameter in doc

### DIFF
--- a/doc/source/parameters/cfd/mesh_adaptation_control.rst
+++ b/doc/source/parameters/cfd/mesh_adaptation_control.rst
@@ -96,7 +96,7 @@ This subsection controls the mesh adaptation method, with default values given b
 
 * The maximum number of elements in the entire domain can be controlled with the ``max number elements`` parameter.
 
-* The boolean parameter ``mesh refinement controller`` activates a controller that overrides the value of the of ``fraction coarsening`` parameter. If activated, the controller will try to maintain the total number of elements in the domain equal to the value of ``max number elements`` parameter. The control is done using a PID controller.
+* The boolean parameter ``mesh refinement controller`` activates a controller that overrides the value of the ``fraction coarsening`` parameter. If activated, the controller will try to maintain the total number of elements in the domain equal to the value of ``max number elements`` parameter. The control is done using a PID controller.
 
 .. note:: 
     If the ``fraction refinement`` parameter is too high, the controller may not be able to maintain the number of elements constant. If ``fraction type = number``, the maximal ``fraction refinement`` that is stable in 3D is 0.125. In 2D, it is 0.25.

--- a/doc/source/parameters/cfd/mesh_adaptation_control.rst
+++ b/doc/source/parameters/cfd/mesh_adaptation_control.rst
@@ -38,6 +38,9 @@ This subsection controls the mesh adaptation method, with default values given b
     # Maximum number of elements
     set max number elements      = 100000000
 
+    # Enabling the mesh adaptation controller to obtain a constant number of elements
+    mesh refinement controller   = false
+
     # Number of initial (pre-solve) refinement steps
     set initial refinement steps = 0
 
@@ -93,7 +96,7 @@ This subsection controls the mesh adaptation method, with default values given b
 
 * The maximum number of elements in the entire domain can be controlled with the ``max number elements`` parameter.
 
-* The boolean parameter ``enable mesh refinement controller`` activates a controller that overrides the value of the of ``fraction coarsening`` parameter. If activated, the controller will try to maintain the total number of elements in the domain equal to the value of ``max number elements`` parameter. The control is done using a PID controller.
+* The boolean parameter ``mesh refinement controller`` activates a controller that overrides the value of the of ``fraction coarsening`` parameter. If activated, the controller will try to maintain the total number of elements in the domain equal to the value of ``max number elements`` parameter. The control is done using a PID controller.
 
 .. note:: 
     If the ``fraction refinement`` parameter is too high, the controller may not be able to maintain the number of elements constant. If ``fraction type = number``, the maximal ``fraction refinement`` that is stable in 3D is 0.125. In 2D, it is 0.25.


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The mesh refinement controller parameter was wrongly named `enable mesh refinement controller` in the documentation when the real parameter is actually named `mesh refinement controller`. This PR fixes this documentation issue.


Closes #1435 

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge