### PR TITLE
Fix mass conservation table output in VOF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2025-05-27
+
+### Fixed
+
+- MINOR The output of the mass conservation table in VOF was resulting in a seg fault in 3D. It was permanently fixed by adding the missing column name in 3D. [#1541](https://github.com/chaos-polymtl/lethe/pull/1541)
+
 ## [Master] - 2025-05-26
 
 ### Changed

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -1264,10 +1264,9 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
                 }
               else if constexpr (dim == 3)
                 {
-                  volume_column_name = "volume_" + fluid_id;
-                  mass_column_name   = "mass_" + fluid_id;
-                  geometric_volume_column_name =
-                    "geometric_" + fluid_id;
+                  volume_column_name           = "volume_" + fluid_id;
+                  mass_column_name             = "mass_" + fluid_id;
+                  geometric_volume_column_name = "geometric_" + fluid_id;
                 }
 
               // Add "surface" or "volume" column

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -1266,6 +1266,8 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
                 {
                   volume_column_name = "volume_" + fluid_id;
                   mass_column_name   = "mass_" + fluid_id;
+                  geometric_volume_column_name =
+                    "geometric_" + fluid_id;
                 }
 
               // Add "surface" or "volume" column

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -1266,7 +1266,7 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
                 {
                   volume_column_name           = "volume_" + fluid_id;
                   mass_column_name             = "mass_" + fluid_id;
-                  geometric_volume_column_name = "geometric_" + fluid_id;
+                  geometric_volume_column_name = "geometric_volume_" + fluid_id;
                 }
 
               // Add "surface" or "volume" column


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The output of the mass conservation table in VOF was resulting in a seg fault in 3D.

### Solution

It was permanently fixed by adding the missing column name in 3D.

### Testing

The case (capillary migration in 3D) previously failing is now working.

### Documentation

No need!

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge