### PR TITLE
Add find-line-sphere-intersection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Master] - 2025-04-24
 
+### Added
+
+- MINOR This PR Adds the find_line_sphere_intersection in lethe_grid_tools for use in the case of ray-particle intersection for the profilometry hackathon project. This function simply evaluates all intersection points between a line and a sphere. [#1511] (https://github.com/chaos-polymtl/lethe/pull/1511)
+
+## [Master] - 2025-04-24
+
 ### Changed
 
 - MAJOR The parameters of the function which calculates the contact force, torque and heat transfer rate between particles were changed. Parameters torque, force and heat_transfer_rate were replaced by a class object ParticleInteractionOutcomes where they are stored. A function to resize these containers is also implemented in the class. [#1504](https://github.com/chaos-polymtl/lethe/pull/1504) 

--- a/include/core/lethe_grid_tools.h
+++ b/include/core/lethe_grid_tools.h
@@ -328,15 +328,16 @@ namespace LetheGridTools
    * @param[in] line_direction The direction of the line
    * @param[in] sphere_center The center of the sphere
    * @param[in] sphere_radius The radius of the sphere
-   * @param[out] intersection_points A vector to store the intersection points
+   * @return A vector of points that are the intersection points between the line
+   * and the sphere. The vector can be empty if there is no intersection, or
+   * contain one or two points if there is an intersection.
    */
   template <int dim>
-  void
+  std::vector<Point<dim>>
   find_line_sphere_intersection(const Point<dim>        &line_start,
                                 const Tensor<1, dim>    &line_direction,
                                 const Point<dim>        &sphere_center,
-                                const double            &sphere_radius,
-                                std::vector<Point<dim>> &intersection_points);
+                                const double            &sphere_radius);
 
 
   /**

--- a/include/core/lethe_grid_tools.h
+++ b/include/core/lethe_grid_tools.h
@@ -324,11 +324,11 @@ namespace LetheGridTools
    * reference is available at:
    * https://www.sciencedirect.com/science/article/pii/B978155860594750014X
    * 
-   * @param line_start The starting point of the line
-   * @param line_direction The direction of the line
-   * @param sphere_center The center of the sphere
-   * @param sphere_radius The radius of the sphere
-   * @param intersection_points A vector to store the intersection points
+   * @param[in] line_start The starting point of the line
+   * @param[in] line_direction The direction of the line
+   * @param[in] sphere_center The center of the sphere
+   * @param[in] sphere_radius The radius of the sphere
+   * @param[out] intersection_points A vector to store the intersection points
    */
   template <int dim>
   void

--- a/include/core/lethe_grid_tools.h
+++ b/include/core/lethe_grid_tools.h
@@ -316,6 +316,29 @@ namespace LetheGridTools
   find_point_triangle_distance(const std::vector<Point<dim>> &triangle_vertices,
                                const Point<dim>              &point);
 
+
+  /**
+   * @brief Calculates the intersection points between a line and a sphere. The
+   * full calculation is taken from  Geometric Tools for Computer Graphics,
+   * Eberly 2003 Chapter 11.3.2 - LINEAR COMPONENTS AND A SPHERE. The entire
+   * reference is available at:
+   * https://www.sciencedirect.com/science/article/pii/B978155860594750014X
+   * 
+   * @param line_start The starting point of the line
+   * @param line_direction The direction of the line
+   * @param sphere_center The center of the sphere
+   * @param sphere_radius The radius of the sphere
+   * @param intersection_points A vector to store the intersection points
+   */
+  template <int dim>
+  void
+  find_line_sphere_intersection(const Point<dim>        &line_start,
+                                const Tensor<1, dim>    &line_direction,
+                                const Point<dim>        &sphere_center,
+                                const double            &sphere_radius,
+                                std::vector<Point<dim>> &intersection_points);
+
+
   /**
    * @brief Calculate the minimum distance between a point and a line (defined using
    * its orign and direction). The full calculation is taken from

--- a/include/core/lethe_grid_tools.h
+++ b/include/core/lethe_grid_tools.h
@@ -323,7 +323,7 @@ namespace LetheGridTools
    * Eberly 2003 Chapter 11.3.2 - LINEAR COMPONENTS AND A SPHERE. The entire
    * reference is available at:
    * https://www.sciencedirect.com/science/article/pii/B978155860594750014X
-   * 
+   *
    * @param[in] line_start The starting point of the line
    * @param[in] line_direction The direction of the line
    * @param[in] sphere_center The center of the sphere
@@ -334,10 +334,10 @@ namespace LetheGridTools
    */
   template <int dim>
   std::vector<Point<dim>>
-  find_line_sphere_intersection(const Point<dim>        &line_start,
-                                const Tensor<1, dim>    &line_direction,
-                                const Point<dim>        &sphere_center,
-                                const double            &sphere_radius);
+  find_line_sphere_intersection(const Point<dim>     &line_start,
+                                const Tensor<1, dim> &line_direction,
+                                const Point<dim>     &sphere_center,
+                                const double         &sphere_radius);
 
 
   /**

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -1731,13 +1731,12 @@ LetheGridTools::find_point_triangle_distance(
   const Point<3>              &point);
 
 template <int dim>
-void
+std::vector<Point<dim>>
 LetheGridTools::find_line_sphere_intersection(
   const Point<dim>        &line_start,
   const Tensor<1, dim>    &line_direction,
   const Point<dim>        &sphere_center,
-  const double            &sphere_radius,
-  std::vector<Point<dim>> &intersection_points)
+  const double            &sphere_radius)
 {
   // Calculate the coefficients of the quadratic equation
   const double a = line_direction.norm_square();
@@ -1745,20 +1744,19 @@ LetheGridTools::find_line_sphere_intersection(
   const double c =
     (line_start - sphere_center).norm_square() - sphere_radius * sphere_radius;
 
+  // Initialize the vector to store intersection points
+  // Note: This vector will be empty if there are no intersection points
+  std::vector<Point<dim>> intersection_points;
+
   // Calculate the discriminant
   const double discriminant = b * b - 4 * a * c;
-  if (discriminant < 0.)
-    {
-      // No intersection
-      return;
-    }
-  else if (discriminant == 0.)
+  if (discriminant == 0.)
     {
       // One intersection point
       const double t = -b / (2. * a);
       intersection_points.push_back(line_start + t * line_direction);
     }
-  else
+  else if (discriminant > 0.)
     {
       // Two intersection points
       const double sqrt_discriminant = std::sqrt(discriminant);
@@ -1768,19 +1766,21 @@ LetheGridTools::find_line_sphere_intersection(
       intersection_points.push_back(line_start + t1 * line_direction);
       intersection_points.push_back(line_start + t2 * line_direction);
     }
+  // If the discriminant is negative, there are no intersection points therefore 
+  // the vector remains empty
+
+  return intersection_points;
 }
 
-template void
+template std::vector<Point<2>>
 LetheGridTools::find_line_sphere_intersection(
   const Point<2>        &line_start,
   const Tensor<1, 2>    &line_direction,
   const Point<2>        &sphere_center,
-  const double          &sphere_radius,
-  std::vector<Point<2>> &intersection_points);
-template void
+  const double          &sphere_radius);
+template std::vector<Point<3>>
 LetheGridTools::find_line_sphere_intersection(
   const Point<3>        &line_start,
   const Tensor<1, 3>    &line_direction,
   const Point<3>        &sphere_center,
-  const double          &sphere_radius,
-  std::vector<Point<3>> &intersection_points);
+  const double          &sphere_radius);

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -1733,14 +1733,15 @@ LetheGridTools::find_point_triangle_distance(
 template <int dim>
 std::vector<Point<dim>>
 LetheGridTools::find_line_sphere_intersection(
-  const Point<dim>        &line_start,
-  const Tensor<1, dim>    &line_direction,
-  const Point<dim>        &sphere_center,
-  const double            &sphere_radius)
+  const Point<dim>     &line_start,
+  const Tensor<1, dim> &line_direction,
+  const Point<dim>     &sphere_center,
+  const double         &sphere_radius)
 {
   // Calculate the coefficients of the quadratic equation
   const double a = line_direction.norm_square();
-  const double b = 2 * scalar_product(line_direction, line_start - sphere_center);
+  const double b =
+    2 * scalar_product(line_direction, line_start - sphere_center);
   const double c =
     (line_start - sphere_center).norm_square() - sphere_radius * sphere_radius;
 
@@ -1760,13 +1761,13 @@ LetheGridTools::find_line_sphere_intersection(
     {
       // Two intersection points
       const double sqrt_discriminant = std::sqrt(discriminant);
-      const double t1               = (-b - sqrt_discriminant) / (2. * a);
-      const double t2               = (-b + sqrt_discriminant) / (2. * a);
+      const double t1                = (-b - sqrt_discriminant) / (2. * a);
+      const double t2                = (-b + sqrt_discriminant) / (2. * a);
 
       intersection_points.push_back(line_start + t1 * line_direction);
       intersection_points.push_back(line_start + t2 * line_direction);
     }
-  // If the discriminant is negative, there are no intersection points therefore 
+  // If the discriminant is negative, there are no intersection points therefore
   // the vector remains empty
 
   return intersection_points;
@@ -1774,13 +1775,13 @@ LetheGridTools::find_line_sphere_intersection(
 
 template std::vector<Point<2>>
 LetheGridTools::find_line_sphere_intersection(
-  const Point<2>        &line_start,
-  const Tensor<1, 2>    &line_direction,
-  const Point<2>        &sphere_center,
-  const double          &sphere_radius);
+  const Point<2>     &line_start,
+  const Tensor<1, 2> &line_direction,
+  const Point<2>     &sphere_center,
+  const double       &sphere_radius);
 template std::vector<Point<3>>
 LetheGridTools::find_line_sphere_intersection(
-  const Point<3>        &line_start,
-  const Tensor<1, 3>    &line_direction,
-  const Point<3>        &sphere_center,
-  const double          &sphere_radius);
+  const Point<3>     &line_start,
+  const Tensor<1, 3> &line_direction,
+  const Point<3>     &sphere_center,
+  const double       &sphere_radius);

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -1729,3 +1729,58 @@ template double
 LetheGridTools::find_point_triangle_distance(
   const std::vector<Point<3>> &triangle,
   const Point<3>              &point);
+
+template <int dim>
+void
+LetheGridTools::find_line_sphere_intersection(
+  const Point<dim>        &line_start,
+  const Tensor<1, dim>    &line_direction,
+  const Point<dim>        &sphere_center,
+  const double            &sphere_radius,
+  std::vector<Point<dim>> &intersection_points)
+{
+  // Calculate the coefficients of the quadratic equation
+  double a = line_direction.norm_square();
+  double b = 2 * scalar_product(line_direction, line_start - sphere_center);
+  double c =
+    (line_start - sphere_center).norm_square() - sphere_radius * sphere_radius;
+
+  // Calculate the discriminant
+  double discriminant = b * b - 4 * a * c;
+  if (discriminant < 0)
+    {
+      // No intersection
+      return;
+    }
+  else if (discriminant == 0)
+    {
+      // One intersection point
+      double t = -b / (2 * a);
+      intersection_points.push_back(line_start + t * line_direction);
+    }
+  else
+    {
+      // Two intersection points
+      double sqrt_discriminant = std::sqrt(discriminant);
+      double t1               = (-b - sqrt_discriminant) / (2 * a);
+      double t2               = (-b + sqrt_discriminant) / (2 * a);
+
+      intersection_points.push_back(line_start + t1 * line_direction);
+      intersection_points.push_back(line_start + t2 * line_direction);
+    }
+}
+
+template void
+LetheGridTools::find_line_sphere_intersection(
+  const Point<2>        &line_start,
+  const Tensor<1, 2>    &line_direction,
+  const Point<2>        &sphere_center,
+  const double          &sphere_radius,
+  std::vector<Point<2>> &intersection_points);
+template void
+LetheGridTools::find_line_sphere_intersection(
+  const Point<3>        &line_start,
+  const Tensor<1, 3>    &line_direction,
+  const Point<3>        &sphere_center,
+  const double          &sphere_radius,
+  std::vector<Point<3>> &intersection_points);

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -1740,30 +1740,30 @@ LetheGridTools::find_line_sphere_intersection(
   std::vector<Point<dim>> &intersection_points)
 {
   // Calculate the coefficients of the quadratic equation
-  double a = line_direction.norm_square();
-  double b = 2 * scalar_product(line_direction, line_start - sphere_center);
-  double c =
+  const double a = line_direction.norm_square();
+  const double b = 2 * scalar_product(line_direction, line_start - sphere_center);
+  const double c =
     (line_start - sphere_center).norm_square() - sphere_radius * sphere_radius;
 
   // Calculate the discriminant
-  double discriminant = b * b - 4 * a * c;
-  if (discriminant < 0)
+  const double discriminant = b * b - 4 * a * c;
+  if (discriminant < 0.)
     {
       // No intersection
       return;
     }
-  else if (discriminant == 0)
+  else if (discriminant == 0.)
     {
       // One intersection point
-      double t = -b / (2 * a);
+      const double t = -b / (2. * a);
       intersection_points.push_back(line_start + t * line_direction);
     }
   else
     {
       // Two intersection points
-      double sqrt_discriminant = std::sqrt(discriminant);
-      double t1               = (-b - sqrt_discriminant) / (2 * a);
-      double t2               = (-b + sqrt_discriminant) / (2 * a);
+      const double sqrt_discriminant = std::sqrt(discriminant);
+      const double t1               = (-b - sqrt_discriminant) / (2. * a);
+      const double t2               = (-b + sqrt_discriminant) / (2. * a);
 
       intersection_points.push_back(line_start + t1 * line_direction);
       intersection_points.push_back(line_start + t2 * line_direction);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

This PR Adds the find_line_sphere_intersection in lethe_grid_tools for use in the case of ray-particle intersection for the profilometry hackathon project. This function simply evaluates all intersection points between a line and a sphere.

### Testing

The methodology was tested locally for both 2D and 3D intersection.

### Documentation

No new documentation needed.

### Miscellaneous (will be removed when merged)

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge