### PR TITLE
Add particle heat transfer calculation in force calculation

### DIFF
--- a/include/dem/multiphysics_integrator.h
+++ b/include/dem/multiphysics_integrator.h
@@ -21,14 +21,14 @@
  * @tparam PropertiesIndex Index of the properties used within the ParticleHandler.
  * @param particle_handler Storage of particles and their accessor functions.
  * @param[in] dt DEM time step.
- * @param[in,out] heat_transfer Particle-particle heat transfer.
+ * @param[in,out] heat_transfer_rate Particle-particle heat transfer rate.
  * @param[in] heat_source Additional heat source term.
  */
 template <int dim, typename PropertiesIndex>
 void
 integrate_temperature(Particles::ParticleHandler<dim> &particle_handler,
                       const double                     dt,
-                      std::vector<double>             &heat_transfer,
+                      std::vector<double>             &heat_transfer_rate,
                       const std::vector<double>       &heat_source);
 
 #endif

--- a/include/dem/particle_particle_contact_force.h
+++ b/include/dem/particle_particle_contact_force.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_particle_particle_contact_force_h

--- a/include/dem/particle_particle_contact_force.h
+++ b/include/dem/particle_particle_contact_force.h
@@ -35,7 +35,7 @@ class ParticleParticleContactForceBase
 {
 public:
   /**
-   * @brief Calculate the contact forces and heat transfer using the contact pair information
+   * @brief Calculate the contact forces and heat transfer rates using the contact pair information
    * obtained in the fine search and physical properties of particles.
    *
    * @param local_adjacent_particles Container of the contact pair candidates
@@ -55,10 +55,10 @@ public:
    * @param dt DEM time step.
    * @param torque Torque acting on particles.
    * @param force Force acting on particles.
-   * @param heat_transfer Heat transfer applied to particles.
+   * @param heat_transfer_rate Heat transfer rate applied to particles.
    */
   virtual void
-  calculate_particle_particle_contact_force_and_heat_transfer(
+  calculate_particle_particle_contact_force_and_heat_transfer_rate(
     typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
       &local_adjacent_particles,
     typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
@@ -72,7 +72,7 @@ public:
     const double               dt,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force,
-    std::vector<double>       &heat_transfer) = 0;
+    std::vector<double>       &heat_transfer_rate) = 0;
 
   /**
    * @brief Calculate the contact forces using the contact pair information
@@ -150,7 +150,7 @@ public:
   {}
 
   /**
-   * @brief Calculate the contact forces and heat transfer using the contact pair information
+   * @brief Calculate the contact forces and heat transfer rates using the contact pair information
    * obtained in the fine search and physical properties of particles.
    *
    * @param local_adjacent_particles Container of the contact pair candidates
@@ -170,10 +170,10 @@ public:
    * @param dt DEM time step.
    * @param torque Torque acting on particles.
    * @param force Force acting on particles.
-   * @param heat_transfer Heat transfer applied to particles.
+   * @param heat_transfer_rate Heat transfer rate applied to particles.
    */
   virtual void
-  calculate_particle_particle_contact_force_and_heat_transfer(
+  calculate_particle_particle_contact_force_and_heat_transfer_rate(
     typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
       &local_adjacent_particles,
     typename DEM::dem_data_structures<dim>::adjacent_particle_pairs
@@ -187,7 +187,7 @@ public:
     const double               dt,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force,
-    std::vector<double>       &heat_transfer) override;
+    std::vector<double>       &heat_transfer_rate) override;
 
   /**
    * @brief Calculate the contact forces using the contact pair information
@@ -1673,7 +1673,7 @@ private:
   }
 
   /**
-   * @brief Set every containers needed to carry the heat transfer
+   * @brief Set every containers needed to carry the heat transfer rate
    * calculation.
    *
    * @param[in] dem_parameters DEM parameters declared in the .prm
@@ -1745,7 +1745,7 @@ private:
    * particles
    * @param[out] torque Torque acting on particles.
    * @param[out] force Force acting on particles.
-   * @param[out] heat_transfer Heat transfer applied to particles.
+   * @param[out] heat_transfer_rate Heat transfer rate applied to particles.
    * @param[in] dt DEM time step.
    */
   template <ContactType contact_type>
@@ -1755,7 +1755,7 @@ private:
                               &adjacent_particles_list,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force,
-    std::vector<double>       &heat_transfer,
+    std::vector<double>       &heat_transfer_rate,
     const double               dt)
   {
     // No contact calculation if no adjacent particles
@@ -1974,9 +1974,9 @@ private:
                                      DEM::DEMMPProperties::PropertiesIndex>)
           {
             AssertThrow(
-              heat_transfer.size() == force.size(),
+              heat_transfer_rate.size() == force.size(),
               ExcMessage(
-                "Invalid size of heat_transfer in particle particle heat transfer calculation."));
+                "Invalid size of heat_transfer_rate in particle particle heat transfer rate calculation."));
 
             if (normal_overlap > 0)
               {
@@ -1992,10 +1992,10 @@ private:
                   particle_two_properties[PropertiesIndex::T];
                 types::particle_index particle_two_id =
                   particle_two->get_local_index();
-                double &particle_one_heat_transfer =
-                  heat_transfer[particle_one_id];
-                double &particle_two_heat_transfer =
-                  heat_transfer[particle_two_id];
+                double &particle_one_heat_transfer_rate =
+                  heat_transfer_rate[particle_one_id];
+                double &particle_two_heat_transfer_rate =
+                  heat_transfer_rate[particle_two_id];
 
                 double thermal_conductance;
                 calculate_contact_thermal_conductance(
@@ -2025,8 +2025,8 @@ private:
                       temperature_one,
                       temperature_two,
                       thermal_conductance,
-                      particle_one_heat_transfer,
-                      particle_two_heat_transfer);
+                      particle_one_heat_transfer_rate,
+                      particle_two_heat_transfer_rate);
                   }
 
                 // Apply the heat transfer only to the local
@@ -2040,7 +2040,7 @@ private:
                       temperature_one,
                       temperature_two,
                       thermal_conductance,
-                      particle_one_heat_transfer);
+                      particle_one_heat_transfer_rate);
                   }
 
                 // Apply the heat transfer only to the local
@@ -2053,7 +2053,7 @@ private:
                       temperature_two,
                       temperature_one,
                       thermal_conductance,
-                      particle_two_heat_transfer);
+                      particle_two_heat_transfer_rate);
                   }
               }
           }

--- a/include/dem/particle_particle_heat_transfer.h
+++ b/include/dem/particle_particle_heat_transfer.h
@@ -180,18 +180,18 @@ calculate_contact_thermal_conductance(
  * @param[in] temperature_two Temperature of particle two.
  * @param[in] thermal_conductance Total thermal conductance between the two
  * particles.
- * @param[in,out] particle_one_heat_transfer_rate Heat transfer rate due to contact
- * applied to particle one.
- * @param[in,out] particle_two_heat_transfer_rate Heat transfer rate due to contact
- * applied to particle two.
+ * @param[in,out] particle_one_heat_transfer_rate Heat transfer rate due to
+ * contact applied to particle one.
+ * @param[in,out] particle_two_heat_transfer_rate Heat transfer rate due to
+ * contact applied to particle two.
  *
  */
 void
 apply_heat_transfer_on_local_particles(const double temperature_one,
                                        const double temperature_two,
                                        const double thermal_conductance,
-                                       double      &particle_one_heat_transfer_rate,
-                                       double      &particle_two_heat_transfer_rate);
+                                       double &particle_one_heat_transfer_rate,
+                                       double &particle_two_heat_transfer_rate);
 
 /**
  * @brief Apply the heat transfer to the local-ghost particle pair in contact.
@@ -202,8 +202,8 @@ apply_heat_transfer_on_local_particles(const double temperature_one,
  * @param[in] temperature_two Temperature of particle two.
  * @param[in] thermal_conductance Total thermal conductance between the two
  * particles.
- * @param[in,out] particle_one_heat_transfer_rate Heat transfer rate due to contact
- * applied to particle one.
+ * @param[in,out] particle_one_heat_transfer_rate Heat transfer rate due to
+ * contact applied to particle one.
  *
  */
 void

--- a/include/dem/particle_particle_heat_transfer.h
+++ b/include/dem/particle_particle_heat_transfer.h
@@ -180,9 +180,9 @@ calculate_contact_thermal_conductance(
  * @param[in] temperature_two Temperature of particle two.
  * @param[in] thermal_conductance Total thermal conductance between the two
  * particles.
- * @param[in,out] particle_one_heat_transfer Heat transfer due to contact
+ * @param[in,out] particle_one_heat_transfer_rate Heat transfer rate due to contact
  * applied to particle one.
- * @param[in,out] particle_two_heat_transfer Heat transfer due to contact
+ * @param[in,out] particle_two_heat_transfer_rate Heat transfer rate due to contact
  * applied to particle two.
  *
  */
@@ -190,8 +190,8 @@ void
 apply_heat_transfer_on_local_particles(const double temperature_one,
                                        const double temperature_two,
                                        const double thermal_conductance,
-                                       double      &particle_one_heat_transfer,
-                                       double      &particle_two_heat_transfer);
+                                       double      &particle_one_heat_transfer_rate,
+                                       double      &particle_two_heat_transfer_rate);
 
 /**
  * @brief Apply the heat transfer to the local-ghost particle pair in contact.
@@ -202,7 +202,7 @@ apply_heat_transfer_on_local_particles(const double temperature_one,
  * @param[in] temperature_two Temperature of particle two.
  * @param[in] thermal_conductance Total thermal conductance between the two
  * particles.
- * @param[in,out] particle_one_heat_transfer Heat transfer due to contact
+ * @param[in,out] particle_one_heat_transfer_rate Heat transfer rate due to contact
  * applied to particle one.
  *
  */
@@ -211,6 +211,6 @@ apply_heat_transfer_on_single_local_particle(
   const double temperature_one,
   const double temperature_two,
   const double thermal_conductance,
-  double      &particle_one_heat_transfer);
+  double      &particle_one_heat_transfer_rate);
 
 #endif

--- a/source/dem/multiphysics_integrator.cc
+++ b/source/dem/multiphysics_integrator.cc
@@ -7,7 +7,7 @@ template <int dim, typename PropertiesIndex>
 void
 integrate_temperature(Particles::ParticleHandler<dim> &particle_handler,
                       const double                     dt,
-                      std::vector<double>             &heat_transfer,
+                      std::vector<double>             &heat_transfer_rate,
                       const std::vector<double>       &heat_source)
 {
   for (auto particle = particle_handler.begin();
@@ -16,7 +16,7 @@ integrate_temperature(Particles::ParticleHandler<dim> &particle_handler,
     {
       const types::particle_index particle_id = particle->get_local_index();
       auto         particle_properties        = particle->get_properties();
-      double      &particle_heat_transfer     = heat_transfer[particle_id];
+      double      &particle_heat_transfer_rate     = heat_transfer_rate[particle_id];
       double       particle_heat_source       = heat_source[particle_id];
       const double mass_inverse =
         1 / particle_properties[PropertiesIndex::mass];
@@ -25,11 +25,11 @@ integrate_temperature(Particles::ParticleHandler<dim> &particle_handler,
 
       // Integration
       particle_properties[PropertiesIndex::T] +=
-        dt * (particle_heat_transfer + particle_heat_source) * mass_inverse *
+        dt * (particle_heat_transfer_rate + particle_heat_source) * mass_inverse *
         specific_heat_inverse;
 
-      // Reinitialize heat_transfer
-      particle_heat_transfer = 0;
+      // Reinitialize heat_transfer_rate
+      particle_heat_transfer_rate = 0;
     }
 }
 
@@ -37,12 +37,12 @@ template void
 integrate_temperature<2, DEM::DEMMPProperties::PropertiesIndex>(
   Particles::ParticleHandler<2> &particle_handler,
   const double                   dt,
-  std::vector<double>           &heat_transfer,
+  std::vector<double>           &heat_transfer_rate,
   const std::vector<double>     &heat_source);
 
 template void
 integrate_temperature<3, DEM::DEMMPProperties::PropertiesIndex>(
   Particles::ParticleHandler<3> &particle_handler,
   const double                   dt,
-  std::vector<double>           &heat_transfer,
+  std::vector<double>           &heat_transfer_rate,
   const std::vector<double>     &heat_source);

--- a/source/dem/multiphysics_integrator.cc
+++ b/source/dem/multiphysics_integrator.cc
@@ -15,9 +15,9 @@ integrate_temperature(Particles::ParticleHandler<dim> &particle_handler,
        ++particle)
     {
       const types::particle_index particle_id = particle->get_local_index();
-      auto         particle_properties        = particle->get_properties();
-      double      &particle_heat_transfer_rate     = heat_transfer_rate[particle_id];
-      double       particle_heat_source       = heat_source[particle_id];
+      auto    particle_properties             = particle->get_properties();
+      double &particle_heat_transfer_rate     = heat_transfer_rate[particle_id];
+      double  particle_heat_source            = heat_source[particle_id];
       const double mass_inverse =
         1 / particle_properties[PropertiesIndex::mass];
       const double specific_heat_inverse =
@@ -25,8 +25,8 @@ integrate_temperature(Particles::ParticleHandler<dim> &particle_handler,
 
       // Integration
       particle_properties[PropertiesIndex::T] +=
-        dt * (particle_heat_transfer_rate + particle_heat_source) * mass_inverse *
-        specific_heat_inverse;
+        dt * (particle_heat_transfer_rate + particle_heat_source) *
+        mass_inverse * specific_heat_inverse;
 
       // Reinitialize heat_transfer_rate
       particle_heat_transfer_rate = 0;

--- a/source/dem/particle_particle_contact_force.cc
+++ b/source/dem/particle_particle_contact_force.cc
@@ -53,8 +53,8 @@ ParticleParticleContactForce<dim,
     std::vector<Tensor<1, 3>> &force,
     std::vector<double>       &heat_transfer_rate)
 {
-  // Calculating the contact forces and heat transfer rates for local-local adjacent
-  // particles.
+  // Calculating the contact forces and heat transfer rates for local-local
+  // adjacent particles.
   for (auto &&adjacent_particles_list :
        local_adjacent_particles | boost::adaptors::map_values)
     {
@@ -62,8 +62,8 @@ ParticleParticleContactForce<dim,
         adjacent_particles_list, torque, force, heat_transfer_rate, dt);
     }
 
-  // Calculating the contact forces and heat transfer rates for local-ghost adjacent
-  // particles.
+  // Calculating the contact forces and heat transfer rates for local-ghost
+  // adjacent particles.
   for (auto &&adjacent_particles_list :
        ghost_adjacent_particles | boost::adaptors::map_values)
     {
@@ -71,34 +71,46 @@ ParticleParticleContactForce<dim,
         adjacent_particles_list, torque, force, heat_transfer_rate, dt);
     }
 
-  // Calculating the contact forces and heat transfer rates for local-local periodic
-  // adjacent particles.
+  // Calculating the contact forces and heat transfer rates for local-local
+  // periodic adjacent particles.
   for (auto &&periodic_adjacent_particles_list :
        local_local_periodic_adjacent_particles | boost::adaptors::map_values)
     {
       execute_contact_calculation<
         ContactType::local_periodic_particle_particle>(
-        periodic_adjacent_particles_list, torque, force, heat_transfer_rate, dt);
+        periodic_adjacent_particles_list,
+        torque,
+        force,
+        heat_transfer_rate,
+        dt);
     }
 
-  // Calculating the contact forces and heat transfer rates for local-ghost periodic
-  // adjacent particles.
+  // Calculating the contact forces and heat transfer rates for local-ghost
+  // periodic adjacent particles.
   for (auto &&periodic_adjacent_particles_list :
        local_ghost_periodic_adjacent_particles | boost::adaptors::map_values)
     {
       execute_contact_calculation<
         ContactType::ghost_periodic_particle_particle>(
-        periodic_adjacent_particles_list, torque, force, heat_transfer_rate, dt);
+        periodic_adjacent_particles_list,
+        torque,
+        force,
+        heat_transfer_rate,
+        dt);
     }
 
-  // Calculating the contact forces and heat transfer rates for ghost-local periodic
-  // adjacent particles.
+  // Calculating the contact forces and heat transfer rates for ghost-local
+  // periodic adjacent particles.
   for (auto &&periodic_adjacent_particles_list :
        ghost_local_periodic_adjacent_particles | boost::adaptors::map_values)
     {
       execute_contact_calculation<
         ContactType::ghost_local_periodic_particle_particle>(
-        periodic_adjacent_particles_list, torque, force, heat_transfer_rate, dt);
+        periodic_adjacent_particles_list,
+        torque,
+        force,
+        heat_transfer_rate,
+        dt);
     }
 }
 
@@ -128,8 +140,8 @@ ParticleParticleContactForce<dim,
 {
   std::vector<double> heat_transfer_rate;
 
-  // Calling calculate_particle_particle_contact_force_and_heat_transfer_rate with
-  // empty heat_transfer_rate
+  // Calling calculate_particle_particle_contact_force_and_heat_transfer_rate
+  // with empty heat_transfer_rate
   calculate_particle_particle_contact_force_and_heat_transfer_rate(
     local_adjacent_particles,
     ghost_adjacent_particles,

--- a/source/dem/particle_particle_contact_force.cc
+++ b/source/dem/particle_particle_contact_force.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/parameters_lagrangian.h>

--- a/source/dem/particle_particle_contact_force.cc
+++ b/source/dem/particle_particle_contact_force.cc
@@ -37,7 +37,7 @@ ParticleParticleContactForce<dim,
                              PropertiesIndex,
                              contact_model,
                              rolling_friction_model>::
-  calculate_particle_particle_contact_force_and_heat_transfer(
+  calculate_particle_particle_contact_force_and_heat_transfer_rate(
     typename dem_data_structures<dim>::adjacent_particle_pairs
       &local_adjacent_particles,
     typename dem_data_structures<dim>::adjacent_particle_pairs
@@ -51,54 +51,54 @@ ParticleParticleContactForce<dim,
     const double               dt,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force,
-    std::vector<double>       &heat_transfer)
+    std::vector<double>       &heat_transfer_rate)
 {
-  // Calculating the contact forces and heat transfer for local-local adjacent
+  // Calculating the contact forces and heat transfer rates for local-local adjacent
   // particles.
   for (auto &&adjacent_particles_list :
        local_adjacent_particles | boost::adaptors::map_values)
     {
       execute_contact_calculation<ContactType::local_particle_particle>(
-        adjacent_particles_list, torque, force, heat_transfer, dt);
+        adjacent_particles_list, torque, force, heat_transfer_rate, dt);
     }
 
-  // Calculating the contact forces and heat transfer for local-ghost adjacent
+  // Calculating the contact forces and heat transfer rates for local-ghost adjacent
   // particles.
   for (auto &&adjacent_particles_list :
        ghost_adjacent_particles | boost::adaptors::map_values)
     {
       execute_contact_calculation<ContactType::ghost_particle_particle>(
-        adjacent_particles_list, torque, force, heat_transfer, dt);
+        adjacent_particles_list, torque, force, heat_transfer_rate, dt);
     }
 
-  // Calculating the contact forces and heat transfer for local-local periodic
+  // Calculating the contact forces and heat transfer rates for local-local periodic
   // adjacent particles.
   for (auto &&periodic_adjacent_particles_list :
        local_local_periodic_adjacent_particles | boost::adaptors::map_values)
     {
       execute_contact_calculation<
         ContactType::local_periodic_particle_particle>(
-        periodic_adjacent_particles_list, torque, force, heat_transfer, dt);
+        periodic_adjacent_particles_list, torque, force, heat_transfer_rate, dt);
     }
 
-  // Calculating the contact forces and heat transfer for local-ghost periodic
+  // Calculating the contact forces and heat transfer rates for local-ghost periodic
   // adjacent particles.
   for (auto &&periodic_adjacent_particles_list :
        local_ghost_periodic_adjacent_particles | boost::adaptors::map_values)
     {
       execute_contact_calculation<
         ContactType::ghost_periodic_particle_particle>(
-        periodic_adjacent_particles_list, torque, force, heat_transfer, dt);
+        periodic_adjacent_particles_list, torque, force, heat_transfer_rate, dt);
     }
 
-  // Calculating the contact forces and heat transfer for ghost-local periodic
+  // Calculating the contact forces and heat transfer rates for ghost-local periodic
   // adjacent particles.
   for (auto &&periodic_adjacent_particles_list :
        ghost_local_periodic_adjacent_particles | boost::adaptors::map_values)
     {
       execute_contact_calculation<
         ContactType::ghost_local_periodic_particle_particle>(
-        periodic_adjacent_particles_list, torque, force, heat_transfer, dt);
+        periodic_adjacent_particles_list, torque, force, heat_transfer_rate, dt);
     }
 }
 
@@ -126,11 +126,11 @@ ParticleParticleContactForce<dim,
     std::vector<Tensor<1, 3>> &torque,
     std::vector<Tensor<1, 3>> &force)
 {
-  std::vector<double> heat_transfer;
+  std::vector<double> heat_transfer_rate;
 
-  // Calling calculate_particle_particle_contact_force_and_heat_transfer with
-  // empty heat_transfer
-  calculate_particle_particle_contact_force_and_heat_transfer(
+  // Calling calculate_particle_particle_contact_force_and_heat_transfer_rate with
+  // empty heat_transfer_rate
+  calculate_particle_particle_contact_force_and_heat_transfer_rate(
     local_adjacent_particles,
     ghost_adjacent_particles,
     local_local_periodic_adjacent_particles,
@@ -139,7 +139,7 @@ ParticleParticleContactForce<dim,
     dt,
     torque,
     force,
-    heat_transfer);
+    heat_transfer_rate);
 }
 
 // dem

--- a/source/dem/particle_particle_heat_transfer.cc
+++ b/source/dem/particle_particle_heat_transfer.cc
@@ -208,21 +208,21 @@ void
 apply_heat_transfer_on_local_particles(const double temperature_one,
                                        const double temperature_two,
                                        const double thermal_conductance,
-                                       double      &particle_one_heat_transfer,
-                                       double      &particle_two_heat_transfer)
+                                       double      &particle_one_heat_transfer_rate,
+                                       double      &particle_two_heat_transfer_rate)
 {
-  const double heat_transfer =
+  const double heat_transfer_rate =
     thermal_conductance * (temperature_two - temperature_one);
-  particle_one_heat_transfer += heat_transfer;
-  particle_two_heat_transfer -= heat_transfer;
+  particle_one_heat_transfer_rate += heat_transfer_rate;
+  particle_two_heat_transfer_rate -= heat_transfer_rate;
 }
 
 void
 apply_heat_transfer_on_single_local_particle(const double temperature_one,
                                              const double temperature_two,
                                              const double thermal_conductance,
-                                             double &particle_one_heat_transfer)
+                                             double &particle_one_heat_transfer_rate)
 {
-  particle_one_heat_transfer +=
+  particle_one_heat_transfer_rate +=
     thermal_conductance * (temperature_two - temperature_one);
 }

--- a/source/dem/particle_particle_heat_transfer.cc
+++ b/source/dem/particle_particle_heat_transfer.cc
@@ -208,8 +208,8 @@ void
 apply_heat_transfer_on_local_particles(const double temperature_one,
                                        const double temperature_two,
                                        const double thermal_conductance,
-                                       double      &particle_one_heat_transfer_rate,
-                                       double      &particle_two_heat_transfer_rate)
+                                       double &particle_one_heat_transfer_rate,
+                                       double &particle_two_heat_transfer_rate)
 {
   const double heat_transfer_rate =
     thermal_conductance * (temperature_two - temperature_one);
@@ -218,10 +218,11 @@ apply_heat_transfer_on_local_particles(const double temperature_one,
 }
 
 void
-apply_heat_transfer_on_single_local_particle(const double temperature_one,
-                                             const double temperature_two,
-                                             const double thermal_conductance,
-                                             double &particle_one_heat_transfer_rate)
+apply_heat_transfer_on_single_local_particle(
+  const double temperature_one,
+  const double temperature_two,
+  const double thermal_conductance,
+  double      &particle_one_heat_transfer_rate)
 {
   particle_one_heat_transfer_rate +=
     thermal_conductance * (temperature_two - temperature_one);

--- a/tests/dem/integration_temperature.cc
+++ b/tests/dem/integration_temperature.cc
@@ -64,9 +64,9 @@ test()
   pit_1->get_properties()[PropertiesIndex::specific_heat] = specific_heat;
 
   // Initialize variables
-  std::vector<double> heat_transfer;
+  std::vector<double> heat_transfer_rate;
   std::vector<double> heat_source;
-  heat_transfer.push_back(0);
+  heat_transfer_rate.push_back(0);
   heat_source.push_back(0);
   double T_analytical;
   double particle_temperature_error_dt_1;
@@ -77,10 +77,10 @@ test()
   double time = 0;
   while (time < time_final)
     {
-      heat_transfer[0] = -particle_properties[PropertiesIndex::T];
+      heat_transfer_rate[0] = -particle_properties[PropertiesIndex::T];
       integrate_temperature<dim, PropertiesIndex>(particle_handler,
                                                   dt_1,
-                                                  heat_transfer,
+                                                  heat_transfer_rate,
                                                   heat_source);
       time += dt_1;
     }
@@ -105,10 +105,10 @@ test()
   time = 0;
   while (time <= time_final)
     {
-      heat_transfer[0] = -particle_properties[PropertiesIndex::T];
+      heat_transfer_rate[0] = -particle_properties[PropertiesIndex::T];
       integrate_temperature<dim, PropertiesIndex>(particle_handler,
                                                   dt_2,
-                                                  heat_transfer,
+                                                  heat_transfer_rate,
                                                   heat_source);
       time += dt_2;
     }

--- a/tests/dem/particle_particle_heat_transfer.cc
+++ b/tests/dem/particle_particle_heat_transfer.cc
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+
+
+/**
+ * @brief This test
+ *
+ */
+
+#include <../tests/dem/test_particles_functions.h>
+#include <dem/particle_particle_contact_force.h>
+#include <dem/particle_particle_heat_transfer.h>
+
+template <int dim, typename PropertiesIndex>
+void
+test()
+{
+  // Creating the mesh and refinement
+  parallel::distributed::Triangulation<dim> triangulation(MPI_COMM_WORLD);
+  const int                                 hyper_cube_length = 1;
+  GridGenerator::hyper_cube(triangulation,
+                            -1 * hyper_cube_length,
+                            hyper_cube_length,
+                            true);
+  const int refinement_number = 2;
+  triangulation.refine_global(refinement_number);
+  MappingQ<dim> mapping(1);
+
+  // Defining simulation general parameters
+  DEMSolverParameters<dim>                              dem_parameters;
+  Parameters::Lagrangian::LagrangianPhysicalProperties &properties =
+    dem_parameters.lagrangian_physical_properties;
+  Parameters::Lagrangian::ModelParameters<dim> &model_param =
+    dem_parameters.model_parameters;
+
+  const Tensor<1, dim> g{{0, 0, 0}};
+  const double         dt                                    = 0.1;
+  const double         particle_diameter                     = 0.01;
+  const double         specific_heat                         = 840;
+  properties.particle_type_number                            = 1;
+  properties.youngs_modulus_particle[0]                      = 65e9;
+  properties.poisson_ratio_particle[0]                       = 0.22;
+  properties.restitution_coefficient_particle[0]             = 0.8;
+  properties.friction_coefficient_particle[0]                = 1;
+  properties.rolling_friction_coefficient_particle[0]        = 0.02;
+  properties.density_particle[0]                             = 2521;
+  properties.rolling_viscous_damping_coefficient_particle[0] = 0.;
+  properties.surface_energy_particle[0]                      = 0.;
+  properties.hamaker_constant_particle[0]                    = 0.;
+  model_param.rolling_resistance_method =
+    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
+
+  const double neighborhood_threshold = std::pow(1.3 * particle_diameter, 2);
+
+  // Defining parameters for thermal DEM
+  properties.surface_roughness_particle[0]     = 25e-9;
+  properties.surface_slope_particle[0]         = 0.078;
+  properties.microhardness_particle[0]         = 9e9;
+  properties.thermal_conductivity_particle[0]  = 1;
+  properties.thermal_conductivity_gas          = 0.027;
+  properties.dynamic_viscosity_gas             = 1.85e-5;
+  properties.specific_heat_gas                 = 1006;
+  properties.specific_heats_ratio_gas          = 1;
+  properties.molecular_mean_free_path_gas      = 68e-9;
+  properties.thermal_accommodation_particle[0] = 0.7;
+
+  // Defining particle handler
+  Particles::ParticleHandler<dim> particle_handler(
+    triangulation, mapping, PropertiesIndex::n_properties);
+
+  // Creating containers manager for finding cell neighbor and also broad and
+  // fine particle-particle search objects
+  DEMContactManager<dim, PropertiesIndex> contact_manager;
+
+  // Finding cell neighbors
+  typename dem_data_structures<dim>::periodic_boundaries_cells_info
+    dummy_pbc_info;
+  contact_manager.execute_cell_neighbors_search(triangulation, dummy_pbc_info);
+
+  // Inserting two particles in contact
+  Point<3>           position_1 = {0, 0, 0};
+  const unsigned int id_1       = 0;
+  Point<3>           position_2 = {0.00999, 0, 0};
+  const unsigned int id_2       = 1;
+
+  // Constructing particle iterators from particle positions (inserting
+  // particles)
+  Particles::ParticleIterator<dim> pit_1 = construct_particle_iterator<dim>(
+    particle_handler, triangulation, position_1, id_1);
+  Particles::ParticleIterator<dim> pit_2 = construct_particle_iterator<dim>(
+    particle_handler, triangulation, position_2, id_2);
+
+  // Setting particle properties
+  Tensor<1, dim>     v_1{{0, 0, 0}};
+  Tensor<1, dim>     omega_1{{0, 0, 0}};
+  Tensor<1, dim>     v_2{{0, 0, 0}};
+  Tensor<1, dim>     omega_2{{0, 0, 0}};
+  const double       mass        = 1;
+  const unsigned int type        = 0;
+  const double       T_initial_1 = 600;
+  const double       T_initial_2 = 100;
+
+  set_particle_properties<dim, PropertiesIndex>(
+    pit_1, type, particle_diameter, mass, v_1, omega_1);
+  set_particle_properties<dim, PropertiesIndex>(
+    pit_2, type, particle_diameter, mass, v_2, omega_2);
+
+  pit_1->get_properties()[PropertiesIndex::T]             = T_initial_1;
+  pit_1->get_properties()[PropertiesIndex::specific_heat] = specific_heat;
+
+  pit_2->get_properties()[PropertiesIndex::T]             = T_initial_2;
+  pit_2->get_properties()[PropertiesIndex::specific_heat] = specific_heat;
+
+  // Initializing variables
+  std::vector<Tensor<1, 3>> torque;
+  std::vector<Tensor<1, 3>> force;
+  std::vector<double>       MOI;
+  std::vector<double>       heat_transfer;
+
+  particle_handler.sort_particles_into_subdomains_and_cells();
+  force.resize(particle_handler.get_max_local_particle_index());
+  torque.resize(force.size());
+  MOI.resize(force.size());
+  for (auto &moi_val : MOI)
+    moi_val = 1;
+  heat_transfer.resize(force.size());
+
+  contact_manager.update_local_particles_in_cells(particle_handler);
+
+  // Dummy Adaptive sparse contacts object and particle-particle broad search
+  AdaptiveSparseContacts<dim, PropertiesIndex> dummy_adaptive_sparse_contacts;
+  contact_manager.execute_particle_particle_broad_search(
+    particle_handler, dummy_adaptive_sparse_contacts);
+
+  // Calling fine search
+  contact_manager.execute_particle_particle_fine_search(neighborhood_threshold);
+
+  // Calculating and applying contact force and heat transfer
+  ParticleParticleContactForce<
+    dim,
+    PropertiesIndex,
+    Parameters::Lagrangian::ParticleParticleContactForceModel::
+      hertz_mindlin_limit_overlap,
+    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
+    nonlinear_force_object(dem_parameters);
+  nonlinear_force_object
+    .calculate_particle_particle_contact_force_and_heat_transfer(
+      contact_manager.get_local_adjacent_particles(),
+      contact_manager.get_ghost_adjacent_particles(),
+      contact_manager.get_local_local_periodic_adjacent_particles(),
+      contact_manager.get_local_ghost_periodic_adjacent_particles(),
+      contact_manager.get_ghost_local_periodic_adjacent_particles(),
+      dt,
+      torque,
+      force,
+      heat_transfer);
+
+  // Output
+  auto particle_one = particle_handler.begin();
+  deallog << "The heat transfer applied to particle one is "
+          << heat_transfer[particle_one->get_id()] << " J/s." << std::endl;
+}
+
+int
+main(int argc, char **argv)
+{
+  try
+    {
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+      initlog();
+      test<3, DEM::DEMMPProperties::PropertiesIndex>();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  return 0;
+}

--- a/tests/dem/particle_particle_heat_transfer.cc
+++ b/tests/dem/particle_particle_heat_transfer.cc
@@ -115,7 +115,7 @@ test()
   std::vector<Tensor<1, 3>> torque;
   std::vector<Tensor<1, 3>> force;
   std::vector<double>       MOI;
-  std::vector<double>       heat_transfer;
+  std::vector<double>       heat_transfer_rate;
 
   particle_handler.sort_particles_into_subdomains_and_cells();
   force.resize(particle_handler.get_max_local_particle_index());
@@ -123,7 +123,7 @@ test()
   MOI.resize(force.size());
   for (auto &moi_val : MOI)
     moi_val = 1;
-  heat_transfer.resize(force.size());
+  heat_transfer_rate.resize(force.size());
 
   contact_manager.update_local_particles_in_cells(particle_handler);
 
@@ -135,7 +135,7 @@ test()
   // Calling fine search
   contact_manager.execute_particle_particle_fine_search(neighborhood_threshold);
 
-  // Calculating and applying contact force and heat transfer
+  // Calculating and applying contact force and heat transfer rate
   ParticleParticleContactForce<
     dim,
     PropertiesIndex,
@@ -144,7 +144,7 @@ test()
     Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
     nonlinear_force_object(dem_parameters);
   nonlinear_force_object
-    .calculate_particle_particle_contact_force_and_heat_transfer(
+    .calculate_particle_particle_contact_force_and_heat_transfer_rate(
       contact_manager.get_local_adjacent_particles(),
       contact_manager.get_ghost_adjacent_particles(),
       contact_manager.get_local_local_periodic_adjacent_particles(),
@@ -153,12 +153,12 @@ test()
       dt,
       torque,
       force,
-      heat_transfer);
+      heat_transfer_rate);
 
   // Output
   auto particle_one = particle_handler.begin();
   deallog << "The heat transfer applied to particle one is "
-          << heat_transfer[particle_one->get_id()] << " J/s." << std::endl;
+          << heat_transfer_rate[particle_one->get_id()] << " J/s." << std::endl;
 }
 
 int

--- a/tests/dem/particle_particle_heat_transfer.output
+++ b/tests/dem/particle_particle_heat_transfer.output
@@ -1,0 +1,2 @@
+
+DEAL::The heat transfer applied to particle one is -1.56046 J/s.

--- a/tests/dem/particle_particle_thermal_resistances.cc
+++ b/tests/dem/particle_particle_thermal_resistances.cc
@@ -118,7 +118,7 @@ test()
   std::vector<Tensor<1, 3>> torque;
   std::vector<Tensor<1, 3>> force;
   std::vector<double>       MOI;
-  std::vector<double>       heat_transfer;
+  std::vector<double>       heat_transfer_rate;
 
   particle_handler.sort_particles_into_subdomains_and_cells();
   force.resize(particle_handler.get_max_local_particle_index());
@@ -126,7 +126,7 @@ test()
   MOI.resize(force.size());
   for (auto &moi_val : MOI)
     moi_val = 1;
-  heat_transfer.resize(force.size());
+  heat_transfer_rate.resize(force.size());
 
   contact_manager.update_local_particles_in_cells(particle_handler);
 
@@ -147,7 +147,7 @@ test()
     Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
     nonlinear_force_object(dem_parameters);
   nonlinear_force_object
-    .calculate_particle_particle_contact_force_and_heat_transfer(
+    .calculate_particle_particle_contact_force_and_heat_transfer_rate(
       contact_manager.get_local_adjacent_particles(),
       contact_manager.get_ghost_adjacent_particles(),
       contact_manager.get_local_local_periodic_adjacent_particles(),
@@ -156,7 +156,7 @@ test()
       dt,
       torque,
       force,
-      heat_transfer);
+      heat_transfer_rate);
 
   // Calculating additional parameters for thermal DEM
   auto     particle_one          = particle_handler.begin();

--- a/tests/dem/particle_particle_thermal_resistances.cc
+++ b/tests/dem/particle_particle_thermal_resistances.cc
@@ -35,24 +35,21 @@ test()
   Parameters::Lagrangian::ModelParameters<dim> &model_param =
     dem_parameters.model_parameters;
 
+  set_default_dem_parameters(1, dem_parameters);
+
   const Tensor<1, dim> g{{0, 0, 0}};
-  const double         dt                                    = 0.001;
-  const double         particle_diameter                     = 0.01;
-  const double         youngs_modulus                        = 5000000;
-  const double         poisson_ratio                         = 0.22;
-  const double         specific_heat                         = 840;
-  properties.particle_type_number                            = 1;
-  properties.youngs_modulus_particle[0]                      = youngs_modulus;
-  properties.poisson_ratio_particle[0]                       = poisson_ratio;
-  properties.restitution_coefficient_particle[0]             = 0.8;
-  properties.friction_coefficient_particle[0]                = 1;
-  properties.rolling_friction_coefficient_particle[0]        = 0.02;
-  properties.density_particle[0]                             = 2521;
-  properties.rolling_viscous_damping_coefficient_particle[0] = 0.;
-  properties.surface_energy_particle[0]                      = 0.;
-  properties.hamaker_constant_particle[0]                    = 0.;
-  model_param.rolling_resistance_method =
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
+  const double         dt                             = 0.001;
+  const double         particle_diameter              = 0.01;
+  const double         youngs_modulus                 = 5000000;
+  const double         poisson_ratio                  = 0.22;
+  const double         specific_heat                  = 840;
+  properties.particle_type_number                     = 1;
+  properties.youngs_modulus_particle[0]               = youngs_modulus;
+  properties.poisson_ratio_particle[0]                = poisson_ratio;
+  properties.restitution_coefficient_particle[0]      = 0.8;
+  properties.friction_coefficient_particle[0]         = 1;
+  properties.rolling_friction_coefficient_particle[0] = 0.02;
+  properties.density_particle[0]                      = 2521;
 
   const double neighborhood_threshold = std::pow(1.3 * particle_diameter, 2);
 
@@ -121,6 +118,7 @@ test()
   std::vector<Tensor<1, 3>> torque;
   std::vector<Tensor<1, 3>> force;
   std::vector<double>       MOI;
+  std::vector<double>       heat_transfer;
 
   particle_handler.sort_particles_into_subdomains_and_cells();
   force.resize(particle_handler.get_max_local_particle_index());
@@ -128,6 +126,7 @@ test()
   MOI.resize(force.size());
   for (auto &moi_val : MOI)
     moi_val = 1;
+  heat_transfer.resize(force.size());
 
   contact_manager.update_local_particles_in_cells(particle_handler);
 
@@ -147,15 +146,17 @@ test()
       hertz_mindlin_limit_overlap,
     Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
     nonlinear_force_object(dem_parameters);
-  nonlinear_force_object.calculate_particle_particle_contact_force(
-    contact_manager.get_local_adjacent_particles(),
-    contact_manager.get_ghost_adjacent_particles(),
-    contact_manager.get_local_local_periodic_adjacent_particles(),
-    contact_manager.get_local_ghost_periodic_adjacent_particles(),
-    contact_manager.get_ghost_local_periodic_adjacent_particles(),
-    dt,
-    torque,
-    force);
+  nonlinear_force_object
+    .calculate_particle_particle_contact_force_and_heat_transfer(
+      contact_manager.get_local_adjacent_particles(),
+      contact_manager.get_ghost_adjacent_particles(),
+      contact_manager.get_local_local_periodic_adjacent_particles(),
+      contact_manager.get_local_ghost_periodic_adjacent_particles(),
+      contact_manager.get_ghost_local_periodic_adjacent_particles(),
+      dt,
+      torque,
+      force,
+      heat_transfer);
 
   // Calculating additional parameters for thermal DEM
   auto     particle_one          = particle_handler.begin();


### PR DESCRIPTION
### Description

This PR adds the calculation of the heat transfer between particles directly within the calculation of the contact force. 
In multiphysic DEM, calculate_particle_particle_contact_force_and_heat_transfer should be called instead of calculate_particle_particle_contact_force.  The function calculate_particle_particle_contact_force should still be used in pure DEM or CFD-DEM.

### Testing

A test particle_particle_heat_transfer is added, it checks the value of the heat transfer between two particles.
Other tests should not be impacted.

### Documentation

<!-- Does this new feature introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [ ] Lethe documentation is up to date
- [x] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge