### PR TITLE
Flag to delete old vtu files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2025-07-03
+
+### Added
+
+- MINOR Add functionality that allows to delete previous vtu and pvd files by using a flag '-R'. [#1569](https://github.com/chaos-polymtl/lethe/pull/1569)
+
 ## [Master] - 2025-06-30
 
 ### Added

--- a/applications/lethe-fluid-block/fluid_dynamics_block.cc
+++ b/applications/lethe-fluid-block/fluid_dynamics_block.cc
@@ -50,6 +50,14 @@ main(int argc, char *argv[])
           prm.parse_input(file_name);
           NSparam.parse(prm);
 
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                NSparam.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
+
           AssertThrow(NSparam.nitsche->number_solids == 0,
                       SolidWarning(NSparam.nitsche->number_solids,
                                    "lethe-fluid-block",
@@ -72,6 +80,14 @@ main(int argc, char *argv[])
           // Parsing of the file
           prm.parse_input(file_name);
           NSparam.parse(prm);
+
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                NSparam.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
 
           AssertThrow(NSparam.nitsche->number_solids == 0,
                       SolidWarning(NSparam.nitsche->number_solids,

--- a/applications/lethe-fluid-matrix-free/fluid_dynamics_matrix_free.cc
+++ b/applications/lethe-fluid-matrix-free/fluid_dynamics_matrix_free.cc
@@ -50,6 +50,14 @@ main(int argc, char *argv[])
           prm.parse_input(file_name);
           NSparam.parse(prm);
 
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                NSparam.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
+
           // Print parameters if needed
           if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
             print_parameters_to_output_file(pcout, prm, file_name);
@@ -67,6 +75,14 @@ main(int argc, char *argv[])
           // Parsing of the file
           prm.parse_input(file_name);
           NSparam.parse(prm);
+
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                NSparam.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
 
           // Print parameters if needed
           if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)

--- a/applications/lethe-fluid-nitsche/fluid_dynamics_nitsche.cc
+++ b/applications/lethe-fluid-nitsche/fluid_dynamics_nitsche.cc
@@ -50,6 +50,14 @@ main(int argc, char *argv[])
           prm.parse_input(file_name);
           NSparam.parse(prm);
 
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                NSparam.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
+
           // Print parameters if needed
           if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
             print_parameters_to_output_file(pcout, prm, file_name);
@@ -67,6 +75,14 @@ main(int argc, char *argv[])
           // Parsing of the file
           prm.parse_input(file_name);
           NSparam.parse(prm);
+
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                NSparam.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
 
           // Print parameters if needed
           if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)

--- a/applications/lethe-fluid-particles/cfd_dem_coupling.cc
+++ b/applications/lethe-fluid-particles/cfd_dem_coupling.cc
@@ -50,6 +50,14 @@ main(int argc, char *argv[])
           prm.parse_input(file_name);
           NSparam.parse(prm);
 
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                NSparam.cfd_parameters.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
+
           // Print parameters if needed
           if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
             print_parameters_to_output_file(pcout, prm, file_name);
@@ -67,6 +75,14 @@ main(int argc, char *argv[])
           // Parsing of the file
           prm.parse_input(file_name);
           NSparam.parse(prm);
+
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                NSparam.cfd_parameters.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
 
           // Print parameters if needed
           if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)

--- a/applications/lethe-fluid-sharp/fluid_dynamics_sharp.cc
+++ b/applications/lethe-fluid-sharp/fluid_dynamics_sharp.cc
@@ -50,6 +50,14 @@ main(int argc, char *argv[])
           prm.parse_input(file_name);
           NSparam.parse(prm);
 
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                NSparam.cfd_parameters.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
+
           // Print parameters if needed
           if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
             print_parameters_to_output_file(pcout, prm, file_name);
@@ -67,6 +75,14 @@ main(int argc, char *argv[])
           // Parsing of the file
           prm.parse_input(file_name);
           NSparam.parse(prm);
+
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                NSparam.cfd_parameters.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
 
           // Print parameters if needed
           if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)

--- a/applications/lethe-fluid-vans-matrix-free/fluid_dynamics_vans_matrix_free.cc
+++ b/applications/lethe-fluid-vans-matrix-free/fluid_dynamics_vans_matrix_free.cc
@@ -50,6 +50,14 @@ main(int argc, char *argv[])
           prm.parse_input(file_name);
           NSparam.parse(prm);
 
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                NSparam.cfd_parameters.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
+
           // Print parameters if needed
           if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
             print_parameters_to_output_file(pcout, prm, file_name);
@@ -67,6 +75,14 @@ main(int argc, char *argv[])
           // Parsing of the file
           prm.parse_input(file_name);
           NSparam.parse(prm);
+
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                NSparam.cfd_parameters.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
 
           // Print parameters if needed
           if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)

--- a/applications/lethe-fluid-vans/fluid_dynamics_vans.cc
+++ b/applications/lethe-fluid-vans/fluid_dynamics_vans.cc
@@ -50,6 +50,14 @@ main(int argc, char *argv[])
           prm.parse_input(file_name);
           NSparam.parse(prm);
 
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                NSparam.cfd_parameters.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
+
           // Print parameters if needed
           if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
             print_parameters_to_output_file(pcout, prm, file_name);
@@ -67,6 +75,14 @@ main(int argc, char *argv[])
           // Parsing of the file
           prm.parse_input(file_name);
           NSparam.parse(prm);
+
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                NSparam.cfd_parameters.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
 
           // Print parameters if needed
           if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)

--- a/applications/lethe-fluid/fluid_dynamics_matrix_based.cc
+++ b/applications/lethe-fluid/fluid_dynamics_matrix_based.cc
@@ -53,7 +53,8 @@ main(int argc, char *argv[])
           // Remove old output files
           if (options["-R"])
             {
-              std::string output_path = NSparam.simulation_control.output_folder;
+              std::string output_path =
+                NSparam.simulation_control.output_folder;
               delete_vtu_and_pvd_files(output_path);
             }
 
@@ -78,11 +79,12 @@ main(int argc, char *argv[])
           // Parsing of the file
           prm.parse_input(file_name);
           NSparam.parse(prm);
-          
+
           // Remove old output files
           if (options["-R"])
             {
-              std::string output_path = NSparam.simulation_control.output_folder;
+              std::string output_path =
+                NSparam.simulation_control.output_folder;
               delete_vtu_and_pvd_files(output_path);
             }
 

--- a/applications/lethe-fluid/fluid_dynamics_matrix_based.cc
+++ b/applications/lethe-fluid/fluid_dynamics_matrix_based.cc
@@ -50,11 +50,11 @@ main(int argc, char *argv[])
           prm.parse_input(file_name);
           NSparam.parse(prm);
 
-          std::cout << __LINE__ << std::endl;
+          // Remove old output files
           if (options["-R"])
             {
-              std::cout << __LINE__ << std::endl;
-              delete_vtu_and_pvd_files(NSparam);
+              std::string output_path = NSparam.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
             }
 
           AssertThrow(NSparam.nitsche->number_solids == 0,
@@ -78,6 +78,13 @@ main(int argc, char *argv[])
           // Parsing of the file
           prm.parse_input(file_name);
           NSparam.parse(prm);
+          
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path = NSparam.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
 
           AssertThrow(NSparam.nitsche->number_solids == 0,
                       SolidWarning(NSparam.nitsche->number_solids,

--- a/applications/lethe-fluid/fluid_dynamics_matrix_based.cc
+++ b/applications/lethe-fluid/fluid_dynamics_matrix_based.cc
@@ -50,6 +50,13 @@ main(int argc, char *argv[])
           prm.parse_input(file_name);
           NSparam.parse(prm);
 
+          std::cout << __LINE__ << std::endl;
+          if (options["-R"])
+            {
+              std::cout << __LINE__ << std::endl;
+              delete_vtu_and_pvd_files(NSparam);
+            }
+
           AssertThrow(NSparam.nitsche->number_solids == 0,
                       SolidWarning(NSparam.nitsche->number_solids,
                                    "lethe-fluid",

--- a/applications/lethe-particles/dem.cc
+++ b/applications/lethe-particles/dem.cc
@@ -50,6 +50,14 @@ main(int argc, char *argv[])
           prm.parse_input(file_name);
           dem_parameters.parse(prm);
 
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                dem_parameters.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
+
           // Print parameters if needed
           if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
             print_parameters_to_output_file(pcout, prm, file_name);
@@ -88,6 +96,14 @@ main(int argc, char *argv[])
           // Parsing of the file
           prm.parse_input(file_name);
           dem_parameters.parse(prm);
+
+          // Remove old output files
+          if (options["-R"])
+            {
+              std::string output_path =
+                dem_parameters.simulation_control.output_folder;
+              delete_vtu_and_pvd_files(output_path);
+            }
 
           // Print parameters if needed
           if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)

--- a/doc/source/tools/command-line-interface-options.rst
+++ b/doc/source/tools/command-line-interface-options.rst
@@ -1,6 +1,6 @@
-======================================
-Useful Flags when Lauching Simulations
-======================================
+==============================
+Command-line Interface Options
+==============================
 
 
 --------------------------------
@@ -22,7 +22,7 @@ run an application. In an example of usage, ``lethe-fluid -V`` yields:
 ----------------------------
 Delete Previous Output Files
 ----------------------------
-The flag ``-R`` allows the user to delete previous ``.vtu`` output files before 
+The flag ``-R`` allows the user to delete previous output files before 
 new ones are written. This is useful, for instance, when launching the simulation
 multiple times with different numbers of steps, so that you make sure only the 
 most recent output files are stored. One example is as follows:
@@ -31,7 +31,7 @@ most recent output files are stored. One example is as follows:
 
    lethe-fluid -R tgv-matrix-based.prm
 
-The previous (if any) ``.vtu`` and ``.pvd`` files, stored in the output path 
+The previous (if any) ``.vtu``, ``.pvtu``, and ``.pvd`` files, stored in the output path 
 determined in the ``prm`` file, will be removed before the files corresponding
 to the current simulation are saved.
 

--- a/doc/source/tools/tools.rst
+++ b/doc/source/tools/tools.rst
@@ -8,7 +8,7 @@ Tools
     :titlesonly:
 
     updating-test-results
-    useful-flags
+    command-line-interface-options
     gmsh/gmsh
     pointwise/pointwise
     automatic_launch/automatic_launch

--- a/doc/source/tools/tools.rst
+++ b/doc/source/tools/tools.rst
@@ -8,6 +8,7 @@ Tools
     :titlesonly:
 
     updating-test-results
+    useful-flags
     gmsh/gmsh
     pointwise/pointwise
     automatic_launch/automatic_launch

--- a/doc/source/tools/useful-flags.rst
+++ b/doc/source/tools/useful-flags.rst
@@ -1,0 +1,42 @@
+======================================
+Useful Flags when Lauching Simulations
+======================================
+
+
+--------------------------------
+Print deal.II and Lethe Versions
+--------------------------------
+The flag ``-V`` allos the user to print the deal.II and Lethe versions used to
+run an application. In an example of usage, ``lethe-fluid -V`` yields:
+
+.. code-block:: shell
+   
+   Running: lethe-fluid -V
+   lethe/1.0-77-g9fe541d99 deal.II/9.6.2-2966-g7a74e69540
+
+.. hint::
+
+   The ``-V`` tag can be used with all Lethe applications.
+
+
+----------------------------
+Delete Previous Output Files
+----------------------------
+The flag ``-R`` allows the user to delete previous ``.vtu`` output files before 
+new ones are written. This is useful, for instance, when launching the simulation
+multiple times with different numbers of steps, so that you make sure only the 
+most recent output files are stored. One example is as follows:
+
+.. code-block:: shell
+
+   lethe-fluid -R tgv-matrix-based.prm
+
+The previous (if any) ``.vtu`` and ``.pvd`` files, stored in the output path 
+determined in the ``prm`` file, will be removed before the files corresponding
+to the current simulation are saved.
+
+.. hint::
+
+   The ``-R`` tag can be used in the applications ``lethe-fluid``, ``lethe-fluid-block``,
+   ``lethe-fluid-matrix-free``, ``lethe-fluid-nitsche``, ``lethe-fluid-particles``,
+   ``lethe-fluid-sharp``, ``lethe-fluid-vans``, and ``lethe-particles``.

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -809,7 +809,7 @@ print_parameters_to_output_file(const ConditionalOStream &pcout,
  * @brief Delete vtu and pvd files
  */
 void
-delete_vtu_and_pvd_files(std::string &output_path);
+delete_vtu_and_pvd_files(const std::string &output_path);
 
 /**
  * @brief Converts point to radius

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -806,6 +806,13 @@ print_parameters_to_output_file(const ConditionalOStream &pcout,
                                 const std::string        &file_name);
 
 /**
+ * @brief Delete vtu and pvd files
+ */
+template <int dim>
+void
+delete_vtu_and_pvd_files(const SimulationParameters<dim> &NSparam);
+
+/**
  * @brief Converts point to radius
  * @param[in] point Point in cartesian coordinates (x-y plane)
  * @param[in] center_of_rotation Reference point

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -808,9 +808,8 @@ print_parameters_to_output_file(const ConditionalOStream &pcout,
 /**
  * @brief Delete vtu and pvd files
  */
-template <int dim>
 void
-delete_vtu_and_pvd_files(const SimulationParameters<dim> &NSparam);
+delete_vtu_and_pvd_files(std::string output_path);
 
 /**
  * @brief Converts point to radius

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -809,7 +809,7 @@ print_parameters_to_output_file(const ConditionalOStream &pcout,
  * @brief Delete vtu and pvd files
  */
 void
-delete_vtu_and_pvd_files(std::string output_path);
+delete_vtu_and_pvd_files(std::string &output_path);
 
 /**
  * @brief Converts point to radius

--- a/source/core/utilities.cc
+++ b/source/core/utilities.cc
@@ -3,7 +3,7 @@
 
 #include <core/revision.h>
 #include <core/utilities.h>
-#include <solvers/simulation_parameters.h>
+
 
 #if __GNUC__ > 7
 #  include <filesystem>
@@ -852,6 +852,6 @@ delete_vtu_and_pvd_files(std::string output_path)
       if (filename.path().extension() == ".vtu" ||
           filename.path().extension() == ".pvd" ||
           filename.path().extension() == ".pvtu")
-          std::filesystem::remove(filename.path());
+        std::filesystem::remove(filename.path());
     }
 }

--- a/source/core/utilities.cc
+++ b/source/core/utilities.cc
@@ -4,7 +4,6 @@
 #include <core/revision.h>
 #include <core/utilities.h>
 
-
 #if __GNUC__ > 7
 #  include <filesystem>
 #endif

--- a/source/core/utilities.cc
+++ b/source/core/utilities.cc
@@ -844,8 +844,9 @@ print_parameters_to_output_file(const ConditionalOStream &pcout,
 }
 
 void
-delete_vtu_and_pvd_files(std::string output_path)
+delete_vtu_and_pvd_files(std::string &output_path)
 {
+#if __GNUC__ > 7
   for (auto const &filename : std::filesystem::directory_iterator{output_path})
     {
       if (filename.path().extension() == ".vtu" ||
@@ -853,4 +854,10 @@ delete_vtu_and_pvd_files(std::string output_path)
           filename.path().extension() == ".pvtu")
         std::filesystem::remove(filename.path());
     }
+#else
+  AssertThrow(
+    false,
+    ExcMessage(
+      "Deleting old vtu files is not possible with the current GNU compiler version."));
+#endif
 }

--- a/source/core/utilities.cc
+++ b/source/core/utilities.cc
@@ -3,6 +3,7 @@
 
 #include <core/revision.h>
 #include <core/utilities.h>
+#include <solvers/simulation_parameters.h>
 
 #if __GNUC__ > 7
 #  include <filesystem>
@@ -840,5 +841,28 @@ print_parameters_to_output_file(const ConditionalOStream &pcout,
                              ParameterHandler::OutputStyle::Short |
                              ParameterHandler::KeepDeclarationOrder);
       pcout << std::endl << std::endl;
+    }
+}
+
+template <int dim>
+void
+delete_vtu_and_pvd_files(const SimulationParameters<dim> &NSparam)
+{
+  std::cout << __LINE__ << std::endl;
+  std::string output_path = NSparam.simulation_control->get_output_path();
+
+  std::cout << __LINE__ << std::endl;
+  
+  for (auto const &filename : std::filesystem::directory_iterator{output_path})
+    {
+      std::cout << __LINE__ << std::endl;
+      if (filename.path().extension() == ".vtu" ||
+          filename.path().extension() == ".pvd" ||
+          filename.path().extension() == ".pvtu")
+        {
+          std::cout << __LINE__ << std::endl;
+          std::filesystem::remove(filename.path());
+          std::cout << __LINE__ << std::endl;
+        }
     }
 }

--- a/source/core/utilities.cc
+++ b/source/core/utilities.cc
@@ -844,7 +844,7 @@ print_parameters_to_output_file(const ConditionalOStream &pcout,
 }
 
 void
-delete_vtu_and_pvd_files(std::string &output_path)
+delete_vtu_and_pvd_files(const std::string &output_path)
 {
 #if __GNUC__ > 7
   for (auto const &filename : std::filesystem::directory_iterator{output_path})
@@ -858,6 +858,6 @@ delete_vtu_and_pvd_files(std::string &output_path)
   AssertThrow(
     false,
     ExcMessage(
-      "Deleting old vtu files is not possible with the current GNU compiler version."));
+      "Deleting old vtu files is not possible with the current compiler version."));
 #endif
 }

--- a/source/core/utilities.cc
+++ b/source/core/utilities.cc
@@ -844,25 +844,14 @@ print_parameters_to_output_file(const ConditionalOStream &pcout,
     }
 }
 
-template <int dim>
 void
-delete_vtu_and_pvd_files(const SimulationParameters<dim> &NSparam)
+delete_vtu_and_pvd_files(std::string output_path)
 {
-  std::cout << __LINE__ << std::endl;
-  std::string output_path = NSparam.simulation_control->get_output_path();
-
-  std::cout << __LINE__ << std::endl;
-  
   for (auto const &filename : std::filesystem::directory_iterator{output_path})
     {
-      std::cout << __LINE__ << std::endl;
       if (filename.path().extension() == ".vtu" ||
           filename.path().extension() == ".pvd" ||
           filename.path().extension() == ".pvtu")
-        {
-          std::cout << __LINE__ << std::endl;
           std::filesystem::remove(filename.path());
-          std::cout << __LINE__ << std::endl;
-        }
     }
 }


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the content of the new feature
       What are the motivations? 
       How is it integrated to the current code? -->

This PR adds a feature that allows to delete old `.vtu` and `.pvd` files, when launching a simulation, before new ones are written. 

### Testing

<!-- How has this been tested?
       What are the new test(s) and what feature(s)/parameter(s) does it test?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works?
       How will you ensure that it will continue to work in the future? -->

The feature was tested with examples from all applications in which the flag `-R` is supported.

### Documentation

<!-- Does this new feature introduce new simulation parameters? If so, describe them. -->

The documentation has been added on a new section in `Tools` -> `Command-Line Interface Options`. Documentation regarding PR #1475 has also been added.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge