### PR TITLE
Update ubuntu version for clang format CI

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -20,7 +20,7 @@ jobs:
   indent:
 
     name: indent
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The Clang format CI for indentation checks uses an old version of Ubuntu that is not supported in Github Actions anymore

### Solution

Update the Ubuntu version

### Testing

If CI passes everything is good.
