### PR TITLE
Add particle-wall heat transfer parameters

### DIFF
--- a/doc/source/parameters/dem/lagrangian_physical_properties.rst
+++ b/doc/source/parameters/dem/lagrangian_physical_properties.rst
@@ -145,11 +145,13 @@ In this subsection, gravitational acceleration, and the physical properties of t
 
 * The ``microhardness particles`` defines the microhardness of particles for each type.
 
-* The ``surface slope particles`` defines the surface slope of particles for each type.
+* The ``surface slope particles`` defines the surface slope of particles for each type. 
+It is a non-dimensional parameter related to roughness and more precisely to the angle of the asperities on the surface. A higher surface slope entails a smaller microcontact resistance, as there are more microcontacts.
 
 * The ``surface roughness particles`` defines the surface roughness of particles for each type.
 
 * The ``thermal accommodation particles`` defines the thermal accommodation coefficient of particles for each type.
+The thermal accommodation coefficient characterizes the quality of thermal energy exchange between gas molecules and a solid surface.
 
 * The ``thermal conductivity gas`` defines the thermal conductivity of the interstitial gas.
 
@@ -160,6 +162,7 @@ In this subsection, gravitational acceleration, and the physical properties of t
 * The ``specific heats ratio gas`` defines the specific heats ratio of the interstitial gas.
 
 * The ``molecular mean free path gas`` defines the molecular mean free path of the interstitial gas.
+It is the average distance a gas molecule will travel between collisions with other gas molecules.
 
 * The ``thermal conductivity wall`` defines the thermal conductivity of the wall.
 

--- a/doc/source/parameters/dem/lagrangian_physical_properties.rst
+++ b/doc/source/parameters/dem/lagrangian_physical_properties.rst
@@ -60,6 +60,11 @@ In this subsection, gravitational acceleration, and the physical properties of t
     set rolling viscous damping wall = 0.1
     set surface energy wall          = 0.0
     set Hamaker constant wall        = 4.e-19
+    set thermal conductivity wall    = 100
+    set microhardness wall           = 1.e9
+    set surface slope wall           = 0.1
+    set surface roughness wall       = 1.e-10
+    set thermal accommodation wall   = 0.7
 
     # Interstitial gas properties
     set thermal conductivity gas     = 0.01
@@ -155,3 +160,13 @@ In this subsection, gravitational acceleration, and the physical properties of t
 * The ``specific heats ratio gas`` defines the specific heats ratio of the interstitial gas.
 
 * The ``molecular mean free path gas`` defines the molecular mean free path of the interstitial gas.
+
+* The ``thermal conductivity wall`` defines the thermal conductivity of the wall.
+
+* The ``microhardness wall`` defines the microhardness of the wall.
+
+* The ``surface slope wall`` defines the surface slope of the wall.
+
+* The ``surface roughness wall`` defines the surface roughness of the wall.
+
+* The ``thermal accommodation wall`` defines the thermal accommodation coefficient of the wall.

--- a/doc/source/parameters/dem/lagrangian_physical_properties.rst
+++ b/doc/source/parameters/dem/lagrangian_physical_properties.rst
@@ -145,13 +145,11 @@ In this subsection, gravitational acceleration, and the physical properties of t
 
 * The ``microhardness particles`` defines the microhardness of particles for each type.
 
-* The ``surface slope particles`` defines the surface slope of particles for each type. 
-It is a non-dimensional parameter related to roughness and more precisely to the angle of the asperities on the surface. A higher surface slope entails a smaller microcontact resistance, as there are more microcontacts.
+* The ``surface slope particles`` defines the surface slope of particles for each type. It is a non-dimensional parameter related to roughness and more precisely to the angle of the asperities on the surface. A higher surface slope entails a smaller microcontact resistance, as there are more microcontacts.
 
 * The ``surface roughness particles`` defines the surface roughness of particles for each type.
 
-* The ``thermal accommodation particles`` defines the thermal accommodation coefficient of particles for each type.
-The thermal accommodation coefficient characterizes the quality of thermal energy exchange between gas molecules and a solid surface.
+* The ``thermal accommodation particles`` defines the thermal accommodation coefficient of particles for each type. The thermal accommodation coefficient characterizes the quality of thermal energy exchange between gas molecules and a solid surface.
 
 * The ``thermal conductivity gas`` defines the thermal conductivity of the interstitial gas.
 
@@ -161,8 +159,7 @@ The thermal accommodation coefficient characterizes the quality of thermal energ
 
 * The ``specific heats ratio gas`` defines the specific heats ratio of the interstitial gas.
 
-* The ``molecular mean free path gas`` defines the molecular mean free path of the interstitial gas.
-It is the average distance a gas molecule will travel between collisions with other gas molecules.
+* The ``molecular mean free path gas`` defines the molecular mean free path of the interstitial gas. It is the average distance a gas molecule will travel between collisions with other gas molecules.
 
 * The ``thermal conductivity wall`` defines the thermal conductivity of the wall.
 

--- a/doc/source/parameters/dem/solid_objects.rst
+++ b/doc/source/parameters/dem/solid_objects.rst
@@ -39,6 +39,13 @@ This subsection explains the solid objects information. First of all, the ``numb
 
        set center of rotation    = 0., 0., 0.
        set output solid object = true
+
+       # Choices are adiabatic|isothermal
+       set thermal boundary type = adiabatic
+       # If type = isothermal
+       subsection temperature
+         set Function expression = 0
+       end
      end
    end
  end
@@ -55,3 +62,6 @@ This subsection explains the solid objects information. First of all, the ``numb
 
 * The ``output solid object`` defines if we want an output file to be generated for the solid object at every output time step.
 
+* The ``thermal boundary type`` defines whether the solid object should be adiabatic or isothermal when launching a multiphysic DEM simulation.
+
+* In the subsection ``temperature``, we define the temperature of the solid object as a function of time. It is used only if the solid object is not adiabatic.

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -152,6 +152,21 @@ namespace Parameters
       // Hamaker constant wall
       double hamaker_constant_wall;
 
+      // Thermal conductivity wall
+      double thermal_conductivity_wall;
+
+      // Microhardness wall
+      double microhardness_wall;
+
+      // Surface slope wall
+      double surface_slope_wall;
+
+      // Surface roughness wall
+      double surface_roughness_wall;
+
+      // Thermal accommodation wall
+      double thermal_accommodation_wall;
+
       // Thermal conductivity of interstitial gas
       double thermal_conductivity_gas;
 

--- a/include/core/serial_solid.h
+++ b/include/core/serial_solid.h
@@ -156,6 +156,17 @@ public:
   }
 
   /**
+   * @brief Returns the temperature of the solid object
+   *
+   * @return The temperature of the solid object
+   */
+  inline double
+  get_temperature() const
+  {
+    return this->current_solid_temperature;
+  }
+
+  /**
    * @brief Returns the solid id of the solid object.
    * This ID is an unsigned integer which is given to the solid object at
    * compile time and is mostly used when writing files.
@@ -285,9 +296,12 @@ private:
   // Elements used to store the velocity of the solid object
   std::shared_ptr<Function<spacedim>> translational_velocity;
   std::shared_ptr<Function<spacedim>> angular_velocity;
+  std::shared_ptr<Function<spacedim>> solid_temperature;
   Point<spacedim>                     center_of_rotation;
   Tensor<1, spacedim>                 current_translational_velocity;
   Tensor<1, 3>                        current_angular_velocity;
+  double                              current_solid_temperature;
+  const ThermalBoundaryType           thermal_boundary_type;
 };
 
 #endif

--- a/include/core/serial_solid.h
+++ b/include/core/serial_solid.h
@@ -171,7 +171,7 @@ public:
    *
    * @return The thermal boundary type of the solid object
    */
-  inline double
+  inline Parameters::ThermalBoundaryType
   get_thermal_boundary_type() const
   {
     return this->thermal_boundary_type;
@@ -189,6 +189,15 @@ public:
   {
     return id;
   }
+
+  /**
+   * @brief Update the temperature of the solid object, which is a function of time.
+   *
+   * @param initial_time The initial time (time t) of the timestep. This is used to
+   * set the time of the temperature function.
+   */
+  void
+  update_solid_temperature(const double initial_time);
 
   /**
    * @brief Moves the vertices of the solid triangulation. This function
@@ -307,12 +316,12 @@ private:
   // Elements used to store the velocity of the solid object
   std::shared_ptr<Function<spacedim>> translational_velocity;
   std::shared_ptr<Function<spacedim>> angular_velocity;
-  std::shared_ptr<Function<spacedim>> solid_temperature;
   Point<spacedim>                     center_of_rotation;
   Tensor<1, spacedim>                 current_translational_velocity;
   Tensor<1, 3>                        current_angular_velocity;
+  std::shared_ptr<Function<spacedim>> solid_temperature;
+  Parameters::ThermalBoundaryType     thermal_boundary_type;
   double                              current_solid_temperature;
-  const ThermalBoundaryType           thermal_boundary_type;
 };
 
 #endif

--- a/include/core/serial_solid.h
+++ b/include/core/serial_solid.h
@@ -167,6 +167,17 @@ public:
   }
 
   /**
+   * @brief Returns the thermal boundary type of the solid object
+   *
+   * @return The thermal boundary type of the solid object
+   */
+  inline double
+  get_thermal_boundary_type() const
+  {
+    return this->thermal_boundary_type;
+  }
+
+  /**
    * @brief Returns the solid id of the solid object.
    * This ID is an unsigned integer which is given to the solid object at
    * compile time and is mostly used when writing files.

--- a/include/core/serial_solid.h
+++ b/include/core/serial_solid.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2022-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_serial_solid_h

--- a/include/core/solid_objects_parameters.h
+++ b/include/core/solid_objects_parameters.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_solid_objects_parameters_h

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -252,6 +252,26 @@ namespace Parameters
                           "4.e-19",
                           Patterns::Double(),
                           "Hamaker constant of wall");
+        prm.declare_entry("thermal conductivity wall",
+                          "100",
+                          Patterns::Double(),
+                          "Thermal conductivity of wall");
+        prm.declare_entry("microhardness wall",
+                          "1.e9",
+                          Patterns::Double(),
+                          "Microhardness of wall");
+        prm.declare_entry("surface slope wall",
+                          "0.1",
+                          Patterns::Double(),
+                          "Surface slope of wall");
+        prm.declare_entry("surface roughness wall",
+                          "1.e-10",
+                          Patterns::Double(),
+                          "Surface roughness of wall");
+        prm.declare_entry("thermal accommodation wall",
+                          "0.7",
+                          Patterns::Double(),
+                          "Thermal accommodation of wall");
 
         prm.declare_entry("thermal conductivity gas",
                           "0.01",
@@ -331,8 +351,13 @@ namespace Parameters
       rolling_friction_wall     = prm.get_double("rolling friction wall");
       rolling_viscous_damping_wall =
         prm.get_double("rolling viscous damping wall");
-      surface_energy_wall   = prm.get_double("surface energy wall");
-      hamaker_constant_wall = prm.get_double("hamaker constant wall");
+      surface_energy_wall        = prm.get_double("surface energy wall");
+      hamaker_constant_wall      = prm.get_double("hamaker constant wall");
+      thermal_conductivity_wall  = prm.get_double("thermal conductivity wall");
+      microhardness_wall         = prm.get_double("microhardness wall");
+      surface_slope_wall         = prm.get_double("surface slope wall");
+      surface_roughness_wall     = prm.get_double("surface roughness wall");
+      thermal_accommodation_wall = prm.get_double("thermal accommodation wall");
 
       thermal_conductivity_gas = prm.get_double("thermal conductivity gas");
       specific_heat_gas        = prm.get_double("specific heat gas");

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -314,7 +314,7 @@ template <int dim, int spacedim>
 void
 SerialSolid<dim, spacedim>::update_solid_temperature(const double initial_time)
 {
-  if constexpr (thermal_boundary_type == ThermalBoundaryType::adiabatic)
+  if (thermal_boundary_type == Parameters::ThermalBoundaryType::adiabatic)
     return;
 
   solid_temperature->set_time(initial_time);

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2022-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/lethe_grid_tools.h>

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -34,6 +34,8 @@ SerialSolid<dim, spacedim>::SerialSolid(
   , translational_velocity(param->translational_velocity)
   , angular_velocity(param->angular_velocity)
   , center_of_rotation(param->center_of_rotation)
+  , solid_temperature(param->solid_temperature)
+  , thermal_boundary_type(param->thermal_boundary_type)
 {
   if (param->solid_mesh.simplex)
     {
@@ -306,6 +308,17 @@ void
 SerialSolid<3, 3>::translate_grid(const Tensor<1, 3> translation)
 {
   GridTools::shift(translation, *solid_tria);
+}
+
+template <int dim, int spacedim>
+void
+SerialSolid<dim, spacedim>::update_solid_temperature(const double initial_time)
+{
+  if constexpr (thermal_boundary_type == ThermalBoundaryType::adiabatic)
+    return;
+
+  solid_temperature->set_time(initial_time);
+  current_solid_temperature = solid_temperature->value(Point<spacedim>());
 }
 
 template <int dim, int spacedim>

--- a/source/core/solid_objects_parameters.cc
+++ b/source/core/solid_objects_parameters.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020, 2022 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/solid_objects_parameters.h>

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -575,6 +575,18 @@ DEMSolver<dim, PropertiesIndex>::move_solid_objects()
     solid_object->move_solid_triangulation(
       simulation_control->get_time_step(),
       simulation_control->get_previous_time());
+
+  if constexpr (std::is_same_v<PropertiesIndex,
+                               DEM::DEMMPProperties::PropertiesIndex>)
+    {
+      for (auto &solid_object : solid_surfaces)
+        solid_object->update_solid_temperature(
+          simulation_control->get_previous_time());
+
+      for (auto &solid_object : solid_volumes)
+        solid_object->update_solid_temperature(
+          simulation_control->get_previous_time());
+    }
 }
 
 template <int dim, typename PropertiesIndex>

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -575,18 +575,6 @@ DEMSolver<dim, PropertiesIndex>::move_solid_objects()
     solid_object->move_solid_triangulation(
       simulation_control->get_time_step(),
       simulation_control->get_previous_time());
-
-  if constexpr (std::is_same_v<PropertiesIndex,
-                               DEM::DEMMPProperties::PropertiesIndex>)
-    {
-      for (auto &solid_object : solid_surfaces)
-        solid_object->update_solid_temperature(
-          simulation_control->get_previous_time());
-
-      for (auto &solid_object : solid_volumes)
-        solid_object->update_solid_temperature(
-          simulation_control->get_previous_time());
-    }
 }
 
 template <int dim, typename PropertiesIndex>

--- a/tests/dem/test_particles_functions.h
+++ b/tests/dem/test_particles_functions.h
@@ -144,6 +144,11 @@ set_default_dem_parameters(const unsigned int        particle_type_number,
   properties.rolling_viscous_damping_wall = 0.1;
   properties.surface_energy_wall          = 0.0;
   properties.hamaker_constant_wall        = 4.e-19;
+  properties.thermal_conductivity_wall    = 100
+  properties.microhardness_wall           = 1.e9
+  properties.surface_slope_wall           = 0.1
+  properties.surface_roughness_wall       = 1.e-10
+  properties.thermal_accommodation_wall   = 0.7
 
   // Interstitial gas parameters
   properties.thermal_conductivity_gas     = 0.01;

--- a/tests/dem/test_particles_functions.h
+++ b/tests/dem/test_particles_functions.h
@@ -144,11 +144,11 @@ set_default_dem_parameters(const unsigned int        particle_type_number,
   properties.rolling_viscous_damping_wall = 0.1;
   properties.surface_energy_wall          = 0.0;
   properties.hamaker_constant_wall        = 4.e-19;
-  properties.thermal_conductivity_wall    = 100
-  properties.microhardness_wall           = 1.e9
-  properties.surface_slope_wall           = 0.1
-  properties.surface_roughness_wall       = 1.e-10
-  properties.thermal_accommodation_wall   = 0.7
+  properties.thermal_conductivity_wall    = 100;
+  properties.microhardness_wall           = 1.e9;
+  properties.surface_slope_wall           = 0.1;
+  properties.surface_roughness_wall       = 1.e-10;
+  properties.thermal_accommodation_wall   = 0.7;
 
   // Interstitial gas parameters
   properties.thermal_conductivity_gas     = 0.01;


### PR DESCRIPTION
### Description

This PR adds the wall parameters for particle-wall heat transfer, including the physical properties, the thermal boundary type (adiabatic or isothermal) and the temperature of the wall if it it isothermal. For now, only solid objects can have a temperature and will be used for particle-wall heat transfer.

### Testing

Tests will be added in a future PR when particle-wall heat transfer is fully implemented.

### Documentation

Documentation for lagrangian physical properties and solid objects was updated.

### Miscellaneous (will be removed when merged)

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [ ] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge