### PR TITLE
Change the rolling friction value on the example

### DIFF
--- a/doc/source/examples/dem/rectangular-hopper/rectangular-hopper.rst
+++ b/doc/source/examples/dem/rectangular-hopper/rectangular-hopper.rst
@@ -115,13 +115,13 @@ The following properties are chosen according to the Anand et al. paper :
         set poisson ratio particles           = 0.3
         set restitution coefficient particles = 0.94
         set friction coefficient particles    = 0.2
-        set rolling friction particles        = 0.09
+        set rolling friction particles        = 0.1786
       end
       set young modulus wall           = 1e6
       set poisson ratio wall           = 0.3
       set friction coefficient wall    = 0.2
       set restitution coefficient wall = 0.9
-      set rolling friction wall        = 0.09
+      set rolling friction wall        = 0.1786
     end
 
 
@@ -328,13 +328,13 @@ The total number of particles of this simulation is 6790: 6 times less than the 
             set poisson ratio particles           = 0.3
             set restitution coefficient particles = 0.94
             set friction coefficient particles    = 0.2
-            set rolling friction particles        = 0.09
+            set rolling friction particles        = 0.1786
         end
         set young modulus wall           = 1e6
         set poisson ratio wall           = 0.3
         set friction coefficient wall    = 0.2
         set restitution coefficient wall = 0.9
-        set rolling friction wall        = 0.09
+        set rolling friction wall        = 0.1786
     end
 
 Insertion Info

--- a/examples/dem/3d-rectangular-hopper/hopper.prm
+++ b/examples/dem/3d-rectangular-hopper/hopper.prm
@@ -56,13 +56,13 @@ subsection lagrangian physical properties
     set poisson ratio particles           = 0.3
     set restitution coefficient particles = 0.94
     set friction coefficient particles    = 0.2
-    set rolling friction particles        = 0.09
+    set rolling friction particles        = 0.1786
   end
   set young modulus wall           = 1e6
   set poisson ratio wall           = 0.3
   set friction coefficient wall    = 0.2
   set restitution coefficient wall = 0.9
-  set rolling friction wall        = 0.09
+  set rolling friction wall        = 0.1786
 end
 
 #---------------------------------------------------

--- a/examples/dem/3d-rectangular-hopper/hopper_periodic.prm
+++ b/examples/dem/3d-rectangular-hopper/hopper_periodic.prm
@@ -56,13 +56,13 @@ subsection lagrangian physical properties
     set poisson ratio particles           = 0.3
     set restitution coefficient particles = 0.94
     set friction coefficient particles    = 0.2
-    set rolling friction particles        = 0.09
+    set rolling friction particles        = 0.1786
   end
   set young modulus wall           = 1e6
   set poisson ratio wall           = 0.3
   set friction coefficient wall    = 0.2
   set restitution coefficient wall = 0.9
-  set rolling friction wall        = 0.09
+  set rolling friction wall        = 0.1786
 end
 
 #---------------------------------------------------


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The rolling friction coefficient used for the hopper example didn't match the reference. This PR fixes this issue. 

Code related list:
- [X] Lethe documentation is up to date
- [X] Copyright headers are present and up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [X] Links are added to parent .rst files
- [X] The example is following the [standard format](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#general-rules-and-format)

Pull request related list:
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] If any future works is planned, an issue is opened
- [X] The PR description is cleaned and ready for merge