### PR TITLE
Update validation for lucille

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
+- MINOR Add tailored capability for validation script to run on Lucille (a compute node) and re-adapt rising bubble case. [#1574](https://github.com/chaos-polymtl/lethe/pull/1574)
+
+## [Master] - 2025-07-03
+
+### Added
+
 - MINOR Add functionality that allows to delete previous vtu and pvd files by using a flag '-R'. [#1569](https://github.com/chaos-polymtl/lethe/pull/1569)
 
 ## [Master] - 2025-06-30

--- a/contrib/validation/validate_lethe.sh
+++ b/contrib/validation/validate_lethe.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2020-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # -----------------------------------------------------------------------------

--- a/contrib/validation/validate_lethe.sh
+++ b/contrib/validation/validate_lethe.sh
@@ -36,8 +36,10 @@ show_help() {
     echo
     echo "Options:"
     echo "  -h, --help       Display this help message"
+    echo "  -i, --input      Specify the input file with the list of cases to validate (default: validation_cases.txt)"
     echo "  -o, --output     Specify the absolute path directory for validation results"
-    echo
+    echo "  -f, --force      Do not ask for confirmation when erasing the contents of the output folder or proceeding with the validation" 
+    echo 
     echo "Description:"
     echo "This script automates the validation of the Computational Fluid Dynamics (CFD)"
     echo "and Discrete Element Method (DEM) software Lethe. It runs a series of predefined"
@@ -93,11 +95,28 @@ verify_or_create_folder() {
 
 show_splash
 
+# Default values for options
+input_file="$lethe_path/contrib/validation/validation_cases.txt"
+force=false # Flag to skip confirmation prompts
+
 # Parse command-line arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
         -h|--help)
             show_help
+            ;;
+        -f|--force)
+            force=true  # Set a flag to skip confirmation prompts
+            shift  # Skip the flag
+            ;;
+        -i|--input)
+            if [[ -n $2 && $2 != -* ]]; then
+                input_file="$2"
+                shift 2  # Skip the flag and its argument
+            else
+                echo "Error: Missing argument for -i|--input."
+                exit 1
+            fi
             ;;
         -o|--output)
             if [[ -n $2 && $2 != -* ]]; then
@@ -166,13 +185,12 @@ else
     exit 1
 fi
 
-echo "Press Enter to continue..."
-read -r  # Wait for user to press Enter
-
-
-
-# Input file
-input_file="$lethe_path/contrib/validation/validation_cases.txt"
+if ($force); then
+    echo "Skipping confirmation prompts as --force was specified."
+else
+    echo "Press Enter to continue..."
+    read -r  # Wait for user to press Enter
+fi
 
 cases=()
 n_procs=()

--- a/contrib/validation/validate_lethe.sh
+++ b/contrib/validation/validate_lethe.sh
@@ -36,7 +36,7 @@ show_help() {
     echo
     echo "Options:"
     echo "  -h, --help       Display this help message"
-    echo "  -i, --input      Specify the input file with the list of cases to validate (default: validation_cases.txt)"
+    echo "  -i, --input      Specify the input file containing the list of cases to validate (default: validation_cases.txt)"
     echo "  -o, --output     Specify the absolute path directory for validation results"
     echo "  -f, --force      Do not ask for confirmation when erasing the contents of the output folder or proceeding with the validation" 
     echo 

--- a/contrib/validation/validation_cases.txt
+++ b/contrib/validation/validation_cases.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # This file contains the list of validation test cases used in the large-scale validation cases for lethe

--- a/contrib/validation/validation_cases_lucille.txt
+++ b/contrib/validation/validation_cases_lucille.txt
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2020-2023 The Lethe Authors
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+
+# This file contains the list of validation test cases used in the large-scale validation cases for lethe
+# The cases assume that the validation is ran from the root folder of the lethe source code
+# For every cases, the path of the vase must be specified followed by the number of processors with which
+# the case must be ran. The file allows for comments, which are specified by a "#"
+
+examples/incompressible-flow/2d-lid-driven-cavity 1
+examples/incompressible-flow/2d-taylor-couette 1
+examples/incompressible-flow/3d-taylor-green-vortex 128
+examples/multiphysics/rising-bubble 128
+examples/dem/3d-rectangular-hopper 64
+examples/dem/3d-rotating-drum 128
+
+

--- a/contrib/validation/validation_cases_lucille.txt
+++ b/contrib/validation/validation_cases_lucille.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # This file contains the list of validation test cases used in the large-scale validation of Lethe
-# The cases assume that the validation is ran from the root folder of the lethe source code
+# The cases assume that the validation is ran from the root folder of the Lethe source code
 # For every cases, the path of the case must be specified followed by the number of processors with which
 # the case must be ran. The file allows for comments, which are specified by a "#"
 

--- a/contrib/validation/validation_cases_lucille.txt
+++ b/contrib/validation/validation_cases_lucille.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # This file contains the list of validation test cases used in the large-scale validation cases for lethe

--- a/contrib/validation/validation_cases_lucille.txt
+++ b/contrib/validation/validation_cases_lucille.txt
@@ -3,7 +3,7 @@
 
 # This file contains the list of validation test cases used in the large-scale validation cases for lethe
 # The cases assume that the validation is ran from the root folder of the lethe source code
-# For every cases, the path of the vase must be specified followed by the number of processors with which
+# For every cases, the path of the case must be specified followed by the number of processors with which
 # the case must be ran. The file allows for comments, which are specified by a "#"
 
 examples/incompressible-flow/2d-lid-driven-cavity 1

--- a/contrib/validation/validation_cases_lucille.txt
+++ b/contrib/validation/validation_cases_lucille.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
-# This file contains the list of validation test cases used in the large-scale validation cases for lethe
+# This file contains the list of validation test cases used in the large-scale validation of Lethe
 # The cases assume that the validation is ran from the root folder of the lethe source code
 # For every cases, the path of the case must be specified followed by the number of processors with which
 # the case must be ran. The file allows for comments, which are specified by a "#"

--- a/contrib/validation/validation_functions.sh
+++ b/contrib/validation/validation_functions.sh
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 The Lethe Authors
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Function to recreate the folder
 recreate_folder() {

--- a/examples/multiphysics/rising-bubble/rising-bubble-alge.prm
+++ b/examples/multiphysics/rising-bubble/rising-bubble-alge.prm
@@ -11,14 +11,15 @@ set dimension = 2
 #---------------------------------------------------
 
 subsection simulation control
-  set method           = bdf2
-  set time end         = 3
-  set time step        = 0.001
-  set adapt            = true
-  set max cfl          = 0.80
-  set output name      = rising-bubble
-  set output frequency = 20
-  set output path      = ./rising-bubble-alge/
+  set method                            = bdf2
+  set time end                          = 3
+  set time step                         = 0.001
+  set adapt                             = true
+  set max cfl                           = 0.80
+  set output name                       = rising-bubble
+  set output frequency                  = 20
+  set output path                       = ./rising-bubble-alge/
+  set time step independent of end time = false
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/rising-bubble/rising-bubble-geo.prm
+++ b/examples/multiphysics/rising-bubble/rising-bubble-geo.prm
@@ -11,14 +11,15 @@ set dimension = 2
 #---------------------------------------------------
 
 subsection simulation control
-  set method           = bdf2
-  set time end         = 3
-  set time step        = 0.001
-  set adapt            = true
-  set max cfl          = 0.80
-  set output name      = rising-bubble
-  set output frequency = 20
-  set output path      = ./rising-bubble-geo/
+  set method                            = bdf2
+  set time end                          = 3
+  set time step                         = 0.001
+  set adapt                             = true
+  set max cfl                           = 0.80
+  set output name                       = rising-bubble
+  set output frequency                  = 20
+  set output path                       = ./rising-bubble-geo/
+  set time step independent of end time = false
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/rising-bubble/rising-bubble-proj.prm
+++ b/examples/multiphysics/rising-bubble/rising-bubble-proj.prm
@@ -11,14 +11,15 @@ set dimension = 2
 #---------------------------------------------------
 
 subsection simulation control
-  set method           = bdf2
-  set time end         = 3
-  set time step        = 0.001
-  set adapt            = true
-  set max cfl          = 0.80
-  set output name      = rising-bubble
-  set output frequency = 20
-  set output path      = ./rising-bubble-proj/
+  set method                            = bdf2
+  set time end                          = 3
+  set time step                         = 0.001
+  set adapt                             = true
+  set max cfl                           = 0.80
+  set output name                       = rising-bubble
+  set output frequency                  = 20
+  set output path                       = ./rising-bubble-proj/
+  set time step independent of end time = false
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/rising-bubble/rising-bubble.py
+++ b/examples/multiphysics/rising-bubble/rising-bubble.py
@@ -380,7 +380,7 @@ ax4.set_xlabel(r'Rising time [T]')
 ax4.ticklabel_format(useOffset=False, style='plain', axis='y')
 ax4.legend(loc="upper left")
 if (args.validate):
-  fig3.savefig(f'./geo-mass-conservation-case' + str(case_number) + '.pdf')
+  fig4.savefig(f'./geo-mass-conservation-case' + str(case_number) + '.pdf')
 else:
   fig4.savefig(f'./geo-mass-conservation-case' + str(case_number) + '.png',dpi=300)
   plt.show()

--- a/examples/multiphysics/rising-bubble/rising-bubble.py
+++ b/examples/multiphysics/rising-bubble/rising-bubble.py
@@ -157,8 +157,13 @@ ax0.set_ylabel(r'Barycenter height [L]')
 ax0.set_xlabel(r'Rising time [T]')
 ax0.legend(loc="upper left")
 if (args.validate):
-  
-  fig0.savefig(f'./ymean-t-case' + str(case_number) + '.pdf')
+  solution = np.column_stack((t_proj, y_proj))
+  np.savetxt("solution-barycenter-case" + str(case_number) + "-" + "Projection" + ".dat", solution, header="t y") 
+  solution = np.column_stack((t_geo, y_geo))
+  np.savetxt("solution-barycenter-case" + str(case_number) + "-" + "Geometric" + ".dat", solution, header="t y") 
+  solution = np.column_stack((t_alge, y_alge))
+  np.savetxt("solution-barycenter-case" + str(case_number) + "-" + "PDE-based" + ".dat", solution, header="t y") 
+  fig0.savefig(f'./bubble-barycenter-case' + str(case_number) + '.pdf')
 else:  
   fig0.savefig(f'./ymean-t-case' + str(case_number) + '.png',dpi=300)
   plt.show()
@@ -189,6 +194,12 @@ ax1.set_ylabel(r'Rise velocity [LT$^{-1}$]')
 ax1.set_xlabel(r'Rising time [T]')
 ax1.legend(loc=4)
 if (args.validate):
+  solution = np.column_stack((t_proj, vy_proj))
+  np.savetxt("solution-velocity-case" + str(case_number) + "-" + "Projection" + ".dat", solution, header="t vy") 
+  solution = np.column_stack((t_geo, vy_geo))
+  np.savetxt("solution-velocity-case" + str(case_number) + "-" + "Geometric" + ".dat", solution, header="t vy") 
+  solution = np.column_stack((t_alge, vy_alge))
+  np.savetxt("solution-velocity-case" + str(case_number) + "-" + "PDE-based" + ".dat", solution, header="t vy") 
   fig1.savefig(f'./bubble-rise-velocity-case' + str(case_number) + '.pdf')
 else:
   fig1.savefig(f'./bubble-rise-velocity-case' + str(case_number) + '.png',dpi=300)

--- a/examples/multiphysics/rising-bubble/rising-bubble.py
+++ b/examples/multiphysics/rising-bubble/rising-bubble.py
@@ -156,8 +156,12 @@ elif case_number ==2 :
 ax0.set_ylabel(r'Barycenter height [L]')
 ax0.set_xlabel(r'Rising time [T]')
 ax0.legend(loc="upper left")
-fig0.savefig(f'./ymean-t-case' + str(case_number) + '.png',dpi=300)
-plt.show()
+if (args.validate):
+  
+  fig0.savefig(f'./ymean-t-case' + str(case_number) + '.pdf')
+else:  
+  fig0.savefig(f'./ymean-t-case' + str(case_number) + '.png',dpi=300)
+  plt.show()
 
 # Plot the velocity
 fig1 = plt.figure()
@@ -184,8 +188,11 @@ elif case_number == 2 :
 ax1.set_ylabel(r'Rise velocity [LT$^{-1}$]')
 ax1.set_xlabel(r'Rising time [T]')
 ax1.legend(loc=4)
-fig1.savefig(f'./bubble-rise-velocity-case' + str(case_number) + '.png',dpi=300)
-plt.show()
+if (args.validate):
+  fig1.savefig(f'./bubble-rise-velocity-case' + str(case_number) + '.pdf')
+else:
+  fig1.savefig(f'./bubble-rise-velocity-case' + str(case_number) + '.png',dpi=300)
+  plt.show()
 
 # Plot the contour of the bubble in the last frame
 if has_proj:
@@ -247,7 +254,10 @@ for i in range(n):
     ax2= fig2.add_subplot(111)
     
     ax2.scatter(x[i], y[i], s=2, marker="s", color=colors[i], label=label[i], linewidths=1)
-    
+    if (args.validate):
+        solution = np.column_stack((x[i], y[i]))
+        np.savetxt("solution-contour-case" + str(case_number) + "-" + label[i] + ".dat", solution, header="x y")
+
     if case_number == 1 :
 
         ax2.plot(df_contour_ZKR['x'], df_contour_ZKR['y'], '-k',
@@ -280,8 +290,6 @@ for i in range(n):
     ax2.grid( which='major', color='grey', linestyle='--')
 
     if (args.validate):
-        solution = np.column_stack((x, y))
-        np.savetxt("solution-contour-case" + str(case_number) + ".dat", solution, header="x y")
         fig2.savefig("bubble-contour-case" + str(case_number) + ".pdf")
     else:
         fig2.savefig(fig_name[i] + "-bubble-contour-case" + str(case_number) + ".png",dpi=300)
@@ -293,6 +301,9 @@ if n > 1:
     ax2= fig2.add_subplot(111)
     for i in range(len(x)):
         ax2.scatter(x[i], y[i], s=1, marker="s", color=colors[i], label=label[i], linewidths=1)
+        if (args.validate):
+            solution = np.column_stack((x[i], y[i]))
+            np.savetxt("solution-contour-case" + str(case_number) + "-" + label[i] + ".dat", solution, header="x y")
 
     ax2.set_xlabel(r'x [L]')
     ax2.set_ylabel(r'y [L]')
@@ -304,9 +315,11 @@ if n > 1:
     if case_number == 2 :
         ax2.set_xlim([0,1])
         ax2.set_ylim([0.5,1.4])    
-        
-    fig2.savefig("bubble-contour-case" + str(case_number) + ".png",dpi=300)
-    plt.show()
+    if (args.validate):
+      fig2.savefig("bubble-contour-case" + str(case_number) + ".pdf")
+    else:
+      fig2.savefig("bubble-contour-case" + str(case_number) + ".png",dpi=300)
+      plt.show()
     
 # Plot the mass conservation for the global and local mass
 fig3 = plt.figure()
@@ -329,8 +342,11 @@ ax3.set_ylabel(r'$V/{V_\mathrm{0}}[-]$')
 ax3.set_xlabel(r'Rising time [T]')
 ax3.ticklabel_format(useOffset=False, style='plain', axis='y')
 ax3.legend(loc="upper left")
-fig3.savefig(f'./global-mass-conservation-case' + str(case_number) + '.png',dpi=300)
-plt.show()
+if (args.validate):
+  fig3.savefig(f'./global-mass-conservation-case' + str(case_number) + '.pdf')
+else:
+  fig3.savefig(f'./global-mass-conservation-case' + str(case_number) + '.png',dpi=300)
+  plt.show()
 
 fig4 = plt.figure()
 ax4 = fig4.add_subplot(111)
@@ -352,5 +368,8 @@ ax4.set_ylabel(r'$V/{V_\mathrm{0}}[-]$')
 ax4.set_xlabel(r'Rising time [T]')
 ax4.ticklabel_format(useOffset=False, style='plain', axis='y')
 ax4.legend(loc="upper left")
-fig4.savefig(f'./geo-mass-conservation-case' + str(case_number) + '.png',dpi=300)
-plt.show()
+if (args.validate):
+  fig3.savefig(f'./geo-mass-conservation-case' + str(case_number) + '.pdf')
+else:
+  fig4.savefig(f'./geo-mass-conservation-case' + str(case_number) + '.png',dpi=300)
+  plt.show()

--- a/examples/multiphysics/rising-bubble/rising-bubble.py
+++ b/examples/multiphysics/rising-bubble/rising-bubble.py
@@ -282,7 +282,7 @@ for i in range(n):
     if (args.validate):
         solution = np.column_stack((x, y))
         np.savetxt("solution-contour-case" + str(case_number) + ".dat", solution, header="x y")
-        fig2.savefig("bubble-contour-case" + str(case_number) + ".png")
+        fig2.savefig("bubble-contour-case" + str(case_number) + ".pdf")
     else:
         fig2.savefig(fig_name[i] + "-bubble-contour-case" + str(case_number) + ".png",dpi=300)
         plt.show()

--- a/examples/multiphysics/rising-bubble/rising-bubble.py
+++ b/examples/multiphysics/rising-bubble/rising-bubble.py
@@ -200,7 +200,7 @@ if (args.validate):
   np.savetxt("solution-velocity-case" + str(case_number) + "-" + "Geometric" + ".dat", solution, header="t vy") 
   solution = np.column_stack((t_alge, vy_alge))
   np.savetxt("solution-velocity-case" + str(case_number) + "-" + "PDE-based" + ".dat", solution, header="t vy") 
-  fig1.savefig(f'./bubble-rise-velocity-case' + str(case_number) + '.pdf')
+  fig1.savefig(f'./bubble-velocity-case' + str(case_number) + '.pdf')
 else:
   fig1.savefig(f'./bubble-rise-velocity-case' + str(case_number) + '.png',dpi=300)
   plt.show()

--- a/examples/multiphysics/rising-bubble/rising-bubble.py
+++ b/examples/multiphysics/rising-bubble/rising-bubble.py
@@ -301,7 +301,7 @@ for i in range(n):
     ax2.grid( which='major', color='grey', linestyle='--')
 
     if (args.validate):
-        fig2.savefig("bubble-contour-case" + str(case_number) + ".pdf")
+        fig2.savefig(fig_name[i] +"-bubble-contour-case" + str(case_number) + ".pdf")
     else:
         fig2.savefig(fig_name[i] + "-bubble-contour-case" + str(case_number) + ".png",dpi=300)
         plt.show()

--- a/examples/multiphysics/rising-bubble/validate.sh
+++ b/examples/multiphysics/rising-bubble/validate.sh
@@ -8,10 +8,10 @@
 . ../../../contrib/validation/validation_functions.sh
 
 # Store filenames of all plots in a variable (space-seperated)
-plots="bubble-rise-barycenter.pdf bubble-rise-velocity.pdf bubble-contour.pdf"
+plots="bubble-rise-barycenter-case1.pdf bubble-rise-velocity-case1.pdf bubble-contour-case1.pdf geo-mass-conservation-case1.pdf global-mass-conservation-case1.pdf"
 
 # Store filenames of all data files in a variable (space-seperated)
-data="solution-barycenter.dat solution-contour.dat solution-velocity.dat"
+data="solution-contour-case1-Geometric.dat solution-contour-case1-PDE-based.dat solution-contour-case1-Projection.dat
 
 # Default path
 output_root="./"
@@ -23,13 +23,15 @@ n_proc=16
 parse_command_line "$@"
 
 folder="$output_root/rising-bubble"
-action="mpirun -np $n_proc lethe-fluid rising-bubble.prm" 
+action="mpirun -np $n_proc lethe-fluid rising-bubble-proj.prm" 
+action="mpirun -np $n_proc lethe-fluid rising-bubble-geo.prm" 
+action="mpirun -np $n_proc lethe-fluid rising-bubble-alge.prm" 
 recreate_folder "$folder"
 
 { time $action ; } &> "$folder/log"
 
 # Process the simulation
-python3 rising-bubble.py -f output  --validate -c 1
+python3 ./rising-bubble.py -s rising-bubble-proj -g rising-bubble-geo -a rising-bubble-alge -c 1 --validate
 
 # Copy the information to the log folder
 cp $plots $folder

--- a/examples/multiphysics/rising-bubble/validate.sh
+++ b/examples/multiphysics/rising-bubble/validate.sh
@@ -8,7 +8,7 @@
 . ../../../contrib/validation/validation_functions.sh
 
 # Store filenames of all plots in a variable (space-seperated)
-plots="bubble-barycenter-case1.pdf bubble-velocity-case1.pdf bubble-contour-case1.pdf geo-mass-conservation-case1.pdf global-mass-conservation-case1.pdf"
+plots="bubble-barycenter-case1.pdf bubble-velocity-case1.pdf alge-bubble-contour-case1.pdf geo-bubble-contour-case1.pdf proj-bubble-contour-case1.pdf bubble-contour-case1.pdf geo-mass-conservation-case1.pdf global-mass-conservation-case1.pdf"
 
 # Store filenames of all data files in a variable (space-seperated)
 data="solution-contour-case1-Geometric.dat solution-contour-case1-PDE-based.dat solution-contour-case1-Projection.dat solution-barycenter-case1-Geometric.dat solution-barycenter-case1-PDE-based.dat solution-barycenter-case1-Projection.dat solution-velocity-case1-Geometric.dat solution-velocity-case1-PDE-based.dat solution-velocity-case1-Projection.dat"

--- a/examples/multiphysics/rising-bubble/validate.sh
+++ b/examples/multiphysics/rising-bubble/validate.sh
@@ -33,7 +33,7 @@ recreate_folder "$folder"
 
 
 # Process the simulation
-python3 ./rising-bubble.py -s rising-bubble-proj -g rising-bubble-geo -a rising-bubble-alge -c 1 --validate
+python3 ./rising-bubble.py -p rising-bubble-proj -g rising-bubble-geo -a rising-bubble-alge -c 1 --validate
 
 # Copy the information to the log folder
 cp $plots $folder

--- a/examples/multiphysics/rising-bubble/validate.sh
+++ b/examples/multiphysics/rising-bubble/validate.sh
@@ -22,12 +22,15 @@ n_proc=16
 parse_command_line "$@"
 
 folder="$output_root/rising-bubble"
-action="mpirun -np $n_proc lethe-fluid rising-bubble-proj.prm" 
-action="mpirun -np $n_proc lethe-fluid rising-bubble-geo.prm" 
-action="mpirun -np $n_proc lethe-fluid rising-bubble-alge.prm" 
+action_proj="mpirun -np $n_proc lethe-fluid rising-bubble-proj.prm" 
+action_geo="mpirun -np $n_proc lethe-fluid rising-bubble-geo.prm" 
+action_alge="mpirun -np $n_proc lethe-fluid rising-bubble-alge.prm" 
 recreate_folder "$folder"
 
-{ time $action ; } &> "$folder/log"
+{ time $action_proj ; } &> "$folder/log-proj"
+{ time $action_geo ; } &> "$folder/log-geo"
+{ time $action_alge ; } &> "$folder/log-alge"
+
 
 # Process the simulation
 python3 ./rising-bubble.py -s rising-bubble-proj -g rising-bubble-geo -a rising-bubble-alge -c 1 --validate

--- a/examples/multiphysics/rising-bubble/validate.sh
+++ b/examples/multiphysics/rising-bubble/validate.sh
@@ -8,7 +8,7 @@
 . ../../../contrib/validation/validation_functions.sh
 
 # Store filenames of all plots in a variable (space-seperated)
-plots="bubble-rise-barycenter-case1.pdf bubble-rise-velocity-case1.pdf bubble-contour-case1.pdf geo-mass-conservation-case1.pdf global-mass-conservation-case1.pdf"
+plots="bubble-barycenter-case1.pdf bubble-velocity-case1.pdf bubble-contour-case1.pdf geo-mass-conservation-case1.pdf global-mass-conservation-case1.pdf"
 
 # Store filenames of all data files in a variable (space-seperated)
 data="solution-contour-case1-Geometric.dat solution-contour-case1-PDE-based.dat solution-contour-case1-Projection.dat solution-barycenter-case1-Geometric.dat solution-barycenter-case1-PDE-based.dat solution-barycenter-case1-Projection.dat solution-velocity-case1-Geometric.dat solution-velocity-case1-PDE-based.dat solution-velocity-case1-Projection.dat"

--- a/examples/multiphysics/rising-bubble/validate.sh
+++ b/examples/multiphysics/rising-bubble/validate.sh
@@ -29,7 +29,7 @@ recreate_folder "$folder"
 { time $action ; } &> "$folder/log"
 
 # Process the simulation
-python3 rising-bubble.py -f output  --validate
+python3 rising-bubble.py -f output  --validate -c 1
 
 # Copy the information to the log folder
 cp $plots $folder

--- a/examples/multiphysics/rising-bubble/validate.sh
+++ b/examples/multiphysics/rising-bubble/validate.sh
@@ -11,11 +11,11 @@
 plots="bubble-rise-barycenter-case1.pdf bubble-rise-velocity-case1.pdf bubble-contour-case1.pdf geo-mass-conservation-case1.pdf global-mass-conservation-case1.pdf"
 
 # Store filenames of all data files in a variable (space-seperated)
-data="solution-contour-case1-Geometric.dat solution-contour-case1-PDE-based.dat solution-contour-case1-Projection.dat
+data="solution-contour-case1-Geometric.dat solution-contour-case1-PDE-based.dat solution-contour-case1-Projection.dat solution-barycenter-case1-Geometric.dat solution-barycenter-case1-PDE-based.dat solution-barycenter-case1-Projection.dat solution-velocity-case1-Geometric.dat solution-velocity-case1-PDE-based.dat solution-velocity-case1-Projection.dat"
 
 # Default path
 output_root="./"
-
+solution-barycenter-case1-Geometric.datu
 # Default number of cores
 n_proc=16
 

--- a/examples/multiphysics/rising-bubble/validate.sh
+++ b/examples/multiphysics/rising-bubble/validate.sh
@@ -15,7 +15,6 @@ data="solution-contour-case1-Geometric.dat solution-contour-case1-PDE-based.dat 
 
 # Default path
 output_root="./"
-solution-barycenter-case1-Geometric.datu
 # Default number of cores
 n_proc=16
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The automatic validation of Lethe had two issues:
1- It was not tailored to run on the Lucille node we have.
2- The rising bubble test case was not running correctly since #1558 

### Solution

1- I have changed the validation script to be able to run without user input. It can now be launched from a SLURM job easily using a -f option. I have also created another validation test cases files with different processor count that correspond to the Lucille node. This is the one I will be running every week or so on the node.


2- The python script and the validate.sh script of the rising bubble have been changed to generate graphs that can now be incorporated within the validation.

### Testing

I have run the validation on Lucille with this and the report generates well (see attached artifact).

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge


[report.pdf](https://github.com/user-attachments/files/21121864/report.pdf)
