### PR TITLE
Add buoyancy term to matrix-free operators and GMG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2025-05-09
+
+### Added
+
+- MAJOR Added the buoyancy term to the matrix free operators to be able to support two way coupling between the heat transfer solver and the matrix-free fluid solver. In the GMG preconditioner the temperature solution is also transfered to all the MG levels. [#1524](https://github.com/chaos-polymtl/lethe/pull/1524)
+
 ## [Master] - 2025-05-07
 
 ### Fixed

--- a/include/solvers/fluid_dynamics_matrix_free.h
+++ b/include/solvers/fluid_dynamics_matrix_free.h
@@ -290,6 +290,17 @@ protected:
   /// Vector holding number of coarse grid iterations
   mutable std::vector<unsigned int> coarse_grid_iterations;
 
+  /// Temperature DoF handlers for each of the levels of the global coarsening
+  /// algorithm
+  MGLevelObject<DoFHandler<dim>> temperature_dof_handlers;
+
+  /// Temperature transfers for each of the levels of the global coarsening
+  /// algorithm
+  MGLevelObject<MGTwoLevelTransfer<dim, MGVectorType>> transfers_temperature;
+
+  /// Transfer operator for global coarsening for the temperature
+  std::shared_ptr<GCTransferType> mg_transfer_gc_temperature;
+
 public:
   /// Timer for specific geometric multigrid components.
   mutable TimerOutput mg_setup_timer;
@@ -312,7 +323,7 @@ public:
   using MGVectorType =
     typename MFNavierStokesPreconditionGMGBase<dim>::MGVectorType;
   using MGNumber = typename MFNavierStokesPreconditionGMGBase<dim>::MGNumber;
-
+  using GCTransferType = MGTransferGlobalCoarsening<dim, MGVectorType>;
 
   /**
    * Constructor.
@@ -346,6 +357,21 @@ public:
              FlowControl<dim>                         &flow_control,
              const VectorType                         &present_solution,
              const VectorType &time_derivative_previous_solutions);
+
+  /**
+   * @brief Transfer the current temperature solution to the different multigrid levels and compute the buoyancy term in each of the multigrid operators.
+   *
+   * @param[in] temperature_dof_handler DoF Handler used for the heat transfer.
+   * @param[in] temperature_present_solution Present solution of the temperature
+   * as given by the multiphysics interface.
+   * @param[in] physical_properties_manager Properties manager to extract
+   * thermal expansion coefficient and the reference temperature.
+   */
+  void
+  initialize_auxiliary_physics(
+    const DoFHandler<dim>           &temperature_dof_handler,
+    const VectorType                &temperature_present_solution,
+    const PhysicalPropertiesManager &physical_properties_manager);
 };
 
 /**

--- a/include/solvers/fluid_dynamics_matrix_free.h
+++ b/include/solvers/fluid_dynamics_matrix_free.h
@@ -445,6 +445,14 @@ protected:
   virtual void
   update_solutions_for_multiphysics() override;
 
+
+  /**
+   * @brief  Provide present multiphysics solutions from the multiphysics
+   * interface to the fluid dynamics.
+   */
+  virtual void
+  update_solutions_for_fluid_dynamics() override;
+
   /**
    * @brief Calculate and store time derivatives of previous solutions according to
    * time-stepping scheme to use them in the operator.
@@ -585,6 +593,12 @@ protected:
    *
    */
   std::vector<TrilinosWrappers::MPI::Vector> multiphysics_previous_solutions;
+
+  /**
+   * @brief Vector storing the present temperature solution from the heat transfer solver.
+   *
+   */
+  VectorType temperature_present_solution;
 };
 
 #endif

--- a/include/solvers/fluid_dynamics_matrix_free_operators.h
+++ b/include/solvers/fluid_dynamics_matrix_free_operators.h
@@ -216,6 +216,16 @@ public:
   void
   compute_forcing_term();
 
+
+  /**
+   * @brief Precompute buoyancy term for heat-transfer coupling.
+   */
+  void
+  compute_buoyancy_term(
+    const VectorType                &temperature_solution,
+    const DoFHandler<dim>           &temperature_dof_handler,
+    const PhysicalPropertiesManager &physical_properties_manager);
+
   /**
    * @brief Get the total number of DoFs.
    *
@@ -599,6 +609,13 @@ protected:
    *
    */
   Table<2, Tensor<1, dim, VectorizedArray<number>>> forcing_terms;
+
+
+  /**
+   * @brief Table with precomputed buoyancy term values.
+   *
+   */
+  Table<2, Tensor<1, dim, VectorizedArray<number>>> buoyancy_term;
 
   /**
    * @brief Flag to turn the calculation of face terms on or off.

--- a/include/solvers/fluid_dynamics_matrix_free_operators.h
+++ b/include/solvers/fluid_dynamics_matrix_free_operators.h
@@ -220,9 +220,9 @@ public:
   /**
    * @brief Precompute buoyancy term for heat-transfer coupling.
    *
-   * @param[in] temperature_dof_handler DoF Handler used for the heat transfer.
-   * @param[in] temperature_present_solution Present solution of the temperature
+   * @param[in] temperature_solution Present solution of the temperature
    * as given by the multiphysics interface.
+   * @param[in] temperature_dof_handler DoF Handler used for the heat transfer.
    * @param[in] physical_properties_manager Properties manager to extract
    * thermal expansion coefficient and the reference temperature.
    */

--- a/include/solvers/fluid_dynamics_matrix_free_operators.h
+++ b/include/solvers/fluid_dynamics_matrix_free_operators.h
@@ -219,6 +219,12 @@ public:
 
   /**
    * @brief Precompute buoyancy term for heat-transfer coupling.
+   *
+   * @param[in] temperature_dof_handler DoF Handler used for the heat transfer.
+   * @param[in] temperature_present_solution Present solution of the temperature
+   * as given by the multiphysics interface.
+   * @param[in] physical_properties_manager Properties manager to extract
+   * thermal expansion coefficient and the reference temperature.
    */
   void
   compute_buoyancy_term(

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -314,6 +314,13 @@ protected:
   update_solutions_for_multiphysics()
   {}
 
+  /**
+   * @brief  Required only for the matrix-free solver to update multiphysics solutions within iterate function.
+   */
+  virtual void
+  update_solutions_for_fluid_dynamics()
+  {}
+
   virtual void
   set_initial_condition_fd(
     Parameters::InitialConditionType initial_condition_type,

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -2194,10 +2194,12 @@ FluidDynamicsMatrixFree<dim>::solve()
       if (this->multiphysics->get_active_physics().size() > 1)
         {
           update_solutions_for_fluid_dynamics();
-          this->system_operator->compute_buoyancy_term(
-            temperature_present_solution,
-            *this->multiphysics->get_dof_handler(PhysicsID::heat_transfer),
-            this->simulation_parameters.physical_properties_manager);
+
+          if (this->simulation_parameters.multiphysics.buoyancy_force)
+            this->system_operator->compute_buoyancy_term(
+              temperature_present_solution,
+              *this->multiphysics->get_dof_handler(PhysicsID::heat_transfer),
+              this->simulation_parameters.physical_properties_manager);
         }
 
       this->iterate();
@@ -2680,7 +2682,7 @@ void
 FluidDynamicsMatrixFree<dim>::initialize_GMG()
 {
   // Initialize everything related to heat transfer within the MG algorithm
-  if (this->multiphysics->get_active_physics().size() > 1)
+  if (this->simulation_parameters.multiphysics.buoyancy_force)
     dynamic_cast<MFNavierStokesPreconditionGMG<dim> *>(gmg_preconditioner.get())
       ->initialize_auxiliary_physics(
         *this->multiphysics->get_dof_handler(PhysicsID::heat_transfer),

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -2070,6 +2070,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize_auxiliary_physics(
       this->mg_transfer_gc_temperature =
         std::make_shared<GCTransferType>(this->transfers_temperature);
 
+#if DEAL_II_VERSION_GTE(9, 7, 0)
       this->mg_transfer_gc_temperature->build(
         temperature_dof_handler, [&](const auto l, auto &vec) {
           vec.reinit(this->temperature_dof_handlers[l].locally_owned_dofs(),
@@ -2077,6 +2078,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize_auxiliary_physics(
                        this->temperature_dof_handlers[l]),
                      this->temperature_dof_handlers[l].get_mpi_communicator());
         });
+#endif
 
       MGLevelObject<MGVectorType> mg_temperature_solution(this->minlevel,
                                                           this->maxlevel);
@@ -2853,6 +2855,7 @@ FluidDynamicsMatrixFree<dim>::update_solutions_for_fluid_dynamics()
   const auto &heat_solution =
     *this->multiphysics->get_solution(PhysicsID::heat_transfer);
 
+#ifndef LETHE_USE_LDV
   const auto &heat_dof_handler =
     *this->multiphysics->get_dof_handler(PhysicsID::heat_transfer);
 
@@ -2872,6 +2875,9 @@ FluidDynamicsMatrixFree<dim>::update_solutions_for_fluid_dynamics()
   convert_vector_trilinos_to_dealii(this->temperature_present_solution,
                                     temp_heat_solution);
 
+#else
+  this->temperature_present_solution = heat_solution;
+#endif
   // Update ghost values for deal.II vector
   this->temperature_present_solution.update_ghost_values();
 }

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -357,10 +357,14 @@ NavierStokesOperatorBase<dim, number>::compute_buoyancy_term(
 
           for (const auto q : fe_values.quadrature_point_indices())
             {
+              // The following term is precomputed: (1 - β (T -Tref))
               const auto scaling =
                 1 - thermal_expansion[q] *
                       (cell_temperature_solution[q] - reference_temperature);
 
+              // Store in table the total buoyancy term given as:
+              // (1 - β (T -Tref))g where the g has already been precomputed in
+              // compute_forcing_term() function.
               for (unsigned int c = 0; c < dim; ++c)
                 buoyancy_term[cell][q][c][lane] =
                   forcing_terms[cell][q][c][lane] * scaling;

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -1315,7 +1315,9 @@ NavierStokesStabilizedOperator<dim, number>::do_cell_integral_local(
       Tensor<1, dim, VectorizedArray<number>> source_value;
 
       // Evaluate source term function if enabled
-      if (this->forcing_function)
+      if (!this->buoyancy_term.empty())
+        source_value = this->buoyancy_term(cell, q);
+      else if (this->forcing_function)
         source_value = this->forcing_terms(cell, q);
 
       // Add to source term the dynamic flow control force (zero if not
@@ -1538,7 +1540,9 @@ NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
           Tensor<1, dim, VectorizedArray<number>> source_value;
 
           // Evaluate source term function if enabled
-          if (this->forcing_function)
+          if (!this->buoyancy_term.empty())
+            source_value = this->buoyancy_term(cell, q);
+          else if (this->forcing_function)
             source_value = this->forcing_terms(cell, q);
 
           // Add to source term the dynamic flow control force (zero if not


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the content of the new feature
       What are the motivations? 
       How is it integrated to the current code? -->

This PR adds the implementation of the buoyancy term to the matrix-free operators, by implementing the following functionalities:
-  Add a function that gets the temperature solution from the multiphysics interface and converts it to deal.II vectors. 
- Precompute the buoyancy term using an FEValues object and a temperature DoFHandler. This is precomputed for its usage within the cell and residual loop of the operator.
- In order to use the GMG preconditioner an additional function `initialize_auxiliary_physics(...)` has been created. It transfers the current temperature solution to the different MG levels. 

### Testing

<!-- How has this been tested?
       What are the new test(s) and what feature(s)/parameter(s) does it test?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works?
       How will you ensure that it will continue to work in the future? -->

No changes in current tests should be observed. A test should be added in the future since more testing is needed regarding the effect of the buoyancy term into the smoothers/coarse-grid solution of the GMG. 

### Documentation

<!-- Does this new feature introduce new simulation parameters? If so, describe them. -->

Nothing has been added to the documentation yet, since it is still a feature that needs to be tested. 

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [X] Lethe documentation is up to date
- [X] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [X] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge