### PR TITLE
Fix two warnings

### DIFF
--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -4166,7 +4166,7 @@ namespace Parameters
                         "Center of rotation coordinates of rotor domain");
     }
     prm.leave_subsection();
-  };
+  }
 
   template <int dim>
   void

--- a/source/dem/insertion_volume.cc
+++ b/source/dem/insertion_volume.cc
@@ -190,7 +190,7 @@ InsertionVolume<dim, PropertiesIndex>::find_insertion_location_volume(
   std::vector<int> insertion_index;
   insertion_index.resize(dim);
 
-  unsigned int axis_0, axis_1, axis_2;
+  unsigned int axis_0, axis_1;
   int          number_of_particles_0, number_of_particles_1;
 
   // First direction (axis) to have particles inserted
@@ -228,6 +228,7 @@ InsertionVolume<dim, PropertiesIndex>::find_insertion_location_volume(
                                    this->maximum_diameter;
 
       // Third direction (axis) to have particles inserted
+      unsigned int axis_2;
       axis_2 = insertion_information.direction_sequence.at(2);
       insertion_index[axis_2] =
         static_cast<int>(id / (number_of_particles_0 * number_of_particles_1));


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

This PR removes a semicolon and moves a variable within the scope of an if-statement to fix two warnings.

