### PR TITLE
Mortar: add application test with rotated mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Change Log
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
+
+### [Master] - 2025-07-11
+
+### Fixed
+
+- MINOR The rotor mesh rotation was not in the right place in the code, so that at the start of the simulation the accessed mapping information was still incorrect. This PR fixes this, and adds an application test for a rotor rotated mesh. [#1579](https://github.com/chaos-polymtl/lethe/pull/1579)
 ### [Master] - 2025-07-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 
 - MINOR The rotor mesh rotation was not in the right place in the code, so that at the start of the simulation the accessed mapping information was still incorrect. This PR fixes this, and adds an application test for a rotor rotated mesh. [#1579](https://github.com/chaos-polymtl/lethe/pull/1579)
-### [Master] - 2025-07-11
 
 ### Added
 
 - MINOR Removes the old gas-solid-spouted-bed example which has now been replaced with the much better gas-solid-spouted-rectangular-bed. The newer example features validation and other components which make it significnatly more relevant than the previous one which just displayed the capabilities of the solver. [#1578](https://github.com/chaos-polymtl/lethe/pull/1578)
+
 ### [Master] - 2025-07-10
 
 ### Added
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - MINOR Add tailored capability for validation script to run on Lucille (a compute node) and re-adapt rising bubble case. [#1574](https://github.com/chaos-polymtl/lethe/pull/1574)
+
 ## [Master] - 2025-07-07
 
 ### Changed

--- a/applications_tests/lethe-fluid/mortar_mms_rotated.mpirun=3.output
+++ b/applications_tests/lethe-fluid/mortar_mms_rotated.mpirun=3.output
@@ -1,0 +1,32 @@
+Running on 3 MPI rank(s)...
+Mortar - Rotor grid angle is: 0.5 rad 
+
+   Number of active cells:       320
+   Number of degrees of freedom: 4131
+   Volume of triangulation:      4
+
+*****************************
+Steady iteration:        1/3
+*****************************
+
+*****************************
+Steady iteration:        2/3
+*****************************
+Mortar - Rotor grid angle is: 0.5 rad 
+
+   Number of active cells:       1280
+   Number of degrees of freedom: 15939
+   Volume of triangulation:      4
+
+*****************************
+Steady iteration:        3/3
+*****************************
+Mortar - Rotor grid angle is: 0.5 rad 
+
+   Number of active cells:       5120
+   Number of degrees of freedom: 62595
+   Volume of triangulation:      4
+cells  error_velocity    error_pressure   
+  320 1.095199e-02    - 1.270732e-01    - 
+ 1280 1.365251e-03 3.00 3.005519e-02 2.08 
+ 5120 1.685403e-04 3.02 7.350672e-03 2.03 

--- a/applications_tests/lethe-fluid/mortar_mms_rotated.prm
+++ b/applications_tests/lethe-fluid/mortar_mms_rotated.prm
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method            = steady
+  set output name       = mms-mortar_output
+  set number mesh adapt = 2
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  set number of fluids = 1
+  subsection fluid 0
+    set kinematic viscosity = 1.0
+  end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = hyper_cube_with_cylindrical_hole
+  set grid arguments     = 0.5 : 1 : 0 : 1 : false
+  set initial refinement = 2
+end
+
+#---------------------------------------------------
+# Mortar
+#---------------------------------------------------
+
+subsection mortar
+  set enable = true
+  subsection mesh
+    set type               = dealii
+    set grid type          = hyper_ball_balanced
+    set grid arguments     = 0.0, 0.0 : 0.5
+    set initial refinement = 2
+  end
+  set rotor boundary id  = 2
+  set stator boundary id = 1
+  subsection rotor rotation angle
+    set Function expression = 0.5
+  end
+  set center of rotation = 0, 0
+  set penalty factor     = 1
+  set verbosity          = verbose
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+
+subsection FEM
+  set velocity order = 2
+  set pressure order = 2
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions
+  set number = 3
+  subsection bc 0
+    set id   = 0
+    set type = noslip
+  end
+  subsection bc 1
+    set id   = 1
+    set type = none
+  end
+  subsection bc 2
+    set id   = 2
+    set type = none
+  end
+end
+
+# --------------------------------------------------
+# Source term
+#---------------------------------------------------
+
+subsection source term
+  subsection fluid dynamics
+    set enable              = true
+    set Function constants  = nu=1
+    set Function expression = pi*sin(pi*y)*(-16*pi*nu*sin(pi*x)*sin(pi*x)*cos(pi*y)+ 4*pi*nu*cos(pi*y)+4*sin(pi*x)*sin(pi*x)*sin(pi*x)*sin(pi*y)*cos(pi*x)+cos(pi*x)); pi*sin(pi*x)*(16*pi*nu*sin(pi*y)*sin(pi*y)*cos(pi*x)- 4*pi*nu*cos(pi*x)+4*sin(pi*x)*sin(pi*y)*sin(pi*y)*sin(pi*y)*cos(pi*y)+cos(pi*y)); 0
+  end
+end
+
+# --------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+
+subsection analytical solution
+  set enable = true
+  subsection uvwp
+    set Function expression = -2*sin(pi*x) * sin(pi*x) * cos(pi*y) * sin(pi*y) ; 2*cos(pi*x) * sin(pi*x) * sin(pi*y) * sin(pi*y); sin(pi*x)*sin(pi*y)
+  end
+end
+
+#---------------------------------------------------
+# Mesh Adaptation Control
+#---------------------------------------------------
+
+subsection mesh adaptation
+  set type = uniform
+end
+
+#---------------------------------------------------
+# Timer
+#---------------------------------------------------
+
+subsection timer
+  # set type = iteration
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection fluid dynamics
+    set verbosity = quiet
+    set tolerance = 1e-10
+  end
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection fluid dynamics
+    set preconditioner              = amg
+    set amg preconditioner ilu fill = 3
+    set verbosity                   = quiet
+  end
+end

--- a/include/core/mortar_coupling_manager.h
+++ b/include/core/mortar_coupling_manager.h
@@ -281,7 +281,7 @@ MortarManagerCircle<dim>::MortarManagerCircle(
       compute_n_subdivisions_and_radius(dof_handler.get_triangulation(),
                                         mortar_parameters)
         .second,
-      mortar_parameters.rotor_angular_velocity->value(Point<dim>()),
+      mortar_parameters.rotor_rotation_angle->value(Point<dim>()),
       mortar_parameters.center_of_rotation)
 {}
 

--- a/include/core/mortar_coupling_manager.h
+++ b/include/core/mortar_coupling_manager.h
@@ -489,6 +489,15 @@ class CouplingEvaluationBase
 {
 public:
   /**
+   * @brief Update coupling evaluation information
+   */
+  virtual void
+  update_evaluator_data(
+    const Mapping<dim>    &mapping,
+    const DoFHandler<dim> &dof_handler,
+    const unsigned int     first_selected_component = 0) const = 0;
+
+  /**
    * Number of data points of type Number associated to a quadrature point.
    */
   virtual unsigned int
@@ -584,6 +593,20 @@ public:
     const unsigned int                                         bid_m,
     const unsigned int                                         bid_p,
     const double                                               sip_factor);
+
+  /**
+   * @brief Update coupling operator information
+   */
+  void
+  update_operator_data(
+    const Mapping<dim>                                        &mapping,
+    const DoFHandler<dim>                                     &dof_handler,
+    const AffineConstraints<Number>                           &constraints,
+    const std::shared_ptr<CouplingEvaluationBase<dim, Number>> evaluator,
+    const std::shared_ptr<MortarManagerBase<dim>>              mortar_manager,
+    const unsigned int                                         bid_m,
+    const unsigned int                                         bid_p,
+    const double sip_factor);
 
   /**
    * @brief Return object containing problem constraints
@@ -797,6 +820,12 @@ public:
                          const DoFHandler<dim> &dof_handler,
                          const unsigned int     first_selected_component = 0);
 
+  void
+  update_evaluator_data(
+    const Mapping<dim>    &mapping,
+    const DoFHandler<dim> &dof_handler,
+    const unsigned int     first_selected_component = 0) const override;
+
   unsigned int
   data_size() const override;
 
@@ -831,7 +860,7 @@ public:
   mutable FEPointIntegrator phi_m;
 
   /// Relevant dof indices
-  std::vector<unsigned int> relevant_dof_indices;
+  mutable std::vector<unsigned int> relevant_dof_indices;
 };
 
 template <int dim, typename Number>
@@ -847,6 +876,12 @@ public:
   NavierStokesCouplingEvaluation(const Mapping<dim>    &mapping,
                                  const DoFHandler<dim> &dof_handler,
                                  const double           kinematic_viscosity);
+
+  void
+  update_evaluator_data(
+    const Mapping<dim>    &mapping,
+    const DoFHandler<dim> &dof_handler,
+    const unsigned int     first_selected_component = 0) const override;
 
   unsigned int
   data_size() const override;
@@ -884,7 +919,7 @@ public:
   mutable FEPointIntegratorP phi_p_m;
 
   /// Relevant dof indices
-  std::vector<unsigned int> relevant_dof_indices;
+  mutable std::vector<unsigned int> relevant_dof_indices;
 
   /// Kinematic viscosity
   const double kinematic_viscosity;

--- a/include/core/mortar_coupling_manager.h
+++ b/include/core/mortar_coupling_manager.h
@@ -489,15 +489,6 @@ class CouplingEvaluationBase
 {
 public:
   /**
-   * @brief Update coupling evaluation information
-   */
-  virtual void
-  update_evaluator_data(
-    const Mapping<dim>    &mapping,
-    const DoFHandler<dim> &dof_handler,
-    const unsigned int     first_selected_component = 0) const = 0;
-
-  /**
    * Number of data points of type Number associated to a quadrature point.
    */
   virtual unsigned int
@@ -593,20 +584,6 @@ public:
     const unsigned int                                         bid_m,
     const unsigned int                                         bid_p,
     const double                                               sip_factor);
-
-  /**
-   * @brief Update coupling operator information
-   */
-  void
-  update_operator_data(
-    const Mapping<dim>                                        &mapping,
-    const DoFHandler<dim>                                     &dof_handler,
-    const AffineConstraints<Number>                           &constraints,
-    const std::shared_ptr<CouplingEvaluationBase<dim, Number>> evaluator,
-    const std::shared_ptr<MortarManagerBase<dim>>              mortar_manager,
-    const unsigned int                                         bid_m,
-    const unsigned int                                         bid_p,
-    const double sip_factor);
 
   /**
    * @brief Return object containing problem constraints
@@ -820,12 +797,6 @@ public:
                          const DoFHandler<dim> &dof_handler,
                          const unsigned int     first_selected_component = 0);
 
-  void
-  update_evaluator_data(
-    const Mapping<dim>    &mapping,
-    const DoFHandler<dim> &dof_handler,
-    const unsigned int     first_selected_component = 0) const override;
-
   unsigned int
   data_size() const override;
 
@@ -860,7 +831,7 @@ public:
   mutable FEPointIntegrator phi_m;
 
   /// Relevant dof indices
-  mutable std::vector<unsigned int> relevant_dof_indices;
+  std::vector<unsigned int> relevant_dof_indices;
 };
 
 template <int dim, typename Number>
@@ -876,12 +847,6 @@ public:
   NavierStokesCouplingEvaluation(const Mapping<dim>    &mapping,
                                  const DoFHandler<dim> &dof_handler,
                                  const double           kinematic_viscosity);
-
-  void
-  update_evaluator_data(
-    const Mapping<dim>    &mapping,
-    const DoFHandler<dim> &dof_handler,
-    const unsigned int     first_selected_component = 0) const override;
 
   unsigned int
   data_size() const override;
@@ -919,7 +884,7 @@ public:
   mutable FEPointIntegratorP phi_p_m;
 
   /// Relevant dof indices
-  mutable std::vector<unsigned int> relevant_dof_indices;
+  std::vector<unsigned int> relevant_dof_indices;
 
   /// Kinematic viscosity
   const double kinematic_viscosity;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1802,8 +1802,8 @@ namespace Parameters
     unsigned int stator_boundary_id;
     /// Center of rotation of the rotor domain
     Point<dim> center_of_rotation;
-    /// Rotation function of the rotor domain
-    std::shared_ptr<Functions::ParsedFunction<dim>> rotor_angular_velocity;
+    /// Rotation angle of the rotor domain in radians
+    std::shared_ptr<Functions::ParsedFunction<dim>> rotor_rotation_angle;
     /// Penalty factor for mortar elements
     double sip_factor;
     /// Oversampling factor for quadrature points

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -441,7 +441,7 @@ protected:
    * @brief Initialize mortar coupling operator
    */
   void
-  init_mortar_coupling();
+  update_mortar_coupling();
 
   /**
    * @brief Returns the mapping shared pointer. A MappingQCache is

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -941,6 +941,8 @@ protected:
   // Mortar coupling manager and operator
   std::shared_ptr<MortarManagerCircle<dim>>      mortar_manager;
   std::shared_ptr<CouplingOperator<dim, double>> mortar_coupling_operator;
+  std::shared_ptr<NavierStokesCouplingEvaluation<dim, double>>
+    mortar_coupling_evaluator;
 
   // Initial mapping for rotor mesh rotation in mortar method
   std::shared_ptr<Mapping<dim>>       initial_mapping;

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -450,8 +450,7 @@ protected:
   inline std::shared_ptr<Mapping<dim>>
   get_mapping()
   {
-    if (!this->simulation_parameters.mortar.enable ||
-        this->simulation_control->is_at_start())
+    if (!this->simulation_parameters.mortar.enable)
       return this->mapping;
     else
       return this->mapping_cache;
@@ -944,8 +943,7 @@ protected:
   std::shared_ptr<NavierStokesCouplingEvaluation<dim, double>>
     mortar_coupling_evaluator;
 
-  // Initial mapping for rotor mesh rotation in mortar method
-  std::shared_ptr<Mapping<dim>>       initial_mapping;
+  // Mapping cache used in rotor mesh rotation in mortar method
   std::shared_ptr<MappingQCache<dim>> mapping_cache;
 
   // Assemblers for the matrix and rhs

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -425,12 +425,6 @@ read_mesh_and_manifolds_for_stator_and_rotor(
       Triangulation<dim> rotor_temp_tria;
       attach_grid_to_triangulation(rotor_temp_tria,
                                    *mortar_parameters.rotor_mesh);
-      /* This rotation of the rotor configuration refers to an initial rotation
-       * of the triangulation itself. Further rotor rotations are done by
-       * rotating the mapping, using the (time-dependent) rotor_angular_velocity
-       * parameter at every iteration. */
-      GridTools::rotate(mortar_parameters.rotor_mesh->rotation_angle,
-                        rotor_temp_tria);
 
       // Get stator manifold ids without flat id
       unsigned int stator_ids_no_flat = 0;

--- a/source/core/mortar_coupling_manager.cc
+++ b/source/core/mortar_coupling_manager.cc
@@ -1544,15 +1544,13 @@ NavierStokesCouplingEvaluation<dim, Number>::local_integrate(
       const auto penalty_parameter = data.all_penalty_parameter[q_index];
       const auto normal            = data.all_normals[q_index];
 
-      // The expression for the jump on the mortar interface is
-      // jump(u) = u_m * normal_m + u_p * normal_p. Since we are accessing only
-      // the value of normal_m, we use a minus sign here because normal_p = -
-      // normal_m
-      const auto u_value_jump = outer(u_value_m - u_value_p, normal);
+      // jump(u) = u_m - u_p
+      const auto u_value_jump = u_value_m - u_value_p;
 
       // The expression for the average on the mortar interface is
-      // avg(∇u).n = (∇u_m.normal_m + ∇u_p.normal_p) * 0.5. For the same reason
-      // above, we include the negative sign here
+      // avg(∇u).n = (∇u_m.normal_m + ∇u_p.normal_p) * 0.5. Since we are accessing only
+      // the value of normal_m, we use a minus sign here because normal_p = -
+      // normal_m
       const auto u_grad_avg = (u_grad_normal_m - u_grad_normal_p) * 0.5;
 
       // {{p}} = (p_m + p_p)/2
@@ -1569,9 +1567,9 @@ NavierStokesCouplingEvaluation<dim, Number>::local_integrate(
       // - (n avg(∇v), jump(u))
       u_grad_result -= u_value_jump;
       // - (jump(v), ν avg(∇δu) n)
-      u_value_result -= u_grad_avg;
+      u_value_result -= u_grad_avg * this->kinematic_viscosity;
       // + (jump(v), ν σ jump(δu))
-      u_value_result += sigma * u_value_jump;
+      u_value_result += sigma * this->kinematic_viscosity * u_value_jump;
 
       /* Contribution from pressure gradient term */
       // + (jump(v), avg(δp) n)
@@ -1579,12 +1577,11 @@ NavierStokesCouplingEvaluation<dim, Number>::local_integrate(
 
       /* Contribution from velocity divergence term */
       // - (avg(q), jump(u) n)
-      p_value_result -= 0.5 * u_value_jump * normal;
-      // p_value_result += u_value_avg * normal;
+      p_value_result -= 0.5 * contract(u_value_jump, normal);
 
       // - (n avg(∇v), ν/2 jump(δu))
-      phi_u_m.submit_gradient(outer(u_grad_result, normal) * 0.5 * JxW, q);
-      phi_u_m.submit_value(u_value_result * this->kinematic_viscosity * JxW, q);
+      phi_u_m.submit_gradient(outer(u_grad_result, normal) * this->kinematic_viscosity * 0.5 * JxW, q);
+      phi_u_m.submit_value(u_value_result * JxW, q);
       phi_p_m.submit_value(p_value_result * JxW, q);
     }
 

--- a/source/core/mortar_coupling_manager.cc
+++ b/source/core/mortar_coupling_manager.cc
@@ -534,57 +534,11 @@ CouplingOperator<dim, Number>::CouplingOperator(
   , evaluator(evaluator)
   , mortar_manager(mortar_manager)
 {
-  this->update_operator_data(mapping,
-                             dof_handler,
-                             constraints,
-                             evaluator,
-                             mortar_manager,
-                             bid_m,
-                             bid_p,
-                             sip_factor);
-}
-#else
-template <int dim, typename Number>
-CouplingOperator<dim, Number>::CouplingOperator(
-  const Mapping<dim>                                        &mapping,
-  const DoFHandler<dim>                                     &dof_handler,
-  const AffineConstraints<Number>                           &constraints,
-  const std::shared_ptr<CouplingEvaluationBase<dim, Number>> evaluator,
-  const std::shared_ptr<MortarManagerBase<dim>>              mortar_manager,
-  const unsigned int                                         bid_m,
-  const unsigned int                                         bid_p,
-  const double)
-  : mapping(mapping)
-  , dof_handler(dof_handler)
-  , constraints(constraints)
-  , bid_m(bid_m)
-  , bid_p(bid_p)
-  , evaluator(evaluator)
-  , mortar_manager(mortar_manager)
-{
-  AssertThrow(false,
-              ExcMessage(
-                "The mortar coupling requires deal.II 9.7 or more recent."));
-}
-#endif
-
-template <int dim, typename Number>
-void
-CouplingOperator<dim, Number>::update_operator_data(
-  const Mapping<dim>                                        &mapping,
-  const DoFHandler<dim>                                     &dof_handler,
-  const AffineConstraints<Number>                           &constraints,
-  const std::shared_ptr<CouplingEvaluationBase<dim, Number>> evaluator,
-  const std::shared_ptr<MortarManagerBase<dim>>              mortar_manager,
-  const unsigned int                                         bid_m,
-  const unsigned int                                         bid_p,
-  const double                                               sip_factor)
-{
   this->q_data_size          = evaluator->data_size();
   this->relevant_dof_indices = evaluator->get_relevant_dof_indices();
   this->n_dofs_per_cell      = this->relevant_dof_indices.size();
 
-  this->data.penalty_factor =
+  data.penalty_factor =
     compute_penalty_factor(dof_handler.get_fe().degree, sip_factor);
 
   // Number of quadrature points
@@ -667,7 +621,7 @@ CouplingOperator<dim, Number>::update_operator_data(
             // Weights of quadrature points
             const auto weights =
               mortar_manager->get_weights(get_face_center(cell, face));
-            this->data.all_weights.insert(data.all_weights.end(),
+            data.all_weights.insert(data.all_weights.end(),
                                     weights.begin(),
                                     weights.end());
 
@@ -680,7 +634,7 @@ CouplingOperator<dim, Number>::update_operator_data(
                 mapping.transform_points_real_to_unit_cell(cell,
                                                            points,
                                                            points_ref);
-                this->all_points_ref.insert(all_points_ref.end(),
+                all_points_ref.insert(all_points_ref.end(),
                                       points_ref.begin(),
                                       points_ref.end());
 
@@ -709,8 +663,8 @@ CouplingOperator<dim, Number>::update_operator_data(
 
                 fe_face_values.reinit(cell, face_no);
 
-                this->data.all_normals.insert(
-                  this->data.all_normals.end(),
+                data.all_normals.insert(
+                  data.all_normals.end(),
                   fe_face_values.get_normal_vectors().begin(),
                   fe_face_values.get_normal_vectors().end());
               }
@@ -721,7 +675,7 @@ CouplingOperator<dim, Number>::update_operator_data(
                 if (face->boundary_id() == bid_p)
                   for (auto &normal : normals)
                     normal *= -1.0;
-                this->data.all_normals.insert(this->data.all_normals.end(),
+                data.all_normals.insert(data.all_normals.end(),
                                         normals.begin(),
                                         normals.end());
 
@@ -750,12 +704,12 @@ CouplingOperator<dim, Number>::update_operator_data(
                     if (face_no / 2 == 0)
                       {
                         for (auto &p : points)
-                          this->all_points_ref.emplace_back(face_no % 2, p[0]);
+                          all_points_ref.emplace_back(face_no % 2, p[0]);
                       }
                     else if (face_no / 2 == 1)
                       {
                         for (auto &p : points)
-                          this->all_points_ref.emplace_back(p[0], face_no % 2);
+                          all_points_ref.emplace_back(p[0], face_no % 2);
                       }
                     else
                       {
@@ -771,7 +725,7 @@ CouplingOperator<dim, Number>::update_operator_data(
 
             // Store penalty parameter for all quadrature points
             for (unsigned int i = 0; i < mortar_manager->get_n_points(); ++i)
-              this->data.all_penalty_parameter.emplace_back(penalty_parameter);
+              data.all_penalty_parameter.emplace_back(penalty_parameter);
           }
 
   // Setup communication
@@ -782,16 +736,16 @@ CouplingOperator<dim, Number>::update_operator_data(
 
   // Finalized penalty parameters
   std::vector<Number> all_penalty_parameter_ghost(
-    this->data.all_penalty_parameter.size());
-  this->partitioner.template export_to_ghosted_array<Number, 1>(
+    data.all_penalty_parameter.size());
+  partitioner.template export_to_ghosted_array<Number, 1>(
     data.all_penalty_parameter, all_penalty_parameter_ghost);
   for (unsigned int i = 0; i < data.all_penalty_parameter.size(); ++i)
-    this->data.all_penalty_parameter[i] =
+    data.all_penalty_parameter[i] =
       std::max(data.all_penalty_parameter[i], all_penalty_parameter_ghost[i]);
 
   // Finialize DoF indices and update constraints
-  this->dof_indices_ghost.resize(dof_indices.size());
-  this->partitioner_cell.template export_to_ghosted_array<types::global_dof_index, 0>(
+  dof_indices_ghost.resize(dof_indices.size());
+  partitioner_cell.template export_to_ghosted_array<types::global_dof_index, 0>(
     dof_indices, dof_indices_ghost, n_dofs_per_cell);
 
   {
@@ -818,6 +772,30 @@ CouplingOperator<dim, Number>::update_operator_data(
       dof_handler.get_mpi_communicator());
   }
 }
+#else
+template <int dim, typename Number>
+CouplingOperator<dim, Number>::CouplingOperator(
+  const Mapping<dim>                                        &mapping,
+  const DoFHandler<dim>                                     &dof_handler,
+  const AffineConstraints<Number>                           &constraints,
+  const std::shared_ptr<CouplingEvaluationBase<dim, Number>> evaluator,
+  const std::shared_ptr<MortarManagerBase<dim>>              mortar_manager,
+  const unsigned int                                         bid_m,
+  const unsigned int                                         bid_p,
+  const double)
+  : mapping(mapping)
+  , dof_handler(dof_handler)
+  , constraints(constraints)
+  , bid_m(bid_m)
+  , bid_p(bid_p)
+  , evaluator(evaluator)
+  , mortar_manager(mortar_manager)
+{
+  AssertThrow(false,
+              ExcMessage(
+                "The mortar coupling requires deal.II 9.7 or more recent."));
+}
+#endif
 
 template <int dim, typename Number>
 const AffineConstraints<Number> &
@@ -1275,22 +1253,12 @@ CouplingEvaluationSIPG<dim, n_components, Number>::CouplingEvaluationSIPG(
            n_components)
   , phi_m(mapping, fe_sub, update_values | update_gradients)
 {
-  update_evaluator_data(mapping, dof_handler, first_selected_component);
-}
-
-template <int dim, int n_components, typename Number>
-void
-CouplingEvaluationSIPG<dim, n_components, Number>::update_evaluator_data(
-  const Mapping<dim>    &mapping,
-  const DoFHandler<dim> &dof_handler,
-  const unsigned int     first_selected_component) const
-{
   for (unsigned int i = 0; i < dof_handler.get_fe().n_dofs_per_cell(); ++i)
     if ((first_selected_component <=
          dof_handler.get_fe().system_to_component_index(i).first) &&
         (dof_handler.get_fe().system_to_component_index(i).first <
          first_selected_component + n_components))
-      this->relevant_dof_indices.push_back(i);
+      relevant_dof_indices.push_back(i);
 }
 
 template <int dim, int n_components, typename Number>
@@ -1422,23 +1390,13 @@ NavierStokesCouplingEvaluation<dim, Number>::NavierStokesCouplingEvaluation(
   , phi_p_m(mapping, fe_sub_p, update_values)
   , kinematic_viscosity(kinematic_viscosity)
 {
-  update_evaluator_data(mapping, dof_handler, 0);
-}
-
-template <int dim, typename Number>
-void
-NavierStokesCouplingEvaluation<dim, Number>::update_evaluator_data(
-  const Mapping<dim>    &mapping,
-  const DoFHandler<dim> &dof_handler,
-  const unsigned int     first_selected_component) const
-{
   for (unsigned int i = 0; i < dof_handler.get_fe().n_dofs_per_cell(); ++i)
     if (dof_handler.get_fe().system_to_component_index(i).first < dim)
-      this->relevant_dof_indices.push_back(i);
+      relevant_dof_indices.push_back(i);
 
   for (unsigned int i = 0; i < dof_handler.get_fe().n_dofs_per_cell(); ++i)
     if (dof_handler.get_fe().system_to_component_index(i).first == dim)
-      this->relevant_dof_indices.push_back(i);
+      relevant_dof_indices.push_back(i);
 
   AssertDimension(dof_handler.get_fe().n_dofs_per_cell(),
                   relevant_dof_indices.size());
@@ -1548,9 +1506,9 @@ NavierStokesCouplingEvaluation<dim, Number>::local_integrate(
       const auto u_value_jump = u_value_m - u_value_p;
 
       // The expression for the average on the mortar interface is
-      // avg(∇u).n = (∇u_m.normal_m + ∇u_p.normal_p) * 0.5. Since we are accessing only
-      // the value of normal_m, we use a minus sign here because normal_p = -
-      // normal_m
+      // avg(∇u).n = (∇u_m.normal_m + ∇u_p.normal_p) * 0.5. Since we are
+      // accessing only the value of normal_m, we use a minus sign here because
+      // normal_p = - normal_m
       const auto u_grad_avg = (u_grad_normal_m - u_grad_normal_p) * 0.5;
 
       // {{p}} = (p_m + p_p)/2
@@ -1580,7 +1538,9 @@ NavierStokesCouplingEvaluation<dim, Number>::local_integrate(
       p_value_result -= 0.5 * contract(u_value_jump, normal);
 
       // - (n avg(∇v), ν/2 jump(δu))
-      phi_u_m.submit_gradient(outer(u_grad_result, normal) * this->kinematic_viscosity * 0.5 * JxW, q);
+      phi_u_m.submit_gradient(outer(u_grad_result, normal) *
+                                this->kinematic_viscosity * 0.5 * JxW,
+                              q);
       phi_u_m.submit_value(u_value_result * JxW, q);
       phi_p_m.submit_value(p_value_result * JxW, q);
     }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -4162,10 +4162,10 @@ namespace Parameters
                         default_entry_point,
                         Patterns::List(Patterns::Double()),
                         "Center of rotation coordinates of rotor domain");
-      prm.enter_subsection("rotor angular velocity");
-      rotor_angular_velocity =
+      prm.enter_subsection("rotor rotation angle");
+      rotor_rotation_angle =
         std::make_shared<Functions::ParsedFunction<dim>>();
-      rotor_angular_velocity->declare_parameters(prm);
+      rotor_rotation_angle->declare_parameters(prm);
       prm.leave_subsection();
       prm.declare_entry("penalty factor",
                         "1.",
@@ -4197,9 +4197,9 @@ namespace Parameters
       stator_boundary_id = prm.get_integer("stator boundary id");
       center_of_rotation =
         value_string_to_tensor<dim>(prm.get("center of rotation"));
-      prm.enter_subsection("rotor angular velocity");
-      rotor_angular_velocity->parse_parameters(prm);
-      rotor_angular_velocity->set_time(0);
+      prm.enter_subsection("rotor rotation angle");
+      rotor_rotation_angle->parse_parameters(prm);
+      rotor_rotation_angle->set_time(0);
       prm.leave_subsection();
       sip_factor          = prm.get_double("penalty factor");
       oversampling_factor = prm.get_integer("oversampling factor");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -4163,8 +4163,7 @@ namespace Parameters
                         Patterns::List(Patterns::Double()),
                         "Center of rotation coordinates of rotor domain");
       prm.enter_subsection("rotor rotation angle");
-      rotor_rotation_angle =
-        std::make_shared<Functions::ParsedFunction<dim>>();
+      rotor_rotation_angle = std::make_shared<Functions::ParsedFunction<dim>>();
       rotor_rotation_angle->declare_parameters(prm);
       prm.leave_subsection();
       prm.declare_entry("penalty factor",

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -1653,13 +1653,19 @@ FluidDynamicsMatrixBased<dim>::solve()
   this->computing_timer.enter_subsection("Read mesh and manifolds");
 
   if (this->simulation_parameters.mortar.enable)
-    read_mesh_and_manifolds_for_stator_and_rotor(
-      *this->triangulation,
-      this->simulation_parameters.mesh,
-      this->simulation_parameters.manifolds_parameters,
-      this->simulation_parameters.restart_parameters.restart,
-      this->simulation_parameters.boundary_conditions,
-      this->simulation_parameters.mortar);
+    {
+      read_mesh_and_manifolds_for_stator_and_rotor(
+        *this->triangulation,
+        this->simulation_parameters.mesh,
+        this->simulation_parameters.manifolds_parameters,
+        this->simulation_parameters.restart_parameters.restart,
+        this->simulation_parameters.boundary_conditions,
+        this->simulation_parameters.mortar);
+      // Create and initialize mapping cache
+      this->mapping_cache =
+        std::make_shared<MappingQCache<dim>>(this->velocity_fem_degree);
+      this->mapping_cache->initialize(*this->mapping, *this->triangulation);
+    }
   else
     read_mesh_and_manifolds(
       *this->triangulation,

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -85,7 +85,7 @@ FluidDynamicsMatrixBased<dim>::setup_dofs_fd()
   this->define_zero_constraints();
 
   // If enabled, create mortar coupling
-  this->init_mortar_coupling();
+  this->update_mortar_coupling();
 
   this->present_solution.reinit(this->locally_owned_dofs,
                                 this->locally_relevant_dofs,

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -1664,7 +1664,7 @@ FluidDynamicsMatrixBased<dim>::solve()
       // Create and initialize mapping cache
       this->mapping_cache =
         std::make_shared<MappingQCache<dim>>(this->velocity_fem_degree);
-      this->mapping_cache->initialize(*this->mapping, *this->triangulation);
+      this->rotate_mortar_mapping();
     }
   else
     read_mesh_and_manifolds(

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2034,6 +2034,10 @@ NavierStokesBase<dim, VectorType, DofsType>::rotate_mortar_mapping()
                                           this->simulation_parameters.mortar)
           .second,
         rotation_angle);
+
+      // Update mortar information
+      // this->update_mortar_coupling();
+      // setup_dofs();
     }
 }
 

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1227,19 +1227,9 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_uniform()
   auto &nonzero_constraints = this->nonzero_constraints;
   nonzero_constraints.distribute(tmp);
 
+  // If mortar is enabled, update mortar manager, operator, and evaluator
   if (this->simulation_parameters.mortar.enable)
-    {
-      this->mortar_coupling_evaluator->update_evaluator_data(*this->get_mapping(),
-                                                           this->dof_handler);
-      this->mortar_coupling_operator->update_operator_data(*this->get_mapping(),
-      this->dof_handler,
-      this->zero_constraints,
-      this->mortar_coupling_evaluator,
-      this->mortar_manager,
-      this->simulation_parameters.mortar.rotor_boundary_id,
-      this->simulation_parameters.mortar.stator_boundary_id,
-      this->simulation_parameters.mortar.sip_factor);
-    }
+    this->init_mortar_coupling();
     
   // Fix on the new mesh
   present_solution = tmp;

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1966,7 +1966,7 @@ NavierStokesBase<dim, VectorType, DofsType>::define_zero_constraints()
 
 template <int dim, typename VectorType, typename DofsType>
 void
-NavierStokesBase<dim, VectorType, DofsType>::init_mortar_coupling()
+NavierStokesBase<dim, VectorType, DofsType>::update_mortar_coupling()
 {
   if (!this->simulation_parameters.mortar.enable)
     return;

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1967,8 +1967,11 @@ NavierStokesBase<dim, VectorType, DofsType>::update_mortar_coupling()
   if (!this->simulation_parameters.mortar.enable)
     return;
 
-  // Rotate mapping
-  rotate_mortar_mapping();
+  // Rotate mapping, but first check if we are not at the start of the
+  // simulation so we don't rotate it twice. For following iterations, this will
+  // be done only once when setup_dofs() is called
+  if (!this->simulation_control->is_at_start())
+    rotate_mortar_mapping();
 
   // Create mortar manager
   this->mortar_manager = std::make_shared<MortarManagerCircle<dim>>(
@@ -2008,8 +2011,7 @@ NavierStokesBase<dim, VectorType, DofsType>::rotate_mortar_mapping()
       simulation_parameters.mortar.rotor_rotation_angle->set_time(
         this->simulation_control->get_current_time());
       const double rotation_angle =
-        simulation_parameters.mortar.rotor_rotation_angle->value(
-          Point<dim>());
+        simulation_parameters.mortar.rotor_rotation_angle->value(Point<dim>());
 
       if (simulation_parameters.mortar.verbosity ==
           Parameters::Verbosity::verbose)
@@ -2020,7 +2022,7 @@ NavierStokesBase<dim, VectorType, DofsType>::rotate_mortar_mapping()
       // Create new mapping cache
       this->mapping_cache =
         std::make_shared<MappingQCache<dim>>(this->velocity_fem_degree);
-        
+
       LetheGridTools::rotate_mapping(
         this->dof_handler,
         *this->mapping_cache,

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2000,16 +2000,16 @@ NavierStokesBase<dim, VectorType, DofsType>::rotate_mortar_mapping()
 {
   if (this->simulation_parameters.mortar.enable)
     {
-      // Get updated rotation angle
-      simulation_parameters.mortar.rotor_angular_velocity->set_time(
+      // Get updated rotation angle (radians)
+      simulation_parameters.mortar.rotor_rotation_angle->set_time(
         this->simulation_control->get_current_time());
       const double rotation_angle =
-        simulation_parameters.mortar.rotor_angular_velocity->value(
+        simulation_parameters.mortar.rotor_rotation_angle->value(
           Point<dim>());
 
       if (simulation_parameters.mortar.verbosity ==
           Parameters::Verbosity::verbose)
-        this->pcout << "Mortar - Rotating rotor grid: " << rotation_angle
+        this->pcout << "Mortar - Rotor grid angle is: " << rotation_angle
                     << " rad \n"
                     << std::endl;
 

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2017,6 +2017,10 @@ NavierStokesBase<dim, VectorType, DofsType>::rotate_mortar_mapping()
                     << " rad \n"
                     << std::endl;
 
+      // Create new mapping cache
+      this->mapping_cache =
+        std::make_shared<MappingQCache<dim>>(this->velocity_fem_degree);
+        
       LetheGridTools::rotate_mapping(
         this->dof_handler,
         *this->mapping_cache,

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1227,10 +1227,6 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_uniform()
   auto &nonzero_constraints = this->nonzero_constraints;
   nonzero_constraints.distribute(tmp);
 
-  // If mortar is enabled, update mortar manager, operator, and evaluator
-  if (this->simulation_parameters.mortar.enable)
-    this->init_mortar_coupling();
-    
   // Fix on the new mesh
   present_solution = tmp;
 

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1962,6 +1962,8 @@ template <int dim, typename VectorType, typename DofsType>
 void
 NavierStokesBase<dim, VectorType, DofsType>::update_mortar_coupling()
 {
+  TimerOutput::Scope t(this->computing_timer, "Update mortar");
+
   if (!this->simulation_parameters.mortar.enable)
     return;
 
@@ -1998,6 +2000,8 @@ template <int dim, typename VectorType, typename DofsType>
 void
 NavierStokesBase<dim, VectorType, DofsType>::rotate_mortar_mapping()
 {
+  TimerOutput::Scope t(this->computing_timer, "Rotate mortar");
+
   if (this->simulation_parameters.mortar.enable)
     {
       // Get updated rotation angle (radians)


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

The rotor mesh rotation was not in the right place in the code, so that at the start of the simulation the accessed mapping information was still incorrect. This PR fixes this, and adds an application test for a rotor rotated mesh.

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->

The `rotate_mapping()` is now done at the beginning of the simulation, as well as when the mesh is refined (called inside `setup_dofs()`).

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

A new application test of MMS with mortar and a rotated rotor mesh has been added.

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

Some other small fixes in the code have been done to improve readability/make the code clearer - e.g., change the name of the `rotor rotation angle` parameter and the `update_mortar_coupling()` function name.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge