### PR TITLE
Apply filter before starting reinitialization process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- MINOR Phase fraction gradient projection is computed with the filtered phase fraction gradient. However, before the starting the VOF algebraic interface reinitialization process, the filter was not applied leading wrong values of filtered phase fraction gradient and therefore curvature. This is now fixed. [#1474](https://github.com/chaos-polymtl/lethe/pull/1474)
+- MINOR Phase fraction gradient projection is computed with the filtered phase fraction gradient. However, before the starting the VOF algebraic interface reinitialization process, the filter was not applied leading to wrong values of filtered phase fraction gradient and therefore curvature. This is now fixed. [#1474](https://github.com/chaos-polymtl/lethe/pull/1474)
 
 ## [Master] - 2025-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- MINOR Phase fraction gradient projection is computed with the filtered phase fraction gradient. However, before the starting the VOF algebraic interface reinitialization process, the filter was not applied leading to wrong values of filtered phase fraction gradient and therefore curvature. This is now fixed. [#1474](https://github.com/chaos-polymtl/lethe/pull/1474)
+- MINOR Phase fraction gradient projection is computed with the filtered phase fraction gradient. However, before the starting the VOF algebraic interface reinitialization process, the filter was not applied leading to wrong values of filtered phase fraction gradient and therefore curvature. This is now fixed. Also, in the calculate_momentum function of VOF postprocessing quantities, the FEValues of the fluid dynamics was initialized with the FE degree of the fluid dynamics physics instead of the VOF one leading to a vector size error when getting the function values. The quadrature formula has now been changed to the VOF one. [#1474](https://github.com/chaos-polymtl/lethe/pull/1474)
 
 ## [Master] - 2025-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2025-03-28
+
+### Fixed
+
+- MINOR Phase fraction gradient projection is computed with the filtered phase fraction gradient. However, before the starting the VOF algebraic interface reinitialization process, the filter was not applied leading wrong values of filtered phase fraction gradient and therefore curvature. This is now fixed. [#1474](https://github.com/chaos-polymtl/lethe/pull/1474)
+
 ## [Master] - 2025-03-26
 
 ### Changed

--- a/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle.output
+++ b/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle.output
@@ -8,7 +8,7 @@ Running on 1 MPI rank(s)...
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-0.000000e+00    1.427734e+01            1.427734e+02       3.541211e+00       0.000000e+00    1.722656e+00            1.722656e+01       4.306640e-01       0.000000e+00         5.000000e-01 
+0.000000e+00    1.427734e+01            1.427734e+02       3.548503e+00       0.000000e+00    1.722656e+00            1.722656e+01       4.306641e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter
@@ -24,7 +24,7 @@ Transient iteration: 1        Time: 1        Time step: 1        CFL: 0.770874
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.000000e+00    1.427577e+01            1.427577e+02       3.540818e+00       0.000000e+00    1.724227e+00            1.724227e+01       4.310567e-01       0.000000e+00         5.000000e-01 
+1.000000e+00    1.427577e+01            1.427577e+02       3.548110e+00       0.000000e+00    1.724227e+00            1.724227e+01       4.310567e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter
@@ -40,7 +40,7 @@ Transient iteration: 2        Time: 2        Time step: 1        CFL: 0.770874
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.000000e+00    1.427466e+01            1.427466e+02       3.540541e+00       0.000000e+00    1.725337e+00            1.725337e+01       4.313343e-01       0.000000e+00         5.000000e-01 
+2.000000e+00    1.427466e+01            1.427466e+02       3.547832e+00       0.000000e+00    1.725337e+00            1.725337e+01       4.313343e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter
@@ -56,7 +56,7 @@ Transient iteration: 3        Time: 3        Time step: 1        CFL: 0.770874
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-3.000000e+00    1.427364e+01            1.427364e+02       3.540286e+00       0.000000e+00    1.726358e+00            1.726358e+01       4.315895e-01       0.000000e+00         5.000000e-01 
+3.000000e+00    1.427364e+01            1.427364e+02       3.547577e+00       0.000000e+00    1.726358e+00            1.726358e+01       4.315895e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter
@@ -72,7 +72,7 @@ Transient iteration: 4        Time: 4        Time step: 1        CFL: 0.770874
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-4.000000e+00    1.427264e+01            1.427264e+02       3.540034e+00       0.000000e+00    1.727362e+00            1.727362e+01       4.318406e-01       0.000000e+00         5.000000e-01 
+4.000000e+00    1.427264e+01            1.427264e+02       3.547326e+00       0.000000e+00    1.727362e+00            1.727362e+01       4.318406e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter
@@ -88,7 +88,7 @@ Transient iteration: 5        Time: 5        Time step: 1        CFL: 0.770874
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-5.000000e+00    1.427164e+01            1.427164e+02       3.539784e+00       0.000000e+00    1.728363e+00            1.728363e+01       4.320907e-01       0.000000e+00         5.000000e-01 
+5.000000e+00    1.427164e+01            1.427164e+02       3.547076e+00       0.000000e+00    1.728363e+00            1.728363e+01       4.320907e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter
@@ -104,7 +104,7 @@ Transient iteration: 6        Time: 6        Time step: 1        CFL: 0.770874
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-6.000000e+00    1.427064e+01            1.427064e+02       3.539534e+00       0.000000e+00    1.729362e+00            1.729362e+01       4.323406e-01       0.000000e+00         5.000000e-01 
+6.000000e+00    1.427064e+01            1.427064e+02       3.546826e+00       0.000000e+00    1.729362e+00            1.729362e+01       4.323406e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter
@@ -120,7 +120,7 @@ Transient iteration: 7        Time: 7        Time step: 1        CFL: 0.770874
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-7.000000e+00    1.426964e+01            1.426964e+02       3.539285e+00       0.000000e+00    1.730361e+00            1.730361e+01       4.325902e-01       0.000000e+00         5.000000e-01 
+7.000000e+00    1.426964e+01            1.426964e+02       3.546576e+00       0.000000e+00    1.730361e+00            1.730361e+01       4.325902e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter
@@ -136,7 +136,7 @@ Transient iteration: 8        Time: 8        Time step: 1        CFL: 0.770874
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-8.000000e+00    1.426864e+01            1.426864e+02       3.539035e+00       0.000000e+00    1.731359e+00            1.731359e+01       4.328397e-01       0.000000e+00         5.000000e-01 
+8.000000e+00    1.426864e+01            1.426864e+02       3.546327e+00       0.000000e+00    1.731359e+00            1.731359e+01       4.328397e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter
@@ -152,7 +152,7 @@ Transient iteration: 9        Time: 9        Time step: 1        CFL: 0.770874
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-9.000000e+00    1.426764e+01            1.426764e+02       3.538786e+00       0.000000e+00    1.732356e+00            1.732356e+01       4.330890e-01       0.000000e+00         5.000000e-01 
+9.000000e+00    1.426764e+01            1.426764e+02       3.546078e+00       0.000000e+00    1.732356e+00            1.732356e+01       4.330890e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter
@@ -168,7 +168,7 @@ Transient iteration: 10       Time: 10       Time step: 1        CFL: 0.770874
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.000000e+01    1.426665e+01            1.426665e+02       3.538537e+00       0.000000e+00    1.733352e+00            1.733352e+01       4.333381e-01       0.000000e+00         5.000000e-01 
+1.000000e+01    1.426665e+01            1.426665e+02       3.545829e+00       0.000000e+00    1.733352e+00            1.733352e+01       4.333381e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter
@@ -184,7 +184,7 @@ Transient iteration: 11       Time: 11       Time step: 1        CFL: 0.770874
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.100000e+01    1.426565e+01            1.426565e+02       3.538288e+00       0.000000e+00    1.734348e+00            1.734348e+01       4.335871e-01       0.000000e+00         5.000000e-01 
+1.100000e+01    1.426565e+01            1.426565e+02       3.545580e+00       0.000000e+00    1.734348e+00            1.734348e+01       4.335871e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter
@@ -200,7 +200,7 @@ Transient iteration: 12       Time: 12       Time step: 1        CFL: 0.770874
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.200000e+01    1.426466e+01            1.426466e+02       3.538039e+00       0.000000e+00    1.735343e+00            1.735343e+01       4.338359e-01       0.000000e+00         5.000000e-01 
+1.200000e+01    1.426466e+01            1.426466e+02       3.545331e+00       0.000000e+00    1.735343e+00            1.735343e+01       4.338359e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter
@@ -216,7 +216,7 @@ Transient iteration: 13       Time: 13       Time step: 1        CFL: 0.770874
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.300000e+01    1.426366e+01            1.426366e+02       3.537790e+00       0.000000e+00    1.736338e+00            1.736338e+01       4.340845e-01       0.000000e+00         5.000000e-01 
+1.300000e+01    1.426366e+01            1.426366e+02       3.545082e+00       0.000000e+00    1.736338e+00            1.736338e+01       4.340845e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter
@@ -232,7 +232,7 @@ Transient iteration: 14       Time: 14       Time step: 1        CFL: 0.770874
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.400000e+01    1.426267e+01            1.426267e+02       3.537542e+00       0.000000e+00    1.737332e+00            1.737332e+01       4.343330e-01       0.000000e+00         5.000000e-01 
+1.400000e+01    1.426267e+01            1.426267e+02       3.544834e+00       0.000000e+00    1.737332e+00            1.737332e+01       4.343330e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter
@@ -248,7 +248,7 @@ Transient iteration: 15       Time: 15       Time step: 1        CFL: 0.770874
 VOF Mass Conservation
 ----------------------
     time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.500000e+01    1.426167e+01            1.426167e+02       3.537294e+00       0.000000e+00    1.738325e+00            1.738325e+01       4.345813e-01       0.000000e+00         5.000000e-01 
+1.500000e+01    1.426167e+01            1.426167e+02       3.544585e+00       0.000000e+00    1.738325e+00            1.738325e+01       4.345813e-01       0.000000e+00         5.000000e-01 
 
 ---------------
 VOF Barycenter

--- a/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle.output
+++ b/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle.output
@@ -1,0 +1,257 @@
+Running on 1 MPI rank(s)...
+   Number of active cells:       4096
+   Number of degrees of freedom: 37507
+   Volume of triangulation:      16
+   Number of VOF degrees of freedom: 4225
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+0.000000e+00    1.427734e+01            1.427734e+02       3.541211e+00       0.000000e+00    1.722656e+00            1.722656e+01       4.306640e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time         x_vof         y_vof        vx_vof       vy_vof    
+0.000000e+00 -1.181863e-13 -1.247898e-13 2.500000e-02 0.000000e+00 
+
+*******************************************************************************
+Transient iteration: 1        Time: 1        Time step: 1        CFL: 0.770874
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.000000e+00    1.427577e+01            1.427577e+02       3.540818e+00       0.000000e+00    1.724227e+00            1.724227e+01       4.310567e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time        x_vof        y_vof        vx_vof       vy_vof    
+1.000000e+00 2.506755e-02 1.631306e-12 2.500000e-02 0.000000e+00 
+
+*******************************************************************************
+Transient iteration: 2        Time: 2        Time step: 1        CFL: 0.770874
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+2.000000e+00    1.427466e+01            1.427466e+02       3.540541e+00       0.000000e+00    1.725337e+00            1.725337e+01       4.313343e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time        x_vof        y_vof        vx_vof       vy_vof    
+2.000000e+00 5.014212e-02 8.302096e-13 2.500000e-02 0.000000e+00 
+
+*******************************************************************************
+Transient iteration: 3        Time: 3        Time step: 1        CFL: 0.770874
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+3.000000e+00    1.427364e+01            1.427364e+02       3.540286e+00       0.000000e+00    1.726358e+00            1.726358e+01       4.315895e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time        x_vof         y_vof        vx_vof       vy_vof    
+3.000000e+00 7.522088e-02 -2.672438e-12 2.500000e-02 0.000000e+00 
+
+*******************************************************************************
+Transient iteration: 4        Time: 4        Time step: 1        CFL: 0.770874
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+4.000000e+00    1.427264e+01            1.427264e+02       3.540034e+00       0.000000e+00    1.727362e+00            1.727362e+01       4.318406e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time        x_vof         y_vof        vx_vof       vy_vof    
+4.000000e+00 1.003005e-01 -5.351681e-12 2.500000e-02 0.000000e+00 
+
+*******************************************************************************
+Transient iteration: 5        Time: 5        Time step: 1        CFL: 0.770874
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+5.000000e+00    1.427164e+01            1.427164e+02       3.539784e+00       0.000000e+00    1.728363e+00            1.728363e+01       4.320907e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time        x_vof         y_vof        vx_vof       vy_vof    
+5.000000e+00 1.253804e-01 -7.773579e-12 2.500000e-02 0.000000e+00 
+
+*******************************************************************************
+Transient iteration: 6        Time: 6        Time step: 1        CFL: 0.770874
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+6.000000e+00    1.427064e+01            1.427064e+02       3.539534e+00       0.000000e+00    1.729362e+00            1.729362e+01       4.323406e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time        x_vof         y_vof        vx_vof       vy_vof    
+6.000000e+00 1.504605e-01 -9.756904e-12 2.500000e-02 0.000000e+00 
+
+*******************************************************************************
+Transient iteration: 7        Time: 7        Time step: 1        CFL: 0.770874
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+7.000000e+00    1.426964e+01            1.426964e+02       3.539285e+00       0.000000e+00    1.730361e+00            1.730361e+01       4.325902e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time        x_vof         y_vof        vx_vof       vy_vof    
+7.000000e+00 1.755406e-01 -1.175912e-11 2.500000e-02 0.000000e+00 
+
+*******************************************************************************
+Transient iteration: 8        Time: 8        Time step: 1        CFL: 0.770874
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+8.000000e+00    1.426864e+01            1.426864e+02       3.539035e+00       0.000000e+00    1.731359e+00            1.731359e+01       4.328397e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time        x_vof         y_vof        vx_vof       vy_vof    
+8.000000e+00 2.006210e-01 -1.341001e-11 2.500000e-02 0.000000e+00 
+
+*******************************************************************************
+Transient iteration: 9        Time: 9        Time step: 1        CFL: 0.770874
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+9.000000e+00    1.426764e+01            1.426764e+02       3.538786e+00       0.000000e+00    1.732356e+00            1.732356e+01       4.330890e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time        x_vof         y_vof        vx_vof       vy_vof    
+9.000000e+00 2.257013e-01 -1.488647e-11 2.500000e-02 0.000000e+00 
+
+*******************************************************************************
+Transient iteration: 10       Time: 10       Time step: 1        CFL: 0.770874
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.000000e+01    1.426665e+01            1.426665e+02       3.538537e+00       0.000000e+00    1.733352e+00            1.733352e+01       4.333381e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time        x_vof         y_vof        vx_vof       vy_vof    
+1.000000e+01 2.507819e-01 -1.637135e-11 2.500000e-02 0.000000e+00 
+
+*******************************************************************************
+Transient iteration: 11       Time: 11       Time step: 1        CFL: 0.770874
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.100000e+01    1.426565e+01            1.426565e+02       3.538288e+00       0.000000e+00    1.734348e+00            1.734348e+01       4.335871e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time        x_vof         y_vof        vx_vof       vy_vof    
+1.100000e+01 2.758625e-01 -1.734158e-11 2.500000e-02 0.000000e+00 
+
+*******************************************************************************
+Transient iteration: 12       Time: 12       Time step: 1        CFL: 0.770874
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.200000e+01    1.426466e+01            1.426466e+02       3.538039e+00       0.000000e+00    1.735343e+00            1.735343e+01       4.338359e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time        x_vof         y_vof        vx_vof       vy_vof    
+1.200000e+01 3.009432e-01 -1.828241e-11 2.500000e-02 0.000000e+00 
+
+*******************************************************************************
+Transient iteration: 13       Time: 13       Time step: 1        CFL: 0.770874
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.300000e+01    1.426366e+01            1.426366e+02       3.537790e+00       0.000000e+00    1.736338e+00            1.736338e+01       4.340845e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time        x_vof         y_vof        vx_vof       vy_vof    
+1.300000e+01 3.260240e-01 -1.891741e-11 2.500000e-02 0.000000e+00 
+
+*******************************************************************************
+Transient iteration: 14       Time: 14       Time step: 1        CFL: 0.770874
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.400000e+01    1.426267e+01            1.426267e+02       3.537542e+00       0.000000e+00    1.737332e+00            1.737332e+01       4.343330e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time        x_vof         y_vof        vx_vof       vy_vof    
+1.400000e+01 3.511049e-01 -1.953249e-11 2.500000e-02 0.000000e+00 
+
+*******************************************************************************
+Transient iteration: 15       Time: 15       Time step: 1        CFL: 0.770874
+*******************************************************************************
+
+----------------------
+VOF Mass Conservation
+----------------------
+    time     surface_fluid_0 mass_per_length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 mass_per_length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
+1.500000e+01    1.426167e+01            1.426167e+02       3.537294e+00       0.000000e+00    1.738325e+00            1.738325e+01       4.345813e-01       0.000000e+00         5.000000e-01 
+
+---------------
+VOF Barycenter
+---------------
+    time        x_vof         y_vof        vx_vof       vy_vof    
+1.500000e+01 3.761857e-01 -2.011634e-11 2.500000e-02 0.000000e+00 

--- a/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle.prm
+++ b/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle.prm
+++ b/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle.prm
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 The Lethe Authors
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method           = bdf1
+  set time end         = 15
+  set time step        = 1
+  set output name      = vof-algebraic-interface-reinitialization-advected-circle
+  set output frequency = 0
+end
+
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+
+subsection multiphysics
+  set VOF            = true
+  set fluid dynamics = false
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = hyper_rectangle
+  set grid arguments     = -2, -2 : 2, 2 : false
+  set initial refinement = 6
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+
+subsection initial conditions
+  set type = nodal
+  subsection uvwp
+    set Function expression = 0.025; 0; 0
+  end
+  subsection VOF
+    set Function expression = if(((x*x+y*y)<=0.75^2), 1, 0)
+    subsection projection step
+      set enable           = true
+      set diffusion factor = 2
+    end
+  end
+end
+
+#---------------------------------------------------
+# VOF
+#---------------------------------------------------
+
+subsection VOF
+  subsection interface regularization method
+    set type      = algebraic interface reinitialization
+    set frequency = 1
+    subsection algebraic interface reinitialization
+      set diffusivity multiplier = 0.6
+      set diffusivity power      = 1
+      set max steps number       = 5
+      set reinitialization CFL   = 1
+    end
+  end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  set number of fluids = 2
+  subsection fluid 1
+    set density             = 10
+    set kinematic viscosity = 0.1
+  end
+  subsection fluid 0
+    set density             = 10
+    set kinematic viscosity = 0.1
+  end
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions
+  set number = 1
+  subsection bc 0
+    set id   = 0
+    set type = slip
+  end
+end
+
+subsection boundary conditions VOF
+  set number = 1
+end
+
+#---------------------------------------------------
+# Post-processing
+#---------------------------------------------------
+
+subsection post-processing
+  set verbosity            = verbose
+  set postprocessed fluid  = fluid 1
+  set calculate barycenter = true
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+
+subsection FEM
+  set velocity order = 2
+  set pressure order = 1
+  set VOF order      = 1
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection VOF
+    set tolerance      = 1e-9
+    set max iterations = 30
+    set verbosity      = quiet
+  end
+  subsection VOF algebraic interface reinitialization
+    set tolerance      = 1e-9
+    set max iterations = 30
+    set verbosity      = quiet
+  end
+  subsection fluid dynamics
+    set tolerance      = 1e-9
+    set max iterations = 20
+    set verbosity      = quiet
+  end
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection fluid dynamics
+    set verbosity         = quiet
+    set method            = gmres
+    set relative residual = 1e-3
+    set minimum residual  = 1e-10
+    set preconditioner    = ilu
+  end
+  subsection VOF
+    set verbosity         = quiet
+    set method            = gmres
+    set relative residual = 1e-3
+    set minimum residual  = 1e-10
+    set preconditioner    = ilu
+  end
+  subsection VOF algebraic interface reinitialization
+    set verbosity         = quiet
+    set method            = gmres
+    set relative residual = 1e-3
+    set minimum residual  = 1e-10
+    set preconditioner    = ilu
+  end
+end

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -638,10 +638,9 @@ VolumeOfFluid<dim>::calculate_momentum(
   const DoFHandler<dim> *dof_handler_fd =
     multiphysics->get_dof_handler(PhysicsID::fluid_dynamics);
 
-  QGauss<dim>   quadrature_formula(dof_handler_fd->get_fe().degree + 1);
   FEValues<dim> fe_values_fd(*this->mapping,
                              dof_handler_fd->get_fe(),
-                             quadrature_formula,
+                             *this->cell_quadrature,
                              update_values);
 
   const FEValuesExtractors::Vector velocity(0);

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -2423,6 +2423,7 @@ template <int dim>
 void
 VolumeOfFluid<dim>::reinitialize_interface_with_algebraic_method()
 {
+  apply_phase_filter();
   this->subequations->solve_specific_subequation(
     VOFSubequationsID::phase_gradient_projection);
   this->subequations->solve_specific_subequation(


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

Phase fraction gradient projection is computed with the filtered phase fraction gradient. However, before the starting the VOF algebraic interface reinitialization process, the filter was not applied leading to wrong values of filtered phase fraction gradient and therefore curvature. This is now fixed.

Also, in the calculate_momentum function of VOF post-processing quantities, the FEValues of fluid dynamics was initialized with the FE degree of the fluid dynamics physics instead of the VOF one leading to a vector size error when getting the function values. The quadrature formula has now been changed to the VOF one.

### Solution

Applying the VOF filter to the phase fraction field before computing the phase fraction gradient projection and before starting the reinitialization process.

### Testing

The fix was tested with two examples: rising bubble and Rayleigh-Taylor. For both cases, no visible differences are observed.
A new application test with an advected circle was added. The test uses the algebraic interface reinitialization feature and Q1Q2Q1 elements (phase fraction, velocity, pressure).


### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge