### PR TITLE
Cfd dem void fraction linear solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+### [Master] - 2025-07-13
+
+### Change
+
+- MAJOR The void fraction linear tolerance can now be specified directly within the .prm file. The previous default value which was 1e-15 has now been changed to the default value used for all linear solvers. We advise users to explicitely specify the minimum tolerance for the void fraction within their parameter files. [#1580](https://github.com/chaos-polymtl/lethe/pull/1580)
+
 ### [Master] - 2025-07-11
 
 ### Fixed
@@ -38,6 +44,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Master] - 2025-07-07
 
 ### Changed
+
 - MINOR The default parameter for the linear solver of the matrix-free solvers now uses eigenvalue estimation instead of not. This approach is generally more robust and should be preferred. [#1572](https://github.com/chaos-polymtl/lethe/pull/1572)
 
 ## [Master] - 2025-07-03

--- a/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_gcmg.prm
@@ -120,7 +120,7 @@ subsection linear solver
 
     #MG parameters
     set mg verbosity               = quiet
-    set mg smoother eig estimation = false 
+    set mg smoother eig estimation = false
 
     #smoother
     set mg smoother iterations = 10

--- a/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_lsmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms3d_fe1_lsmg.prm
@@ -120,6 +120,6 @@ subsection linear solver
 
     #MG parameters
     set mg verbosity               = quiet
-    set mg smoother eig estimation = false 
+    set mg smoother eig estimation = false
   end
 end

--- a/applications_tests/lethe-fluid-particles/adaptive_sparse_contacts.prm
+++ b/applications_tests/lethe-fluid-particles/adaptive_sparse_contacts.prm
@@ -184,6 +184,11 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
   subsection fluid dynamics
     set max iters                             = 200
     set relative residual                     = 1e-4

--- a/applications_tests/lethe-fluid-particles/adaptive_sparse_contacts.prm
+++ b/applications_tests/lethe-fluid-particles/adaptive_sparse_contacts.prm
@@ -184,7 +184,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet

--- a/applications_tests/lethe-fluid-particles/dynamic_contact_search.prm
+++ b/applications_tests/lethe-fluid-particles/dynamic_contact_search.prm
@@ -206,7 +206,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet

--- a/applications_tests/lethe-fluid-particles/dynamic_contact_search.prm
+++ b/applications_tests/lethe-fluid-particles/dynamic_contact_search.prm
@@ -206,6 +206,11 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000

--- a/applications_tests/lethe-fluid-particles/dynamic_particle_insertion.prm
+++ b/applications_tests/lethe-fluid-particles/dynamic_particle_insertion.prm
@@ -209,6 +209,7 @@ subsection linear solver
   subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
+    set verbopsity        = quiet
   end
   subsection fluid dynamics
     set method             = gmres

--- a/applications_tests/lethe-fluid-particles/dynamic_particle_insertion.prm
+++ b/applications_tests/lethe-fluid-particles/dynamic_particle_insertion.prm
@@ -206,6 +206,10 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+  end
   subsection fluid dynamics
     set method             = gmres
     set max iters          = 200

--- a/applications_tests/lethe-fluid-particles/dynamic_particle_insertion.prm
+++ b/applications_tests/lethe-fluid-particles/dynamic_particle_insertion.prm
@@ -209,7 +209,7 @@ subsection linear solver
   subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
-    set verbopsity        = quiet
+    set verbosity        = quiet
   end
   subsection fluid dynamics
     set method             = gmres

--- a/applications_tests/lethe-fluid-particles/liquid_fluidized_bed.prm
+++ b/applications_tests/lethe-fluid-particles/liquid_fluidized_bed.prm
@@ -268,7 +268,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection fluid dynamics
+  subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
+ subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000
     set relative residual                     = 1e-3

--- a/applications_tests/lethe-fluid-particles/liquid_fluidized_bed.prm
+++ b/applications_tests/lethe-fluid-particles/liquid_fluidized_bed.prm
@@ -268,12 +268,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet
   end
- subsection fluid dynamics
+  subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000
     set relative residual                     = 1e-3

--- a/applications_tests/lethe-fluid-particles/particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/particle_sedimentation.prm
@@ -206,7 +206,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection fluid dynamics
+    subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
+ subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000
     set relative residual                     = 1e-3

--- a/applications_tests/lethe-fluid-particles/particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/particle_sedimentation.prm
@@ -206,12 +206,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-    subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet
   end
- subsection fluid dynamics
+  subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000
     set relative residual                     = 1e-3

--- a/applications_tests/lethe-fluid-particles/periodic_particles_qcm.prm
+++ b/applications_tests/lethe-fluid-particles/periodic_particles_qcm.prm
@@ -198,7 +198,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection fluid dynamics
+    subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
+ subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 200
     set relative residual                     = 1e-4

--- a/applications_tests/lethe-fluid-particles/periodic_particles_qcm.prm
+++ b/applications_tests/lethe-fluid-particles/periodic_particles_qcm.prm
@@ -198,12 +198,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-    subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet
   end
- subsection fluid dynamics
+  subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 200
     set relative residual                     = 1e-4

--- a/applications_tests/lethe-fluid-particles/qcm_gauss_lobatto_particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/qcm_gauss_lobatto_particle_sedimentation.prm
@@ -210,7 +210,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection fluid dynamics
+    subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
+ subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000
     set relative residual                     = 1e-3

--- a/applications_tests/lethe-fluid-particles/qcm_gauss_lobatto_particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/qcm_gauss_lobatto_particle_sedimentation.prm
@@ -210,12 +210,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-    subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet
   end
- subsection fluid dynamics
+  subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000
     set relative residual                     = 1e-3

--- a/applications_tests/lethe-fluid-particles/qcm_gauss_particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/qcm_gauss_particle_sedimentation.prm
@@ -210,6 +210,11 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000

--- a/applications_tests/lethe-fluid-particles/qcm_gauss_particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/qcm_gauss_particle_sedimentation.prm
@@ -210,7 +210,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet

--- a/applications_tests/lethe-fluid-particles/restart_gas_solid_fluidized_bed.prm
+++ b/applications_tests/lethe-fluid-particles/restart_gas_solid_fluidized_bed.prm
@@ -226,12 +226,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
- subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet
- end
- subsection fluid dynamics
+  end
+  subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 200
     set relative residual                     = 1e-3

--- a/applications_tests/lethe-fluid-particles/restart_gas_solid_fluidized_bed.prm
+++ b/applications_tests/lethe-fluid-particles/restart_gas_solid_fluidized_bed.prm
@@ -226,7 +226,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection fluid dynamics
+ subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+ end
+ subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 200
     set relative residual                     = 1e-3

--- a/applications_tests/lethe-fluid-particles/restart_particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/restart_particle_sedimentation.prm
@@ -206,12 +206,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet
   end
- subsection fluid dynamics
+  subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000
     set relative residual                     = 1e-3

--- a/applications_tests/lethe-fluid-particles/restart_particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/restart_particle_sedimentation.prm
@@ -206,7 +206,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection fluid dynamics
+  subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
+ subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000
     set relative residual                     = 1e-3

--- a/applications_tests/lethe-fluid-particles/spouted_bed_load_balancing.prm
+++ b/applications_tests/lethe-fluid-particles/spouted_bed_load_balancing.prm
@@ -202,6 +202,11 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 1000

--- a/applications_tests/lethe-fluid-particles/spouted_bed_load_balancing.prm
+++ b/applications_tests/lethe-fluid-particles/spouted_bed_load_balancing.prm
@@ -202,7 +202,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_no_drag.output
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_no_drag.output
@@ -19,5 +19,5 @@ Void Fraction
     Level 0: 544 DoFs, 80 cells
     Level 1: 3300 DoFs, 640 cells
 
-Pressure drop: -0.7498557614 Pa
-Total pressure drop: -0.7498558168 Pa
+Pressure drop: -0.7498551485 Pa
+Total pressure drop: -0.7498552055 Pa

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_no_drag.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_no_drag.prm
@@ -165,7 +165,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet
@@ -178,9 +178,9 @@ subsection linear solver
     set preconditioner     = gcmg
     set verbosity          = quiet
     set max krylov vectors = 1000
-  
+
     #MG parameters
-    set mg verbosity               = verbose
-    set eig estimation verbosity   = quiet
+    set mg verbosity             = verbose
+    set eig estimation verbosity = quiet
   end
 end

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_no_drag.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_no_drag.prm
@@ -165,6 +165,11 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
   subsection fluid dynamics
     set method             = gmres
     set max iters          = 1000

--- a/applications_tests/lethe-fluid-vans/beetstra_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/beetstra_packed_bed.mpirun=1.output
@@ -15,12 +15,12 @@ Void Fraction
 Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 39.5890128 Pa
-Total pressure drop: 39.58901305 Pa
-Global continuity equation error: 1.366311946e-12 s^-1
-Max local continuity error: 6.583710939e-08 s^-1
+Total pressure drop: 39.58901306 Pa
+Global continuity equation error: 1.366311913e-12 s^-1
+Max local continuity error: 6.583710935e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2134851788
+Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2134851789
 ***********************************************************************************
 --------------
 Void Fraction
@@ -30,11 +30,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 25.17923183 Pa
 Total pressure drop: 25.1792324 Pa
-Global continuity equation error: -4.536564517e-12 s^-1
-Max local continuity error: 6.53807774e-08 s^-1
+Global continuity equation error: -4.536564461e-12 s^-1
+Max local continuity error: 6.538077735e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2150199472
+Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2150199473
 ***********************************************************************************
 --------------
 Void Fraction
@@ -44,8 +44,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 25.15492774 Pa
 Total pressure drop: 25.15492853 Pa
-Global continuity equation error: 8.486973943e-12 s^-1
-Max local continuity error: 6.578293329e-08 s^-1
+Global continuity equation error: 8.486973966e-12 s^-1
+Max local continuity error: 6.578293324e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2148583204
@@ -58,11 +58,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 25.1545732 Pa
 Total pressure drop: 25.15457413 Pa
-Global continuity equation error: 1.994905581e-11 s^-1
-Max local continuity error: 6.600906743e-08 s^-1
+Global continuity equation error: 1.99490557e-11 s^-1
+Max local continuity error: 6.600906738e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2149321063
+Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2149321064
 ***********************************************************************************
 --------------
 Void Fraction
@@ -72,11 +72,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 25.15446043 Pa
 Total pressure drop: 25.15446148 Pa
-Global continuity equation error: 2.974422043e-12 s^-1
-Max local continuity error: 6.615452164e-08 s^-1
+Global continuity equation error: 2.974422064e-12 s^-1
+Max local continuity error: 6.61545216e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2149586756
+Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2149586757
 ***********************************************************************************
 --------------
 Void Fraction
@@ -86,8 +86,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 25.15439923 Pa
 Total pressure drop: 25.15440034 Pa
-Global continuity equation error: 2.237168777e-12 s^-1
-Max local continuity error: 6.625849347e-08 s^-1
+Global continuity equation error: 2.237168825e-12 s^-1
+Max local continuity error: 6.625849343e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2149787266
@@ -99,9 +99,9 @@ Void Fraction
 Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 25.15436252 Pa
-Total pressure drop: 25.15436365 Pa
-Global continuity equation error: 1.836324959e-12 s^-1
-Max local continuity error: 6.633773563e-08 s^-1
+Total pressure drop: 25.15436366 Pa
+Global continuity equation error: 1.836324938e-12 s^-1
+Max local continuity error: 6.633773559e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2149931277
@@ -114,8 +114,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 25.15436142 Pa
 Total pressure drop: 25.15436253 Pa
-Global continuity equation error: 3.253936533e-11 s^-1
-Max local continuity error: 6.640113551e-08 s^-1
+Global continuity equation error: 3.253936492e-11 s^-1
+Max local continuity error: 6.640113546e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2150041922
@@ -128,8 +128,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 25.15436067 Pa
 Total pressure drop: 25.15436173 Pa
-Global continuity equation error: 8.218806567e-11 s^-1
-Max local continuity error: 6.6453289e-08 s^-1
+Global continuity equation error: 8.218806462e-11 s^-1
+Max local continuity error: 6.645328896e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2150129959
@@ -142,5 +142,5 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 25.15435913 Pa
 Total pressure drop: 25.15436012 Pa
-Global continuity equation error: 1.080719857e-10 s^-1
-Max local continuity error: 6.649743519e-08 s^-1
+Global continuity equation error: 1.080719841e-10 s^-1
+Max local continuity error: 6.649743514e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/beetstra_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/beetstra_packed_bed.prm
@@ -167,7 +167,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet

--- a/applications_tests/lethe-fluid-vans/beetstra_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/beetstra_packed_bed.prm
@@ -167,6 +167,11 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000

--- a/applications_tests/lethe-fluid-vans/case0_vans_B.output
+++ b/applications_tests/lethe-fluid-vans/case0_vans_B.output
@@ -12,7 +12,7 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Global continuity equation error: -2.41235e-18 s^-1
+Global continuity equation error: 7.58942e-19 s^-1
 Max local continuity error: 0.000853354 s^-1
 
 *****************************
@@ -27,7 +27,7 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Global continuity equation error: -9.84252e-18 s^-1
+Global continuity equation error: 9.54776e-18 s^-1
 Max local continuity error: 0.000120612 s^-1
 
 *****************************
@@ -42,7 +42,7 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Global continuity equation error: 6.36842e-18 s^-1
+Global continuity equation error: 2.30181e-18 s^-1
 Max local continuity error: 1.56852e-05 s^-1
 cells  error_velocity    error_pressure   
   256 3.208513e-02    - 2.196294e-01    - 

--- a/applications_tests/lethe-fluid-vans/case1_vans_B.output
+++ b/applications_tests/lethe-fluid-vans/case1_vans_B.output
@@ -12,7 +12,7 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Global continuity equation error: -2.32538e-17 s^-1
+Global continuity equation error: -1.58812e-17 s^-1
 Max local continuity error: 0.00226328 s^-1
 
 *****************************
@@ -27,7 +27,7 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Global continuity equation error: 2.92656e-17 s^-1
+Global continuity equation error: -5.84735e-17 s^-1
 Max local continuity error: 0.000290049 s^-1
 
 *****************************
@@ -42,7 +42,7 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Global continuity equation error: -9.1371e-19 s^-1
+Global continuity equation error: -1.62924e-17 s^-1
 Max local continuity error: 3.65184e-05 s^-1
 cells  error_velocity    error_pressure   
   256 6.359579e-02    - 4.459124e-01    - 

--- a/applications_tests/lethe-fluid-vans/case2_vans_B.output
+++ b/applications_tests/lethe-fluid-vans/case2_vans_B.output
@@ -12,7 +12,7 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Global continuity equation error: 3.79267e-17 s^-1
+Global continuity equation error: 1.7293e-17 s^-1
 Max local continuity error: 0.000519468 s^-1
 
 *****************************
@@ -27,7 +27,7 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Global continuity equation error: -1.51263e-17 s^-1
+Global continuity equation error: -2.13791e-17 s^-1
 Max local continuity error: 5.72143e-05 s^-1
 
 *****************************
@@ -42,7 +42,7 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Global continuity equation error: -4.14924e-17 s^-1
+Global continuity equation error: -1.93073e-17 s^-1
 Max local continuity error: 7.19543e-06 s^-1
 cells  error_velocity    error_pressure   
   256 8.541669e-02    - 6.552167e-01    - 

--- a/applications_tests/lethe-fluid-vans/dallavalle_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/dallavalle_packed_bed.mpirun=1.output
@@ -16,8 +16,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.66864502 Pa
 Total pressure drop: 21.6686444 Pa
-Global continuity equation error: -2.025635605e-11 s^-1
-Max local continuity error: 7.259414537e-08 s^-1
+Global continuity equation error: -2.025635609e-11 s^-1
+Max local continuity error: 7.259414532e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2278619765
@@ -30,11 +30,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 8.438090807 Pa
 Total pressure drop: 8.438090502 Pa
-Global continuity equation error: -1.820678494e-12 s^-1
-Max local continuity error: 6.96104513e-08 s^-1
+Global continuity equation error: -1.820678674e-12 s^-1
+Max local continuity error: 6.961045125e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2189051178
+Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2189051179
 ***********************************************************************************
 --------------
 Void Fraction
@@ -44,8 +44,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 8.415543984 Pa
 Total pressure drop: 8.415543921 Pa
-Global continuity equation error: -1.694754328e-11 s^-1
-Max local continuity error: 6.993461713e-08 s^-1
+Global continuity equation error: -1.694754317e-11 s^-1
+Max local continuity error: 6.993461708e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2195594114
@@ -58,11 +58,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 8.414647415 Pa
 Total pressure drop: 8.414647499 Pa
-Global continuity equation error: -1.557087683e-11 s^-1
-Max local continuity error: 7.013276277e-08 s^-1
+Global continuity equation error: -1.557087674e-11 s^-1
+Max local continuity error: 7.013276272e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2197822686
+Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2197822687
 ***********************************************************************************
 --------------
 Void Fraction
@@ -72,12 +72,12 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 8.414337103 Pa
 Total pressure drop: 8.414337264 Pa
-Global continuity equation error: 4.397883093e-12 s^-1
-Max local continuity error: 7.025617184e-08 s^-1
+Global continuity equation error: 4.397882763e-12 s^-1
+Max local continuity error: 7.02561718e-08 s^-1
 
-***********************************************************************************
-Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2198935489
-***********************************************************************************
+**********************************************************************************
+Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.219893549
+**********************************************************************************
 --------------
 Void Fraction
 --------------
@@ -86,8 +86,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 8.414187132 Pa
 Total pressure drop: 8.414187346 Pa
-Global continuity equation error: 7.92829611e-12 s^-1
-Max local continuity error: 7.034154077e-08 s^-1
+Global continuity equation error: 7.928296536e-12 s^-1
+Max local continuity error: 7.034154072e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2199627458
@@ -100,11 +100,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 8.414096369 Pa
 Total pressure drop: 8.414096611 Pa
-Global continuity equation error: 7.73149953e-12 s^-1
-Max local continuity error: 7.040495922e-08 s^-1
+Global continuity equation error: 7.73149911e-12 s^-1
+Max local continuity error: 7.040495918e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2200111721
+Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2200111722
 ***********************************************************************************
 --------------
 Void Fraction
@@ -113,9 +113,9 @@ Void Fraction
 Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 8.414035582 Pa
-Total pressure drop: 8.414035834 Pa
-Global continuity equation error: 4.74210643e-12 s^-1
-Max local continuity error: 7.045462029e-08 s^-1
+Total pressure drop: 8.414035835 Pa
+Global continuity equation error: 4.742107509e-12 s^-1
+Max local continuity error: 7.045462025e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2200474804
@@ -128,8 +128,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 8.413993426 Pa
 Total pressure drop: 8.413993668 Pa
-Global continuity equation error: 6.620836767e-12 s^-1
-Max local continuity error: 7.049506429e-08 s^-1
+Global continuity equation error: 6.620837797e-12 s^-1
+Max local continuity error: 7.049506424e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2200759291
@@ -142,5 +142,5 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 8.413960507 Pa
 Total pressure drop: 8.413960729 Pa
-Global continuity equation error: 5.496179489e-12 s^-1
-Max local continuity error: 7.052898812e-08 s^-1
+Global continuity equation error: 5.496179359e-12 s^-1
+Max local continuity error: 7.052898808e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/dallavalle_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/dallavalle_packed_bed.prm
@@ -167,7 +167,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection fluid dynamics
+   subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
+   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000
     set relative residual                     = 1e-3

--- a/applications_tests/lethe-fluid-vans/dallavalle_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/dallavalle_packed_bed.prm
@@ -167,12 +167,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-   subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet
   end
-   subsection fluid dynamics
+  subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000
     set relative residual                     = 1e-3

--- a/applications_tests/lethe-fluid-vans/difelice_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/difelice_packed_bed.mpirun=1.output
@@ -16,11 +16,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 28.27228746 Pa
 Total pressure drop: 28.27228722 Pa
-Global continuity equation error: 2.308224603e-12 s^-1
-Max local continuity error: 6.969283925e-08 s^-1
+Global continuity equation error: 2.308218418e-12 s^-1
+Max local continuity error: 6.969283921e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2172030838
+Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2172030839
 ***********************************************************************************
 --------------
 Void Fraction
@@ -30,8 +30,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 20.9903267 Pa
 Total pressure drop: 20.99032684 Pa
-Global continuity equation error: -7.535107456e-12 s^-1
-Max local continuity error: 6.634264839e-08 s^-1
+Global continuity equation error: -7.535107535e-12 s^-1
+Max local continuity error: 6.634264834e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2136378826
@@ -44,8 +44,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 20.95118891 Pa
 Total pressure drop: 20.95118925 Pa
-Global continuity equation error: 9.363695933e-11 s^-1
-Max local continuity error: 6.675503179e-08 s^-1
+Global continuity equation error: 9.363695858e-11 s^-1
+Max local continuity error: 6.675503175e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2137644066
@@ -58,11 +58,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 20.9506567 Pa
 Total pressure drop: 20.95065729 Pa
-Global continuity equation error: 4.200276779e-13 s^-1
-Max local continuity error: 6.700288478e-08 s^-1
+Global continuity equation error: 4.200232593e-13 s^-1
+Max local continuity error: 6.700288474e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2137294396
+Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2137294397
 ***********************************************************************************
 --------------
 Void Fraction
@@ -72,8 +72,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 20.95049453 Pa
 Total pressure drop: 20.95049522 Pa
-Global continuity equation error: 1.424488182e-11 s^-1
-Max local continuity error: 6.715590418e-08 s^-1
+Global continuity equation error: 1.42448816e-11 s^-1
+Max local continuity error: 6.715590413e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2137276968
@@ -86,8 +86,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 20.95040815 Pa
 Total pressure drop: 20.95040891 Pa
-Global continuity equation error: 4.187521365e-12 s^-1
-Max local continuity error: 6.726379966e-08 s^-1
+Global continuity equation error: 4.187521532e-12 s^-1
+Max local continuity error: 6.726379961e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2137238023
@@ -98,13 +98,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 20.95035819 Pa
+Pressure drop: 20.9503582 Pa
 Total pressure drop: 20.95035899 Pa
-Global continuity equation error: 6.579252239e-13 s^-1
-Max local continuity error: 6.734456575e-08 s^-1
+Global continuity equation error: 6.579252363e-13 s^-1
+Max local continuity error: 6.73445657e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2137275588
+Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2137275589
 ***********************************************************************************
 --------------
 Void Fraction
@@ -114,11 +114,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 20.95032686 Pa
 Total pressure drop: 20.95032766 Pa
-Global continuity equation error: 4.726183166e-14 s^-1
-Max local continuity error: 6.740821933e-08 s^-1
+Global continuity equation error: 4.726182489e-14 s^-1
+Max local continuity error: 6.740821929e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2137413832
+Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2137413833
 ***********************************************************************************
 --------------
 Void Fraction
@@ -128,12 +128,12 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 20.95032588 Pa
 Total pressure drop: 20.95032665 Pa
-Global continuity equation error: 1.543047901e-11 s^-1
-Max local continuity error: 6.746046873e-08 s^-1
+Global continuity equation error: 1.543047879e-11 s^-1
+Max local continuity error: 6.746046868e-08 s^-1
 
-**********************************************************************************
-Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.213752275
-**********************************************************************************
+***********************************************************************************
+Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2137522751
+***********************************************************************************
 --------------
 Void Fraction
 --------------
@@ -142,5 +142,5 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 20.95032454 Pa
 Total pressure drop: 20.95032525 Pa
-Global continuity equation error: 5.178803616e-11 s^-1
-Max local continuity error: 6.750424791e-08 s^-1
+Global continuity equation error: 5.178803538e-11 s^-1
+Max local continuity error: 6.750424787e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/difelice_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/difelice_packed_bed.prm
@@ -167,7 +167,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet

--- a/applications_tests/lethe-fluid-vans/difelice_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/difelice_packed_bed.prm
@@ -167,6 +167,11 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000

--- a/applications_tests/lethe-fluid-vans/gidaspow_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/gidaspow_packed_bed.mpirun=1.output
@@ -16,11 +16,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 58.90343086 Pa
 Total pressure drop: 58.90343123 Pa
-Global continuity equation error: -2.413411287e-12 s^-1
-Max local continuity error: 6.3776455e-08 s^-1
+Global continuity equation error: -2.413411202e-12 s^-1
+Max local continuity error: 6.377645489e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2074372958
+Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2074372959
 ***********************************************************************************
 --------------
 Void Fraction
@@ -30,8 +30,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 54.8606949 Pa
 Total pressure drop: 54.86069565 Pa
-Global continuity equation error: -3.064962437e-11 s^-1
-Max local continuity error: 6.342821224e-08 s^-1
+Global continuity equation error: -3.064962461e-11 s^-1
+Max local continuity error: 6.342821215e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2100869009
@@ -44,12 +44,12 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 54.77364863 Pa
 Total pressure drop: 54.7736496 Pa
-Global continuity equation error: 4.044608723e-11 s^-1
-Max local continuity error: 6.350542421e-08 s^-1
+Global continuity equation error: 4.044608693e-11 s^-1
+Max local continuity error: 6.350542411e-08 s^-1
 
-***********************************************************************************
-Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2094033649
-***********************************************************************************
+**********************************************************************************
+Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.209403365
+**********************************************************************************
 --------------
 Void Fraction
 --------------
@@ -58,8 +58,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 54.77375508 Pa
 Total pressure drop: 54.77375628 Pa
-Global continuity equation error: -1.006163984e-11 s^-1
-Max local continuity error: 6.342597788e-08 s^-1
+Global continuity equation error: -1.006163961e-11 s^-1
+Max local continuity error: 6.342597778e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2095234104
@@ -72,12 +72,12 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 54.7737519 Pa
 Total pressure drop: 54.7737532 Pa
-Global continuity equation error: 6.01653939e-12 s^-1
-Max local continuity error: 6.339701468e-08 s^-1
+Global continuity equation error: 6.016538177e-12 s^-1
+Max local continuity error: 6.339701459e-08 s^-1
 
-***********************************************************************************
-Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2095035179
-***********************************************************************************
+**********************************************************************************
+Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.209503518
+**********************************************************************************
 --------------
 Void Fraction
 --------------
@@ -86,8 +86,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 54.77379252 Pa
 Total pressure drop: 54.77379388 Pa
-Global continuity equation error: 4.600785769e-13 s^-1
-Max local continuity error: 6.337212573e-08 s^-1
+Global continuity equation error: 4.600784213e-13 s^-1
+Max local continuity error: 6.337212564e-08 s^-1
 
 *********************************************************************************
 Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.20950744
@@ -100,11 +100,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 54.77379298 Pa
 Total pressure drop: 54.77379432 Pa
-Global continuity equation error: 6.11604229e-11 s^-1
-Max local continuity error: 6.335414823e-08 s^-1
+Global continuity equation error: 6.11604226e-11 s^-1
+Max local continuity error: 6.335414814e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2095070204
+Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2095070205
 ***********************************************************************************
 --------------
 Void Fraction
@@ -113,12 +113,12 @@ Void Fraction
 Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 54.77380593 Pa
-Total pressure drop: 54.77380728 Pa
-Global continuity equation error: 2.769474171e-11 s^-1
-Max local continuity error: 6.334008666e-08 s^-1
+Total pressure drop: 54.77380729 Pa
+Global continuity equation error: 2.769474094e-11 s^-1
+Max local continuity error: 6.334008657e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2095073921
+Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2095073922
 ***********************************************************************************
 --------------
 Void Fraction
@@ -128,12 +128,12 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 54.77380999 Pa
 Total pressure drop: 54.77381135 Pa
-Global continuity equation error: -2.985879617e-11 s^-1
-Max local continuity error: 6.332882959e-08 s^-1
+Global continuity equation error: -2.985879699e-11 s^-1
+Max local continuity error: 6.33288295e-08 s^-1
 
-*********************************************************************************
-Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.20950759
-*********************************************************************************
+***********************************************************************************
+Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2095075901
+***********************************************************************************
 --------------
 Void Fraction
 --------------
@@ -142,5 +142,5 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 54.77382282 Pa
 Total pressure drop: 54.77382416 Pa
-Global continuity equation error: -8.239892794e-11 s^-1
-Max local continuity error: 6.331973219e-08 s^-1
+Global continuity equation error: -8.239892849e-11 s^-1
+Max local continuity error: 6.33197321e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/gidaspow_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/gidaspow_packed_bed.prm
@@ -167,12 +167,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet
   end
-   subsection fluid dynamics
+  subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000
     set relative residual                     = 1e-3

--- a/applications_tests/lethe-fluid-vans/gidaspow_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/gidaspow_packed_bed.prm
@@ -167,7 +167,12 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection fluid dynamics
+  subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
+   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000
     set relative residual                     = 1e-3

--- a/applications_tests/lethe-fluid-vans/kochhill_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/kochhill_packed_bed.mpirun=1.output
@@ -16,11 +16,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 39.30134329 Pa
 Total pressure drop: 39.30134352 Pa
-Global continuity equation error: 1.287681666e-13 s^-1
-Max local continuity error: 6.590508987e-08 s^-1
+Global continuity equation error: 1.287692721e-13 s^-1
+Max local continuity error: 6.590508983e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2134143023
+Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2134143024
 ***********************************************************************************
 --------------
 Void Fraction
@@ -30,11 +30,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 24.7550814 Pa
 Total pressure drop: 24.75508194 Pa
-Global continuity equation error: -7.416076481e-13 s^-1
-Max local continuity error: 6.539036655e-08 s^-1
+Global continuity equation error: -7.416069355e-13 s^-1
+Max local continuity error: 6.53903665e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2128015674
+Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2128015675
 ***********************************************************************************
 --------------
 Void Fraction
@@ -42,10 +42,10 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 24.7340337 Pa
+Pressure drop: 24.73403371 Pa
 Total pressure drop: 24.73403444 Pa
-Global continuity equation error: 1.19221227e-11 s^-1
-Max local continuity error: 6.585488711e-08 s^-1
+Global continuity equation error: 1.192212329e-11 s^-1
+Max local continuity error: 6.585488706e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2128038218
@@ -58,11 +58,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 24.73367735 Pa
 Total pressure drop: 24.73367822 Pa
-Global continuity equation error: 2.11768192e-11 s^-1
-Max local continuity error: 6.609221249e-08 s^-1
+Global continuity equation error: 2.117681912e-11 s^-1
+Max local continuity error: 6.609221244e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2127978565
+Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2127978566
 ***********************************************************************************
 --------------
 Void Fraction
@@ -72,8 +72,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 24.73354448 Pa
 Total pressure drop: 24.73354545 Pa
-Global continuity equation error: 2.84138782e-12 s^-1
-Max local continuity error: 6.624388774e-08 s^-1
+Global continuity equation error: 2.841387768e-12 s^-1
+Max local continuity error: 6.62438877e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2127944991
@@ -86,11 +86,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 24.73347714 Pa
 Total pressure drop: 24.73347816 Pa
-Global continuity equation error: 2.056317614e-12 s^-1
-Max local continuity error: 6.635146902e-08 s^-1
+Global continuity equation error: 2.05631759e-12 s^-1
+Max local continuity error: 6.635146897e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2127922851
+Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2127922852
 ***********************************************************************************
 --------------
 Void Fraction
@@ -100,11 +100,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 24.73343719 Pa
 Total pressure drop: 24.73343822 Pa
-Global continuity equation error: 1.674562614e-12 s^-1
-Max local continuity error: 6.643314397e-08 s^-1
+Global continuity equation error: 1.674562621e-12 s^-1
+Max local continuity error: 6.643314393e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2127908051
+Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2127908052
 ***********************************************************************************
 --------------
 Void Fraction
@@ -114,12 +114,12 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 24.73341229 Pa
 Total pressure drop: 24.73341331 Pa
-Global continuity equation error: 1.307650935e-12 s^-1
-Max local continuity error: 6.649815324e-08 s^-1
+Global continuity equation error: 1.307650907e-12 s^-1
+Max local continuity error: 6.649815319e-08 s^-1
 
-***********************************************************************************
-Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2127898069
-***********************************************************************************
+**********************************************************************************
+Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.212789807
+**********************************************************************************
 --------------
 Void Fraction
 --------------
@@ -128,11 +128,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 24.73341145 Pa
 Total pressure drop: 24.73341243 Pa
-Global continuity equation error: 1.008904829e-11 s^-1
-Max local continuity error: 6.655186965e-08 s^-1
+Global continuity equation error: 1.008904799e-11 s^-1
+Max local continuity error: 6.65518696e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2127965353
+Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2127965354
 ***********************************************************************************
 --------------
 Void Fraction
@@ -142,5 +142,5 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 24.73341099 Pa
 Total pressure drop: 24.7334119 Pa
-Global continuity equation error: 3.643634836e-11 s^-1
-Max local continuity error: 6.65971599e-08 s^-1
+Global continuity equation error: 3.643634756e-11 s^-1
+Max local continuity error: 6.659715986e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/kochhill_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/kochhill_packed_bed.prm
@@ -167,7 +167,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet

--- a/applications_tests/lethe-fluid-vans/kochhill_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/kochhill_packed_bed.prm
@@ -167,6 +167,11 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000

--- a/applications_tests/lethe-fluid-vans/pcm_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/pcm_packed_bed.mpirun=1.output
@@ -16,8 +16,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 28.56817619 Pa
 Total pressure drop: 28.568176 Pa
-Global continuity equation error: -4.991481748e-12 s^-1
-Max local continuity error: 6.995406117e-08 s^-1
+Global continuity equation error: -4.991481972e-12 s^-1
+Max local continuity error: 6.995406113e-08 s^-1
 
 **********************************************************************************
 Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.220079361
@@ -30,12 +30,12 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.64035002 Pa
 Total pressure drop: 21.64035016 Pa
-Global continuity equation error: 2.794408716e-12 s^-1
-Max local continuity error: 6.614301298e-08 s^-1
+Global continuity equation error: 2.79440862e-12 s^-1
+Max local continuity error: 6.614301294e-08 s^-1
 
-***********************************************************************************
-Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2133312429
-***********************************************************************************
+**********************************************************************************
+Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.213331243
+**********************************************************************************
 --------------
 Void Fraction
 --------------
@@ -44,11 +44,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.60006306 Pa
 Total pressure drop: 21.60006341 Pa
-Global continuity equation error: 1.246871425e-10 s^-1
-Max local continuity error: 6.664333017e-08 s^-1
+Global continuity equation error: 1.246871467e-10 s^-1
+Max local continuity error: 6.664333013e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2138305573
+Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2138305574
 ***********************************************************************************
 --------------
 Void Fraction
@@ -58,8 +58,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.59968712 Pa
 Total pressure drop: 21.59968774 Pa
-Global continuity equation error: 2.676158058e-13 s^-1
-Max local continuity error: 6.689010128e-08 s^-1
+Global continuity equation error: 2.676180519e-13 s^-1
+Max local continuity error: 6.689010124e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2137513785
@@ -70,13 +70,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.59950541 Pa
+Pressure drop: 21.59950542 Pa
 Total pressure drop: 21.59950613 Pa
-Global continuity equation error: 1.516728785e-11 s^-1
-Max local continuity error: 6.704577551e-08 s^-1
+Global continuity equation error: 1.516728774e-11 s^-1
+Max local continuity error: 6.704577547e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2138020177
+Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2138020178
 ***********************************************************************************
 --------------
 Void Fraction
@@ -86,11 +86,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.59942523 Pa
 Total pressure drop: 21.59942602 Pa
-Global continuity equation error: 5.236851376e-12 s^-1
-Max local continuity error: 6.715494792e-08 s^-1
+Global continuity equation error: 5.236851398e-12 s^-1
+Max local continuity error: 6.715494787e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2138247557
+Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2138247558
 ***********************************************************************************
 --------------
 Void Fraction
@@ -99,13 +99,13 @@ Void Fraction
 Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.59937742 Pa
-Total pressure drop: 21.59937824 Pa
-Global continuity equation error: 1.011831245e-12 s^-1
-Max local continuity error: 6.723664359e-08 s^-1
+Total pressure drop: 21.59937825 Pa
+Global continuity equation error: 1.011831223e-12 s^-1
+Max local continuity error: 6.723664354e-08 s^-1
 
-***********************************************************************************
-Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2138430269
-***********************************************************************************
+**********************************************************************************
+Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.213843027
+**********************************************************************************
 --------------
 Void Fraction
 --------------
@@ -114,11 +114,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.59934847 Pa
 Total pressure drop: 21.5993493 Pa
-Global continuity equation error: 7.388918162e-13 s^-1
-Max local continuity error: 6.730099965e-08 s^-1
+Global continuity equation error: 7.388917977e-13 s^-1
+Max local continuity error: 6.730099961e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2138565348
+Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2138565349
 ***********************************************************************************
 --------------
 Void Fraction
@@ -127,12 +127,12 @@ Void Fraction
 Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.59934752 Pa
-Total pressure drop: 21.59934832 Pa
-Global continuity equation error: 1.674474567e-11 s^-1
-Max local continuity error: 6.735380721e-08 s^-1
+Total pressure drop: 21.59934833 Pa
+Global continuity equation error: 1.674474542e-11 s^-1
+Max local continuity error: 6.735380717e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2138671712
+Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2138671713
 ***********************************************************************************
 --------------
 Void Fraction
@@ -142,5 +142,5 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.59934651 Pa
 Total pressure drop: 21.59934725 Pa
-Global continuity equation error: 5.111915485e-11 s^-1
-Max local continuity error: 6.739805955e-08 s^-1
+Global continuity equation error: 5.111915406e-11 s^-1
+Max local continuity error: 6.739805951e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/pcm_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/pcm_packed_bed.prm
@@ -167,7 +167,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-   subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet

--- a/applications_tests/lethe-fluid-vans/pcm_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/pcm_packed_bed.prm
@@ -167,6 +167,11 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+   subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000

--- a/applications_tests/lethe-fluid-vans/qcm_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/qcm_packed_bed.mpirun=1.output
@@ -16,7 +16,7 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 31.39660793 Pa
 Total pressure drop: 31.39662442 Pa
-Global continuity equation error: -2.498505714e-08 s^-1
+Global continuity equation error: -2.49850572e-08 s^-1
 Max local continuity error: 2.744187332e-07 s^-1
 
 ***********************************************************************************
@@ -30,5 +30,5 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 29.86117108 Pa
 Total pressure drop: 29.86116845 Pa
-Global continuity equation error: 1.591115213e-09 s^-1
+Global continuity equation error: 1.591115216e-09 s^-1
 Max local continuity error: 2.398790037e-07 s^-1

--- a/applications_tests/lethe-fluid-vans/qcm_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/qcm_packed_bed.prm
@@ -168,7 +168,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet

--- a/applications_tests/lethe-fluid-vans/qcm_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/qcm_packed_bed.prm
@@ -168,6 +168,11 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000

--- a/applications_tests/lethe-fluid-vans/rong_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/rong_packed_bed.mpirun=1.output
@@ -16,8 +16,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 28.56817619 Pa
 Total pressure drop: 28.568176 Pa
-Global continuity equation error: -4.991481748e-12 s^-1
-Max local continuity error: 6.995406117e-08 s^-1
+Global continuity equation error: -4.991481972e-12 s^-1
+Max local continuity error: 6.995406113e-08 s^-1
 
 **********************************************************************************
 Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.220079361
@@ -30,12 +30,12 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.64035002 Pa
 Total pressure drop: 21.64035016 Pa
-Global continuity equation error: 2.794408716e-12 s^-1
-Max local continuity error: 6.614301298e-08 s^-1
+Global continuity equation error: 2.79440862e-12 s^-1
+Max local continuity error: 6.614301294e-08 s^-1
 
-***********************************************************************************
-Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2133312429
-***********************************************************************************
+**********************************************************************************
+Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.213331243
+**********************************************************************************
 --------------
 Void Fraction
 --------------
@@ -44,11 +44,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.60006306 Pa
 Total pressure drop: 21.60006341 Pa
-Global continuity equation error: 1.246871425e-10 s^-1
-Max local continuity error: 6.664333017e-08 s^-1
+Global continuity equation error: 1.246871467e-10 s^-1
+Max local continuity error: 6.664333013e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2138305573
+Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2138305574
 ***********************************************************************************
 --------------
 Void Fraction
@@ -58,8 +58,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.59968712 Pa
 Total pressure drop: 21.59968774 Pa
-Global continuity equation error: 2.676158058e-13 s^-1
-Max local continuity error: 6.689010128e-08 s^-1
+Global continuity equation error: 2.676180519e-13 s^-1
+Max local continuity error: 6.689010124e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2137513785
@@ -70,13 +70,13 @@ Void Fraction
 -------------------------------
 Volume-Averaged Fluid Dynamics
 -------------------------------
-Pressure drop: 21.59950541 Pa
+Pressure drop: 21.59950542 Pa
 Total pressure drop: 21.59950613 Pa
-Global continuity equation error: 1.516728785e-11 s^-1
-Max local continuity error: 6.704577551e-08 s^-1
+Global continuity equation error: 1.516728774e-11 s^-1
+Max local continuity error: 6.704577547e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2138020177
+Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2138020178
 ***********************************************************************************
 --------------
 Void Fraction
@@ -86,11 +86,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.59942523 Pa
 Total pressure drop: 21.59942602 Pa
-Global continuity equation error: 5.236851376e-12 s^-1
-Max local continuity error: 6.715494792e-08 s^-1
+Global continuity equation error: 5.236851398e-12 s^-1
+Max local continuity error: 6.715494787e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2138247557
+Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2138247558
 ***********************************************************************************
 --------------
 Void Fraction
@@ -99,13 +99,13 @@ Void Fraction
 Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.59937742 Pa
-Total pressure drop: 21.59937824 Pa
-Global continuity equation error: 1.011831245e-12 s^-1
-Max local continuity error: 6.723664359e-08 s^-1
+Total pressure drop: 21.59937825 Pa
+Global continuity equation error: 1.011831223e-12 s^-1
+Max local continuity error: 6.723664354e-08 s^-1
 
-***********************************************************************************
-Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2138430269
-***********************************************************************************
+**********************************************************************************
+Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.213843027
+**********************************************************************************
 --------------
 Void Fraction
 --------------
@@ -114,11 +114,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.59934847 Pa
 Total pressure drop: 21.5993493 Pa
-Global continuity equation error: 7.388918162e-13 s^-1
-Max local continuity error: 6.730099965e-08 s^-1
+Global continuity equation error: 7.388917977e-13 s^-1
+Max local continuity error: 6.730099961e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2138565348
+Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2138565349
 ***********************************************************************************
 --------------
 Void Fraction
@@ -127,12 +127,12 @@ Void Fraction
 Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.59934752 Pa
-Total pressure drop: 21.59934832 Pa
-Global continuity equation error: 1.674474567e-11 s^-1
-Max local continuity error: 6.735380721e-08 s^-1
+Total pressure drop: 21.59934833 Pa
+Global continuity equation error: 1.674474542e-11 s^-1
+Max local continuity error: 6.735380717e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2138671712
+Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2138671713
 ***********************************************************************************
 --------------
 Void Fraction
@@ -142,5 +142,5 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.59934651 Pa
 Total pressure drop: 21.59934725 Pa
-Global continuity equation error: 5.111915485e-11 s^-1
-Max local continuity error: 6.739805955e-08 s^-1
+Global continuity equation error: 5.111915406e-11 s^-1
+Max local continuity error: 6.739805951e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/rong_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/rong_packed_bed.prm
@@ -167,7 +167,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet

--- a/applications_tests/lethe-fluid-vans/rong_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/rong_packed_bed.prm
@@ -167,6 +167,11 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000

--- a/applications_tests/lethe-fluid-vans/spm_packed_bed.mpirun=1.output
+++ b/applications_tests/lethe-fluid-vans/spm_packed_bed.mpirun=1.output
@@ -16,8 +16,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 28.56987871 Pa
 Total pressure drop: 28.5698785 Pa
-Global continuity equation error: -1.417566079e-12 s^-1
-Max local continuity error: 7.051396532e-08 s^-1
+Global continuity equation error: -1.417565989e-12 s^-1
+Max local continuity error: 7.051396537e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 2        Time: 0.004    Time step: 0.002    CFL: 0.2206759011
@@ -30,8 +30,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.64235085 Pa
 Total pressure drop: 21.64235075 Pa
-Global continuity equation error: -1.602742144e-13 s^-1
-Max local continuity error: 6.587716251e-08 s^-1
+Global continuity equation error: -1.602741854e-13 s^-1
+Max local continuity error: 6.587716246e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 3        Time: 0.006    Time step: 0.002    CFL: 0.2128169778
@@ -44,11 +44,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.60258686 Pa
 Total pressure drop: 21.60258693 Pa
-Global continuity equation error: 1.03141038e-10 s^-1
-Max local continuity error: 6.628317872e-08 s^-1
+Global continuity equation error: 1.031410405e-10 s^-1
+Max local continuity error: 6.628317868e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2138361794
+Transient iteration: 4        Time: 0.008    Time step: 0.002    CFL: 0.2138361795
 ***********************************************************************************
 --------------
 Void Fraction
@@ -58,8 +58,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.60225092 Pa
 Total pressure drop: 21.60225121 Pa
-Global continuity equation error: 1.108935524e-11 s^-1
-Max local continuity error: 6.651048819e-08 s^-1
+Global continuity equation error: 1.108935962e-11 s^-1
+Max local continuity error: 6.651048814e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 5        Time: 0.01     Time step: 0.002    CFL: 0.2137558199
@@ -72,11 +72,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.60207902 Pa
 Total pressure drop: 21.60207941 Pa
-Global continuity equation error: 1.310064563e-11 s^-1
-Max local continuity error: 6.6651475e-08 s^-1
+Global continuity equation error: 1.31006456e-11 s^-1
+Max local continuity error: 6.665147495e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2138134438
+Transient iteration: 6        Time: 0.012    Time step: 0.002    CFL: 0.2138134439
 ***********************************************************************************
 --------------
 Void Fraction
@@ -86,8 +86,8 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.602005 Pa
 Total pressure drop: 21.60200546 Pa
-Global continuity equation error: 4.376847423e-12 s^-1
-Max local continuity error: 6.675045495e-08 s^-1
+Global continuity equation error: 4.376847402e-12 s^-1
+Max local continuity error: 6.675045491e-08 s^-1
 
 ***********************************************************************************
 Transient iteration: 7        Time: 0.014    Time step: 0.002    CFL: 0.2138364324
@@ -100,11 +100,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.60195984 Pa
 Total pressure drop: 21.60196033 Pa
-Global continuity equation error: 7.53448969e-13 s^-1
-Max local continuity error: 6.682425195e-08 s^-1
+Global continuity equation error: 7.534489944e-13 s^-1
+Max local continuity error: 6.682425191e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2138547145
+Transient iteration: 8        Time: 0.016    Time step: 0.002    CFL: 0.2138547146
 ***********************************************************************************
 --------------
 Void Fraction
@@ -114,12 +114,12 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.60193211 Pa
 Total pressure drop: 21.60193261 Pa
-Global continuity equation error: 2.112020365e-13 s^-1
-Max local continuity error: 6.688221746e-08 s^-1
+Global continuity equation error: 2.112020703e-13 s^-1
+Max local continuity error: 6.688221741e-08 s^-1
 
-***********************************************************************************
-Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.2138681889
-***********************************************************************************
+**********************************************************************************
+Transient iteration: 9        Time: 0.018    Time step: 0.002    CFL: 0.213868189
+**********************************************************************************
 --------------
 Void Fraction
 --------------
@@ -128,11 +128,11 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.60193111 Pa
 Total pressure drop: 21.60193158 Pa
-Global continuity equation error: 1.341079499e-11 s^-1
-Max local continuity error: 6.692966538e-08 s^-1
+Global continuity equation error: 1.34107948e-11 s^-1
+Max local continuity error: 6.692966533e-08 s^-1
 
 ***********************************************************************************
-Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2138787663
+Transient iteration: 10       Time: 0.02     Time step: 0.002    CFL: 0.2138787664
 ***********************************************************************************
 --------------
 Void Fraction
@@ -142,5 +142,5 @@ Volume-Averaged Fluid Dynamics
 -------------------------------
 Pressure drop: 21.60192987 Pa
 Total pressure drop: 21.60193029 Pa
-Global continuity equation error: 4.386096778e-11 s^-1
-Max local continuity error: 6.696932649e-08 s^-1
+Global continuity equation error: 4.386096703e-11 s^-1
+Max local continuity error: 6.696932645e-08 s^-1

--- a/applications_tests/lethe-fluid-vans/spm_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/spm_packed_bed.prm
@@ -167,7 +167,7 @@ end
 #---------------------------------------------------
 
 subsection linear solver
-  subsection void fraction 
+  subsection void fraction
     set relative residual = 1e-15
     set minimum residual  = 1e-15
     set verbosity         = quiet

--- a/applications_tests/lethe-fluid-vans/spm_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/spm_packed_bed.prm
@@ -167,6 +167,11 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction 
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+    set verbosity         = quiet
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000

--- a/doc/source/parameters/cfd/linear_solver_control.rst
+++ b/doc/source/parameters/cfd/linear_solver_control.rst
@@ -2,7 +2,7 @@
 Linear Solver
 =============
 
-In this subsection, the control options of the linear solvers are specified. The default values for the linear solver parameters are given in the text box below. Lethe supports different physics (``fluid dynamics``, ``VOF``, ``heat transfer``, ``cahn hilliard`` and ``tracer``) and it is possible to specify linear solver parameters for each of them. The ``VOF algebraic interface reinitialization`` subequation has also its own subsection.
+In this subsection, the control options of the linear solvers are specified. The default values for the linear solver parameters are given in the text box below. Lethe supports different physics (``fluid dynamics``, ``VOF``, ``heat transfer``, ``cahn hilliard``, ``tracer`` and ``void fraction``) and it is possible to specify linear solver parameters for each of them. The ``VOF algebraic interface reinitialization`` subequation has also its own subsection.
 
 In the example below, only ``fluid dynamics`` is used, however, the same block can be used for other physics.
 

--- a/examples/dem-mp/3d-heat-transfer-in-aligned-particles/equilibrium.prm
+++ b/examples/dem-mp/3d-heat-transfer-in-aligned-particles/equilibrium.prm
@@ -77,9 +77,9 @@ end
 #---------------------------------------------------
 
 subsection insertion info
-  set insertion method                               = file
-  set insertion frequency                            = 10000
-  set list of input files                            = particles-equilibrium.input
+  set insertion method    = file
+  set insertion frequency = 10000
+  set list of input files = particles-equilibrium.input
 end
 
 #---------------------------------------------------

--- a/examples/dem-mp/3d-heat-transfer-in-aligned-particles/wall-heating.prm
+++ b/examples/dem-mp/3d-heat-transfer-in-aligned-particles/wall-heating.prm
@@ -82,9 +82,9 @@ end
 #---------------------------------------------------
 
 subsection insertion info
-  set insertion method                               = file
-  set insertion frequency                            = 10000
-  set list of input files                            = particles-wall-heating.input
+  set insertion method    = file
+  set insertion frequency = 10000
+  set list of input files = particles-wall-heating.input
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/cylinder-cooling/cylinder-xi-0_01.prm
+++ b/examples/multiphysics/cylinder-cooling/cylinder-xi-0_01.prm
@@ -50,7 +50,7 @@ subsection initial conditions
   end
 
   subsection temperature
-    set Function expression = if(((x-8)^2+(y-0)^2)^0.5-0.5001<0,1,0) 
+    set Function expression = if(((x-8)^2+(y-0)^2)^0.5-0.5001<0,1,0)
   end
 end
 
@@ -65,7 +65,7 @@ subsection physical properties
     set density              = 1
     set thermal conductivity = 0.2
   end
-  
+
   set number of solids = 1
   subsection solid 0
     set thermal conductivity = 0.2
@@ -108,7 +108,7 @@ subsection boundary conditions
   set number = 3
   subsection bc 0
     set type = function
-    set id = 3
+    set id   = 3
     subsection u
       set Function expression = 20
     end
@@ -120,11 +120,11 @@ subsection boundary conditions
     end
   end
   subsection bc 1
-    set id = 4
+    set id   = 4
     set type = outlet
   end
   subsection bc 2
-    set id = 5
+    set id   = 5
     set type = slip
   end
 end
@@ -136,8 +136,8 @@ end
 subsection boundary conditions heat transfer
   set number = 3
   subsection bc 0
-    set id    = 3
-    set type  = temperature
+    set id   = 3
+    set type = temperature
     subsection value
       set Function expression = 0
     end
@@ -151,7 +151,6 @@ subsection boundary conditions heat transfer
     set type = noflux
   end
 end
-
 
 #---------------------------------------------------
 # Non-Linear Solver Control
@@ -176,18 +175,18 @@ end
 
 subsection linear solver
   subsection fluid dynamics
-    set max iters            = 1000
-    set relative residual    = 1e-4
-    set minimum residual     = 1e-8
-    set preconditioner       = amg
-    set max krylov vectors   = 1000
+    set max iters          = 1000
+    set relative residual  = 1e-4
+    set minimum residual   = 1e-8
+    set preconditioner     = amg
+    set max krylov vectors = 1000
   end
   subsection heat transfer
-    set max iters            = 1000
-    set relative residual    = 1e-8
-    set minimum residual     = 1e-9
-    set max krylov vectors   = 1000
+    set max iters          = 1000
+    set relative residual  = 1e-8
+    set minimum residual   = 1e-9
+    set max krylov vectors = 1000
 
-    set minimum residual     = 1e-9
+    set minimum residual = 1e-9
   end
 end

--- a/examples/multiphysics/cylinder-cooling/cylinder-xi-1.prm
+++ b/examples/multiphysics/cylinder-cooling/cylinder-xi-1.prm
@@ -50,7 +50,7 @@ subsection initial conditions
   end
 
   subsection temperature
-    set Function expression = if(((x-8)^2+(y-0)^2)^0.5-0.5001<0,1,0) 
+    set Function expression = if(((x-8)^2+(y-0)^2)^0.5-0.5001<0,1,0)
   end
 end
 
@@ -65,7 +65,7 @@ subsection physical properties
     set density              = 1
     set thermal conductivity = 0.2
   end
-  
+
   set number of solids = 1
   subsection solid 0
     set thermal conductivity = 0.2
@@ -90,7 +90,7 @@ end
 subsection boundary conditions
   set number = 3
   subsection bc 0
-    set id = 3
+    set id   = 3
     set type = function
     subsection u
       set Function expression = 20
@@ -103,11 +103,11 @@ subsection boundary conditions
     end
   end
   subsection bc 1
-    set id = 4
+    set id   = 4
     set type = outlet
   end
   subsection bc 2
-    set id = 5
+    set id   = 5
     set type = slip
   end
 end
@@ -119,8 +119,8 @@ end
 subsection boundary conditions heat transfer
   set number = 3
   subsection bc 0
-    set id    = 3
-    set type  = temperature
+    set id   = 3
+    set type = temperature
     subsection value
       set Function expression = 0
     end
@@ -175,16 +175,16 @@ end
 
 subsection linear solver
   subsection fluid dynamics
-    set max iters             = 5000
-    set relative residual     = 1e-4
-    set minimum residual      = 1e-8
-    set preconditioner        = amg
-    set max krylov vectors   = 1000
+    set max iters          = 5000
+    set relative residual  = 1e-4
+    set minimum residual   = 1e-8
+    set preconditioner     = amg
+    set max krylov vectors = 1000
   end
   subsection heat transfer
-    set max iters             = 5000
-    set relative residual     = 1e-8
-    set minimum residual      = 1e-9
-    set max krylov vectors   = 1000
+    set max iters          = 5000
+    set relative residual  = 1e-8
+    set minimum residual   = 1e-9
+    set max krylov vectors = 1000
   end
 end

--- a/examples/multiphysics/cylinder-cooling/cylinder-xi-100.prm
+++ b/examples/multiphysics/cylinder-cooling/cylinder-xi-100.prm
@@ -50,7 +50,7 @@ subsection initial conditions
   end
 
   subsection temperature
-    set Function expression = if(((x-8)^2+(y-0)^2)^0.5-0.5001<0,1,0) 
+    set Function expression = if(((x-8)^2+(y-0)^2)^0.5-0.5001<0,1,0)
   end
 end
 
@@ -65,7 +65,7 @@ subsection physical properties
     set density              = 1
     set thermal conductivity = 0.2
   end
-  
+
   set number of solids = 1
   subsection solid 0
     set thermal conductivity = 0.2
@@ -91,7 +91,7 @@ subsection boundary conditions
   set number = 3
   subsection bc 0
     set type = function
-    set id = 3
+    set id   = 3
     subsection u
       set Function expression = 20
     end
@@ -107,7 +107,7 @@ subsection boundary conditions
     set type = outlet
   end
   subsection bc 2
-    set id = 5
+    set id   = 5
     set type = slip
   end
 end
@@ -119,8 +119,8 @@ end
 subsection boundary conditions heat transfer
   set number = 3
   subsection bc 0
-    set id    = 3
-    set type  = temperature
+    set id   = 3
+    set type = temperature
     subsection value
       set Function expression = 0
     end
@@ -175,17 +175,17 @@ end
 
 subsection linear solver
   subsection fluid dynamics
-    set max iters           = 5000
-    set relative residual   = 1e-4
-    set minimum residual    = 1e-8
-    set preconditioner      = amg
-    set max krylov vectors  = 1000
+    set max iters          = 5000
+    set relative residual  = 1e-4
+    set minimum residual   = 1e-8
+    set preconditioner     = amg
+    set max krylov vectors = 1000
   end
   subsection heat transfer
-    set max iters           = 5000
-    set relative residual   = 1e-8
-    set minimum residual    = 1e-9
-    set preconditioner      = ilu
-    set max krylov vectors  = 1000
+    set max iters          = 5000
+    set relative residual  = 1e-8
+    set minimum residual   = 1e-9
+    set preconditioner     = ilu
+    set max krylov vectors = 1000
   end
 end

--- a/examples/sharp-immersed-boundary/sedimentation-1-cuboid/sedimentation-1-cuboid.prm
+++ b/examples/sharp-immersed-boundary/sedimentation-1-cuboid/sedimentation-1-cuboid.prm
@@ -13,8 +13,8 @@ set dimension = 3
 subsection simulation control
   set method             = bdf2
   set bdf startup method = multiple step bdf
-  set time step          = 0.0005 
-  set time end           = 0.6   
+  set time step          = 0.0005
+  set time end           = 0.6
   set output path        = out/
 end
 
@@ -24,7 +24,7 @@ end
 
 subsection physical properties
   subsection fluid 0
-    set kinematic viscosity = 1.07 
+    set kinematic viscosity = 1.07
     set density             = 0.00124
   end
 end
@@ -100,11 +100,11 @@ subsection particles
   end
 
   subsection DEM
-    set particle nonlinear tolerance      = 1e-2
-    set enable lubrication force          = false
-    set explicit contact impulsion        = true
-    set explicit position integration     = true
-    set contact search radius factor      = 1.2
+    set particle nonlinear tolerance  = 1e-2
+    set enable lubrication force      = false
+    set explicit contact impulsion    = true
+    set explicit position integration = true
+    set contact search radius factor  = 1.2
     subsection gravity
       set Function expression = 0;-981;0
     end
@@ -145,7 +145,7 @@ subsection mesh adaptation
   set max refinement level = 8
   set min refinement level = 4
 
-  set type = kelly
+  set type     = kelly
   set variable = velocity
 end
 

--- a/examples/unresolved-cfd-dem/cylindrical-packed-bed/flow-in-bed.prm
+++ b/examples/unresolved-cfd-dem/cylindrical-packed-bed/flow-in-bed.prm
@@ -137,6 +137,10 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 2000

--- a/examples/unresolved-cfd-dem/dense-pneumatic-conveying/pneumatic-conveying.prm
+++ b/examples/unresolved-cfd-dem/dense-pneumatic-conveying/pneumatic-conveying.prm
@@ -194,6 +194,10 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 200

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-bed/gas-solid-fluidized-bed.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-bed/gas-solid-fluidized-bed.prm
@@ -223,6 +223,10 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000

--- a/examples/unresolved-cfd-dem/gas-solid-spouted-cylinder-bed/gas-solid-spouted-cylinder-bed.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-spouted-cylinder-bed/gas-solid-spouted-cylinder-bed.prm
@@ -259,6 +259,10 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 1000

--- a/examples/unresolved-cfd-dem/gas-solid-spouted-rectangular-bed/gas-solid-spouted-rectangular-bed.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-spouted-rectangular-bed/gas-solid-spouted-rectangular-bed.prm
@@ -266,6 +266,10 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 200

--- a/examples/unresolved-cfd-dem/liquid-solid-fluidized-bed/liquid-solid-fluidized-bed.prm
+++ b/examples/unresolved-cfd-dem/liquid-solid-fluidized-bed/liquid-solid-fluidized-bed.prm
@@ -213,6 +213,10 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 5000

--- a/examples/unresolved-cfd-dem/single-particle-sedimentation/single-particle-sedimentation.prm
+++ b/examples/unresolved-cfd-dem/single-particle-sedimentation/single-particle-sedimentation.prm
@@ -135,6 +135,10 @@ end
 #---------------------------------------------------
 
 subsection linear solver
+  subsection void fraction
+    set relative residual = 1e-15
+    set minimum residual  = 1e-15
+  end
   subsection fluid dynamics
     set method                                = gmres
     set max iters                             = 500

--- a/include/core/multiphysics.h
+++ b/include/core/multiphysics.h
@@ -57,7 +57,9 @@ get_physics_id(std::string physics_name)
   else if (physics_name == "void fraction")
     return PhysicsID::void_fraction;
   else
-    AssertThrow(false, dealii::StandardExceptions::ExcMessage("An unknown Physics name was requested"));
+    AssertThrow(false,
+                dealii::StandardExceptions::ExcMessage(
+                  "An unknown Physics name was requested"));
 }
 
 #endif

--- a/include/core/multiphysics.h
+++ b/include/core/multiphysics.h
@@ -57,7 +57,7 @@ get_physics_id(std::string physics_name)
   else if (physics_name == "void fraction")
     return PhysicsID::void_fraction;
   else
-    AssertThrow(false, ExcMessage("An unknown Physics name was requested"));
+    AssertThrow(false, dealii::StandardExceptions::ExcMessage("An unknown Physics name was requested"));
 }
 
 #endif

--- a/include/core/multiphysics.h
+++ b/include/core/multiphysics.h
@@ -10,7 +10,8 @@ enum PhysicsID : unsigned int
   heat_transfer  = 1,
   tracer         = 2,
   VOF            = 3,
-  cahn_hilliard  = 4
+  cahn_hilliard  = 4,
+  void_fraction  = 5
 };
 
 /**
@@ -51,8 +52,12 @@ get_physics_id(std::string physics_name)
     return PhysicsID::tracer;
   else if (physics_name == "VOF")
     return PhysicsID::VOF;
-  else
+  else if (physics_name == "cahn hilliard")
     return PhysicsID::cahn_hilliard;
+  else if (physics_name == "void fraction")
+    return PhysicsID::void_fraction;
+  else
+    AssertThrow(false, ExcMessage("An unknown Physics name was requested"));
 }
 
 #endif

--- a/include/core/multiphysics.h
+++ b/include/core/multiphysics.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2019, 2021-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2019, 2021-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_multiphysics_h

--- a/include/fem-dem/fluid_dynamics_vans.h
+++ b/include/fem-dem/fluid_dynamics_vans.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_fluid_dynamics_vans_h

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -495,7 +495,8 @@ private:
                                             "heat transfer",
                                             "tracer",
                                             "VOF",
-                                            "cahn hilliard"};
+                                            "cahn hilliard",
+                                            "void fraction"};
   // Names of subequations within VOF that inherits from PhysicsSolver
   std::vector<std::string> vof_subequations_names = {
     "VOF algebraic interface reinitialization"};

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/grids.h>

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -24,7 +24,7 @@ FluidDynamicsVANS<dim>::FluidDynamicsVANS(
       &(*this->triangulation),
       nsparam.void_fraction,
       this->cfd_dem_simulation_parameters.cfd_parameters.linear_solver.at(
-        PhysicsID::fluid_dynamics),
+        PhysicsID::void_fraction),
       &particle_handler,
       this->cfd_dem_simulation_parameters.cfd_parameters.fem_parameters
         .void_fraction_order,

--- a/source/fem-dem/fluid_dynamics_vans_matrix_free.cc
+++ b/source/fem-dem/fluid_dynamics_vans_matrix_free.cc
@@ -139,7 +139,7 @@ FluidDynamicsVANSMatrixFree<dim>::FluidDynamicsVANSMatrixFree(
       &(*this->triangulation),
       param.void_fraction,
       this->cfd_dem_simulation_parameters.cfd_parameters.linear_solver.at(
-        PhysicsID::fluid_dynamics),
+        PhysicsID::void_fraction),
       &particle_handler,
       this->cfd_dem_simulation_parameters.cfd_parameters.fem_parameters
         .void_fraction_order,

--- a/source/fem-dem/void_fraction.cc
+++ b/source/fem-dem/void_fraction.cc
@@ -1120,7 +1120,7 @@ void
 VoidFractionBase<dim>::solve_linear_system_and_update_solution()
 {
   // Solve the L2 projection system
-  const double linear_solver_tolerance = 1e-15;
+  const double linear_solver_tolerance =linear_solver_parameters.minimum_residual;
 
   if (linear_solver_parameters.verbosity != Parameters::Verbosity::quiet)
     {

--- a/source/fem-dem/void_fraction.cc
+++ b/source/fem-dem/void_fraction.cc
@@ -1120,7 +1120,8 @@ void
 VoidFractionBase<dim>::solve_linear_system_and_update_solution()
 {
   // Solve the L2 projection system
-  const double linear_solver_tolerance =linear_solver_parameters.minimum_residual;
+  const double linear_solver_tolerance =
+    linear_solver_parameters.minimum_residual;
 
   if (linear_solver_parameters.verbosity != Parameters::Verbosity::quiet)
     {


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The calculation of the void fraction within the VANS and the CFD-DEM solvers can require the solution of a linear system of equation if the void fraction is calculated from particles.
The tolerance for the calculation of this void fraction was hard coded to 1e-15 and the parameters for the linear solver could not be controlled independently from those of the navier-stokes equations. This PR fixes that


### Testing

Since the default value now does not match the previous one, all of the examples and tests were modified so that the tolerance of 1e-15 appears explicitely instead of implicitely.

### Documentation

This new element is documented in the linear solver section.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge