### PR TITLE
DEM default parameters for tests

### DIFF
--- a/tests/dem/particle_particle_contact_force_linear.cc
+++ b/tests/dem/particle_particle_contact_force_linear.cc
@@ -33,22 +33,18 @@ test()
   Parameters::Lagrangian::ModelParameters<dim> &model_param =
     dem_parameters.model_parameters;
 
+  set_default_dem_parameters(1, dem_parameters);
+
   Tensor<1, dim> g{{0, 0, -9.81}};
-  double         dt                                               = 0.00001;
-  double         particle_diameter                                = 0.005;
-  lagrangian_prop.particle_type_number                            = 1;
-  lagrangian_prop.youngs_modulus_particle[0]                      = 50000000;
-  lagrangian_prop.poisson_ratio_particle[0]                       = 0.3;
-  lagrangian_prop.restitution_coefficient_particle[0]             = 0.5;
-  lagrangian_prop.friction_coefficient_particle[0]                = 0.5;
-  lagrangian_prop.rolling_viscous_damping_coefficient_particle[0] = 0.5;
-  lagrangian_prop.rolling_friction_coefficient_particle[0]        = 0.1;
-  lagrangian_prop.surface_energy_particle[0]                      = 0.;
-  lagrangian_prop.hamaker_constant_particle[0]                    = 0.;
-  lagrangian_prop.rolling_friction_wall                           = 0.1;
-  lagrangian_prop.density_particle[0]                             = 2500;
-  model_param.rolling_resistance_method =
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
+  double         dt                                        = 0.00001;
+  double         particle_diameter                         = 0.005;
+  lagrangian_prop.particle_type_number                     = 1;
+  lagrangian_prop.youngs_modulus_particle[0]               = 50000000;
+  lagrangian_prop.poisson_ratio_particle[0]                = 0.3;
+  lagrangian_prop.restitution_coefficient_particle[0]      = 0.5;
+  lagrangian_prop.friction_coefficient_particle[0]         = 0.5;
+  lagrangian_prop.rolling_friction_coefficient_particle[0] = 0.1;
+  lagrangian_prop.density_particle[0]                      = 2500;
 
   const double neighborhood_threshold = std::pow(1.3 * particle_diameter, 2);
 

--- a/tests/dem/test_particles_functions.h
+++ b/tests/dem/test_particles_functions.h
@@ -55,7 +55,7 @@ construct_particle_iterator(
 
 
 /**
- * @brief Set the properties of the particle in the PropertiesIndex.
+ * @brief the properties of the particle in the PropertiesIndex.
  *
  * @tparam dim Integer that denotes the number of spatial dimensions.
  * @tparam PropertiesIndex Index of the properties used within the ParticleHandler.
@@ -70,13 +70,13 @@ template <int dim, typename PropertiesIndex>
 void
 set_particle_properties(Particles::ParticleIterator<dim> &pit,
                         int                               type,
-                        double                            particle_diameter,
+                        double                            diameter,
                         double                            mass,
                         Tensor<1, dim>                   &v,
                         Tensor<1, dim>                   &omega)
 {
   pit->get_properties()[PropertiesIndex::type]    = type;
-  pit->get_properties()[PropertiesIndex::dp]      = particle_diameter;
+  pit->get_properties()[PropertiesIndex::dp]      = diameter;
   pit->get_properties()[PropertiesIndex::mass]    = mass;
   pit->get_properties()[PropertiesIndex::v_x]     = v[0];
   pit->get_properties()[PropertiesIndex::omega_x] = omega[0];
@@ -91,6 +91,61 @@ set_particle_properties(Particles::ParticleIterator<dim> &pit,
       pit->get_properties()[PropertiesIndex::omega_z] = omega[2];
     }
 }
+
+
+/**
+ * @brief Set default values for all lagrangian properties.
+ *
+ * @tparam dim Integer that denotes the number of spatial dimensions.
+ * @param particle_type_number Number of particle types
+ * @param dem_parameters Simulation parameters
+ */
+template <int dim>
+void
+set_default_dem_parameters(const unsigned int        particle_type_number,
+                           DEMSolverParameters<dim> &dem_parameters)
+{
+  Parameters::Lagrangian::LagrangianPhysicalProperties &properties =
+    dem_parameters.lagrangian_physical_properties;
+
+  // particle parameters
+  for (unsigned int i = 0; i < particle_type_number; ++i)
+    {
+      properties.density_particle[i]                             = 1000;
+      properties.youngs_modulus_particle[i]                      = 1000000;
+      properties.poisson_ratio_particle[i]                       = 0.3;
+      properties.restitution_coefficient_particle[i]             = 0.1;
+      properties.friction_coefficient_particle[i]                = 0.1;
+      properties.rolling_friction_coefficient_particle[i]        = 0.1;
+      properties.rolling_viscous_damping_coefficient_particle[i] = 0.1;
+      properties.surface_energy_particle[i]                      = 0.0;
+      properties.hamaker_constant_particle[i]                    = 4.e-19;
+      properties.thermal_conductivity_particle[i]                = 1;
+      properties.specific_heat_particle[i]                       = 1000;
+      properties.microhardness_particle[i]                       = 1.e9;
+      properties.surface_slope_particle[i]                       = 0.1;
+      properties.surface_roughness_particle[i]                   = 1.e-9;
+      properties.thermal_accommodation_particle[i]               = 0.7;
+    }
+
+  // wall parameters
+  properties.youngs_modulus_wall          = 1000000;
+  properties.poisson_ratio_wall           = 0.3;
+  properties.restitution_coefficient_wall = 0.1;
+  properties.friction_coefficient_wall    = 0.1;
+  properties.rolling_friction_wall        = 0.1;
+  properties.rolling_viscous_damping_wall = 0.1;
+  properties.surface_energy_wall          = 0.0;
+  properties.hamaker_constant_wall        = 4.e-19;
+
+  // gas parameters
+  properties.thermal_conductivity_gas     = 0.01;
+  properties.specific_heat_gas            = 1000;
+  properties.dynamic_viscosity_gas        = 1.e-5;
+  properties.specific_heats_ratio_gas     = 1;
+  properties.molecular_mean_free_path_gas = 68.e-9;
+}
+
 
 
 #endif // test_particles_functions_h

--- a/tests/dem/test_particles_functions.h
+++ b/tests/dem/test_particles_functions.h
@@ -97,8 +97,8 @@ set_particle_properties(Particles::ParticleIterator<dim> &pit,
  * @brief Set default values for all lagrangian properties.
  *
  * @tparam dim Integer that denotes the number of spatial dimensions.
- * @param particle_type_number Number of particle types
- * @param dem_parameters Simulation parameters
+ * @param[in] particle_type_number Number of particle types.
+ * @param[out] dem_parameters Simulation parameters
  */
 template <int dim>
 void
@@ -108,7 +108,13 @@ set_default_dem_parameters(const unsigned int        particle_type_number,
   Parameters::Lagrangian::LagrangianPhysicalProperties &properties =
     dem_parameters.lagrangian_physical_properties;
 
-  // particle parameters
+  properties.particle_type_number = particle_type_number;
+
+  // Rolling resistance method
+  dem_parameters.model_parameters.rolling_resistance_method =
+    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
+
+  // Particle parameters
   for (unsigned int i = 0; i < particle_type_number; ++i)
     {
       properties.density_particle[i]                             = 1000;
@@ -128,7 +134,7 @@ set_default_dem_parameters(const unsigned int        particle_type_number,
       properties.thermal_accommodation_particle[i]               = 0.7;
     }
 
-  // wall parameters
+  // Wall parameters
   properties.youngs_modulus_wall          = 1000000;
   properties.poisson_ratio_wall           = 0.3;
   properties.restitution_coefficient_wall = 0.1;
@@ -138,14 +144,12 @@ set_default_dem_parameters(const unsigned int        particle_type_number,
   properties.surface_energy_wall          = 0.0;
   properties.hamaker_constant_wall        = 4.e-19;
 
-  // gas parameters
+  // Interstitial gas parameters
   properties.thermal_conductivity_gas     = 0.01;
   properties.specific_heat_gas            = 1000;
   properties.dynamic_viscosity_gas        = 1.e-5;
   properties.specific_heats_ratio_gas     = 1;
   properties.molecular_mean_free_path_gas = 68.e-9;
 }
-
-
 
 #endif // test_particles_functions_h


### PR DESCRIPTION
### Description

This PR adds a function to set all default parameters for a DEM test, so that we have to initialize manually only those that impact the results. This also avoids errors of missing parameters.

### Testing

Example of possible use in particle_particle_contact_force_linear.cc

### Miscellaneous (will be removed when merged)

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [ ] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge