### PR TITLE
Fix velocity subsection in ale parameters doc

### DIFF
--- a/doc/source/parameters/cfd/ale.rst
+++ b/doc/source/parameters/cfd/ale.rst
@@ -24,6 +24,6 @@ The ALE velocity field is specified through the ``velocity`` subsection.
 
 * The ``Function expression`` parameter sets the expression for the ALE velocity field in regards to :math:`u` and :math:`v`  for a 2D simulation and to :math:`u`, :math:`v`, :math:`w` for a 3D simulation.
 
-.. warning:: The current implementation of the ALE module does not support time-dependent or non-divergence velocity fields.
+.. warning:: The current implementation of the ALE module does not support time-dependent or divergence-free velocity fields.
 
 

--- a/doc/source/parameters/cfd/ale.rst
+++ b/doc/source/parameters/cfd/ale.rst
@@ -24,6 +24,6 @@ The ALE velocity field is specified through the ``velocity`` subsection.
 
 * The ``Function expression`` parameter sets the expression for the ALE velocity field in regards to :math:`u` and :math:`v`  for a 2D simulation and to :math:`u`, :math:`v`, :math:`w` for a 3D simulation.
 
-.. warning:: The current implementation of the ALE module does not support time-dependent or divergence-free velocity fields.
+.. warning:: The current implementation of the ALE module does not support time-dependent or non divergence-free velocity fields.
 
 

--- a/doc/source/parameters/cfd/ale.rst
+++ b/doc/source/parameters/cfd/ale.rst
@@ -8,20 +8,22 @@ Lethe contains a small Arbitrary Lagrangian-Eulerian (ALE) module which enables 
 .. code-block:: text
 
    subsection ALE
-    set enable                = false
+    set enable = false
 
-    subsection uvw
+    subsection velocity
       set Function expression = 0; 0 # In 2D : u;v
-        or
+      # or
       set Function expression = 0; 0; 0 #In 3D u;v;w
     end
    
    end
 
-* The ``enable`` parameter is set to true if the ALE velocity should be substracted from the fluid velocity.
+* The ``enable`` parameter is set to ``true`` if the ALE velocity should be subtracted from the fluid velocity.
+
+The ALE velocity field is specified through the ``velocity`` subsection.
 
 * The ``Function expression`` parameter sets the expression for the ALE velocity field in regards to :math:`u` and :math:`v`  for a 2D simulation and to :math:`u`, :math:`v`, :math:`w` for a 3D simulation.
 
-.. warning:: The current implementation of the ALE module does not support time-dependent or non-divergence velocity fields
+.. warning:: The current implementation of the ALE module does not support time-dependent or non-divergence velocity fields.
 
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The subsection to specify the ALE velocity field in the parameters was not well-documented `uvw` instead of `velocity`.
This PR corrects the subsection name in the online documentation.


### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge