### PR TITLE
Update initlog

### DIFF
--- a/tests/dem/particle_particle_contact_on_two_processors.mpirun=2.output
+++ b/tests/dem/particle_particle_contact_on_two_processors.mpirun=2.output
@@ -99,3 +99,4 @@ DEAL::The location of particle 0 is: 0.00000 0.00424622
 DEAL::The location of particle 0 is: 0.00000 0.00429122
 DEAL::The location of particle 0 is: 0.00000 0.00433623
 DEAL::The location of particle 0 is: 0.00000 0.00438123
+

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -463,7 +463,7 @@ initlog(bool                          console = false,
                                               std::ios::left)
 {
   deallogname = "output";
-  deallogfile.open(deallogname.c_str());
+  deallogfile.open(deallogname.c_str(), std::ios::app);
   deallog.attach(deallogfile, true, flags);
   deallog.depth_console(console ? 10 : 0);
 }


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->
For mpi communication, the `initlog()` function for the tests was printing information only from one mpi process. It has been updated to allow one to print the information from more than one/all mpi processes, which will be useful for future tests.
 
### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->
`initlog()` now allows us to append data from different mpi processes into the same output file.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->
All previous tests still pass.

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge