### PR TITLE
Fix level set output when geometry is moving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2025-04-13
+
+### Fixed
+
+- MINOR In the sharp immersed boundaries solver, added a condition that clears the combined_shape cache if a particle has moved. This fixes a bug that would lead to an incorrect level set function when particles would move accross subdomains. This only affected the visualization of the particles. [#1479](https://github.com/chaos-polymtl/lethe/pull/1495)
+
+
 ## [Master] - 2025-04-10
 
 ### Added

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -1687,6 +1687,8 @@ template <int dim>
 void
 FluidDynamicsSharp<dim>::output_field_hook(DataOut<dim> &data_out)
 {
+  // If the particles have moved, the combined shapes will have been cleared by
+  // the particle integration routines.
   levelset_postprocessor =
     std::make_shared<LevelsetPostprocessor<dim>>(combined_shapes);
   data_out.add_data_vector(this->present_solution, *levelset_postprocessor);
@@ -2170,10 +2172,17 @@ FluidDynamicsSharp<dim>::integrate_particles()
 
       unsigned int worst_residual_particle_id = UINT_MAX;
 
+      bool clear_combined_shape_cache = false;
+
       for (unsigned int p = 0; p < particles.size(); ++p)
         {
           if (particles[p].integrate_motion)
             {
+              // If the motion of a single particle is to be integrated, the
+              // combined cache should be cleared after the integration.
+              // Otherwise, the visualization of the level set will be wrong.
+              clear_combined_shape_cache = true;
+
               // calculate the volume of fluid displaced by the particle.
               double volume = particles[p].volume;
 
@@ -2563,17 +2572,18 @@ FluidDynamicsSharp<dim>::integrate_particles()
                     particles[p].previous_orientation[0])
                 {
                   particles[p].clear_shape_cache();
+                  // One particle h as moved significantly, the combined shape
+                  // cache should be cleared for visualization purposes.
+                  clear_combined_shape_cache = true;
                 }
-              if (particles[p].position != particles[p].previous_positions[0] ||
-                  particles[p].orientation !=
-                    particles[p].previous_orientation[0])
-                {
-                  particles[p].clear_shape_cache();
-                }
+
               particles[p].set_position(particles[p].position);
               particles[p].set_orientation(particles[p].orientation);
             }
         }
+
+      if (clear_combined_shape_cache)
+        combined_shapes->clear_cache();
 
 
       if (this->simulation_parameters.non_linear_solver

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -2572,7 +2572,7 @@ FluidDynamicsSharp<dim>::integrate_particles()
                     particles[p].previous_orientation[0])
                 {
                   particles[p].clear_shape_cache();
-                  // One particle h as moved significantly, the combined shape
+                  // One particle has moved significantly: the combined shape
                   // cache should be cleared for visualization purposes.
                   clear_combined_shape_cache = true;
                 }


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The caching mechanism for the level set calculation  prevented the recalculation of the combined_shape level set when the particles were moving.

### Solution

Added a check that forces clearing the level set cache of the combined_shape for the cases where particle motion is imposed OR particle integration.

### Testing

No test results should change. I'm not sure how to test this adequately at the moment so that this bug never happens again, I'll try to figure out a test in a follow-up PR. This was a visualization bug.

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge