### PR TITLE
Update define_constraints Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2025-05-20
+
+### Fixed
+
+- MINOR The functions used to define constraints in navier_stokes_base were calling reinit() without passing the locally_owned_dofs. This caused the constraints object to not have the updated locally owned DoFs in each process. This has now been fixed. [#1533](https://github.com/chaos-polymtl/lethe/pull/1533)
+
 ## [Master] - 2025-05-09
 
 ### Added

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1764,11 +1764,13 @@ NavierStokesBase<dim, VectorType, DofsType>::define_non_zero_constraints()
         locally_relevant_dofs_acquisition.get_view(0, dof_u);
       this->locally_relevant_dofs[1] =
         locally_relevant_dofs_acquisition.get_view(dof_u, dof_u + dof_p);
-      nonzero_constraints.reinit(locally_relevant_dofs_acquisition);
+      nonzero_constraints.reinit(this->dof_handler.locally_owned_dofs(),
+                                 locally_relevant_dofs_acquisition);
     }
   else
     {
-      nonzero_constraints.reinit(this->locally_relevant_dofs);
+      nonzero_constraints.reinit(this->dof_handler.locally_owned_dofs(),
+                                 this->locally_relevant_dofs);
     }
 
   DoFTools::make_hanging_node_constraints(this->dof_handler,
@@ -1870,13 +1872,15 @@ NavierStokesBase<dim, VectorType, DofsType>::define_zero_constraints()
         locally_relevant_dofs_acquisition.get_view(0, dof_u);
       this->locally_relevant_dofs[1] =
         locally_relevant_dofs_acquisition.get_view(dof_u, dof_u + dof_p);
-      this->zero_constraints.reinit(locally_relevant_dofs_acquisition);
+      this->zero_constraints.reinit(this->dof_handler.locally_owned_dofs(),
+                                    locally_relevant_dofs_acquisition);
     }
   else
     {
       this->locally_relevant_dofs =
         DoFTools::extract_locally_relevant_dofs(this->dof_handler);
-      this->zero_constraints.reinit(this->locally_relevant_dofs);
+      this->zero_constraints.reinit(this->dof_handler.locally_owned_dofs(),
+                                    this->locally_relevant_dofs);
     }
 
   DoFTools::make_hanging_node_constraints(this->dof_handler,

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -2347,7 +2347,8 @@ VolumeOfFluid<dim>::define_zero_constraints()
 {
   // Zero constraints
   this->zero_constraints.clear();
-  this->zero_constraints.reinit(this->locally_relevant_dofs);
+  this->zero_constraints.reinit(this->locally_owned_dofs,
+                                this->locally_relevant_dofs);
 
   DoFTools::make_hanging_node_constraints(this->dof_handler,
                                           this->zero_constraints);
@@ -2385,7 +2386,8 @@ VolumeOfFluid<dim>::define_non_zero_constraints()
 {
   {
     nonzero_constraints.clear();
-    nonzero_constraints.reinit(this->locally_relevant_dofs);
+    nonzero_constraints.reinit(this->locally_owned_dofs,
+                               this->locally_relevant_dofs);
 
     DoFTools::make_hanging_node_constraints(this->dof_handler,
                                             nonzero_constraints);

--- a/source/solvers/vof_algebraic_interface_reinitialization.cc
+++ b/source/solvers/vof_algebraic_interface_reinitialization.cc
@@ -84,7 +84,8 @@ void
 VOFAlgebraicInterfaceReinitialization<dim>::define_zero_constraints()
 {
   this->zero_constraints.clear();
-  this->zero_constraints.reinit(this->locally_relevant_dofs);
+  this->zero_constraints.reinit(this->locally_owned_dofs,
+                                this->locally_relevant_dofs);
 
   DoFTools::make_hanging_node_constraints(*this->dof_handler,
                                           this->zero_constraints);
@@ -125,7 +126,8 @@ void
 VOFAlgebraicInterfaceReinitialization<dim>::define_non_zero_constraints()
 {
   this->nonzero_constraints.clear();
-  this->nonzero_constraints.reinit(this->locally_relevant_dofs);
+  this->nonzero_constraints.reinit(this->locally_owned_dofs,
+                                   this->locally_relevant_dofs);
 
   DoFTools::make_hanging_node_constraints(*this->dof_handler,
                                           this->nonzero_constraints);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

The functions used to define constraints in `navier_stokes_base` (`define_non_zero_constraints` and `define_zero_constraints`) were calling `reinit()` without passing the `locally_owned_dofs`. This caused the constraints object to not have the updated locally owned DoFs in each process. This has now been fixed.

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->

The `reinit()` function is now called passing both `locally_owned_dofs` and `locally_relevant_dofs`.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

All previous tests pass.

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge