### PR TITLE
Correct year in changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,19 +3,19 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [Master] - 2024-05-07
+## [Master] - 2025-05-07
 
 ### Fixed
 
 - MINOR The solution preceding the algebraic interface reinitialization time-step is now also regularized using the same process to ensure consistency in the time integration scheme. This is done by replacing the relevant previous solution with the reinitialized previous solution. A new application-test (`vof-algebraic-interface-reinitialization-advected-circle-bdf2-frequency-check`) has been added to test this implementation. Also, a new validity map has been added to the VOFSubequationInterface. This ensures that subequations are solved using the correct VOF solution and in the right order. Subequations dependency checks are also made before solving each subequation. [#1507](https://github.com/chaos-polymtl/lethe/pull/1507)
 
-## [Master] - 2024-04-30
+## [Master] - 2025-04-30
 
 ### Added
 
 - MAJOR Multiphysic DEM simulations can now be launched with solver type dem_mp to follow the evolution of the temperature of the particles. The temperature is also added in the properties printed by application tests for the solver type dem_mp. [#1514](https://github.com/chaos-polymtl/lethe/pull/1514)
 
-## [Master] - 2024-04-25
+## [Master] - 2025-04-25
 
 ### Changed 
 
@@ -41,7 +41,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MAJOR The parameters of the function which calculates the contact force, torque and heat transfer rate between particles were changed. Parameters torque, force and heat_transfer_rate were replaced by a class object ParticleInteractionOutcomes where they are stored. A function to resize these containers is also implemented in the class. [#1504](https://github.com/chaos-polymtl/lethe/pull/1504)
 
-## [Master] - 2024-04-22
+## [Master] - 2025-04-22
 
 ### Added 
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

Fix some recent entries in the changelog file that state 2024 instead of 2025. 
