### PR TITLE
Add options to print version and parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2025-03-28
+
+### Added
+
+- MINOR Added a functionality that allows to print the deal.II and Lethe versions when running an application via a '-V' flag. Also, a parameter that allows to print content of the input file to output is added. [#1475](https://github.com/chaos-polymtl/lethe/pull/1475)
+
 ## [Master] - 2025-03-26
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ endif()
 
 
 add_subdirectory(source)
-target_include_directories(lethe-solvers PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include)
+target_include_directories(lethe-core PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 add_subdirectory(applications)
 

--- a/applications/lethe-fluid-matrix-free/fluid_dynamics_matrix_free.cc
+++ b/applications/lethe-fluid-matrix-free/fluid_dynamics_matrix_free.cc
@@ -3,10 +3,7 @@
 
 #include "solvers/fluid_dynamics_matrix_free.h"
 
-#include <core/revision.h>
-
-#include <deal.II/base/revision.h>
-
+#include <core/utilities.h>
 
 int
 main(int argc, char *argv[])
@@ -15,58 +12,47 @@ main(int argc, char *argv[])
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
-      if (argc == 1)
+      ConditionalOStream pcout(
+        std::cout, (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
+
+      auto [options, args] = parse_args(argc, argv);
+
+      // Print version information
+      if (options["-V"])
         {
-          std::cout << "Usage:" << argv[0] << " input_file" << std::endl;
-          std::exit(1);
+          pcout << "Running: " << concatenate_strings(argc, argv) << std::endl;
+
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_version_info(pcout);
+
+          return EXIT_SUCCESS;
         }
 
+      if (args.empty())
+        {
+          pcout << "Usage: " << argv[0] << " input_file" << std::endl;
+          return EXIT_FAILURE;
+        }
 
-      const std::string file_name(argv[argc - 1]);
-      const bool        print_parameters =
-        (argc == 2) ? false : (std::string(argv[1]) == "--print-parameters");
+      const std::string file_name(args[0]);
 
       const unsigned int                  dim = get_dimension(file_name);
       const Parameters::SizeOfSubsections size_of_subsections =
         Parameters::get_size_of_subsections(file_name);
-
-      ConditionalOStream pcout(std::cout,
-                               (Utilities::MPI::this_mpi_process(
-                                  MPI_COMM_WORLD) == 0) &&
-                                 print_parameters);
-
-      if (print_parameters)
-        {
-          pcout << "Running: " << concatenate_strings(argc, argv) << std::endl;
-          pcout << "  - deal.II (branch: " << DEAL_II_GIT_BRANCH
-                << "; revision: " << DEAL_II_GIT_REVISION
-                << "; short: " << DEAL_II_GIT_SHORTREV << ")" << std::endl;
-          pcout << "  - Lethe (branch: " << LETHE_GIT_BRANCH
-                << "; revision: " << LETHE_GIT_REVISION
-                << "; short: " << LETHE_GIT_SHORTREV << ")" << std::endl;
-          pcout << std::endl;
-          pcout << std::endl;
-        }
 
       if (dim == 2)
         {
           ParameterHandler        prm;
           SimulationParameters<2> NSparam;
           NSparam.declare(prm, size_of_subsections);
+
           // Parsing of the file
           prm.parse_input(file_name);
           NSparam.parse(prm);
 
-          if (pcout.is_active())
-            prm.print_parameters(pcout.get_stream(),
-                                 ParameterHandler::OutputStyle::PRM |
-                                   ParameterHandler::OutputStyle::Short |
-                                   ParameterHandler::KeepDeclarationOrder
-#if DEAL_II_VERSION_GTE(9, 7, 0)
-                                   | ParameterHandler::KeepOnlyChanged
-#endif
-            );
-          pcout << std::endl << std::endl;
+          // Print parameters if needed
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_parameters_to_output_file(pcout, prm, file_name);
 
           FluidDynamicsMatrixFree<2> problem(NSparam);
           problem.solve();
@@ -77,20 +63,14 @@ main(int argc, char *argv[])
           ParameterHandler        prm;
           SimulationParameters<3> NSparam;
           NSparam.declare(prm, size_of_subsections);
+
           // Parsing of the file
           prm.parse_input(file_name);
           NSparam.parse(prm);
 
-          if (pcout.is_active())
-            prm.print_parameters(pcout.get_stream(),
-                                 ParameterHandler::OutputStyle::PRM |
-                                   ParameterHandler::OutputStyle::Short |
-                                   ParameterHandler::KeepDeclarationOrder
-#if DEAL_II_VERSION_GTE(9, 7, 0)
-                                   | ParameterHandler::KeepOnlyChanged
-#endif
-            );
-          pcout << std::endl << std::endl;
+          // Print parameters if needed
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_parameters_to_output_file(pcout, prm, file_name);
 
           FluidDynamicsMatrixFree<3> problem(NSparam);
           problem.solve();

--- a/applications/lethe-fluid-nitsche/fluid_dynamics_nitsche.cc
+++ b/applications/lethe-fluid-nitsche/fluid_dynamics_nitsche.cc
@@ -3,6 +3,8 @@
 
 #include "solvers/fluid_dynamics_nitsche.h"
 
+#include <core/utilities.h>
+
 int
 main(int argc, char *argv[])
 {
@@ -10,25 +12,47 @@ main(int argc, char *argv[])
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
-      if (argc != 2)
+      ConditionalOStream pcout(
+        std::cout, (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
+
+      auto [options, args] = parse_args(argc, argv);
+
+      // Print version information
+      if (options["-V"])
         {
-          std::cout << "Usage:" << argv[0] << " input_file" << std::endl;
-          std::exit(1);
+          pcout << "Running: " << concatenate_strings(argc, argv) << std::endl;
+
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_version_info(pcout);
+
+          return EXIT_SUCCESS;
         }
 
-      const unsigned int                  dim = get_dimension(argv[1]);
-      const Parameters::SizeOfSubsections size_of_subsections =
-        Parameters::get_size_of_subsections(argv[1]);
+      if (args.empty())
+        {
+          pcout << "Usage: " << argv[0] << " input_file" << std::endl;
+          return EXIT_FAILURE;
+        }
 
+      const std::string file_name(args[0]);
+
+      const unsigned int                  dim = get_dimension(file_name);
+      const Parameters::SizeOfSubsections size_of_subsections =
+        Parameters::get_size_of_subsections(file_name);
 
       if (dim == 2)
         {
           ParameterHandler        prm;
           SimulationParameters<2> NSparam;
           NSparam.declare(prm, size_of_subsections);
+
           // Parsing of the file
-          prm.parse_input(argv[1]);
+          prm.parse_input(file_name);
           NSparam.parse(prm);
+
+          // Print parameters if needed
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_parameters_to_output_file(pcout, prm, file_name);
 
           FluidDynamicsNitsche<2> problem_22(NSparam);
           problem_22.solve();
@@ -39,9 +63,14 @@ main(int argc, char *argv[])
           ParameterHandler        prm;
           SimulationParameters<3> NSparam;
           NSparam.declare(prm, size_of_subsections);
+
           // Parsing of the file
-          prm.parse_input(argv[1]);
+          prm.parse_input(file_name);
           NSparam.parse(prm);
+
+          // Print parameters if needed
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_parameters_to_output_file(pcout, prm, file_name);
 
           FluidDynamicsNitsche<3> problem_33(NSparam);
           problem_33.solve();

--- a/applications/lethe-fluid-sharp/fluid_dynamics_sharp.cc
+++ b/applications/lethe-fluid-sharp/fluid_dynamics_sharp.cc
@@ -3,6 +3,8 @@
 
 #include "fem-dem/fluid_dynamics_sharp.h"
 
+#include <core/utilities.h>
+
 int
 main(int argc, char *argv[])
 {
@@ -10,24 +12,47 @@ main(int argc, char *argv[])
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
-      if (argc != 2)
+      ConditionalOStream pcout(
+        std::cout, (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
+
+      auto [options, args] = parse_args(argc, argv);
+
+      // Print version information
+      if (options["-V"])
         {
-          std::cout << "Usage:" << argv[0] << " input_file" << std::endl;
-          std::exit(1);
+          pcout << "Running: " << concatenate_strings(argc, argv) << std::endl;
+
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_version_info(pcout);
+
+          return EXIT_SUCCESS;
         }
 
-      const unsigned int                  dim = get_dimension(argv[1]);
+      if (args.empty())
+        {
+          pcout << "Usage: " << argv[0] << " input_file" << std::endl;
+          return EXIT_FAILURE;
+        }
+
+      const std::string file_name(args[0]);
+
+      const unsigned int                  dim = get_dimension(file_name);
       const Parameters::SizeOfSubsections size_of_subsections =
-        Parameters::get_size_of_subsections(argv[1]);
+        Parameters::get_size_of_subsections(file_name);
 
       if (dim == 2)
         {
           ParameterHandler              prm;
           CFDDEMSimulationParameters<2> NSparam;
           NSparam.declare(prm, size_of_subsections);
+
           // Parsing of the file
-          prm.parse_input(argv[1]);
+          prm.parse_input(file_name);
           NSparam.parse(prm);
+
+          // Print parameters if needed
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_parameters_to_output_file(pcout, prm, file_name);
 
           FluidDynamicsSharp<2> problem(NSparam);
           problem.solve();
@@ -38,9 +63,14 @@ main(int argc, char *argv[])
           ParameterHandler              prm;
           CFDDEMSimulationParameters<3> NSparam;
           NSparam.declare(prm, size_of_subsections);
+
           // Parsing of the file
-          prm.parse_input(argv[1]);
+          prm.parse_input(file_name);
           NSparam.parse(prm);
+
+          // Print parameters if needed
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_parameters_to_output_file(pcout, prm, file_name);
 
           FluidDynamicsSharp<3> problem(NSparam);
           problem.solve();

--- a/applications/lethe-fluid-vans-matrix-free/fluid_dynamics_vans_matrix_free.cc
+++ b/applications/lethe-fluid-vans-matrix-free/fluid_dynamics_vans_matrix_free.cc
@@ -5,8 +5,6 @@
 
 #include <core/utilities.h>
 
-#include <deal.II/base/revision.h>
-
 int
 main(int argc, char *argv[])
 {

--- a/applications/lethe-fluid-vans/fluid_dynamics_vans.cc
+++ b/applications/lethe-fluid-vans/fluid_dynamics_vans.cc
@@ -3,6 +3,8 @@
 
 #include "fem-dem/fluid_dynamics_vans.h"
 
+#include <core/utilities.h>
+
 int
 main(int argc, char *argv[])
 {
@@ -10,24 +12,47 @@ main(int argc, char *argv[])
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
-      if (argc != 2)
+      ConditionalOStream pcout(
+        std::cout, (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
+
+      auto [options, args] = parse_args(argc, argv);
+
+      // Print version information
+      if (options["-V"])
         {
-          std::cout << "Usage:" << argv[0] << " input_file" << std::endl;
-          std::exit(1);
+          pcout << "Running: " << concatenate_strings(argc, argv) << std::endl;
+
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_version_info(pcout);
+
+          return EXIT_SUCCESS;
         }
 
-      const unsigned int                  dim = get_dimension(argv[1]);
+      if (args.empty())
+        {
+          pcout << "Usage: " << argv[0] << " input_file" << std::endl;
+          return EXIT_FAILURE;
+        }
+
+      const std::string file_name(args[0]);
+
+      const unsigned int                  dim = get_dimension(file_name);
       const Parameters::SizeOfSubsections size_of_subsections =
-        Parameters::get_size_of_subsections(argv[1]);
+        Parameters::get_size_of_subsections(file_name);
 
       if (dim == 2)
         {
           ParameterHandler              prm;
           CFDDEMSimulationParameters<2> NSparam;
           NSparam.declare(prm, size_of_subsections);
+
           // Parsing of the file
-          prm.parse_input(argv[1]);
+          prm.parse_input(file_name);
           NSparam.parse(prm);
+
+          // Print parameters if needed
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_parameters_to_output_file(pcout, prm, file_name);
 
           FluidDynamicsVANS<2> problem(NSparam);
           problem.solve();
@@ -38,9 +63,14 @@ main(int argc, char *argv[])
           ParameterHandler              prm;
           CFDDEMSimulationParameters<3> NSparam;
           NSparam.declare(prm, size_of_subsections);
+
           // Parsing of the file
-          prm.parse_input(argv[1]);
+          prm.parse_input(file_name);
           NSparam.parse(prm);
+
+          // Print parameters if needed
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_parameters_to_output_file(pcout, prm, file_name);
 
           FluidDynamicsVANS<3> problem(NSparam);
           problem.solve();

--- a/applications/lethe-fluid/fluid_dynamics_matrix_based.cc
+++ b/applications/lethe-fluid/fluid_dynamics_matrix_based.cc
@@ -3,6 +3,8 @@
 
 #include "solvers/fluid_dynamics_matrix_based.h"
 
+#include <core/utilities.h>
+
 int
 main(int argc, char *argv[])
 {
@@ -10,30 +12,52 @@ main(int argc, char *argv[])
     {
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
-      if (argc != 2)
+      ConditionalOStream pcout(
+        std::cout, (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
+
+      auto [options, args] = parse_args(argc, argv);
+
+      // Print version information
+      if (options["-V"])
         {
-          std::cout << "Usage:" << argv[0] << " input_file" << std::endl;
-          std::exit(1);
+          pcout << "Running: " << concatenate_strings(argc, argv) << std::endl;
+
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_version_info(pcout);
+
+          return EXIT_SUCCESS;
         }
 
-      const unsigned int                  dim = get_dimension(argv[1]);
-      const Parameters::SizeOfSubsections size_of_subsections =
-        Parameters::get_size_of_subsections(argv[1]);
+      if (args.empty())
+        {
+          pcout << "Usage: " << argv[0] << " input_file" << std::endl;
+          return EXIT_FAILURE;
+        }
 
+      const std::string file_name(args[0]);
+
+      const unsigned int                  dim = get_dimension(file_name);
+      const Parameters::SizeOfSubsections size_of_subsections =
+        Parameters::get_size_of_subsections(file_name);
 
       if (dim == 2)
         {
           ParameterHandler        prm;
           SimulationParameters<2> NSparam;
           NSparam.declare(prm, size_of_subsections);
+
           // Parsing of the file
-          prm.parse_input(argv[1]);
+          prm.parse_input(file_name);
           NSparam.parse(prm);
 
           AssertThrow(NSparam.nitsche->number_solids == 0,
                       SolidWarning(NSparam.nitsche->number_solids,
                                    "lethe-fluid",
                                    "lethe-fluid-nitsche"));
+
+          // Print parameters if needed
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_parameters_to_output_file(pcout, prm, file_name);
 
           FluidDynamicsMatrixBased<2> problem(NSparam);
           problem.solve();
@@ -45,13 +69,17 @@ main(int argc, char *argv[])
           SimulationParameters<3> NSparam;
           NSparam.declare(prm, size_of_subsections);
           // Parsing of the file
-          prm.parse_input(argv[1]);
+          prm.parse_input(file_name);
           NSparam.parse(prm);
 
           AssertThrow(NSparam.nitsche->number_solids == 0,
                       SolidWarning(NSparam.nitsche->number_solids,
                                    "lethe-fluid",
                                    "lethe-fluid-nitsche"));
+
+          // Print parameters if needed
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_parameters_to_output_file(pcout, prm, file_name);
 
           FluidDynamicsMatrixBased<3> problem(NSparam);
           problem.solve();

--- a/applications/lethe-particles/dem.cc
+++ b/applications/lethe-particles/dem.cc
@@ -85,7 +85,6 @@ main(int argc, char *argv[])
           prm.parse_input(file_name);
           dem_parameters.parse(prm);
 
-
           // Print parameters if needed
           if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
             print_parameters_to_output_file(pcout, prm, file_name);

--- a/applications/lethe-rpt-3d/rpt_3d.cc
+++ b/applications/lethe-rpt-3d/rpt_3d.cc
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2021 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
+#include <core/utilities.h>
+
 #include <rpt/rpt.h>
 #include <rpt/rpt_calculating_parameters.h>
 
@@ -14,19 +16,50 @@ main(int argc, char *argv[])
 {
   try
     {
-      if (argc != 2)
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+      // Check the number of MPI processes
+      int number_of_processes;
+      MPI_Comm_size(MPI_COMM_WORLD, &number_of_processes);
+      AssertThrow(number_of_processes == 1,
+                  ExcMessage(
+                    "The rpt_3d application can only run with 1 MPI process."));
+
+      ConditionalOStream pcout(
+        std::cout, (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
+
+      auto [options, args] = parse_args(argc, argv);
+
+      // Print version information
+      if (options["-V"])
         {
-          std::cout << "Usage:" << argv[0] << " input_file" << std::endl;
-          std::exit(1);
+          pcout << "Running: " << concatenate_strings(argc, argv) << std::endl;
+
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_version_info(pcout);
+
+          return EXIT_SUCCESS;
         }
+
+      if (args.empty())
+        {
+          pcout << "Usage: " << argv[0] << " input_file" << std::endl;
+          return EXIT_FAILURE;
+        }
+
+      const std::string file_name(args[0]);
 
       ParameterHandler         prm;
       RPTCalculatingParameters rpt_parameters;
       rpt_parameters.declare(prm);
 
       // Parsing of the file
-      prm.parse_input(argv[1]);
+      prm.parse_input(file_name);
       rpt_parameters.parse(prm);
+
+      // Print parameters if needed
+      if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+        print_parameters_to_output_file(pcout, prm, file_name);
 
       RPT<3> rpt(rpt_parameters);
       rpt.setup_and_calculate();

--- a/applications/lethe-rpt-cell-reconstruction-3d/rpt_cell_reconstruction_3d.cc
+++ b/applications/lethe-rpt-cell-reconstruction-3d/rpt_cell_reconstruction_3d.cc
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2021, 2024 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
+#include <core/utilities.h>
+
 #include <rpt/rpt_calculating_parameters.h>
 #include <rpt/rpt_cell_reconstruction.h>
 
@@ -14,21 +16,43 @@ main(int argc, char *argv[])
 {
   try
     {
-      if (argc != 2)
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+      ConditionalOStream pcout(
+        std::cout, (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
+
+      auto [options, args] = parse_args(argc, argv);
+
+      // Print version information
+      if (options["-V"])
         {
-          std::cout << "Usage:" << argv[0] << " input_file" << std::endl;
-          std::exit(1);
+          pcout << "Running: " << concatenate_strings(argc, argv) << std::endl;
+
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_version_info(pcout);
+
+          return EXIT_SUCCESS;
         }
 
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      if (args.empty())
+        {
+          pcout << "Usage: " << argv[0] << " input_file" << std::endl;
+          return EXIT_FAILURE;
+        }
+
+      const std::string file_name(args[0]);
 
       ParameterHandler         prm;
       RPTCalculatingParameters rpt_parameters;
       rpt_parameters.declare(prm);
 
       // Parsing of the file
-      prm.parse_input(argv[1]);
+      prm.parse_input(file_name);
       rpt_parameters.parse(prm);
+
+      // Print parameters if needed
+      if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+        print_parameters_to_output_file(pcout, prm, file_name);
 
       RPTCellReconstruction<3> rpt_cell_reconstruction(
         rpt_parameters.rpt_param,

--- a/applications/lethe-rpt-l2-projection-3d/rpt_l2_projection_3d.cc
+++ b/applications/lethe-rpt-l2-projection-3d/rpt_l2_projection_3d.cc
@@ -14,21 +14,43 @@ main(int argc, char *argv[])
 {
   try
     {
-      if (argc != 2)
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+      ConditionalOStream pcout(
+        std::cout, (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
+
+      auto [options, args] = parse_args(argc, argv);
+
+      // Print version information
+      if (options["-V"])
         {
-          std::cout << "Usage:" << argv[0] << " input_file" << std::endl;
-          std::exit(1);
+          pcout << "Running: " << concatenate_strings(argc, argv) << std::endl;
+
+          if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+            print_version_info(pcout);
+
+          return EXIT_SUCCESS;
         }
 
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      if (args.empty())
+        {
+          pcout << "Usage: " << argv[0] << " input_file" << std::endl;
+          return EXIT_FAILURE;
+        }
+
+      const std::string file_name(args[0]);
 
       ParameterHandler         prm;
       RPTCalculatingParameters rpt_parameters;
       rpt_parameters.declare(prm);
 
       // Parsing of the file
-      prm.parse_input(argv[1]);
+      prm.parse_input(file_name);
       rpt_parameters.parse(prm);
+
+      // Print parameters if needed
+      if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+        print_parameters_to_output_file(pcout, prm, file_name);
 
       RPTL2Projection<3> rpt_l2_project(rpt_parameters.rpt_param,
                                         rpt_parameters.fem_reconstruction_param,

--- a/include/core/revision.h.in
+++ b/include/core/revision.h.in
@@ -4,16 +4,6 @@
 #pragma once
 
 /**
- * Name of the local git branch of the source directory.
+ * Tag of the current git HEAD as obtained with `git describe`.
  */
-#define LETHE_GIT_BRANCH "@LETHE_GIT_BRANCH@"
-
-/**
- * Full sha1 revision of the current git HEAD.
- */
-#define LETHE_GIT_REVISION "@LETHE_GIT_REVISION@"
-
-/**
- * Short sha1 revision of the current git HEAD.
- */
-#define LETHE_GIT_SHORTREV "@LETHE_GIT_SHORTREV@"
+#define LETHE_GIT_FANCY_TAG "@LETHE_GIT_FANCY_TAG@"

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -4,7 +4,11 @@
 #ifndef lethe_utilities_h
 #define lethe_utilities_h
 
+#include <core/revision.h>
+
 #include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/revision.h>
 #include <deal.II/base/table_handler.h>
 #include <deal.II/base/tensor.h>
 
@@ -15,8 +19,12 @@
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
 
+#include <iostream>
+#include <map>
 #include <regex>
-
+#include <string>
+#include <tuple>
+#include <vector>
 
 using namespace dealii;
 
@@ -772,6 +780,121 @@ concatenate_strings(const int argc, char **argv)
   return result;
 }
 
+/**
+ * @brief Print the information of the deal.II and Lethe branches
+ * used to run an application in the "git describe" format.
+ *
+ * @param[in] pcout Parallel output stream
+ */
+inline void
+print_version_info(const ConditionalOStream &pcout)
+{
+  (void)pcout;
+#if DEAL_II_VERSION_GTE(9, 7, 0)
+  // Copy the tags to be able to delete the first v
+  std::string lethe_tag  = LETHE_GIT_FANCY_TAG;
+  std::string dealii_tag = DEAL_II_GIT_FANCY_TAG;
 
+  // Print tags using the right format
+  pcout << "lethe/" << lethe_tag.erase(0, 1) << " deal.II/"
+        << dealii_tag.erase(0, 1) << std::endl;
+  pcout << std::endl;
+#else
+  AssertThrow(
+    false,
+    ExcMessage(
+      "To print version information using -V you need a version of deal.II >= 9.7.0."));
+#endif
+}
+
+/**
+ * @brief Parse the arguments given to the application
+ *
+ * @param[in] argc Number of arguments
+ * @param[in] argv Array of strings representing the arguments
+ * @return Tuple containing a map with the command line flags
+ * and a boolean set to 1 for the specific flag; and a vector of
+ * strings with the rest of the arguments that are not flags; in Lethe,
+ * this corresponds to the parameter file given to the application.
+ */
+inline std::tuple<std::map<std::string, bool>, std::vector<std::string>>
+parse_args(int argc, char **argv)
+{
+  int                         argi = 1; // skip program name
+  std::map<std::string, bool> options{};
+  for (; argi < argc; ++argi)
+    {
+      std::string arg{argv[argi]};
+      auto        n{arg.length()};
+      if (n == 0 || arg[0] != '-' || n == 1)
+        { // empty arg or single hyphen
+          break;
+        }
+      if (arg[1] != '-')
+        { // short option
+          for (decltype(n) i = 1; i < n; ++i)
+            {
+              options[std::string{'-'} + std::string{arg[i]}] = true;
+            }
+        }
+      else
+        { // long option
+          if (n == 2)
+            { // done options on "--" and skip it
+              argi++;
+              break;
+            }
+          options[arg] = true;
+        }
+    }
+  std::vector<std::string> args{};
+  for (; argi < argc; ++argi)
+    {
+      std::string arg{argv[argi]};
+      args.push_back(arg);
+    }
+  return {options, args};
+}
+
+/**
+ * @brief Print the parameters given by the parameter file of the application
+ *
+ * @param[in] pcout Parallel output stream
+ * @param[in] prm Object containing the parameters parsed from the parameter
+ * file
+ */
+inline void
+print_parameters_to_output_file(const ConditionalOStream &pcout,
+                                const ParameterHandler   &prm,
+                                const std::string        &file_name)
+{
+  const std::string print_parameters =
+    get_last_value_of_parameter(file_name, "print parameters");
+
+  if (print_parameters == "only changed")
+    {
+#if DEAL_II_VERSION_GTE(9, 7, 0)
+      prm.print_parameters(pcout.get_stream(),
+                           ParameterHandler::OutputStyle::PRM |
+                             ParameterHandler::OutputStyle::Short |
+                             ParameterHandler::KeepDeclarationOrder |
+                             ParameterHandler::KeepOnlyChanged);
+      pcout << std::endl << std::endl;
+#else
+      AssertThrow(
+        false,
+        ExcMessage(
+          "To print only changed parameters you need a version of deal.II >= 9.7.0."));
+#endif
+    }
+  else if (print_parameters == "all")
+    {
+      prm.print_parameters(pcout.get_stream(),
+                           ParameterHandler::OutputStyle::PRM |
+                             ParameterHandler::OutputStyle::Short |
+                             ParameterHandler::KeepDeclarationOrder);
+      pcout << std::endl << std::endl;
+    }
+}
 
 #endif

--- a/include/dem/dem_solver_parameters.h
+++ b/include/dem/dem_solver_parameters.h
@@ -40,6 +40,13 @@ public:
                       "0",
                       Patterns::Integer(),
                       "Dimension of the problem");
+
+    prm.declare_entry("print parameters",
+                      "none",
+                      Patterns::Selection("none|only changed|all"),
+                      "Print all the parameters, or only"
+                      "the changed parameters or none");
+
     Parameters::SimulationControl::declare_parameters(prm);
     Parameters::Mesh::declare_parameters(prm);
     Parameters::Restart::declare_parameters(prm);

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -75,6 +75,12 @@ public:
                       Patterns::Integer(),
                       "Dimension of the problem");
 
+    prm.declare_entry("print parameters",
+                      "none",
+                      Patterns::Selection("none|only changed|all"),
+                      "Print all the parameters, or only"
+                      "the changed parameters or none");
+
     dimensionality.declare_parameters(prm);
     Parameters::SimulationControl::declare_parameters(prm);
     physical_properties.declare_parameters(prm);

--- a/source/rpt/rpt_calculating_parameters.cc
+++ b/source/rpt/rpt_calculating_parameters.cc
@@ -6,6 +6,12 @@
 void
 RPTCalculatingParameters::declare(ParameterHandler &prm)
 {
+  prm.declare_entry("print parameters",
+                    "none",
+                    Patterns::Selection("none|only changed|all"),
+                    "Print all the parameters, or only"
+                    "the changed parameters or none");
+
   Parameters::RPTParameters::declare_parameters(prm);
   Parameters::RPTTuningParameters::declare_parameters(prm);
   Parameters::DetectorParameters::declare_parameters(prm);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the content of the new feature
       What are the motivations? 
       How is it integrated to the current code? -->

This PR adds two new features:

1. Allows to print the deal.II and Lethe versions used to run an application. An example of the usage would be as follows:
` lethe-fluid -V`
yields:
```
Running: lethe-fluid -V
lethe/1.0-77-g9fe541d99 deal.II/9.6.2-2966-g7a74e69540
```
2. Allows to print the parameters of the input file by specifying an additional parameter as follows:
```
#---------------------------------------------
# Print non-default parameters to output file
#---------------------------------------------

set print parameters = only changed
```
Options are none (default), all, or only changed (only supported with deal.II versions > 9.7).

### Testing

<!-- How has this been tested?
       What are the new test(s) and what feature(s)/parameter(s) does it test?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works?
       How will you ensure that it will continue to work in the future? -->

The features were tested for the examples of all the applications. 

### Documentation

<!-- Does this new feature introduce new simulation parameters? If so, describe them. -->

I have not introduced this in the documentation yet as there is no section for such parameters. We can discuss whether such a section is really needed.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

The idea is to be able to obtain both the version and the parameters when running simulations on the clusters. This will require two calls in the launch files. An example looks as follows:
```
lethe-fluid -V
lethe-fluid parameters.prm
```

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [ ] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge