### PR TITLE
Fix kokkos compilation for new syntax changes

### DIFF
--- a/prototypes/kokkos_poisson/kokkos_poisson.cc
+++ b/prototypes/kokkos_poisson/kokkos_poisson.cc
@@ -305,8 +305,8 @@ class LaplaceOperatorLocal
 public:
   DEAL_II_HOST_DEVICE void
   operator()(const typename Portable::MatrixFree<dim, Number>::Data *data,
-             const Number                                           *src,
-             Number                                                 *dst) const
+             const Portable::DeviceVector<Number>                   &src,
+             Portable::DeviceVector<Number>                         &dst) const
   {
     Portable::FEEvaluation<dim, fe_degree, fe_degree + 1, n_components, Number>
       phi(data);

--- a/prototypes/kokkos_stokes/kokkos_stokes.cc
+++ b/prototypes/kokkos_stokes/kokkos_stokes.cc
@@ -409,8 +409,8 @@ public:
 
   DEAL_II_HOST_DEVICE void
   operator()(const typename Portable::MatrixFree<dim, Number>::Data *data,
-             const Number                                           *src,
-             Number                                                 *dst) const
+             const Portable::DeviceVector<Number>                   &src,
+             Portable::DeviceVector<Number>                         &dst) const
   {
     Portable::FEEvaluation<dim, fe_degree, fe_degree + 1, dim + 1, Number> phi(
       data);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The deal.II PR 18273  (https://github.com/dealii/dealii/pull/18273) has changed the syntax of the Kokkos interface. This prevents compilation of our kokkos prototypes

### Solution

This PR fixes this by adapting the syntax of the examples to the new syntax. This is a minor change and the examples still work just fine.

