### PR TITLE
Add get_mapping and rotate_mapping functions

### DIFF
--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -437,6 +437,20 @@ protected:
   define_zero_constraints();
 
   /**
+   * @brief Returns the mapping shared pointer. A MappingQCache is
+   * necessary for prescribed rotation in rotor-stator configurations
+   */
+  inline std::shared_ptr<Mapping<dim>>
+  get_mapping()
+  {
+    if (!this->simulation_parameters.mortar.enable ||
+        this->get_current_newton_iteration() == 0)
+      return this->mapping;
+    else
+      return this->mapping_cache;
+  }
+
+  /**
    * @brief Rotate rotor mapping in mortar method
    */
   void

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -35,6 +35,7 @@
 #include <deal.II/fe/component_mask.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/mapping_fe.h>
+#include <deal.II/fe/mapping_q_cache.h>
 
 #include <deal.II/grid/grid_out.h>
 
@@ -434,6 +435,12 @@ protected:
    */
   void
   define_zero_constraints();
+
+  /**
+   * @brief Rotate rotor mapping in mortar method
+   */
+  void
+  rotate_mortar_mapping();
 
   /**
    * @brief Update non-zero constraints if the boundary is time dependent.
@@ -910,8 +917,9 @@ protected:
   std::shared_ptr<Quadrature<dim>>     cell_quadrature;
   std::shared_ptr<Quadrature<dim - 1>> face_quadrature;
 
-  // Previous mapping for rotor mesh rotation in mortar method
-  std::shared_ptr<Mapping<dim>> previous_mapping;
+  // Initial mapping for rotor mesh rotation in mortar method
+  std::shared_ptr<Mapping<dim>>       initial_mapping;
+  std::shared_ptr<MappingQCache<dim>> mapping_cache;
 
   // Assemblers for the matrix and rhs
   std::vector<std::shared_ptr<NavierStokesAssemblerBase<dim>>> assemblers;

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -483,7 +483,7 @@ FluidDynamicsMatrixBased<dim>::assemble_system_matrix()
     this->simulation_parameters.physical_properties_manager,
     *this->fe,
     *this->cell_quadrature,
-    *this->mapping,
+    *this->get_mapping(),
     *this->face_quadrature);
 
   if (this->simulation_parameters.multiphysics.VOF)
@@ -493,7 +493,7 @@ FluidDynamicsMatrixBased<dim>::assemble_system_matrix()
       scratch_data.enable_vof(
         dof_handler_vof->get_fe(),
         *this->cell_quadrature,
-        *this->mapping,
+        *this->get_mapping(),
         this->simulation_parameters.multiphysics.vof_parameters.phase_filter);
 
       if (this->simulation_parameters.multiphysics.vof_parameters
@@ -507,10 +507,10 @@ FluidDynamicsMatrixBased<dim>::assemble_system_matrix()
           scratch_data.enable_projected_phase_fraction_gradient(
             projected_phase_fraction_gradient_dof_handler.get_fe(),
             *this->cell_quadrature,
-            *this->mapping);
+            *this->get_mapping());
           scratch_data.enable_curvature(curvature_dof_handler.get_fe(),
                                         *this->cell_quadrature,
-                                        *this->mapping);
+                                        *this->get_mapping());
         }
     }
   else if (this->simulation_parameters.multiphysics.cahn_hilliard)
@@ -520,7 +520,7 @@ FluidDynamicsMatrixBased<dim>::assemble_system_matrix()
       scratch_data.enable_cahn_hilliard(
         dof_handler_cahn_hilliard->get_fe(),
         *this->cell_quadrature,
-        *this->mapping,
+        *this->get_mapping(),
         this->simulation_parameters.multiphysics.cahn_hilliard_parameters);
     }
 
@@ -530,7 +530,7 @@ FluidDynamicsMatrixBased<dim>::assemble_system_matrix()
         this->multiphysics->get_dof_handler(PhysicsID::heat_transfer);
       scratch_data.enable_heat_transfer(dof_handler_ht->get_fe(),
                                         *this->cell_quadrature,
-                                        *this->mapping);
+                                        *this->get_mapping());
     }
 
   WorkStream::run(
@@ -695,7 +695,7 @@ FluidDynamicsMatrixBased<dim>::assemble_system_rhs()
     this->simulation_parameters.physical_properties_manager,
     *this->fe,
     *this->cell_quadrature,
-    *this->mapping,
+    *this->get_mapping(),
     *this->face_quadrature);
 
   if (this->simulation_parameters.multiphysics.VOF)
@@ -705,7 +705,7 @@ FluidDynamicsMatrixBased<dim>::assemble_system_rhs()
       scratch_data.enable_vof(
         dof_handler_vof->get_fe(),
         *this->cell_quadrature,
-        *this->mapping,
+        *this->get_mapping(),
         this->simulation_parameters.multiphysics.vof_parameters.phase_filter);
 
       if (this->simulation_parameters.multiphysics.vof_parameters
@@ -720,10 +720,10 @@ FluidDynamicsMatrixBased<dim>::assemble_system_rhs()
           scratch_data.enable_projected_phase_fraction_gradient(
             projected_phase_fraction_gradient_dof_handler.get_fe(),
             *this->cell_quadrature,
-            *this->mapping);
+            *this->get_mapping());
           scratch_data.enable_curvature(curvature_dof_handler.get_fe(),
                                         *this->cell_quadrature,
-                                        *this->mapping);
+                                        *this->get_mapping());
         }
     }
 
@@ -734,7 +734,7 @@ FluidDynamicsMatrixBased<dim>::assemble_system_rhs()
       scratch_data.enable_cahn_hilliard(
         dof_handler_cahn_hilliard->get_fe(),
         *this->cell_quadrature,
-        *this->mapping,
+        *this->get_mapping(),
         this->simulation_parameters.multiphysics.cahn_hilliard_parameters);
     }
 
@@ -744,7 +744,7 @@ FluidDynamicsMatrixBased<dim>::assemble_system_rhs()
         this->multiphysics->get_dof_handler(PhysicsID::heat_transfer);
       scratch_data.enable_heat_transfer(dof_handler_ht->get_fe(),
                                         *this->cell_quadrature,
-                                        *this->mapping);
+                                        *this->get_mapping());
     }
 
   WorkStream::run(
@@ -1096,7 +1096,7 @@ FluidDynamicsMatrixBased<dim>::assemble_L2_projection()
 {
   system_matrix    = 0;
   this->system_rhs = 0;
-  FEValues<dim>               fe_values(*this->mapping,
+  FEValues<dim>               fe_values(*this->get_mapping(),
                           *this->fe,
                           *this->cell_quadrature,
                           update_values | update_quadrature_points |

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -134,7 +134,7 @@ FluidDynamicsMatrixBased<dim>::setup_dofs_fd()
     }
 
   double global_volume =
-    GridTools::volume(*this->triangulation, *this->mapping);
+    GridTools::volume(*this->triangulation, *this->get_mapping());
 
   this->pcout << "   Number of active cells:       "
               << this->triangulation->n_global_active_cells() << std::endl

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -2263,7 +2263,7 @@ FluidDynamicsMatrixFree<dim>::setup_dofs_fd()
   // Initialize matrix-free object
   unsigned int mg_level = numbers::invalid_unsigned_int;
   this->system_operator->reinit(
-    *this->mapping,
+    *this->get_mapping(),
     this->dof_handler,
     this->zero_constraints,
     *this->cell_quadrature,
@@ -2310,7 +2310,7 @@ FluidDynamicsMatrixFree<dim>::setup_dofs_fd()
     }
 
   double global_volume =
-    GridTools::volume(*this->triangulation, *this->mapping);
+    GridTools::volume(*this->triangulation, *this->get_mapping());
 
   this->pcout << "   Number of active cells:       "
               << this->triangulation->n_global_active_cells() << std::endl
@@ -2556,7 +2556,7 @@ FluidDynamicsMatrixFree<dim>::create_GMG()
     this->dof_handler,
     this->dof_handler_fe_q_iso_q1);
 
-  gmg_preconditioner->reinit(this->mapping,
+  gmg_preconditioner->reinit(this->get_mapping(),
                              this->cell_quadrature,
                              this->forcing_function,
                              this->simulation_control,

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1899,7 +1899,7 @@ NavierStokesBase<dim, VectorType, DofsType>::define_zero_constraints()
           type == BoundaryConditions::BoundaryType::function)
         {
           VectorTools::interpolate_boundary_values(
-            *this->mapping,
+            *this->get_mapping(),
             this->dof_handler,
             id,
             dealii::Functions::ZeroFunction<dim>(dim + 1),

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -192,7 +192,7 @@ NavierStokesBase<dim, VectorType, DofsType>::dynamic_flow_control()
         this->present_solution,
         simulation_parameters.flow_control.boundary_flow_id,
         *this->face_quadrature,
-        *this->mapping);
+        *this->get_mapping());
 
       this->flow_control.calculate_beta(average_velocity,
                                         simulation_control->get_time_step(),
@@ -248,7 +248,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocessing_forces(
                      simulation_parameters.physical_properties_manager,
                      simulation_parameters.boundary_conditions,
                      *this->face_quadrature,
-                     *this->mapping);
+                     *this->get_mapping());
 
   if (simulation_parameters.forces_parameters.verbosity ==
         Parameters::Verbosity::verbose &&
@@ -384,7 +384,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocessing_torques(
                       simulation_parameters.physical_properties_manager,
                       simulation_parameters.boundary_conditions,
                       *this->face_quadrature,
-                      *this->mapping);
+                      *this->get_mapping());
 
   if (simulation_parameters.forces_parameters.verbosity ==
         Parameters::Verbosity::verbose &&
@@ -524,7 +524,7 @@ NavierStokesBase<dim, VectorType, DofsType>::finish_time_step()
                                        this->present_solution,
                                        simulation_control->get_time_step(),
                                        *this->cell_quadrature,
-                                       *this->mapping);
+                                       *this->get_mapping());
       this->simulation_control->set_CFL(CFL);
     }
   if (this->simulation_parameters.restart_parameters.checkpoint &&
@@ -656,7 +656,7 @@ NavierStokesBase<dim, VectorType, DofsType>::
     this->multiphysics->get_dof_handler(PhysicsID::heat_transfer);
 
   this->fe_values_temperature =
-    std::make_shared<FEValues<dim>>(*this->mapping,
+    std::make_shared<FEValues<dim>>(*this->get_mapping(),
                                     dof_handler_ht->get_fe(),
                                     *this->cell_quadrature,
                                     update_values);
@@ -668,7 +668,7 @@ NavierStokesBase<dim, VectorType, DofsType>::
         this->multiphysics->get_dof_handler(PhysicsID::heat_transfer);
 
       this->fe_values_vof =
-        std::make_shared<FEValues<dim>>(*this->mapping,
+        std::make_shared<FEValues<dim>>(*this->get_mapping(),
                                         dof_handler_vof->get_fe(),
                                         *this->cell_quadrature,
                                         update_values);
@@ -968,7 +968,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
       if (ivar.first == Variable::pressure)
         {
           KellyErrorEstimator<dim>::estimate(
-            *this->mapping,
+            *this->get_mapping(),
             this->dof_handler,
             *this->face_quadrature,
             typename std::map<types::boundary_id,
@@ -980,7 +980,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
       else if (ivar.first == Variable::velocity)
         {
           KellyErrorEstimator<dim>::estimate(
-            *this->mapping,
+            *this->get_mapping(),
             this->dof_handler,
             *this->face_quadrature,
             typename std::map<types::boundary_id,
@@ -1260,7 +1260,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
       double enstrophy = calculate_enstrophy(this->dof_handler,
                                              present_solution,
                                              *this->cell_quadrature,
-                                             *this->mapping);
+                                             *this->get_mapping());
 
       this->enstrophy_table.add_value("time",
                                       simulation_control->get_current_time());
@@ -1299,7 +1299,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
         calculate_pressure_power(this->dof_handler,
                                  present_solution,
                                  *this->cell_quadrature,
-                                 *this->mapping);
+                                 *this->get_mapping());
 
       this->pressure_power_table.add_value(
         "time", simulation_control->get_current_time());
@@ -1340,7 +1340,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
         this->dof_handler,
         present_solution,
         *this->cell_quadrature,
-        *this->mapping,
+        *this->get_mapping(),
         simulation_parameters.physical_properties_manager);
 
       this->viscous_dissipation_table.add_value(
@@ -1395,7 +1395,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
       double kE = calculate_kinetic_energy(this->dof_handler,
                                            present_solution,
                                            *this->cell_quadrature,
-                                           *this->mapping);
+                                           *this->get_mapping());
       this->kinetic_energy_table.add_value(
         "time", simulation_control->get_current_time());
       this->kinetic_energy_table.add_value("kinetic-energy", kE);
@@ -1432,7 +1432,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
         this->dof_handler,
         this->present_solution,
         *this->cell_quadrature,
-        *this->mapping,
+        *this->get_mapping(),
         this->simulation_parameters.physical_properties_manager);
 
       this->apparent_viscosity_table.add_value(
@@ -1472,7 +1472,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
       double pressure_drop, total_pressure_drop;
       std::tie(pressure_drop, total_pressure_drop) = calculate_pressure_drop(
         this->dof_handler,
-        *this->mapping,
+        *this->get_mapping(),
         this->evaluation_point,
         *this->cell_quadrature,
         *this->face_quadrature,
@@ -1543,7 +1543,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
                                 this->present_solution,
                                 boundary_id,
                                 *this->face_quadrature,
-                                *this->mapping);
+                                *this->get_mapping());
 
           this->flow_rate_table.add_value(
             "flow-rate-" + Utilities::int_to_string(boundary_id, 2),
@@ -1630,7 +1630,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
                                present_solution,
                                exact_solution,
                                *this->cell_quadrature,
-                               *this->mapping);
+                               *this->get_mapping());
           const double error_velocity = errors.first;
           const double error_pressure = errors.second;
           if (simulation_parameters.simulation_control.method ==
@@ -1699,12 +1699,12 @@ NavierStokesBase<dim, VectorType, DofsType>::set_nodal_values()
 {
   const FEValuesExtractors::Vector velocities(0);
   const FEValuesExtractors::Scalar pressure(dim);
-  VectorTools::interpolate(*this->mapping,
+  VectorTools::interpolate(*this->get_mapping(),
                            this->dof_handler,
                            this->simulation_parameters.initial_condition->uvwp,
                            this->newton_update,
                            this->fe->component_mask(velocities));
-  VectorTools::interpolate(*this->mapping,
+  VectorTools::interpolate(*this->get_mapping(),
                            this->dof_handler,
                            this->simulation_parameters.initial_condition->uvwp,
                            this->newton_update,
@@ -1723,13 +1723,13 @@ NavierStokesBase<dim, VectorType, DofsType>::set_nodal_values()
           const FEValuesExtractors::Vector velocities(0);
           const FEValuesExtractors::Scalar pressure(dim);
           VectorTools::interpolate(
-            *this->mapping,
+            *this->get_mapping(),
             this->dof_handler,
             this->simulation_parameters.initial_condition->uvwp,
             this->newton_update,
             this->fe->component_mask(velocities));
           VectorTools::interpolate(
-            *this->mapping,
+            *this->get_mapping(),
             this->dof_handler,
             this->simulation_parameters.initial_condition->uvwp,
             this->newton_update,
@@ -1787,7 +1787,7 @@ NavierStokesBase<dim, VectorType, DofsType>::define_non_zero_constraints()
       if (type == BoundaryConditions::BoundaryType::noslip)
         {
           VectorTools::interpolate_boundary_values(
-            *this->mapping,
+            *this->get_mapping(),
             this->dof_handler,
             id,
             dealii::Functions::ZeroFunction<dim>(dim + 1),
@@ -1803,7 +1803,7 @@ NavierStokesBase<dim, VectorType, DofsType>::define_non_zero_constraints()
             0,
             no_normal_flux_boundaries,
             nonzero_constraints,
-            *this->mapping);
+            *this->get_mapping());
         }
       else if (type == BoundaryConditions::BoundaryType::function)
         {
@@ -1817,7 +1817,7 @@ NavierStokesBase<dim, VectorType, DofsType>::define_non_zero_constraints()
             .navier_stokes_functions.at(id)
             ->w.set_time(time);
           VectorTools::interpolate_boundary_values(
-            *this->mapping,
+            *this->get_mapping(),
             this->dof_handler,
             id,
             NavierStokesFunctionDefined<dim>(
@@ -1915,7 +1915,7 @@ NavierStokesBase<dim, VectorType, DofsType>::define_zero_constraints()
             0,
             no_normal_flux_boundaries,
             this->zero_constraints,
-            *this->mapping);
+            *this->get_mapping());
         }
       else if (type == BoundaryConditions::BoundaryType::periodic)
         {
@@ -1997,9 +1997,6 @@ NavierStokesBase<dim, VectorType, DofsType>::rotate_mortar_mapping()
                                           this->simulation_parameters.mortar)
           .second,
         rotation_angle);
-
-        // this->mapping = &this->mapping_cache;
-        // this->mapping = static_cast<Mapping<dim> &>(this->mapping_cache);
 #else
       AssertThrow(
         false,
@@ -2705,7 +2702,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
         qcriterion_field =
           qcriterion_smoothing.calculate_smoothed_field(solution,
                                                         this->dof_handler,
-                                                        this->mapping);
+                                                        this->get_mapping());
 
         std::vector<DataComponentInterpretation::DataComponentInterpretation>
           data_component_interpretation(
@@ -2724,7 +2721,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
         continuity_field =
           continuity_smoothing.calculate_smoothed_field(solution,
                                                         this->dof_handler,
-                                                        this->mapping);
+                                                        this->get_mapping());
 
         std::vector<DataComponentInterpretation::DataComponentInterpretation>
           data_component_interpretation(
@@ -2761,7 +2758,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
 
   // Build the patches and write the output
 
-  data_out.build_patches(*this->mapping,
+  data_out.build_patches(*this->get_mapping(),
                          subdivision,
                          DataOut<dim>::curved_inner_cells);
 
@@ -2789,7 +2786,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
       BoundaryPostprocessor<dim> boundary_id;
       data_out_faces.attach_dof_handler(this->dof_handler);
       data_out_faces.add_data_vector(solution, boundary_id);
-      data_out_faces.build_patches(*this->mapping, subdivision);
+      data_out_faces.build_patches(*this->get_mapping(), subdivision);
 
       write_boundaries_vtu<dim>(
         data_out_faces, folder, time, iter, this->mpi_communicator);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

Reintroducing the mapping rotation function from #1536, this PR refactors the use of the mapping shared pointer by introducing a `get_mapping()` function. This way, the `mapping_cache` necessary for the rotor rotation can be updated and integrated with the code.

### Testing

<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

The `rotate_mapping()` function is already being tested by the test case introduced in #1536. Previous tests still pass after introducing the new `get_mapping()` function.

### Documentation

<!-- Does this refactor modify or have new simulation parameters? If so, describe them. -->

The documentation for the rotor angular velocity, a parameter that is used for the mapping rotation, has been added in #1549.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [ ] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge