### PR TITLE
Fix jacobian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MINOR The find_cell_neighbors is now templated with a boolean so that neighboring cell vectors can be reciprocal, which means that vector i and j will contain cell j and i, respectively. [#1512](https://github.com/chaos-polymtl/lethe/pull/1512)
 
+## [Master] - 2025-04-25
+
+### Fixed
+
+- MINOR The Jacobian of the non-Newtonian GLS assembler has an error in the advection term. This has been fixed. [#1513] (https://github.com/chaos-polymtl/lethe/pull/1513)
+
+## [Master] - 2025-04-24
+
 ### Added
 
 - MINOR This PR Adds the find_line_sphere_intersection in lethe_grid_tools for use in the case of ray-particle intersection for the profilometry hackathon project. This function simply evaluates all intersection points between a line and a sphere. [#1511] (https://github.com/chaos-polymtl/lethe/pull/1511)

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -777,7 +777,7 @@ GLSNavierStokesAssemblerNonNewtonianCore<dim>::assemble_matrix(
                   shear_rate_magnitude *
                   scalar_product(grad_phi_u_j_non_newtonian, shear_rate) *
                   scalar_product(shear_rate, grad_phi_u_i) +
-                velocity_gradient_x_phi_u_j[j] * 0.5 * phi_u_i +
+                velocity_gradient_x_phi_u_j[j] * phi_u_i +
                 grad_phi_u_j_x_velocity[j] * phi_u_i - div_phi_u_i * phi_p_j +
                 mass_source * phi_u_j * phi_u_i +
                 // Continuity


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The Jacobian of the Navier-stokes equation for non-newtonian GLS had a small typo (an extra 0.5*)

### Solution

Removes the small typo

### Testing

All tests pass and the number of Newton iteration has decreased at higher Reynolds number.

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge