### PR TITLE
Change Triangulation input in attach_grid_to_triangulation

### DIFF
--- a/include/core/grids.h
+++ b/include/core/grids.h
@@ -22,9 +22,8 @@ using namespace dealii;
  */
 template <int dim, int spacedim = dim>
 void
-attach_grid_to_triangulation(
-  parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
-  const Parameters::Mesh                                &mesh_parameters);
+attach_grid_to_triangulation(Triangulation<dim, spacedim> &triangulation,
+                             const Parameters::Mesh       &mesh_parameters);
 
 
 /**

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -20,9 +20,8 @@
 
 template <int dim, int spacedim>
 void
-attach_grid_to_triangulation(
-  parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
-  const Parameters::Mesh                                &mesh_parameters)
+attach_grid_to_triangulation(Triangulation<dim, spacedim> &triangulation,
+                             const Parameters::Mesh       &mesh_parameters)
 
 {
   // GMSH input
@@ -396,17 +395,14 @@ read_mesh_and_manifolds(
 }
 
 template void
-attach_grid_to_triangulation(
-  parallel::DistributedTriangulationBase<2> &triangulation,
-  const Parameters::Mesh                    &mesh_parameters);
+attach_grid_to_triangulation(Triangulation<2>       &triangulation,
+                             const Parameters::Mesh &mesh_parameters);
 template void
-attach_grid_to_triangulation(
-  parallel::DistributedTriangulationBase<3> &triangulation,
-  const Parameters::Mesh                    &mesh_parameters);
+attach_grid_to_triangulation(Triangulation<3>       &triangulation,
+                             const Parameters::Mesh &mesh_parameters);
 template void
-attach_grid_to_triangulation(
-  parallel::DistributedTriangulationBase<2, 3> &triangulation,
-  const Parameters::Mesh                       &mesh_parameters);
+attach_grid_to_triangulation(Triangulation<2, 3>    &triangulation,
+                             const Parameters::Mesh &mesh_parameters);
 
 
 template void


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->
The function attach_grid_to_triangulation had a parallel::DistributedTriangulationBase as input. This has been changed to a Triangulation input, which will be useful for future implementation of the mortar method.

### Testing

<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->
No new tests were added, but all existent ones still passed.

### Documentation

<!-- Does this refactor modify or have new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [ ] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge