### PR TITLE
Fixing the rectangular hopper example

### DIFF
--- a/doc/source/examples/dem/rectangular-hopper/rectangular-hopper.rst
+++ b/doc/source/examples/dem/rectangular-hopper/rectangular-hopper.rst
@@ -295,8 +295,8 @@ The feature only works with one pair of periodic boundaries.
 
         subsection boundary condition 0
             set type                      = periodic
-            set periodic id 0             = 0
-            set periodic id 1             = 1
+            set periodic id 0             = 1
+            set periodic id 1             = 2
             set periodic direction        = 2
         end
     end

--- a/examples/dem/3d-rectangular-hopper/hopper_periodic.prm
+++ b/examples/dem/3d-rectangular-hopper/hopper_periodic.prm
@@ -122,8 +122,8 @@ subsection DEM boundary conditions
 
   subsection boundary condition 0
     set type               = periodic
-    set periodic id 0      = 0
-    set periodic id 1      = 1
+    set periodic id 0      = 1
+    set periodic id 1      = 2
     set periodic direction = 2
   end
 end


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description
The example wasn't working on master (dealii assert) .... after some investigation and comparison  with the lethe-utils bench-mark, I realized that the only difference were the boundary ids when declaring the periodic boundary condition.  

### Solution

Changed the Boundary ids in the declaration. 


### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [X] Lethe documentation is up to date
- [X] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [X] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] If the fix is temporary, an issue is opened
- [X] The PR description is cleaned and ready for merge