### PR TITLE
Fix restart pvd checkpoint file in CFD_DEM simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2025-06-12
+
+### Fixed
+
+- MINOR Fixed restarts in CFD-DEM simulatiosn with Langrangian post-processing enabled. The checkpointing file for the pvd file was not named correctly. This is now corrected to be consistent. [#1552](https://github.com/chaos-polymtl/lethe/pull/1552)
+
 ## [Master] - 2025-06-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- MINOR Fixed restarts in CFD-DEM simulatiosn with Langrangian post-processing enabled. The checkpointing file for the pvd file was not named correctly. This is now corrected to be consistent. [#1552](https://github.com/chaos-polymtl/lethe/pull/1552)
+- MINOR Fixed restarts in CFD-DEM simulations with Lagrangian post-processing enabled. The checkpointing file for the pvd file was not named correctly. This has now been corrected to ensure consistency. [#1552](https://github.com/chaos-polymtl/lethe/pull/1552)
 
 ## [Master] - 2025-06-11
 

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -384,7 +384,7 @@ CFDDEMSolver<dim>::write_checkpoint()
     this->simulation_parameters.simulation_control.output_folder +
     this->simulation_parameters.restart_parameters.filename;
   std::string prefix_particles = prefix + "_particles";
-  std::string prefix_grid      = prefix + "_postprocess_data";
+  std::string prefix_grid      = prefix + "_lagrangian_postprocessing";
   if (Utilities::MPI::this_mpi_process(this->mpi_communicator) == 0)
     {
       this->simulation_control->save(prefix);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

When the Lagrangian post-processing tools were enabled, the simulation restart would try to read a wrongly named .pvd file for the lagrangian post-processing file. It did not have the right suffix.

### Solution

Fixed the naming of the suffix.

### Testing

Tested on one of the examples and it works well now.

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge