### PR TITLE
Add gravity term in coupling of NS and HT in doc

### DIFF
--- a/doc/source/examples/multiphysics/melting-cavity/melting-cavity.rst
+++ b/doc/source/examples/multiphysics/melting-cavity/melting-cavity.rst
@@ -47,7 +47,7 @@ The incompressible Navier-Stokes equations with a Boussinesq approximation for t
         \nabla \cdot {\bf{u}} = 0
 
     .. math::
-        \rho \frac{\partial {\bf{u}}}{\partial t} + \rho ({\bf{u}} \cdot \nabla) {\bf{u}} = -\nabla p + \nabla \cdot {\bf{\tau}} - \rho \beta {\bf{g}} (T - T_{ref})
+        \rho \frac{\partial {\bf{u}}}{\partial t} + \rho ({\bf{u}} \cdot \nabla) {\bf{u}} = -\nabla p + \nabla \cdot {\bf{\tau}} + (1 - \beta (T - T_{ref}))\rho {\bf{g}}
 
 where :math:`\beta` and :math:`T_{ref}` denote thermal expansion coefficient and a reference temperature, respectively.
 

--- a/doc/source/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection.rst
+++ b/doc/source/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection.rst
@@ -39,7 +39,7 @@ The incompressible Navier-Stokes equations with a Boussinesq approximation for t
 
 .. math::
   \nabla \cdot {\bf{u}} &= 0 \\
-  \rho \frac{\partial {\bf{u}}}{\partial t} + \rho ({\bf{u}} \cdot \nabla) {\bf{u}} &= -\nabla p + \nabla \cdot {\bf{\tau}} - \rho \beta {\bf{g}} (T - T_0)
+  \rho \frac{\partial {\bf{u}}}{\partial t} + \rho ({\bf{u}} \cdot \nabla) {\bf{u}} &= -\nabla p + \nabla \cdot {\bf{\tau}} + (1 - \beta (T - T_0))\rho {\bf{g}}
 
 where :math:`\beta` and :math:`T_0` denote thermal expansion coefficient and a reference temperature, respectively.
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the content of this documentation
       Is it related to Lethe documentation (simulation parameters or theory guide) or in-code documentation? -->

One gravity term was missing from the formulation of the Navier-Stokes equations with the Boussinesq approximation. These equations are shown in only two examples of the documentation where the two-way coupling between fluid dynamics and heat transfer is showcased.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge