### PR TITLE
Sharp: added dynamic_flow_control function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MINOR Added a simple first multiphysic DEM example that consists of lined up particles that are heated by others or by a wall. It verifies the models of particle-particle and particle-wall heat transfer using two simple test cases. This PR also adds dem-mp in the documentation and examples directories. [#1548](https://github.com/chaos-polymtl/lethe/pull/1548)
 
+- MINOR Added initial support for the dynamic flow control in lethe-fluid-sharp. Beta force particle is still missing from the calculation. [#1553] (https://github.com/chaos-polymtl/lethe/pull/1553)
+
 ## [Master] - 2025-06-11
 
 ### Fixed

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -4889,6 +4889,8 @@ FluidDynamicsSharp<dim>::solve()
       this->update_boundary_conditions();
       this->multiphysics->update_boundary_conditions();
 
+      this->dynamic_flow_control();
+
       if (some_particles_are_coupled == false)
         integrate_particles();
 


### PR DESCRIPTION
### Description

Dynamic flow control was not being called in lethe-fluid-sharp solver. Beta force particle is still missing from the calculation.

### Solution

Added the function call to run the dynamic flow control step.

### Testing

Tested a dynamic flow control periodic case with both lethe-fluid and lethe-fluid-sharp and both work the same.

### Documentation

No documentation change needed.

### Miscellaneous (will be removed when merged)

The beta force particle associated with the dynamic flow control remains to be added to the lethe-fluid-sharp solver. An issue regarding this has been open for future reference.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge