### PR TITLE
Add generate triangles flag when extracting slice from vtu

### DIFF
--- a/contrib/postprocessing/extract-from-vtu/extract-slice-from-vtu.py
+++ b/contrib/postprocessing/extract-from-vtu/extract-slice-from-vtu.py
@@ -60,7 +60,7 @@ def extract_slice(vtu_file_path: list, origin: np.array, normal: np.array) -> No
     """
 
     # slice the file
-    sliced_solution = pv.read(vtu_file_path).slice(normal=normal, origin=origin)
+    sliced_solution = pv.read(vtu_file_path).slice(normal=normal, origin=origin, generate_triangles=True)
     sliced_solution = sliced_solution.cast_to_unstructured_grid()
 
     # If the slice is empty (the slice does not intersect the domain), return


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

Minor addition to the postprocessing script that allows to get a slice from vtu files. It adds a "generate_triangles" flag to the slice function to account correctly for vtu files with subdivisions. 