### PR TITLE
Add get_number_of_stages() utility to SimulationControl

### DIFF
--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -147,6 +147,16 @@ public:
 
   SimulationControl(const Parameters::SimulationControl &param);
 
+
+  /**
+ * @brief Return the number of stages associated with the time-stepping method.
+ * For SDIRK methods, the number of stages is given by the last digit of the method name.
+ * For other methods, the number of stages is 1.
+ */
+  static unsigned int
+  get_number_of_stages(const Parameters::SimulationControl::TimeSteppingMethod &method);
+
+  
   /**
    * @brief Pure virtual function to control the progression of the simulation.
    * As long as integrate returns true, a simulation should proceed. The

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -149,14 +149,15 @@ public:
 
 
   /**
- * @brief Return the number of stages associated with the time-stepping method.
- * For SDIRK methods, the number of stages is given by the last digit of the method name.
- * For other methods, the number of stages is 1.
- */
+   * @brief Return the number of stages associated with the time-stepping method.
+   * For SDIRK methods, the number of stages is given by the last digit of the
+   * method name. For other methods, the number of stages is 1.
+   */
   static unsigned int
-  get_number_of_stages(const Parameters::SimulationControl::TimeSteppingMethod &method);
+  get_number_of_stages(
+    const Parameters::SimulationControl::TimeSteppingMethod &method);
 
-  
+
   /**
    * @brief Pure virtual function to control the progression of the simulation.
    * As long as integrate returns true, a simulation should proceed. The

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -152,9 +152,10 @@ public:
    * @brief Return the number of stages associated with the time-stepping method.
    * For SDIRK methods, the number of stages is given by the last digit of the
    * method name. For other methods, the number of stages is 1.
-   * 
-   * @param[in] method The time-stepping method for which the number of stages is requested.
-   * 
+   *
+   * @param[in] method The time-stepping method for which the number of stages
+   * is requested.
+   *
    * @return The number of stages associated with the time-stepping method.
    */
   static unsigned int

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -152,6 +152,10 @@ public:
    * @brief Return the number of stages associated with the time-stepping method.
    * For SDIRK methods, the number of stages is given by the last digit of the
    * method name. For other methods, the number of stages is 1.
+   * 
+   * @param[in] method The time-stepping method for which the number of stages is requested.
+   * 
+   * @return The number of stages associated with the time-stepping method.
    */
   static unsigned int
   get_number_of_stages(

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -136,6 +136,38 @@ SimulationControl::update_assembly_method()
     }
 }
 
+unsigned int
+SimulationControl::get_number_of_stages(
+  const Parameters::SimulationControl::TimeSteppingMethod &method)
+{
+  using Method = Parameters::SimulationControl::TimeSteppingMethod;
+
+      switch (method)
+        {
+          case Method::steady:
+          case Method::steady_bdf:
+          case Method::bdf1:
+          case Method::bdf2:
+          case Method::bdf3:
+            return 1;
+
+          // Important note : the nomenclature used for the name of the SDIRK methods
+          // are sdirkOrderStage sdirk22 means SDIRK with order 2 and 2 stages, sdirk33
+          // means SDIRK with order 3 and 3 stages
+          case Method::sdirk22:
+            return 2;
+
+          case Method::sdirk33:
+            return 3;
+
+          default:
+            AssertThrow(false,
+                        ExcMessage("Unknown TimeSteppingMethod passed to "
+                                   "get_number_of_stages(). Please add the number of stages of the new method in core/simulation_control.cc."));
+            return 1;
+        }
+}
+
 
 
 bool

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -142,30 +142,32 @@ SimulationControl::get_number_of_stages(
 {
   using Method = Parameters::SimulationControl::TimeSteppingMethod;
 
-      switch (method)
-        {
-          case Method::steady:
-          case Method::steady_bdf:
-          case Method::bdf1:
-          case Method::bdf2:
-          case Method::bdf3:
-            return 1;
+  switch (method)
+    {
+      case Method::steady:
+      case Method::steady_bdf:
+      case Method::bdf1:
+      case Method::bdf2:
+      case Method::bdf3:
+        return 1;
 
-          // Important note : the nomenclature used for the name of the SDIRK methods
-          // are sdirkOrderStage sdirk22 means SDIRK with order 2 and 2 stages, sdirk33
-          // means SDIRK with order 3 and 3 stages
-          case Method::sdirk22:
-            return 2;
+      // Important note : the nomenclature used for the name of the SDIRK
+      // methods are sdirkOrderStage sdirk22 means SDIRK with order 2 and 2
+      // stages, sdirk33 means SDIRK with order 3 and 3 stages
+      case Method::sdirk22:
+        return 2;
 
-          case Method::sdirk33:
-            return 3;
+      case Method::sdirk33:
+        return 3;
 
-          default:
-            AssertThrow(false,
-                        ExcMessage("Unknown TimeSteppingMethod passed to "
-                                   "get_number_of_stages(). Please add the number of stages of the new method in core/simulation_control.cc."));
-            return 1;
-        }
+      default:
+        AssertThrow(
+          false,
+          ExcMessage(
+            "Unknown TimeSteppingMethod passed to "
+            "get_number_of_stages(). Please add the number of stages of the new method in core/simulation_control.cc."));
+        return 1;
+    }
 }
 
 

--- a/tests/core/get_number_of_stages.cc
+++ b/tests/core/get_number_of_stages.cc
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+
+/**
+ * @brief Test to check the number of stages returned by the method
+ * SimulationControl::get_number_of_stages()
+ */
+
+// Lethe
+#include <core/simulation_control.h>
+#include <core/parameters.h>
+
+// Tests
+#include <../tests/tests.h>
+
+void
+test()
+{
+  using Method = Parameters::SimulationControl::TimeSteppingMethod;
+
+  std::vector<std::pair<Method, unsigned int>> test_cases = {
+    {Method::steady, 1},
+    {Method::steady_bdf, 1},
+    {Method::bdf1, 1},
+    {Method::bdf2, 1},
+    {Method::bdf3, 1},
+    {Method::sdirk22, 2},
+    {Method::sdirk33, 3},
+  };
+
+  for (const auto &[method, expected] : test_cases)
+    {
+      unsigned int result = SimulationControl::get_number_of_stages(method);
+      deallog << "Method: " << static_cast<int>(method)
+              << " -> Stages: " << result << std::endl;
+      AssertThrow(result == expected,
+                  ExcMessage("get_number_of_stages() returned incorrect value"));
+    }
+}
+
+int
+main(int argc, char *argv[])
+{
+  try
+    {
+      initlog();
+      test();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl;
+      return 1;
+    }
+
+  return 0;
+}

--- a/tests/core/get_number_of_stages.cc
+++ b/tests/core/get_number_of_stages.cc
@@ -7,8 +7,8 @@
  */
 
 // Lethe
-#include <core/simulation_control.h>
 #include <core/parameters.h>
+#include <core/simulation_control.h>
 
 // Tests
 #include <../tests/tests.h>
@@ -34,7 +34,8 @@ test()
       deallog << "Method: " << static_cast<int>(method)
               << " -> Stages: " << result << std::endl;
       AssertThrow(result == expected,
-                  ExcMessage("get_number_of_stages() returned incorrect value"));
+                  ExcMessage(
+                    "get_number_of_stages() returned incorrect value"));
     }
 }
 

--- a/tests/core/get_number_of_stages.output
+++ b/tests/core/get_number_of_stages.output
@@ -1,0 +1,8 @@
+
+DEAL::Method: 0 -> Stages: 1
+DEAL::Method: 1 -> Stages: 1
+DEAL::Method: 2 -> Stages: 1
+DEAL::Method: 3 -> Stages: 1
+DEAL::Method: 4 -> Stages: 1
+DEAL::Method: 5 -> Stages: 2
+DEAL::Method: 6 -> Stages: 3


### PR DESCRIPTION
### Summary

This very small pull request adds a new utility function `SimulationControl::get_number_of_stages()` that returns the number of stages associated with a given time stepping method.

This is particularly useful for SDIRK methods, where the number of stages varies (e.g., 2 for `sdirk22`, 3 for `sdirk33`), while all other methods are assumed to have a single stage.

### Changes

- Implemented `get_number_of_stages()` in `simulation_control.cc`
- Added a test in `tests/core/test_get_number_of_stages.cc` to verify that the correct number of stages is returned for all known time stepping methods


### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Copyright headers are present and up to date
- [ ] Lethe documentation is up to date
- [ ] The branch is rebased onto master
- [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If any future works is planned, an issue is opened
- [ ] The PR description is cleaned and ready for merge