### PR TITLE
Core library cleanup

### DIFF
--- a/include/core/bdf.h
+++ b/include/core/bdf.h
@@ -27,7 +27,7 @@ using namespace dealii;
  * should be in decreasing order.
  *
  * For example, if the method is a BDF2 (\f$n=2\f$), it uses three values for
- * the time: \f$t\f$, \f$t-\Delta t_1\f$ and \f$t-\Delta t_2\f$. Thus the @p
+ * the time: \f$t\f$, \f$t-\Delta t_1\f$ and \f$t-\Delta t_2\f$. Thus, the @p
  * time_steps vector should contain \f$\Delta t_1\f$ and \f$\Delta t_2\f$.
  *
  * @return Vector containing BDF integration coefficient values.
@@ -36,8 +36,8 @@ using namespace dealii;
  */
 Vector<double>
 calculate_bdf_coefficients(
-  const Parameters::SimulationControl::TimeSteppingMethod method,
-  const std::vector<double>                              &time_steps);
+  Parameters::SimulationControl::TimeSteppingMethod method,
+  const std::vector<double>                        &time_steps);
 
 
 /**
@@ -65,12 +65,10 @@ calculate_bdf_coefficients(
  * calculation of BDF coefficients.
  */
 Vector<double>
-delta(const unsigned int    order,
-      const unsigned int    n,
-      const unsigned int    j,
+delta(unsigned int          order,
+      unsigned int          n,
+      unsigned int          j,
       const Vector<double> &times);
-
-
 
 /**
  * @brief Get the maximum number of previous time steps supposed by the BDF
@@ -97,17 +95,17 @@ maximum_number_of_previous_solutions()
  */
 inline unsigned int
 number_of_previous_solutions(
-  Parameters::SimulationControl::TimeSteppingMethod method)
+  const Parameters::SimulationControl::TimeSteppingMethod method)
 {
   if (method == Parameters::SimulationControl::TimeSteppingMethod::bdf1 ||
       method == Parameters::SimulationControl::TimeSteppingMethod::steady_bdf)
     return 1;
-  else if (method == Parameters::SimulationControl::TimeSteppingMethod::bdf2)
+  if (method == Parameters::SimulationControl::TimeSteppingMethod::bdf2)
     return 2;
-  else if (method == Parameters::SimulationControl::TimeSteppingMethod::bdf3)
+  if (method == Parameters::SimulationControl::TimeSteppingMethod::bdf3)
     return 3;
-  else
-    return 0;
+
+  return 0;
 }
 
 /**
@@ -131,7 +129,7 @@ number_of_previous_solutions(
  */
 
 template <typename DataType>
-inline void
+void
 bdf_extrapolate(const std::vector<double>                &time_vector,
                 const std::vector<std::vector<DataType>> &solution_vector,
                 const unsigned int     number_of_previous_solutions,

--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -1272,7 +1272,7 @@ public:
     , w(p_w)
   {}
 
-  virtual double
+  double
   value(const Point<dim> &point, const unsigned int component) const override;
 };
 
@@ -1321,7 +1321,7 @@ public:
     , p(p_p)
   {}
 
-  virtual double
+  double
   value(const Point<dim> &point, unsigned int component) const override;
 };
 

--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -88,7 +88,6 @@ namespace BoundaryConditions
    * special case of periodic boundary condition, a periodic matching id
    * (periodic_id) and a periodic direction (0, 1 or 2).
    */
-  template <int dim>
   class BoundaryConditions
   {
   public:
@@ -160,7 +159,7 @@ namespace BoundaryConditions
    * coherently.
    */
   template <int dim>
-  class NSBoundaryConditions : public BoundaryConditions<dim>
+  class NSBoundaryConditions : public BoundaryConditions
   {
   public:
     /// Functions for (u, v, w, p) for all boundaries
@@ -170,8 +169,8 @@ namespace BoundaryConditions
     void
     parse_boundary(ParameterHandler &prm);
     void
-    declare_default_entry(ParameterHandler        &prm,
-                          const types::boundary_id default_boundary_id);
+    declare_default_entry(ParameterHandler  &prm,
+                          types::boundary_id default_boundary_id);
 
     /**
      * @brief Declares the Navier-Stokes boundary conditions
@@ -180,8 +179,8 @@ namespace BoundaryConditions
      * @param number_of_boundary_conditions The number of boundary conditions to be declared. This parameter is generally pre-parsed from a first read of the prm file.
      */
     void
-    declare_parameters(ParameterHandler  &prm,
-                       const unsigned int number_of_boundary_conditions);
+    declare_parameters(ParameterHandler &prm,
+                       unsigned int      number_of_boundary_conditions);
 
     /**
      * @brief Parses the Navier-Stokes boundary conditions
@@ -217,7 +216,7 @@ namespace BoundaryConditions
    *
    * @param prm A parameter handler which is currently used to parse the simulation information
    *
-   * @param i_bc The boundary condition id.
+   * @param default_boundary_id Default value of the boundary id. This corresponds to the number of the boundary condition subsection.
    */
   template <int dim>
   void
@@ -298,8 +297,6 @@ namespace BoundaryConditions
    * @brief Parse the information for a boundary condition
    *
    * @param prm A parameter handler which is currently used to parse the simulation information
-   *
-   * @param i_bc The boundary condition number (and not necessarily it's id).
    */
   template <int dim>
   void
@@ -514,7 +511,7 @@ namespace BoundaryConditions
    */
 
   template <int dim>
-  class HTBoundaryConditions : public BoundaryConditions<dim>
+  class HTBoundaryConditions : public BoundaryConditions
   {
   public:
     std::map<types::boundary_id,
@@ -535,11 +532,11 @@ namespace BoundaryConditions
     double Stefan_Boltzmann_constant;
 
     void
-    declare_default_entry(ParameterHandler        &prm,
-                          const types::boundary_id default_boundary_id);
+    declare_default_entry(ParameterHandler  &prm,
+                          types::boundary_id default_boundary_id);
     void
-    declare_parameters(ParameterHandler  &prm,
-                       const unsigned int number_of_boundary_conditions);
+    declare_parameters(ParameterHandler &prm,
+                       unsigned int      number_of_boundary_conditions);
     void
     parse_boundary(ParameterHandler &prm);
     void
@@ -555,7 +552,7 @@ namespace BoundaryConditions
    *
    * @param prm A parameter handler which is currently used to parse the simulation information
    *
-   * @param i_bc The boundary condition id.
+   * @param default_boundary_id Default value given to the boundary id.
    */
   template <int dim>
   void
@@ -608,6 +605,8 @@ namespace BoundaryConditions
    * Calls declareDefaultEntry method for each boundary (max 14 boundaries)
    *
    * @param prm A parameter handler which is currently used to parse the simulation information
+   *
+   * @param number_of_boundary_conditions Number of boundary conditions
    */
   template <int dim>
   void
@@ -648,8 +647,6 @@ namespace BoundaryConditions
    * @brief Parse the information for a boundary condition
    *
    * @param prm A parameter handler which is currently used to parse the simulation information
-   *
-   * @param i_bc The boundary condition number (and not necessarily it's id).
    */
 
   template <int dim>
@@ -745,13 +742,10 @@ namespace BoundaryConditions
    * @brief This class manages the boundary conditions for Tracer solver
    * It introduces the boundary functions and declares the boundary conditions
    * coherently.
-   *  - if bc type is "dirichlet" (Dirichlet condition), "value" is the
-   * double passed to the deal.ii ConstantFunction
-
    */
 
   template <int dim>
-  class TracerBoundaryConditions : public BoundaryConditions<dim>
+  class TracerBoundaryConditions : public BoundaryConditions
   {
   public:
     std::map<types::boundary_id,
@@ -760,11 +754,11 @@ namespace BoundaryConditions
 
 
     void
-    declare_default_entry(ParameterHandler        &prm,
-                          const types::boundary_id default_boundary_id);
+    declare_default_entry(ParameterHandler  &prm,
+                          types::boundary_id default_boundary_id);
     void
-    declare_parameters(ParameterHandler  &prm,
-                       const unsigned int number_of_boundary_conditions);
+    declare_parameters(ParameterHandler &prm,
+                       unsigned int      number_of_boundary_conditions);
     void
     parse_boundary(ParameterHandler &prm);
     void
@@ -775,9 +769,9 @@ namespace BoundaryConditions
    * @brief Declares the default parameters for a boundary condition id i_bc
    * i.e. Dirichlet condition (ConstantFunction) with value 0
    *
-   * @param prm A parameter handler which is currently used to parse the simulation information
+   * @param prm A parameter handler which is currently used to parse the simulation information.
    *
-   * @param i_bc The boundary condition id.
+   * @param default_boundary_id Default value given to the boundary id.
    */
   template <int dim>
   void
@@ -808,6 +802,8 @@ namespace BoundaryConditions
    * Calls declareDefaultEntry method for each boundary (max 14 boundaries)
    *
    * @param prm A parameter handler which is currently used to parse the simulation information
+   *
+   * @param number_of_boundary_conditions Number of tracer boundary conditions
    */
   template <int dim>
   void
@@ -915,12 +911,10 @@ namespace BoundaryConditions
    * @brief This class manages the boundary conditions for the Cahn-Hilliard solver
    * It introduces the boundary functions and declares the boundary conditions
    * coherently.
-   *  - if bc type is "dirichlet" (Dirichlet condition), "value" is the
-   * double passed to the deal.ii ConstantFunction
    */
 
   template <int dim>
-  class CahnHilliardBoundaryConditions : public BoundaryConditions<dim>
+  class CahnHilliardBoundaryConditions : public BoundaryConditions
   {
   public:
     std::map<types::boundary_id, double> angle_of_contact;
@@ -930,11 +924,11 @@ namespace BoundaryConditions
       bcFunctions;
 
     void
-    declare_default_entry(ParameterHandler        &prm,
-                          const types::boundary_id default_boundary_id);
+    declare_default_entry(ParameterHandler  &prm,
+                          types::boundary_id default_boundary_id);
     void
-    declare_parameters(ParameterHandler  &prm,
-                       const unsigned int number_of_boundary_conditions);
+    declare_parameters(ParameterHandler &prm,
+                       unsigned int      number_of_boundary_conditions);
     void
     parse_boundary(ParameterHandler &prm);
     void
@@ -942,12 +936,11 @@ namespace BoundaryConditions
   };
 
   /**
-   * @brief Declares the default parameters for a boundary condition id i_bc
-   * i.e. Dirichlet condition (ConstantFunction) with value 0
+   * @brief Declares the default parameters for the Cahn-Hilliard boundary conditions
    *
-   * @param prm A parameter handler which is currently used to parse the simulation information
+   * @param prm A parameter handler which is currently used to parse the simulation information.
    *
-   * @param i_bc The boundary condition id.
+   * @param default_boundary_id Default value given to the boundary id.
    */
   template <int dim>
   void
@@ -977,8 +970,6 @@ namespace BoundaryConditions
     prm.enter_subsection("phi");
     temporary_function.declare_parameters(prm);
     prm.leave_subsection();
-
-    return;
   }
 
   /**
@@ -986,6 +977,8 @@ namespace BoundaryConditions
    * Calls declareDefaultEntry method for each boundary (max 14 boundaries)
    *
    * @param prm A parameter handler which is currently used to parse the simulation information
+   *
+   * @param number_of_boundary_conditions Number of boundary conditions
    */
   template <int dim>
   void
@@ -1022,7 +1015,6 @@ namespace BoundaryConditions
    *
    * @param prm A parameter handler which is currently used to parse the simulation information
    *
-   * @param i_bc The boundary condition number (and not necessarily its id).
    */
 
   template <int dim>
@@ -1101,15 +1093,10 @@ namespace BoundaryConditions
    * @brief This class manages the boundary conditions for VOF solver
    * It introduces the boundary functions and declares the boundary conditions
    * coherently.
-   *
-   * - if bc type is "dirichlet", the function is applied on the selected
-   * boundary
-   *
-   * - if bc type is "none", nothing happens
    */
 
   template <int dim>
-  class VOFBoundaryConditions : public BoundaryConditions<dim>
+  class VOFBoundaryConditions : public BoundaryConditions
   {
   public:
     std::map<types::boundary_id,
@@ -1117,11 +1104,11 @@ namespace BoundaryConditions
       phase_fraction;
 
     void
-    declare_default_entry(ParameterHandler        &prm,
-                          const types::boundary_id default_boundary_id);
+    declare_default_entry(ParameterHandler  &prm,
+                          types::boundary_id default_boundary_id);
     void
-    declare_parameters(ParameterHandler  &prm,
-                       const unsigned int number_of_boundary_conditions);
+    declare_parameters(ParameterHandler &prm,
+                       unsigned int      number_of_boundary_conditions);
     void
     parse_boundary(ParameterHandler &prm);
     void
@@ -1133,7 +1120,7 @@ namespace BoundaryConditions
    *
    * @param prm A parameter handler which is currently used to parse the simulation information
    *
-   * @param i_bc The boundary condition id.
+   * @param default_boundary_id Default value given to the boundary id.
    */
   template <int dim>
   void
@@ -1163,6 +1150,8 @@ namespace BoundaryConditions
    * Calls declareDefaultEntry method for each boundary (max 14 boundaries)
    *
    * @param prm A parameter handler which is currently used to parse the simulation information
+   *
+   * @param number_of_boundary_conditions Number of boundary conditions
    */
   template <int dim>
   void
@@ -1198,8 +1187,6 @@ namespace BoundaryConditions
    * @brief Parse the information for a boundary condition
    *
    * @param prm A parameter handler which is currently used to parse the simulation information
-   *
-   * @param i_bc The boundary condition number (and not necessarily it's id).
    */
 
   template <int dim>
@@ -1216,12 +1203,12 @@ namespace BoundaryConditions
     AssertThrow(this->type.find(boundary_id) == this->type.end(),
                 VOFBoundaryDuplicated(boundary_id));
 
-    const std::string op = prm.get("type");
-    if (op == "none")
+    if (auto const option = prm.get("type"); option == "none")
       {
         this->type[boundary_id] = BoundaryType::none;
       }
-    else if (op == "dirichlet")
+
+    if (auto const option = prm.get("type"); option == "dirichlet")
       {
         this->type[boundary_id] = BoundaryType::vof_dirichlet;
         prm.enter_subsection("dirichlet");
@@ -1271,7 +1258,6 @@ namespace BoundaryConditions
 template <int dim>
 class NavierStokesFunctionDefined : public Function<dim>
 {
-private:
   Functions::ParsedFunction<dim> *u;
   Functions::ParsedFunction<dim> *v;
   Functions::ParsedFunction<dim> *w;
@@ -1287,20 +1273,20 @@ public:
   {}
 
   virtual double
-  value(const Point<dim> &p, const unsigned int component) const override;
+  value(const Point<dim> &point, const unsigned int component) const override;
 };
 
 
 /**
  * @brief Calculates the value of a Function-type Navier-Stokes equations
  *
- * @param p A point (generally a gauss point)
+ * @param point A point at which the function will be evaluated
  *
  * @param component The vector component of the boundary condition (0-x, 1-y and 2-z)
  */
 template <int dim>
 double
-NavierStokesFunctionDefined<dim>::value(const Point<dim>  &p,
+NavierStokesFunctionDefined<dim>::value(const Point<dim>  &point,
                                         const unsigned int component) const
 {
   Assert(component < this->n_components,
@@ -1308,15 +1294,15 @@ NavierStokesFunctionDefined<dim>::value(const Point<dim>  &p,
 
   if (component == 0)
     {
-      return u->value(p);
+      return u->value(point);
     }
-  else if (component == 1)
+  if (component == 1)
     {
-      return v->value(p);
+      return v->value(point);
     }
-  else if (component == 2)
+  if (component == 2)
     {
-      return w->value(p);
+      return w->value(point);
     }
   return 0.;
 }
@@ -1327,7 +1313,6 @@ NavierStokesFunctionDefined<dim>::value(const Point<dim>  &p,
 template <int dim>
 class NavierStokesPressureFunctionDefined : public Function<dim>
 {
-private:
   Functions::ParsedFunction<dim> *p;
 
 public:
@@ -1337,14 +1322,14 @@ public:
   {}
 
   virtual double
-  value(const Point<dim> &p, const unsigned int component) const override;
+  value(const Point<dim> &point, unsigned int component) const override;
 };
 
 
 /**
  * @brief Calculates the value of a Function-type Navier-Stokes equations
  *
- * @param p A point (generally a gauss point)
+ * @param point A point (generally a gauss point)
  *
  * @param component The vector component of the boundary condition (0-x, 1-y and 2-z)
  */
@@ -1378,7 +1363,7 @@ public:
   {}
 
   virtual double
-  value(const Point<dim> &p, const unsigned int component) const override;
+  value(const Point<dim> &p, unsigned int component) const override;
 };
 
 
@@ -1401,7 +1386,7 @@ CahnHilliardFunctionDefined<dim>::value(const Point<dim>  &p,
     {
       return phi->value(p);
     }
-  else if (component == 1)
+  if (component == 1)
     {
       return 0.;
     }

--- a/include/core/dem_properties.h
+++ b/include/core/dem_properties.h
@@ -77,15 +77,6 @@ namespace DEM
   } // namespace CFDDEMProperties
 
   /**
-   * @brief Return the number of properties stored on each particle.
-   * @tparam PropertiesIndex Index of the properties used within the ParticleHandler.
-   * @return Number of DEM properties.
-   */
-  template <typename PropertiesIndex>
-  unsigned int
-  get_number_properties();
-
-  /**
    * @brief Controls the name of output variables for the vtu.
    * @tparam dim An integer that denotes the number of spatial dimensions.
    * @tparam PropertiesIndex Index of the properties used within the ParticleHandler.

--- a/include/core/density_model.h
+++ b/include/core/density_model.h
@@ -133,7 +133,7 @@ public:
    * zero.
    */
   double
-  jacobian(const std::map<field, double> &field_values, field id) override
+  jacobian(const std::map<field, double> &field_values, const field id) override
   {
     (void)field_values;
     (void)id;
@@ -150,7 +150,8 @@ public:
    * @param[in] id Identifier of the field with respect to which a derivative
    * should be computed.
    *
-   * @param[out] jacobian Vector of computed derivative values of the density
+   * @param[out] jacobian_vector Vector of computed derivative values of the
+   * density
    * with respect to the field of the specified @p id. In this case, it returns
    * a vector of zeros since the density remains constant.
    *
@@ -294,7 +295,7 @@ public:
    * specified field.
    */
   double
-  jacobian(const std::map<field, double> &field_values, field id) override
+  jacobian(const std::map<field, double> &field_values, const field id) override
   {
     (void)field_values;
     if (id == field::pressure)
@@ -313,7 +314,7 @@ public:
    * @param[in] id Identifier of the field with respect to which a derivative
    * should be computed.
    *
-   * @param[out] jacobian Vector of computed derivative values of the density
+   * @param[out] jacobian_vector Vector of computed derivative values of the density
    * with respect to the field of the specified @p id.
    */
   void

--- a/include/core/density_model.h
+++ b/include/core/density_model.h
@@ -314,7 +314,8 @@ public:
    * @param[in] id Identifier of the field with respect to which a derivative
    * should be computed.
    *
-   * @param[out] jacobian_vector Vector of computed derivative values of the density
+   * @param[out] jacobian_vector Vector of computed derivative values of the
+   * density
    * with respect to the field of the specified @p id.
    */
   void

--- a/include/core/grids.h
+++ b/include/core/grids.h
@@ -37,8 +37,8 @@ attach_grid_to_triangulation(
 template <int dim, int spacedim = dim>
 void
 setup_periodic_boundary_conditions(
-  parallel::DistributedTriangulationBase<dim, spacedim>  &triangulation,
-  const BoundaryConditions::BoundaryConditions<spacedim> &boundary_conditions);
+  parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
+  const BoundaryConditions::BoundaryConditions          &boundary_conditions);
 
 /**
  * @brief Completely set-up a mesh and its manifold
@@ -54,11 +54,11 @@ setup_periodic_boundary_conditions(
 template <int dim, int spacedim = dim>
 void
 read_mesh_and_manifolds(
-  parallel::DistributedTriangulationBase<dim, spacedim>  &triangulation,
-  const Parameters::Mesh                                 &mesh_parameters,
-  const Parameters::Manifolds                            &manifolds_parameters,
-  const bool                                             &restart,
-  const BoundaryConditions::BoundaryConditions<spacedim> &boundary_conditions);
+  parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
+  const Parameters::Mesh                                &mesh_parameters,
+  const Parameters::Manifolds                           &manifolds_parameters,
+  const bool                                            &restart,
+  const BoundaryConditions::BoundaryConditions          &boundary_conditions);
 
 
 /**

--- a/source/core/bdf.cc
+++ b/source/core/bdf.cc
@@ -45,42 +45,40 @@ calculate_bdf_coefficients(
 {
   switch (method)
     {
-      case (Parameters::SimulationControl::TimeSteppingMethod::bdf1):
+      case Parameters::SimulationControl::TimeSteppingMethod::bdf1:
         return bdf_coefficients(1, time_steps);
-      case (Parameters::SimulationControl::TimeSteppingMethod::steady_bdf):
+      case Parameters::SimulationControl::TimeSteppingMethod::steady_bdf:
         return bdf_coefficients(1, time_steps);
-      case (Parameters::SimulationControl::TimeSteppingMethod::bdf2):
+      case Parameters::SimulationControl::TimeSteppingMethod::bdf2:
         return bdf_coefficients(2, time_steps);
-      case (Parameters::SimulationControl::TimeSteppingMethod::bdf3):
+      case Parameters::SimulationControl::TimeSteppingMethod::bdf3:
         return bdf_coefficients(3, time_steps);
       default:
         throw(std::runtime_error(
           "BDF coefficients were requested without a BDF method"));
-        break;
     }
 }
 
 Vector<double>
-delta(const unsigned int    p,
+delta(const unsigned int    order,
       const unsigned int    n,
       const unsigned int    j,
       const Vector<double> &times)
 {
   if (j == 0)
     {
-      Vector<double> arr(p + 1);
+      Vector<double> arr(order + 1);
       arr    = 0.;
       arr[n] = 1;
       return arr;
     }
-  else
-    {
-      Vector<double> delta_1 = delta(p, n, j - 1, times);
-      Vector<double> delta_2 = delta(p, n + 1, j - 1, times);
-      Vector<double> delta_sol(p + 1);
-      for (unsigned int i_del = 0; i_del < p + 1; ++i_del)
-        delta_sol[i_del] =
-          (delta_1[i_del] - delta_2[i_del]) / (times[n] - times[n + j]);
-      return delta_sol;
-    }
+
+  // else
+  Vector<double> delta_1 = delta(order, n, j - 1, times);
+  Vector<double> delta_2 = delta(order, n + 1, j - 1, times);
+  Vector<double> delta_sol(order + 1);
+  for (unsigned int i_del = 0; i_del < order + 1; ++i_del)
+    delta_sol[i_del] =
+      (delta_1[i_del] - delta_2[i_del]) / (times[n] - times[n + j]);
+  return delta_sol;
 }

--- a/source/core/boundary_conditions.cc
+++ b/source/core/boundary_conditions.cc
@@ -5,8 +5,6 @@
 
 namespace BoundaryConditions
 {
-  extern template class BoundaryConditions<2>;
-  extern template class BoundaryConditions<3>;
   extern template class NSBoundaryConditions<2>;
   extern template class NSBoundaryConditions<3>;
   extern template class HTBoundaryConditions<2>;

--- a/source/core/dem_properties.cc
+++ b/source/core/dem_properties.cc
@@ -3,8 +3,6 @@
 
 #include <core/dem_properties.h>
 
-#include <deal.II/base/exception_macros.h>
-
 #include <type_traits>
 
 

--- a/source/core/dem_properties.cc
+++ b/source/core/dem_properties.cc
@@ -3,6 +3,8 @@
 
 #include <core/dem_properties.h>
 
+#include <deal.II/base/exception_macros.h>
+
 #include <type_traits>
 
 
@@ -12,37 +14,22 @@ namespace DEM
   std::vector<std::pair<std::string, int>>
   ParticleProperties<dim, PropertiesIndex>::get_properties_name()
   {
-    if constexpr (std::is_same_v<PropertiesIndex,
-                                 DEM::DEMProperties::PropertiesIndex>)
-      {
-        std::vector<std::pair<std::string, int>> properties(
-          PropertiesIndex::n_properties);
-        properties[PropertiesIndex::type]    = std::make_pair("type", 1);
-        properties[PropertiesIndex::dp]      = std::make_pair("diameter", 1);
-        properties[PropertiesIndex::v_x]     = std::make_pair("velocity", 3);
-        properties[PropertiesIndex::v_y]     = std::make_pair("velocity", 1);
-        properties[PropertiesIndex::v_z]     = std::make_pair("velocity", 1);
-        properties[PropertiesIndex::omega_x] = std::make_pair("omega", 3);
-        properties[PropertiesIndex::omega_y] = std::make_pair("omega", 1);
-        properties[PropertiesIndex::omega_z] = std::make_pair("omega", 1);
-        properties[PropertiesIndex::mass]    = std::make_pair("mass", 1);
+    std::vector<std::pair<std::string, int>> properties(
+      PropertiesIndex::n_properties);
 
-        return properties;
-      }
+    properties[PropertiesIndex::type]    = std::make_pair("type", 1);
+    properties[PropertiesIndex::dp]      = std::make_pair("diameter", 1);
+    properties[PropertiesIndex::v_x]     = std::make_pair("velocity", 3);
+    properties[PropertiesIndex::v_y]     = std::make_pair("velocity", 1);
+    properties[PropertiesIndex::v_z]     = std::make_pair("velocity", 1);
+    properties[PropertiesIndex::omega_x] = std::make_pair("omega", 3);
+    properties[PropertiesIndex::omega_y] = std::make_pair("omega", 1);
+    properties[PropertiesIndex::omega_z] = std::make_pair("omega", 1);
+    properties[PropertiesIndex::mass]    = std::make_pair("mass", 1);
 
     if constexpr (std::is_same_v<PropertiesIndex,
                                  DEM::CFDDEMProperties::PropertiesIndex>)
       {
-        std::vector<std::pair<std::string, int>> properties(
-          PropertiesIndex::n_properties);
-        properties[PropertiesIndex::type]    = std::make_pair("type", 1);
-        properties[PropertiesIndex::dp]      = std::make_pair("diameter", 1);
-        properties[PropertiesIndex::v_x]     = std::make_pair("velocity", 3);
-        properties[PropertiesIndex::v_y]     = std::make_pair("velocity", 1);
-        properties[PropertiesIndex::v_z]     = std::make_pair("velocity", 1);
-        properties[PropertiesIndex::omega_x] = std::make_pair("omega", 3);
-        properties[PropertiesIndex::omega_y] = std::make_pair("omega", 1);
-        properties[PropertiesIndex::omega_z] = std::make_pair("omega", 1);
         properties[PropertiesIndex::fem_force_x] =
           std::make_pair("fem_force", 3);
         properties[PropertiesIndex::fem_force_y] =
@@ -57,26 +44,13 @@ namespace DEM
           std::make_pair("fem_torque", 1);
         properties[PropertiesIndex::volumetric_contribution] =
           std::make_pair("volumetric_contribution", 1);
-        properties[PropertiesIndex::mass] = std::make_pair("mass", 1);
-
-        return properties;
       }
+    return properties;
   }
 
-  template <typename PropertiesIndex>
-  unsigned int
-  get_number_properties()
-  {
-    return PropertiesIndex::n_properties;
-  }
+  template class ParticleProperties<2, DEMProperties::PropertiesIndex>;
+  template class ParticleProperties<2, CFDDEMProperties::PropertiesIndex>;
+  template class ParticleProperties<3, DEMProperties::PropertiesIndex>;
+  template class ParticleProperties<3, CFDDEMProperties::PropertiesIndex>;
 
-  template class ParticleProperties<2, DEM::DEMProperties::PropertiesIndex>;
-  template class ParticleProperties<2, DEM::CFDDEMProperties::PropertiesIndex>;
-  template class ParticleProperties<3, DEM::DEMProperties::PropertiesIndex>;
-  template class ParticleProperties<3, DEM::CFDDEMProperties::PropertiesIndex>;
-
-  template unsigned int
-  DEM::get_number_properties<DEM::DEMProperties::PropertiesIndex>();
-  template unsigned int
-  DEM::get_number_properties<DEM::CFDDEMProperties::PropertiesIndex>();
 } // namespace DEM

--- a/source/core/density_model.cc
+++ b/source/core/density_model.cc
@@ -14,8 +14,6 @@ DensityModel::model_cast(const Parameters::Material &material_properties)
         material_properties.isothermal_ideal_gas_density_parameters.R,
         material_properties.isothermal_ideal_gas_density_parameters.T);
     }
-  else
-    {
-      return std::make_shared<DensityConstant>(material_properties.density);
-    }
+
+  return std::make_shared<DensityConstant>(material_properties.density);
 }

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -292,8 +292,8 @@ attach_grid_to_triangulation(
 template <int dim, int spacedim>
 void
 setup_periodic_boundary_conditions(
-  parallel::DistributedTriangulationBase<dim, spacedim>  &triangulation,
-  const BoundaryConditions::BoundaryConditions<spacedim> &boundary_conditions)
+  parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
+  const BoundaryConditions::BoundaryConditions          &boundary_conditions)
 
 {
   // Setup periodic boundary conditions
@@ -320,11 +320,11 @@ setup_periodic_boundary_conditions(
 template <int dim, int spacedim>
 void
 read_mesh_and_manifolds(
-  parallel::DistributedTriangulationBase<dim, spacedim>  &triangulation,
-  const Parameters::Mesh                                 &mesh_parameters,
-  const Parameters::Manifolds                            &manifolds_parameters,
-  const bool                                             &restart,
-  const BoundaryConditions::BoundaryConditions<spacedim> &boundary_conditions)
+  parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
+  const Parameters::Mesh                                &mesh_parameters,
+  const Parameters::Manifolds                           &manifolds_parameters,
+  const bool                                            &restart,
+  const BoundaryConditions::BoundaryConditions          &boundary_conditions)
 {
   attach_grid_to_triangulation(triangulation, mesh_parameters);
 
@@ -411,35 +411,35 @@ attach_grid_to_triangulation(
 
 template void
 setup_periodic_boundary_conditions(
-  parallel::DistributedTriangulationBase<2, 2>    &triangulation,
-  const BoundaryConditions::BoundaryConditions<2> &boundary_conditions);
+  parallel::DistributedTriangulationBase<2, 2> &triangulation,
+  const BoundaryConditions::BoundaryConditions &boundary_conditions);
 template void
 setup_periodic_boundary_conditions(
-  parallel::DistributedTriangulationBase<2, 3>    &triangulation,
-  const BoundaryConditions::BoundaryConditions<3> &boundary_conditions);
+  parallel::DistributedTriangulationBase<2, 3> &triangulation,
+  const BoundaryConditions::BoundaryConditions &boundary_conditions);
 template void
 setup_periodic_boundary_conditions(
-  parallel::DistributedTriangulationBase<3, 3>    &triangulation,
-  const BoundaryConditions::BoundaryConditions<3> &boundary_conditions);
+  parallel::DistributedTriangulationBase<3, 3> &triangulation,
+  const BoundaryConditions::BoundaryConditions &boundary_conditions);
 
 template void
 read_mesh_and_manifolds(
-  parallel::DistributedTriangulationBase<2>       &triangulation,
-  const Parameters::Mesh                          &mesh_parameters,
-  const Parameters::Manifolds                     &manifolds_parameters,
-  const bool                                      &restart,
-  const BoundaryConditions::BoundaryConditions<2> &boundary_conditions);
+  parallel::DistributedTriangulationBase<2>    &triangulation,
+  const Parameters::Mesh                       &mesh_parameters,
+  const Parameters::Manifolds                  &manifolds_parameters,
+  const bool                                   &restart,
+  const BoundaryConditions::BoundaryConditions &boundary_conditions);
 template void
 read_mesh_and_manifolds(
-  parallel::DistributedTriangulationBase<3>       &triangulation,
-  const Parameters::Mesh                          &mesh_parameters,
-  const Parameters::Manifolds                     &manifolds_parameters,
-  const bool                                      &restart,
-  const BoundaryConditions::BoundaryConditions<3> &boundary_conditions);
+  parallel::DistributedTriangulationBase<3>    &triangulation,
+  const Parameters::Mesh                       &mesh_parameters,
+  const Parameters::Manifolds                  &manifolds_parameters,
+  const bool                                   &restart,
+  const BoundaryConditions::BoundaryConditions &boundary_conditions);
 template void
 read_mesh_and_manifolds(
-  parallel::DistributedTriangulationBase<2, 3>    &triangulation,
-  const Parameters::Mesh                          &mesh_parameters,
-  const Parameters::Manifolds                     &manifolds_parameters,
-  const bool                                      &restart,
-  const BoundaryConditions::BoundaryConditions<3> &boundary_conditions);
+  parallel::DistributedTriangulationBase<2, 3> &triangulation,
+  const Parameters::Mesh                       &mesh_parameters,
+  const Parameters::Manifolds                  &manifolds_parameters,
+  const bool                                   &restart,
+  const BoundaryConditions::BoundaryConditions &boundary_conditions);

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -41,9 +41,7 @@ DEMSolver<dim, PropertiesIndex>::DEMSolver(
   , checkpoint_controller(parameters.restart)
   , triangulation(this->mpi_communicator)
   , mapping(1)
-  , particle_handler(triangulation,
-                     mapping,
-                     DEM::get_number_properties<PropertiesIndex>())
+  , particle_handler(triangulation, mapping, PropertiesIndex::n_properties)
   , computing_timer(this->mpi_communicator,
                     this->pcout,
                     TimerOutput::summary,

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -320,7 +320,7 @@ CFDDEMSolver<dim>::read_dem()
   Particles::ParticleHandler<dim> temporary_particle_handler(
     *this->triangulation,
     this->particle_mapping,
-    DEM::get_number_properties<DEM::DEMProperties::PropertiesIndex>());
+    DEM::CFDDEMProperties::n_properties);
 
   ia >> temporary_particle_handler;
 

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -320,7 +320,7 @@ CFDDEMSolver<dim>::read_dem()
   Particles::ParticleHandler<dim> temporary_particle_handler(
     *this->triangulation,
     this->particle_mapping,
-    DEM::CFDDEMProperties::n_properties);
+    DEM::DEMProperties::n_properties);
 
   ia >> temporary_particle_handler;
 

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -17,10 +17,9 @@ FluidDynamicsVANS<dim>::FluidDynamicsVANS(
   : FluidDynamicsMatrixBased<dim>(nsparam.cfd_parameters)
   , cfd_dem_simulation_parameters(nsparam)
   , particle_mapping(1)
-  , particle_handler(
-      *this->triangulation,
-      particle_mapping,
-      DEM::get_number_properties<DEM::CFDDEMProperties::PropertiesIndex>())
+  , particle_handler(*this->triangulation,
+                     particle_mapping,
+                     DEM::CFDDEMProperties::n_properties)
   , void_fraction_manager(
       &(*this->triangulation),
       nsparam.void_fraction,
@@ -113,9 +112,7 @@ FluidDynamicsVANS<dim>::read_dem()
 
   // Create a temporary particle_handler with DEM properties
   Particles::ParticleHandler<dim> temporary_particle_handler(
-    *this->triangulation,
-    particle_mapping,
-    DEM::get_number_properties<DEM::DEMProperties::PropertiesIndex>());
+    *this->triangulation, particle_mapping, DEM::DEMProperties::n_properties);
 
 
   ia >> temporary_particle_handler;

--- a/source/fem-dem/fluid_dynamics_vans_matrix_free.cc
+++ b/source/fem-dem/fluid_dynamics_vans_matrix_free.cc
@@ -23,10 +23,9 @@ FluidDynamicsVANSMatrixFree<dim>::FluidDynamicsVANSMatrixFree(
   : FluidDynamicsMatrixFree<dim>(param.cfd_parameters)
   , cfd_dem_simulation_parameters(param)
   , particle_mapping(1)
-  , particle_handler(
-      *this->triangulation,
-      particle_mapping,
-      DEM::get_number_properties<DEM::CFDDEMProperties::PropertiesIndex>())
+  , particle_handler(*this->triangulation,
+                     particle_mapping,
+                     DEM::CFDDEMProperties::n_properties)
   , void_fraction_manager(
       &(*this->triangulation),
       param.void_fraction,

--- a/tests/dem/distribution_normal.cc
+++ b/tests/dem/distribution_normal.cc
@@ -59,7 +59,7 @@ test()
 
   // Defining particle handler
   Particles::ParticleHandler<dim> particle_handler(
-    tr, mapping, DEM::get_number_properties<PropertiesIndex>());
+    tr, mapping, PropertiesIndex::n_properties);
 
   // Calling uniform insertion
   std::vector<std::shared_ptr<Distribution>> distribution_object_container;

--- a/tests/dem/insertion_plane.cc
+++ b/tests/dem/insertion_plane.cc
@@ -68,7 +68,7 @@ test()
 
   // Defining particle handler
   Particles::ParticleHandler<dim> particle_handler(
-    tr, mapping, DEM::get_number_properties<PropertiesIndex>());
+    tr, mapping, PropertiesIndex::n_properties);
 
   insertion_object.insert(particle_handler, tr, dem_parameters);
 

--- a/tests/dem/insertion_volume_1.cc
+++ b/tests/dem/insertion_volume_1.cc
@@ -21,7 +21,7 @@
 
 using namespace dealii;
 
-template <int dim>
+template <int dim, typename PropertiesIndex>
 void
 test()
 {
@@ -56,9 +56,7 @@ test()
 
   // Defining particle handler
   Particles::ParticleHandler<dim> particle_handler(
-    tr,
-    mapping,
-    DEM::get_number_properties<DEM::DEMProperties::PropertiesIndex>());
+    tr, mapping, PropertiesIndex::n_properties);
   // Calling uniform insertion
   std::vector<std::shared_ptr<Distribution>> distribution_object_container;
   distribution_object_container.push_back(std::make_shared<UniformDistribution>(
@@ -95,7 +93,7 @@ main(int argc, char **argv)
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       initlog();
-      test<3>();
+      test<3, DEM::DEMProperties::PropertiesIndex>();
     }
   catch (std::exception &exc)
     {

--- a/tests/dem/insertion_volume_2.cc
+++ b/tests/dem/insertion_volume_2.cc
@@ -21,7 +21,7 @@
 
 using namespace dealii;
 
-template <int dim>
+template <int dim, typename PropertiesIndex>
 void
 test()
 {
@@ -56,9 +56,7 @@ test()
 
   // Defining particle handler
   Particles::ParticleHandler<dim> particle_handler(
-    tr,
-    mapping,
-    DEM::get_number_properties<DEM::DEMProperties::PropertiesIndex>());
+    tr, mapping, PropertiesIndex::n_properties);
   // Calling uniform insertion
   std::vector<std::shared_ptr<Distribution>> distribution_object_container;
   distribution_object_container.push_back(std::make_shared<UniformDistribution>(
@@ -95,7 +93,7 @@ main(int argc, char **argv)
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       initlog();
-      test<3>();
+      test<3, DEM::DEMProperties::PropertiesIndex>();
     }
   catch (std::exception &exc)
     {

--- a/tests/dem/integration_euler.cc
+++ b/tests/dem/integration_euler.cc
@@ -28,7 +28,7 @@
 
 using namespace dealii;
 
-template <int dim>
+template <int dim, typename PropertiesIndex>
 void
 test()
 {
@@ -49,9 +49,7 @@ test()
 
   // Defining particle handler
   Particles::ParticleHandler<dim> particle_handler(
-    tr,
-    mapping,
-    DEM::get_number_properties<DEM::DEMProperties::PropertiesIndex>());
+    tr, mapping, PropertiesIndex::n_properties);
   // inserting one particle at x = 0 , y = 0 and z = 0 m
   // initial velocity of particles = 0, 0, 0 m/s
   // gravitational acceleration = 0, 0, -9.81 m/s2
@@ -111,7 +109,7 @@ main(int argc, char **argv)
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       initlog();
-      test<3>();
+      test<3, DEM::DEMProperties::PropertiesIndex>();
     }
   catch (std::exception &exc)
     {

--- a/tests/dem/integration_velocity_verlet.cc
+++ b/tests/dem/integration_velocity_verlet.cc
@@ -30,7 +30,7 @@
 
 using namespace dealii;
 
-template <int dim>
+template <int dim, typename PropertiesIndex>
 void
 test()
 {
@@ -51,9 +51,7 @@ test()
 
   // Defning particle handler
   Particles::ParticleHandler<dim> particle_handler(
-    tr,
-    mapping,
-    DEM::get_number_properties<DEM::DEMProperties::PropertiesIndex>());
+    tr, mapping, PropertiesIndex::n_properties);
 
 
   // inserting one particle at x = 0 , y = 0 and z = 0 m
@@ -115,7 +113,7 @@ main(int argc, char **argv)
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       initlog();
-      test<3>();
+      test<3, DEM::DEMProperties::PropertiesIndex>();
     }
   catch (std::exception &exc)
     {

--- a/tests/dem/normal_force.cc
+++ b/tests/dem/normal_force.cc
@@ -103,7 +103,7 @@ test()
 
   // Defining particle handler
   Particles::ParticleHandler<dim> particle_handler(
-    tr, mapping, DEM::get_number_properties<PropertiesIndex>());
+    tr, mapping, PropertiesIndex::n_properties);
   // Inserting one particle in contact with wall
   Point<dim>               position1 = {-0.999, 0, 0};
   int                      id        = 0;

--- a/tests/dem/particle_handler_conversion_1.cc
+++ b/tests/dem/particle_handler_conversion_1.cc
@@ -33,9 +33,7 @@ test()
 
   // Define a particle handler with a particle and properties
   Particles::ParticleHandler<dim> particle_handler(
-    tr,
-    mapping,
-    DEM::get_number_properties<DEM::DEMProperties::PropertiesIndex>());
+    tr, mapping, DEM::DEMProperties::PropertiesIndex::n_properties);
   // Inserting one particle in contact with wall
   Point<dim> position1;
   for (int d = 0; d < dim; ++d)
@@ -68,8 +66,7 @@ test()
       deallog << "Particle " << particle->get_id() << std::endl;
       deallog << "Position : " << particle->get_location() << std::endl;
       for (unsigned int i = 0;
-           i <
-           DEM::get_number_properties<DEM::DEMProperties::PropertiesIndex>();
+           i < DEM::DEMProperties::PropertiesIndex::n_properties;
            ++i)
         {
           deallog << "Property " << i << " : " << particle->get_properties()[i]
@@ -80,9 +77,7 @@ test()
 
   // Create a second Particle Handler using a second set of properties
   Particles::ParticleHandler<dim> particle_handler_output(
-    tr,
-    mapping,
-    DEM::get_number_properties<DEM::CFDDEMProperties::PropertiesIndex>());
+    tr, mapping, DEM::CFDDEMProperties::PropertiesIndex::n_properties);
 
   // Fill the second particle handler using the first one
   convert_particle_handler<dim,
@@ -99,8 +94,7 @@ test()
       deallog << "Particle " << particle->get_id() << std::endl;
       deallog << "Position : " << particle->get_location() << std::endl;
       for (unsigned int i = 0;
-           i <
-           DEM::get_number_properties<DEM::CFDDEMProperties::PropertiesIndex>();
+           i < DEM::CFDDEMProperties::PropertiesIndex::n_properties;
            ++i)
         {
           deallog << "Property " << i << " : " << particle->get_properties()[i]

--- a/tests/dem/particle_particle_contact_force_linear.cc
+++ b/tests/dem/particle_particle_contact_force_linear.cc
@@ -53,7 +53,7 @@ test()
   const double neighborhood_threshold = std::pow(1.3 * particle_diameter, 2);
 
   Particles::ParticleHandler<dim> particle_handler(
-    triangulation, mapping, DEM::get_number_properties<PropertiesIndex>());
+    triangulation, mapping, PropertiesIndex::n_properties);
 
   // Creating containers manager for finding cell neighbor and also broad and
   // fine particle-particle search objects

--- a/tests/dem/particle_particle_contact_force_nonlinear.cc
+++ b/tests/dem/particle_particle_contact_force_nonlinear.cc
@@ -51,7 +51,7 @@ test()
   const double neighborhood_threshold = std::pow(1.3 * particle_diameter, 2);
 
   Particles::ParticleHandler<dim> particle_handler(
-    triangulation, mapping, DEM::get_number_properties<PropertiesIndex>());
+    triangulation, mapping, PropertiesIndex::n_properties);
 
   // Creating containers manager for finding cell neighbor and also broad and
   // fine particle-particle search objects

--- a/tests/dem/particle_particle_contact_on_two_processors.cc
+++ b/tests/dem/particle_particle_contact_on_two_processors.cc
@@ -97,7 +97,7 @@ test()
   const double neighborhood_threshold = std::pow(1.3 * particle_diameter, 2);
 
   Particles::ParticleHandler<dim> particle_handler(
-    triangulation, mapping, DEM::get_number_properties<PropertiesIndex>());
+    triangulation, mapping, PropertiesIndex::n_properties);
 
   typename dem_data_structures<2>::particle_index_iterator_map
     local_particle_container;

--- a/tests/dem/particle_particle_fine_search.cc
+++ b/tests/dem/particle_particle_fine_search.cc
@@ -48,7 +48,7 @@ test()
 
   // Defining general simulation parameters
   Particles::ParticleHandler<dim> particle_handler(
-    triangulation, mapping, DEM::get_number_properties<PropertiesIndex>());
+    triangulation, mapping, PropertiesIndex::n_properties);
 
   DEMContactManager<dim, PropertiesIndex> contact_manager;
 

--- a/tests/dem/particle_point_contact.cc
+++ b/tests/dem/particle_point_contact.cc
@@ -80,7 +80,7 @@ test()
 
   // Defining particle handler
   Particles::ParticleHandler<dim> particle_handler(
-    tr, mapping, DEM::get_number_properties<PropertiesIndex>());
+    tr, mapping, PropertiesIndex::n_properties);
   // Inserting one particle in contact with wall
   Point<dim>               position1 = {0.97, 2.05};
   int                      id        = 0;

--- a/tests/dem/particle_wall_contact_force_linear.cc
+++ b/tests/dem/particle_wall_contact_force_linear.cc
@@ -98,7 +98,7 @@ test()
     }
 
   Particles::ParticleHandler<dim> particle_handler(
-    tr, mapping, DEM::get_number_properties<PropertiesIndex>());
+    tr, mapping, PropertiesIndex::n_properties);
 
   // Inserting one particle in contact with a wall
   Point<dim>               position1 = {-0.998, 0, 0};

--- a/tests/dem/particle_wall_contact_force_nonlinear.cc
+++ b/tests/dem/particle_wall_contact_force_nonlinear.cc
@@ -98,7 +98,7 @@ test()
     }
 
   Particles::ParticleHandler<dim> particle_handler(
-    tr, mapping, DEM::get_number_properties<PropertiesIndex>());
+    tr, mapping, PropertiesIndex::n_properties);
 
   // Inserting one particle in contact with a wall
   Point<dim>               position1 = {-0.998, 0, 0};

--- a/tests/dem/particle_wall_fine_search.cc
+++ b/tests/dem/particle_wall_fine_search.cc
@@ -48,7 +48,7 @@ test()
   double particle_diameter = 0.005;
 
   Particles::ParticleHandler<dim> particle_handler(
-    tr, mapping, DEM::get_number_properties<PropertiesIndex>());
+    tr, mapping, PropertiesIndex::n_properties);
 
   // Inserting one particle in contact with a wall
   Point<dim>               position1 = {-0.998, 0, 0};

--- a/tests/dem/post_collision_velocity.cc
+++ b/tests/dem/post_collision_velocity.cc
@@ -101,7 +101,7 @@ test(double coefficient_of_restitution)
 
   // Defining particle handler
   Particles::ParticleHandler<dim> particle_handler(
-    tr, mapping, DEM::get_number_properties<PropertiesIndex>());
+    tr, mapping, PropertiesIndex::n_properties);
   // Inserting one particle in contact with wall
   Point<dim>               position = {-0.999, 0, 0};
   int                      id       = 0;

--- a/tests/dem/two_particles_multiple_contacts_parallel.cc
+++ b/tests/dem/two_particles_multiple_contacts_parallel.cc
@@ -90,7 +90,7 @@ test()
     Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
 
   Particles::ParticleHandler<dim> particle_handler(
-    triangulation, mapping, DEM::get_number_properties<PropertiesIndex>());
+    triangulation, mapping, PropertiesIndex::n_properties);
 
   typename dem_data_structures<2>::particle_index_iterator_map
     local_particle_container;


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

In the aims of deploying a CI that would check for warnings using the clang compiler, I am fixing some of these warnings ahead of time by cleaning the code file by file. This PR addresses this for only 4 files in the core library, but this has impact beyond the code library itself.

One important thing, I have learnt that according to clang we should not mark stuff const in the .h file, but on in the .cc file ( see https://stackoverflow.com/questions/38660537/why-is-const-unnecessary-in-function-declarations-in-header-files-for-parameters) and so I have applied these changes also here.

### Testing

All unit tests should not change. They did not.



### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge