### PR TITLE
Throw exception for non-Newtonian fluid in MF solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2025-03-19
+
+### Added
+
+- MINOR Verify if non-Newtonian fluid parameters are used in the matrix-free solver. Since the MF solver does not support non-Newtonian fluids at the moment, an exception is now shown if this happens. [#1463](https://github.com/chaos-polymtl/lethe/pull/1463)
+
 ## [Master] - 2025-03-13
 
 ### Added

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -1990,6 +1990,9 @@ FluidDynamicsMatrixFree<dim>::FluidDynamicsMatrixFree(
     dealii::ExcMessage(
       "Matrix free Navier-Stokes does not support different orders for the velocity and the pressure!"));
 
+  AssertThrow(!this->simulation_parameters.physical_properties_manager.is_non_newtonian(),
+    ExcMessage("Non-Newtonian fluids are not supported by the matrix free application."));
+
   this->fe = std::make_shared<FESystem<dim>>(
     FE_Q<dim>(nsparam.fem_parameters.velocity_order), dim + 1);
 
@@ -2022,9 +2025,6 @@ FluidDynamicsMatrixFree<dim>::solve()
     this->simulation_parameters.boundary_conditions);
 
   this->computing_timer.leave_subsection("Read mesh and manifolds");
-  
-  AssertThrow(!this->simulation_parameters.physical_properties_manager.is_non_newtonian(),
-    ExcMessage("Non-Newtonian fluids are not supported by the matrix free application."));
 
   this->setup_dofs();
   this->set_initial_condition(

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -2022,6 +2022,9 @@ FluidDynamicsMatrixFree<dim>::solve()
     this->simulation_parameters.boundary_conditions);
 
   this->computing_timer.leave_subsection("Read mesh and manifolds");
+  
+  AssertThrow(!this->simulation_parameters.physical_properties_manager.is_non_newtonian(),
+    ExcMessage("Non-Newtonian fluids are not supported by the matrix free application."));
 
   this->setup_dofs();
   this->set_initial_condition(

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -1990,8 +1990,10 @@ FluidDynamicsMatrixFree<dim>::FluidDynamicsMatrixFree(
     dealii::ExcMessage(
       "Matrix free Navier-Stokes does not support different orders for the velocity and the pressure!"));
 
-  AssertThrow(!this->simulation_parameters.physical_properties_manager.is_non_newtonian(),
-    ExcMessage("Non-Newtonian fluids are not supported by the matrix free application."));
+  AssertThrow(
+    !this->simulation_parameters.physical_properties_manager.is_non_newtonian(),
+    ExcMessage(
+      "Non-Newtonian fluids are not supported by the matrix free application."));
 
   this->fe = std::make_shared<FESystem<dim>>(
     FE_Q<dim>(nsparam.fem_parameters.velocity_order), dim + 1);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->
The matrix-free solver does not support non-Newtonian fluids at the moment. However, if such fluid parameters were included in the prm file, the simulation would still run. 

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->
An exception verification was added to the MF solver so that, if non-Newtonian fluid parameters are passed, the simulation is interrupted and an exception message is shown.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->
Previous example files using the lethe-fluid-matrix-free solver were tested with entries for non-Newtonian fluid before and after the fix. Before the fix the files would still run, while after the fix an exception is shown and the simulation is aborted.

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [ ] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge