### PR TITLE
Fix warnings introduced by functions now marked for deprecation in deal.II 9.8-pre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Change
 
-- MAJOR The introduction of the deal.II-9.8-pre version introduced numerous warnings for functions that will be deprecated in the near future. This PR addresses all of these warnings. Furthermore, I reran all of the prototypes and realized there was an issue with the matrix_free_non_linear prototype in which the multigrid solution did not have their ghost value correctly calculated. I have addressed this issue at the same time. Finally, on my machine I encountered a small segfault when running the kelly error estimator with multiple variables. This is because the solver assumed the number of coarsen and refine flag would be the same in the for loop, there is no reason for this. I have thus fixed this problem within this PR also. [#1581](https://github.com/chaos-polymtl/lethe/pull/1581)
+- MAJOR The introduction of the deal.II-9.8-pre version introduced numerous warnings for functions that will be deprecated in the near future. This PR addresses all of these warnings. Furthermore, I reran all of the prototypes and realized there was an issue with the matrix_free_non_linear prototype in which the multigrid solution did not have their ghost value correctly calculated. I have addressed this issue at the same time. Finally, on my machine I encountered a small segfault when running the kelly error estimator with multiple variables. This is because the solver assumed the number of coarsen and refine flag would be the same in the for loop, there is no reason for this. I have thus fixed this problem within this PR also. [#1582](https://github.com/chaos-polymtl/lethe/pull/1582)
 
 ### [Master] - 2025-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+### [Master] - 2025-07-14
+
+### Change
+
+- MAJOR The introduction of the deal.II-9.8-pre version introduced numerous warnings for functions that will be deprecated in the near future. This PR addresses all of these warnings. Furthermore, I reran all of the prototypes and realized there was an issue with the matrix_free_non_linear prototype in which the multigrid solution did not have their ghost value correctly calculated. I have addressed this issue at the same time. Finally, on my machine I encountered a small segfault when running the kelly error estimator with multiple variables. This is because the solver assumed the number of coarsen and refine flag would be the same in the for loop, there is no reason for this. I have thus fixed this problem within this PR also. [#1581](https://github.com/chaos-polymtl/lethe/pull/1581)
+
 ### [Master] - 2025-07-13
 
 ### Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Change
 
-- MAJOR The introduction of the deal.II-9.8-pre version introduced numerous warnings for functions that will be deprecated in the near future. This PR addresses all of these warnings. Furthermore, I reran all of the prototypes and realized there was an issue with the matrix_free_non_linear prototype in which the multigrid solution did not have their ghost value correctly calculated. I have addressed this issue at the same time. Finally, on my machine I encountered a small segfault when running the kelly error estimator with multiple variables. This is because the solver assumed the number of coarsen and refine flag would be the same in the for loop, there is no reason for this. I have thus fixed this problem within this PR also. [#1582](https://github.com/chaos-polymtl/lethe/pull/1582)
+- MAJOR The introduction of the deal.II-9.8-pre version introduced numerous warnings for functions that will be deprecated in the near future. This PR addresses all of these warnings. Furthermore, I reran all of the prototypes and realized there was an issue with the matrix_free_non_linear prototype in which the multigrid solution did not have their ghost value correctly calculated. I have addressed this issue at the same time. Finally, on my machine I encountered a small segfault when running the kelly error estimator with multiple variables. This is because the solver assumed the number of coarsen and refine flag would be the same in the for loop, while there is no reason for this assumption. I have thus fixed this problem within this PR also. [#1582](https://github.com/chaos-polymtl/lethe/pull/1582)
 
 ### [Master] - 2025-07-13
 

--- a/prototypes/kokkos_poisson/kokkos_poisson.cc
+++ b/prototypes/kokkos_poisson/kokkos_poisson.cc
@@ -141,10 +141,10 @@ private:
   {
     LinearAlgebra::ReadWriteVector<Number2> rw_vector(
       src.get_partitioner()->locally_owned_range());
-    rw_vector.import(src, VectorOperation::insert);
+    rw_vector.import_elements(src, VectorOperation::insert);
 
     dst.reinit(src.get_partitioner());
-    dst.import(rw_vector, VectorOperation::insert);
+    dst.import_elements(rw_vector, VectorOperation::insert);
   }
 
   template <typename Number2>
@@ -156,11 +156,11 @@ private:
   {
     LinearAlgebra::ReadWriteVector<Number2> rw_vector(
       src.get_partitioner()->locally_owned_range());
-    rw_vector.import(src, VectorOperation::insert);
+    rw_vector.import_elements(src, VectorOperation::insert);
 
     if (dst.size() == 0)
       dst.reinit(src.get_partitioner());
-    dst.import(rw_vector, VectorOperation::insert);
+    dst.import_elements(rw_vector, VectorOperation::insert);
   }
 };
 
@@ -498,8 +498,8 @@ run(const unsigned int n_refinements, ConvergenceTable &table)
 
     LinearAlgebra::ReadWriteVector<Number> rw_vector(
       src.get_partitioner()->locally_owned_range());
-    rw_vector.import(src_host, VectorOperation::insert);
-    src.import(rw_vector, VectorOperation::insert);
+    rw_vector.import_elements(src_host, VectorOperation::insert);
+    src.import_elements(rw_vector, VectorOperation::insert);
 
     dst = 0.0;
   }
@@ -624,8 +624,8 @@ run(const unsigned int n_refinements, ConvergenceTable &table)
 
     LinearAlgebra::ReadWriteVector<Number> rw_vector(
       src.get_partitioner()->locally_owned_range());
-    rw_vector.import(dst, VectorOperation::insert);
-    dst_host.import(rw_vector, VectorOperation::insert);
+    rw_vector.import_elements(dst, VectorOperation::insert);
+    dst_host.import_elements(rw_vector, VectorOperation::insert);
 
     std::string file_name = "solution_" + std::to_string(counter++) + ".vtu";
 

--- a/prototypes/kokkos_stokes/kokkos_stokes.cc
+++ b/prototypes/kokkos_stokes/kokkos_stokes.cc
@@ -144,10 +144,10 @@ private:
   {
     LinearAlgebra::ReadWriteVector<Number2> rw_vector(
       src.get_partitioner()->locally_owned_range());
-    rw_vector.import(src, VectorOperation::insert);
+    rw_vector.import_elements(src, VectorOperation::insert);
 
     dst.reinit(src.get_partitioner());
-    dst.import(rw_vector, VectorOperation::insert);
+    dst.import_elements(rw_vector, VectorOperation::insert);
   }
 
   template <typename Number2>
@@ -159,11 +159,11 @@ private:
   {
     LinearAlgebra::ReadWriteVector<Number2> rw_vector(
       src.get_partitioner()->locally_owned_range());
-    rw_vector.import(src, VectorOperation::insert);
+    rw_vector.import_elements(src, VectorOperation::insert);
 
     if (dst.size() == 0)
       dst.reinit(src.get_partitioner());
-    dst.import(rw_vector, VectorOperation::insert);
+    dst.import_elements(rw_vector, VectorOperation::insert);
   }
 };
 
@@ -467,8 +467,8 @@ public:
 
     LinearAlgebra::ReadWriteVector<Number> rw_vector(
       dof_handler.get_triangulation().n_active_cells());
-    rw_vector.import(delta_1_host, VectorOperation::insert);
-    delta_1.import(rw_vector, VectorOperation::insert);
+    rw_vector.import_elements(delta_1_host, VectorOperation::insert);
+    delta_1.import_elements(rw_vector, VectorOperation::insert);
   }
 
   types::global_dof_index
@@ -726,8 +726,8 @@ run(const unsigned int n_refinements, ConvergenceTable &table)
 
     LinearAlgebra::ReadWriteVector<Number> rw_vector(
       src.get_partitioner()->locally_owned_range());
-    rw_vector.import(src_host, VectorOperation::insert);
-    src.import(rw_vector, VectorOperation::insert);
+    rw_vector.import_elements(src_host, VectorOperation::insert);
+    src.import_elements(rw_vector, VectorOperation::insert);
 
     dst = 0.0;
   }
@@ -863,8 +863,8 @@ run(const unsigned int n_refinements, ConvergenceTable &table)
 
     LinearAlgebra::ReadWriteVector<Number> rw_vector(
       src.get_partitioner()->locally_owned_range());
-    rw_vector.import(dst, VectorOperation::insert);
-    dst_host.import(rw_vector, VectorOperation::insert);
+    rw_vector.import_elements(dst, VectorOperation::insert);
+    dst_host.import_elements(rw_vector, VectorOperation::insert);
 
     ExactSolution<dim, Number> exact_solution;
 
@@ -913,8 +913,8 @@ run(const unsigned int n_refinements, ConvergenceTable &table)
 
     LinearAlgebra::ReadWriteVector<Number> rw_vector(
       src.get_partitioner()->locally_owned_range());
-    rw_vector.import(dst, VectorOperation::insert);
-    dst_host.import(rw_vector, VectorOperation::insert);
+    rw_vector.import_elements(dst, VectorOperation::insert);
+    dst_host.import_elements(rw_vector, VectorOperation::insert);
 
     std::string file_name = "solution_" + std::to_string(counter++) + ".vtu";
 

--- a/prototypes/matrix_based_advection_diffusion/matrix_based_advection_diffusion.cc
+++ b/prototypes/matrix_based_advection_diffusion/matrix_based_advection_diffusion.cc
@@ -1093,9 +1093,13 @@ MatrixBasedAdvectionDiffusion<dim, fe_degree>::assemble_gmg()
 
   for (unsigned int level = 0; level < triangulation.n_global_levels(); ++level)
     {
-      const IndexSet dof_set =
+      const IndexSet active_dofs =
+        DoFTools::extract_locally_active_level_dofs(this->dof_handler, level);
+
+      const IndexSet relevant_dofs =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
-      boundary_constraints[level].reinit(dof_set, dof_set);
+
+      boundary_constraints[level].reinit(active_dofs, relevant_dofs);
       boundary_constraints[level].add_lines(
         mg_constrained_dofs.get_refinement_edge_indices(level));
       boundary_constraints[level].add_lines(

--- a/prototypes/matrix_based_advection_diffusion/matrix_based_advection_diffusion.cc
+++ b/prototypes/matrix_based_advection_diffusion/matrix_based_advection_diffusion.cc
@@ -1093,13 +1093,13 @@ MatrixBasedAdvectionDiffusion<dim, fe_degree>::assemble_gmg()
 
   for (unsigned int level = 0; level < triangulation.n_global_levels(); ++level)
     {
-      const IndexSet active_dofs =
-        DoFTools::extract_locally_active_level_dofs(this->dof_handler, level);
+      const IndexSet owned_dofs =
+        this->dof_handler.locally_owned_mg_dofs(level);
 
       const IndexSet relevant_dofs =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
-      boundary_constraints[level].reinit(active_dofs, relevant_dofs);
+      boundary_constraints[level].reinit(owned_dofs, relevant_dofs);
       boundary_constraints[level].add_lines(
         mg_constrained_dofs.get_refinement_edge_indices(level));
       boundary_constraints[level].add_lines(

--- a/prototypes/matrix_based_advection_diffusion/matrix_based_advection_diffusion.cc
+++ b/prototypes/matrix_based_advection_diffusion/matrix_based_advection_diffusion.cc
@@ -588,7 +588,7 @@ MatrixBasedAdvectionDiffusion<dim, fe_degree>::setup_system()
                        mpi_communicator);
 
   constraints.clear();
-  constraints.reinit(locally_relevant_dofs);
+  constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
 
   if (parameters.problem_type == Settings::boundary_layer)
@@ -1095,7 +1095,7 @@ MatrixBasedAdvectionDiffusion<dim, fe_degree>::assemble_gmg()
     {
       const IndexSet dof_set =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
-      boundary_constraints[level].reinit(dof_set);
+      boundary_constraints[level].reinit(dof_set, dof_set);
       boundary_constraints[level].add_lines(
         mg_constrained_dofs.get_refinement_edge_indices(level));
       boundary_constraints[level].add_lines(

--- a/prototypes/matrix_based_non_linear_poisson/matrix_based_non_linear_poisson.cc
+++ b/prototypes/matrix_based_non_linear_poisson/matrix_based_non_linear_poisson.cc
@@ -466,7 +466,7 @@ MatrixBasedPoissonProblem<dim, fe_degree>::setup_system()
                        mpi_communicator);
 
   constraints.clear();
-  constraints.reinit(locally_owned_dofs,locally_relevant_dofs);
+  constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
   VectorTools::interpolate_boundary_values(dof_handler,
                                            0,
@@ -719,7 +719,8 @@ MatrixBasedPoissonProblem<dim, fe_degree>::assemble_gmg()
     {
       const IndexSet dof_set =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
-      boundary_constraints[level].reinit(dof_handler.locally_owned_dofs(), dof_set);
+      boundary_constraints[level].reinit(dof_handler.locally_owned_dofs(),
+                                         dof_set);
       boundary_constraints[level].add_lines(
         mg_constrained_dofs.get_refinement_edge_indices(level));
       boundary_constraints[level].add_lines(

--- a/prototypes/matrix_based_non_linear_poisson/matrix_based_non_linear_poisson.cc
+++ b/prototypes/matrix_based_non_linear_poisson/matrix_based_non_linear_poisson.cc
@@ -466,7 +466,7 @@ MatrixBasedPoissonProblem<dim, fe_degree>::setup_system()
                        mpi_communicator);
 
   constraints.clear();
-  constraints.reinit(locally_relevant_dofs);
+  constraints.reinit(locally_owned_dofs,locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
   VectorTools::interpolate_boundary_values(dof_handler,
                                            0,
@@ -719,7 +719,7 @@ MatrixBasedPoissonProblem<dim, fe_degree>::assemble_gmg()
     {
       const IndexSet dof_set =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
-      boundary_constraints[level].reinit(dof_set);
+      boundary_constraints[level].reinit(dof_handler.locally_owned_dofs(), dof_set);
       boundary_constraints[level].add_lines(
         mg_constrained_dofs.get_refinement_edge_indices(level));
       boundary_constraints[level].add_lines(

--- a/prototypes/matrix_free_advection_diffusion/matrix_free_advection_diffusion.cc
+++ b/prototypes/matrix_free_advection_diffusion/matrix_free_advection_diffusion.cc
@@ -1234,11 +1234,14 @@ MatrixFreeAdvectionDiffusion<dim, fe_degree>::setup_gmg()
   for (unsigned int level = 0; level < nlevels; ++level)
     {
       mg_matrices[level].reinit_operator_parameters(parameters);
+      const IndexSet active_dofs =
+        DoFTools::extract_locally_active_level_dofs(this->dof_handler, level);
+
       const IndexSet relevant_dofs =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
       // AffineConstraints<double> level_constraints;
-      level_constraints[level].reinit(relevant_dofs, relevant_dofs);
+      level_constraints[level].reinit(active_dofs, relevant_dofs);
       level_constraints[level].add_lines(
         mg_constrained_dofs.get_boundary_indices(level));
       level_constraints[level].close();

--- a/prototypes/matrix_free_advection_diffusion/matrix_free_advection_diffusion.cc
+++ b/prototypes/matrix_free_advection_diffusion/matrix_free_advection_diffusion.cc
@@ -1004,7 +1004,7 @@ MatrixFreeAdvectionDiffusion<dim, fe_degree>::setup_system()
     DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.clear();
-  constraints.reinit(locally_relevant_dofs);
+  constraints.reinit(dof_handler.locally_owned_dofs(), locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
 
   // Set homogeneous constraints for the matrix-free operator
@@ -1238,7 +1238,7 @@ MatrixFreeAdvectionDiffusion<dim, fe_degree>::setup_gmg()
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
       // AffineConstraints<double> level_constraints;
-      level_constraints[level].reinit(relevant_dofs);
+      level_constraints[level].reinit(relevant_dofs, relevant_dofs);
       level_constraints[level].add_lines(
         mg_constrained_dofs.get_boundary_indices(level));
       level_constraints[level].close();

--- a/prototypes/matrix_free_advection_diffusion/matrix_free_advection_diffusion.cc
+++ b/prototypes/matrix_free_advection_diffusion/matrix_free_advection_diffusion.cc
@@ -1234,14 +1234,14 @@ MatrixFreeAdvectionDiffusion<dim, fe_degree>::setup_gmg()
   for (unsigned int level = 0; level < nlevels; ++level)
     {
       mg_matrices[level].reinit_operator_parameters(parameters);
-      const IndexSet active_dofs =
-        DoFTools::extract_locally_active_level_dofs(this->dof_handler, level);
+      const IndexSet owned_dofs =
+        this->dof_handler.locally_owned_mg_dofs(level);
 
       const IndexSet relevant_dofs =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
       // AffineConstraints<double> level_constraints;
-      level_constraints[level].reinit(active_dofs, relevant_dofs);
+      level_constraints[level].reinit(owned_dofs, relevant_dofs);
       level_constraints[level].add_lines(
         mg_constrained_dofs.get_boundary_indices(level));
       level_constraints[level].close();

--- a/prototypes/matrix_free_navier_stokes/matrix_free_navier_stokes.cc
+++ b/prototypes/matrix_free_navier_stokes/matrix_free_navier_stokes.cc
@@ -603,10 +603,10 @@ NavierStokesOperator<dim, number>::reinit(
 
   if (this->matrix_free.get_mg_level() != numbers::invalid_unsigned_int)
     {
-      IndexSet                             refinement_edge_indices;
+      IndexSet refinement_edge_indices;
       refinement_edge_indices = get_refinement_edges(this->matrix_free);
       std::vector<types::global_dof_index> interface_indices =
-      refinement_edge_indices.get_index_vector();
+        refinement_edge_indices.get_index_vector();
 
       edge_constrained_indices.clear();
       edge_constrained_indices.reserve(interface_indices.size());
@@ -1271,7 +1271,8 @@ solve_with_gcmg(SolverControl             &solver_control,
 
       const IndexSet locally_relevant_dofs =
         DoFTools::extract_locally_relevant_dofs(dof_handler);
-      constraint.reinit(dof_handler.locally_owned_dofs(), locally_relevant_dofs);
+      constraint.reinit(dof_handler.locally_owned_dofs(),
+                        locally_relevant_dofs);
 
       DoFTools::make_hanging_node_constraints(dof_handler, constraint);
       VectorTools::interpolate_boundary_values(mapping,

--- a/prototypes/matrix_free_navier_stokes/matrix_free_navier_stokes.cc
+++ b/prototypes/matrix_free_navier_stokes/matrix_free_navier_stokes.cc
@@ -603,10 +603,10 @@ NavierStokesOperator<dim, number>::reinit(
 
   if (this->matrix_free.get_mg_level() != numbers::invalid_unsigned_int)
     {
-      std::vector<types::global_dof_index> interface_indices;
       IndexSet                             refinement_edge_indices;
       refinement_edge_indices = get_refinement_edges(this->matrix_free);
-      refinement_edge_indices.fill_index_vector(interface_indices);
+      std::vector<types::global_dof_index> interface_indices =
+      refinement_edge_indices.get_index_vector();
 
       edge_constrained_indices.clear();
       edge_constrained_indices.reserve(interface_indices.size());
@@ -1271,7 +1271,7 @@ solve_with_gcmg(SolverControl             &solver_control,
 
       const IndexSet locally_relevant_dofs =
         DoFTools::extract_locally_relevant_dofs(dof_handler);
-      constraint.reinit(locally_relevant_dofs);
+      constraint.reinit(dof_handler.locally_owned_dofs(), locally_relevant_dofs);
 
       DoFTools::make_hanging_node_constraints(dof_handler, constraint);
       VectorTools::interpolate_boundary_values(mapping,
@@ -1520,7 +1520,7 @@ solve_with_lsmg(SolverControl             &solver_control,
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
       // AffineConstraints<double> level_constraints;
-      level_constraints[level].reinit(relevant_dofs);
+      level_constraints[level].reinit(relevant_dofs, relevant_dofs);
       level_constraints[level].add_lines(
         mg_constrained_dofs.get_boundary_indices(level));
       level_constraints[level].close();
@@ -1750,7 +1750,7 @@ MatrixFreeNavierStokes<dim>::setup_system()
     DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.clear();
-  constraints.reinit(locally_relevant_dofs);
+  constraints.reinit(dof_handler.locally_owned_dofs(), locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
 
   // Set homogeneous constraints for the matrix-free operator

--- a/prototypes/matrix_free_navier_stokes/matrix_free_navier_stokes.cc
+++ b/prototypes/matrix_free_navier_stokes/matrix_free_navier_stokes.cc
@@ -1517,11 +1517,14 @@ solve_with_lsmg(SolverControl             &solver_control,
 
   for (unsigned int level = minlevel; level <= maxlevel; ++level)
     {
+      const IndexSet active_dofs =
+        DoFTools::extract_locally_active_level_dofs(dof_handler, level);
+
       const IndexSet relevant_dofs =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
       // AffineConstraints<double> level_constraints;
-      level_constraints[level].reinit(relevant_dofs, relevant_dofs);
+      level_constraints[level].reinit(active_dofs, relevant_dofs);
       level_constraints[level].add_lines(
         mg_constrained_dofs.get_boundary_indices(level));
       level_constraints[level].close();

--- a/prototypes/matrix_free_navier_stokes/matrix_free_navier_stokes.cc
+++ b/prototypes/matrix_free_navier_stokes/matrix_free_navier_stokes.cc
@@ -1517,8 +1517,7 @@ solve_with_lsmg(SolverControl             &solver_control,
 
   for (unsigned int level = minlevel; level <= maxlevel; ++level)
     {
-      const IndexSet owned_dofs =
-        dof_handler.locally_owned_mg_dofs(level);
+      const IndexSet owned_dofs = dof_handler.locally_owned_mg_dofs(level);
 
       const IndexSet relevant_dofs =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);

--- a/prototypes/matrix_free_navier_stokes/matrix_free_navier_stokes.cc
+++ b/prototypes/matrix_free_navier_stokes/matrix_free_navier_stokes.cc
@@ -1518,7 +1518,7 @@ solve_with_lsmg(SolverControl             &solver_control,
   for (unsigned int level = minlevel; level <= maxlevel; ++level)
     {
       const IndexSet owned_dofs =
-        this->dof_handler.locally_owned_mg_dofs(level);
+        dof_handler.locally_owned_mg_dofs(level);
 
       const IndexSet relevant_dofs =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);

--- a/prototypes/matrix_free_navier_stokes/matrix_free_navier_stokes.cc
+++ b/prototypes/matrix_free_navier_stokes/matrix_free_navier_stokes.cc
@@ -1517,14 +1517,14 @@ solve_with_lsmg(SolverControl             &solver_control,
 
   for (unsigned int level = minlevel; level <= maxlevel; ++level)
     {
-      const IndexSet active_dofs =
-        DoFTools::extract_locally_active_level_dofs(dof_handler, level);
+      const IndexSet owned_dofs =
+        this->dof_handler.locally_owned_mg_dofs(level);
 
       const IndexSet relevant_dofs =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
       // AffineConstraints<double> level_constraints;
-      level_constraints[level].reinit(active_dofs, relevant_dofs);
+      level_constraints[level].reinit(owned_dofs, relevant_dofs);
       level_constraints[level].add_lines(
         mg_constrained_dofs.get_boundary_indices(level));
       level_constraints[level].close();

--- a/prototypes/matrix_free_non_linear_poisson/matrix_free_non_linear_poisson.cc
+++ b/prototypes/matrix_free_non_linear_poisson/matrix_free_non_linear_poisson.cc
@@ -774,6 +774,7 @@ MatrixFreePoissonProblem<dim, fe_degree>::compute_update()
           smoother_data[0].eig_cg_n_iterations = mg_matrices[0].m();
         }
 
+      mg_solution[level].update_ghost_values();
       mg_matrices[level].evaluate_newton_step(mg_solution[level]);
       mg_matrices[level].compute_diagonal();
 

--- a/prototypes/matrix_free_non_linear_poisson/matrix_free_non_linear_poisson.cc
+++ b/prototypes/matrix_free_non_linear_poisson/matrix_free_non_linear_poisson.cc
@@ -564,7 +564,7 @@ MatrixFreePoissonProblem<dim, fe_degree>::setup_system()
     DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.clear();
-  constraints.reinit(locally_relevant_dofs);
+  constraints.reinit(dof_handler.locally_owned_dofs(), locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
   VectorTools::interpolate_boundary_values(dof_handler,
                                            0,
@@ -622,7 +622,7 @@ MatrixFreePoissonProblem<dim, fe_degree>::setup_gmg()
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
       AffineConstraints<double> level_constraints;
-      level_constraints.reinit(relevant_dofs);
+      level_constraints.reinit(relevant_dofs, relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));
       level_constraints.close();

--- a/prototypes/matrix_free_non_linear_poisson/matrix_free_non_linear_poisson.cc
+++ b/prototypes/matrix_free_non_linear_poisson/matrix_free_non_linear_poisson.cc
@@ -618,6 +618,9 @@ MatrixFreePoissonProblem<dim, fe_degree>::setup_gmg()
 
   for (unsigned int level = 0; level < nlevels; ++level)
     {
+      const IndexSet active_dofs =
+        DoFTools::extract_locally_active_level_dofs(dof_handler, level);
+
       const IndexSet relevant_dofs =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 

--- a/prototypes/matrix_free_non_linear_poisson/matrix_free_non_linear_poisson.cc
+++ b/prototypes/matrix_free_non_linear_poisson/matrix_free_non_linear_poisson.cc
@@ -618,14 +618,14 @@ MatrixFreePoissonProblem<dim, fe_degree>::setup_gmg()
 
   for (unsigned int level = 0; level < nlevels; ++level)
     {
-      const IndexSet active_dofs =
-        DoFTools::extract_locally_active_level_dofs(dof_handler, level);
+      const IndexSet owned_dofs =
+        this->dof_handler.locally_owned_mg_dofs(level);
 
       const IndexSet relevant_dofs =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
       AffineConstraints<double> level_constraints;
-      level_constraints.reinit(relevant_dofs, relevant_dofs);
+      level_constraints.reinit(owned_dofs, relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));
       level_constraints.close();

--- a/prototypes/matrix_free_stokes/matrix_free_stokes.cc
+++ b/prototypes/matrix_free_stokes/matrix_free_stokes.cc
@@ -1250,7 +1250,7 @@ solve_with_lsmg(SolverControl             &solver_control,
   for (unsigned int level = minlevel; level <= maxlevel; ++level)
     {
       const IndexSet owned_dofs =
-        this->dof_handler.locally_owned_mg_dofs(level);
+        dof_handler.locally_owned_mg_dofs(level);
 
       const IndexSet relevant_dofs =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);

--- a/prototypes/matrix_free_stokes/matrix_free_stokes.cc
+++ b/prototypes/matrix_free_stokes/matrix_free_stokes.cc
@@ -497,10 +497,11 @@ StokesOperator<dim, number>::reinit(
 
   if (this->matrix_free.get_mg_level() != numbers::invalid_unsigned_int)
     {
-      std::vector<types::global_dof_index> interface_indices;
+
       IndexSet                             refinement_edge_indices;
       refinement_edge_indices = get_refinement_edges(this->matrix_free);
-      refinement_edge_indices.fill_index_vector(interface_indices);
+      std::vector<types::global_dof_index> interface_indices =
+      refinement_edge_indices.get_index_vector();
 
       edge_constrained_indices.clear();
       edge_constrained_indices.reserve(interface_indices.size());
@@ -1036,7 +1037,7 @@ solve_with_gcmg(SolverControl             &solver_control,
 
       const IndexSet locally_relevant_dofs =
         DoFTools::extract_locally_relevant_dofs(dof_handler);
-      constraint.reinit(locally_relevant_dofs);
+      constraint.reinit(dof_handler.locally_owned_dofs(), locally_relevant_dofs);
 
       DoFTools::make_hanging_node_constraints(dof_handler, constraint);
       VectorTools::interpolate_boundary_values(mapping,
@@ -1252,7 +1253,7 @@ solve_with_lsmg(SolverControl             &solver_control,
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
       // AffineConstraints<double> level_constraints;
-      level_constraints[level].reinit(relevant_dofs);
+      level_constraints[level].reinit(relevant_dofs,relevant_dofs);
       level_constraints[level].add_lines(
         mg_constrained_dofs.get_boundary_indices(level));
       level_constraints[level].close();
@@ -1478,7 +1479,7 @@ MatrixFreeStokes<dim>::setup_system()
     DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.clear();
-  constraints.reinit(locally_relevant_dofs);
+  constraints.reinit(dof_handler.locally_owned_dofs(), locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
 
   // Set homogeneous constraints for the matrix-free operator

--- a/prototypes/matrix_free_stokes/matrix_free_stokes.cc
+++ b/prototypes/matrix_free_stokes/matrix_free_stokes.cc
@@ -1249,8 +1249,7 @@ solve_with_lsmg(SolverControl             &solver_control,
 
   for (unsigned int level = minlevel; level <= maxlevel; ++level)
     {
-      const IndexSet owned_dofs =
-        dof_handler.locally_owned_mg_dofs(level);
+      const IndexSet owned_dofs = dof_handler.locally_owned_mg_dofs(level);
 
       const IndexSet relevant_dofs =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);

--- a/prototypes/matrix_free_stokes/matrix_free_stokes.cc
+++ b/prototypes/matrix_free_stokes/matrix_free_stokes.cc
@@ -497,11 +497,10 @@ StokesOperator<dim, number>::reinit(
 
   if (this->matrix_free.get_mg_level() != numbers::invalid_unsigned_int)
     {
-
-      IndexSet                             refinement_edge_indices;
+      IndexSet refinement_edge_indices;
       refinement_edge_indices = get_refinement_edges(this->matrix_free);
       std::vector<types::global_dof_index> interface_indices =
-      refinement_edge_indices.get_index_vector();
+        refinement_edge_indices.get_index_vector();
 
       edge_constrained_indices.clear();
       edge_constrained_indices.reserve(interface_indices.size());
@@ -1037,7 +1036,8 @@ solve_with_gcmg(SolverControl             &solver_control,
 
       const IndexSet locally_relevant_dofs =
         DoFTools::extract_locally_relevant_dofs(dof_handler);
-      constraint.reinit(dof_handler.locally_owned_dofs(), locally_relevant_dofs);
+      constraint.reinit(dof_handler.locally_owned_dofs(),
+                        locally_relevant_dofs);
 
       DoFTools::make_hanging_node_constraints(dof_handler, constraint);
       VectorTools::interpolate_boundary_values(mapping,
@@ -1253,7 +1253,7 @@ solve_with_lsmg(SolverControl             &solver_control,
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
       // AffineConstraints<double> level_constraints;
-      level_constraints[level].reinit(relevant_dofs,relevant_dofs);
+      level_constraints[level].reinit(relevant_dofs, relevant_dofs);
       level_constraints[level].add_lines(
         mg_constrained_dofs.get_boundary_indices(level));
       level_constraints[level].close();

--- a/prototypes/matrix_free_stokes/matrix_free_stokes.cc
+++ b/prototypes/matrix_free_stokes/matrix_free_stokes.cc
@@ -1249,11 +1249,14 @@ solve_with_lsmg(SolverControl             &solver_control,
 
   for (unsigned int level = minlevel; level <= maxlevel; ++level)
     {
+      const IndexSet owned_dofs =
+        this->dof_handler.locally_owned_mg_dofs(level);
+
       const IndexSet relevant_dofs =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
       // AffineConstraints<double> level_constraints;
-      level_constraints[level].reinit(relevant_dofs, relevant_dofs);
+      level_constraints[level].reinit(owned_dofs, relevant_dofs);
       level_constraints[level].add_lines(
         mg_constrained_dofs.get_boundary_indices(level));
       level_constraints[level].close();

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -392,12 +392,12 @@ DEMSolver<dim, PropertiesIndex>::setup_background_dofs()
   if (action_manager->check_periodic_boundaries_enabled() &&
       action_manager->check_sparse_contacts_enabled())
     {
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(background_dh,
-                                              locally_relevant_dofs);
+      IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(background_dh);
 
       background_constraints.clear();
-      background_constraints.reinit(locally_relevant_dofs);
+      background_constraints.reinit(background_dh.locally_owned_dofs(),
+                                    locally_relevant_dofs);
 
       DoFTools::make_periodicity_constraints(
         background_dh,

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -86,15 +86,14 @@ FluidDynamicsSharp<dim>::generate_cut_cells_map()
   // check all the cells if they are cut or not. Put the information in a map
   // with the key being the cell.
   TimerOutput::Scope t(this->computing_timer, "Map cut cells");
-  std::map<types::global_dof_index, Point<dim>> support_points;
+
 
   // A vector of the unordered map. Each map stores if a point is inside or
   // outside of a given particle.
   std::vector<std::unordered_map<types::global_dof_index, bool>>
     inside_outside_support_point_vector(particles.size());
-  DoFTools::map_dofs_to_support_points(*this->mapping,
-                                       this->dof_handler,
-                                       support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(*this->mapping, this->dof_handler);
 
   // When the finite element order > 1, overconstrained cells are impossible
   // since there is always at least a DOF inside the element that is not
@@ -849,10 +848,9 @@ FluidDynamicsSharp<dim>::refine_ib(const bool initial_refinement)
   TimerOutput::Scope                            t(this->computing_timer,
                        "Refine around immersed boundary");
   Point<dim>                                    center_immersed;
-  std::map<types::global_dof_index, Point<dim>> support_points;
-  DoFTools::map_dofs_to_support_points(*this->mapping,
-                                       this->dof_handler,
-                                       support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(*this->mapping, this->dof_handler);
+
   double dt = this->simulation_control->get_time_steps_vector()[0];
 
   const unsigned int                   dofs_per_cell = this->fe->dofs_per_cell;
@@ -1002,11 +1000,8 @@ FluidDynamicsSharp<dim>::force_on_ib()
   std::vector<double> time_steps_vector =
     this->simulation_control->get_time_steps_vector();
   // Define a map to all DOFs and their support points
-  std::map<types::global_dof_index, Point<dim>> support_points;
-
-  DoFTools::map_dofs_to_support_points(*this->mapping,
-                                       this->dof_handler,
-                                       support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(*this->mapping, this->dof_handler);
 
   // Initalize fe value objects in order to do calculation with it later
   QGauss<dim>            q_formula(this->number_quadrature_points);
@@ -1851,10 +1846,8 @@ FluidDynamicsSharp<dim>::calculate_L2_error_particles()
   Function<dim> *l_exact_solution = this->exact_solution;
 
   Point<dim>                                    center_immersed;
-  std::map<types::global_dof_index, Point<dim>> support_points;
-  DoFTools::map_dofs_to_support_points(*this->mapping,
-                                       this->dof_handler,
-                                       support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(*this->mapping, this->dof_handler);
 
   double l2errorU                  = 0.;
   double l2errorU_boundary         = 0.;
@@ -3124,10 +3117,8 @@ FluidDynamicsSharp<dim>::sharp_edge()
   std::vector<double> time_steps_vector =
     this->simulation_control->get_time_steps_vector();
   // Define a map to all DOFs and their support points
-  std::map<types::global_dof_index, Point<dim>> support_points;
-  DoFTools::map_dofs_to_support_points(*this->mapping,
-                                       this->dof_handler,
-                                       support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(*this->mapping, this->dof_handler);
 
   // Initalize fe value objects in order to do calculation with it later
   QGauss<dim>        q_formula(this->number_quadrature_points);

--- a/source/fem-dem/void_fraction.cc
+++ b/source/fem-dem/void_fraction.cc
@@ -99,7 +99,8 @@ VoidFractionBase<dim>::setup_constraints(
   has_periodic_boundaries = false;
   // Define constraints for periodic boundary conditions
   void_fraction_constraints.clear();
-  void_fraction_constraints.reinit(locally_relevant_dofs);
+  void_fraction_constraints.reinit(dof_handler.locally_owned_dofs(),
+                                   locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler,
                                           void_fraction_constraints);
 

--- a/source/fem-dem/void_fraction.cc
+++ b/source/fem-dem/void_fraction.cc
@@ -35,7 +35,7 @@ VoidFractionBase<dim>::setup_dofs()
   locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   void_fraction_constraints.clear();
-  void_fraction_constraints.reinit(locally_relevant_dofs);
+  void_fraction_constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler,
                                           void_fraction_constraints);
 

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -187,7 +187,8 @@ FluidDynamicsMatrixBased<dim>::define_dynamic_zero_constraints()
     return;
 
   this->dynamic_zero_constraints.clear();
-  this->dynamic_zero_constraints.reinit(this->locally_relevant_dofs);
+  this->dynamic_zero_constraints.reinit(this->locally_owned_dofs,
+                                        this->locally_relevant_dofs);
 
   DoFTools::make_hanging_node_constraints(this->dof_handler,
                                           this->dynamic_zero_constraints);

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -677,15 +677,16 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
                   AffineConstraints<double> temp_constraints;
                   temp_constraints.clear();
 
-                  const IndexSet locally_active_level_dofs =
-                    DoFTools::extract_locally_active_level_dofs(
-                      this->dof_handler, level);
+                  const IndexSet locally_owned_level_dofs =
+                    this->dof_handler.locally_owned_mg_dofs(level);
+
+
 
                   const IndexSet locally_relevant_level_dofs =
                     DoFTools::extract_locally_relevant_level_dofs(
                       this->dof_handler, level);
 
-                  temp_constraints.reinit(locally_active_level_dofs,
+                  temp_constraints.reinit(locally_owned_level_dofs,
                                           locally_relevant_level_dofs);
 
                   VectorTools::compute_no_normal_flux_constraints_on_level(
@@ -750,14 +751,14 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
         {
           level_constraints[level].clear();
 
-          const IndexSet active_dofs =
-            DoFTools::extract_locally_active_level_dofs(this->dof_handler,
-                                                        level);
+          const IndexSet owned_dofs =
+            this->dof_handler.locally_owned_mg_dofs(level);
+
           const IndexSet relevant_dofs =
             DoFTools::extract_locally_relevant_level_dofs(this->dof_handler,
                                                           level);
 
-          level_constraints[level].reinit(active_dofs, relevant_dofs);
+          level_constraints[level].reinit(owned_dofs, relevant_dofs);
 
 #if DEAL_II_VERSION_GTE(9, 6, 0)
           this->mg_constrained_dofs.merge_constraints(

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -676,10 +676,13 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
                 {
                   AffineConstraints<double> temp_constraints;
                   temp_constraints.clear();
+
                   const IndexSet locally_relevant_level_dofs =
                     DoFTools::extract_locally_relevant_level_dofs(
                       this->dof_handler, level);
-                  temp_constraints.reinit(locally_relevant_level_dofs);
+                  temp_constraints.reinit(
+                    this->dof_handler.locally_owned_dofs(),
+                    locally_relevant_level_dofs);
                   VectorTools::compute_no_normal_flux_constraints_on_level(
                     this->dof_handler,
                     0,
@@ -746,7 +749,8 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
             DoFTools::extract_locally_relevant_level_dofs(this->dof_handler,
                                                           level);
 
-          level_constraints[level].reinit(relevant_dofs);
+          level_constraints[level].reinit(
+            this->dof_handler.locally_owned_dofs(), relevant_dofs);
 
 #if DEAL_II_VERSION_GTE(9, 6, 0)
           this->mg_constrained_dofs.merge_constraints(
@@ -1082,9 +1086,11 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
           this->mg_setup_timer.enter_subsection("Set boundary conditions");
 
           level_constraint.clear();
+
           const IndexSet locally_relevant_dofs =
             DoFTools::extract_locally_relevant_dofs(level_dof_handler);
-          level_constraint.reinit(locally_relevant_dofs);
+          level_constraint.reinit(level_dof_handler.locally_owned_dofs(),
+                                  locally_relevant_dofs);
 
           DoFTools::make_hanging_node_constraints(level_dof_handler,
                                                   level_constraint);

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -677,11 +677,17 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
                   AffineConstraints<double> temp_constraints;
                   temp_constraints.clear();
 
+                  const IndexSet locally_active_level_dofs =
+                    DoFTools::extract_locally_active_level_dofs(
+                      this->dof_handler, level);
+
                   const IndexSet locally_relevant_level_dofs =
                     DoFTools::extract_locally_relevant_level_dofs(
                       this->dof_handler, level);
-                  temp_constraints.reinit(locally_relevant_level_dofs,
+
+                  temp_constraints.reinit(locally_active_level_dofs,
                                           locally_relevant_level_dofs);
+
                   VectorTools::compute_no_normal_flux_constraints_on_level(
                     this->dof_handler,
                     0,
@@ -744,11 +750,14 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
         {
           level_constraints[level].clear();
 
+          const IndexSet active_dofs =
+            DoFTools::extract_locally_active_level_dofs(this->dof_handler,
+                                                        level);
           const IndexSet relevant_dofs =
             DoFTools::extract_locally_relevant_level_dofs(this->dof_handler,
                                                           level);
 
-          level_constraints[level].reinit(relevant_dofs, relevant_dofs);
+          level_constraints[level].reinit(active_dofs, relevant_dofs);
 
 #if DEAL_II_VERSION_GTE(9, 6, 0)
           this->mg_constrained_dofs.merge_constraints(
@@ -1087,6 +1096,7 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
 
           const IndexSet locally_relevant_dofs =
             DoFTools::extract_locally_relevant_dofs(level_dof_handler);
+
           level_constraint.reinit(level_dof_handler.locally_owned_dofs(),
                                   locally_relevant_dofs);
 

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -680,9 +680,8 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
                   const IndexSet locally_relevant_level_dofs =
                     DoFTools::extract_locally_relevant_level_dofs(
                       this->dof_handler, level);
-                  temp_constraints.reinit(
-                    this->dof_handler.locally_owned_dofs(),
-                    locally_relevant_level_dofs);
+                  temp_constraints.reinit(locally_relevant_level_dofs,
+                                          locally_relevant_level_dofs);
                   VectorTools::compute_no_normal_flux_constraints_on_level(
                     this->dof_handler,
                     0,
@@ -749,8 +748,7 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
             DoFTools::extract_locally_relevant_level_dofs(this->dof_handler,
                                                           level);
 
-          level_constraints[level].reinit(
-            this->dof_handler.locally_owned_dofs(), relevant_dofs);
+          level_constraints[level].reinit(relevant_dofs, relevant_dofs);
 
 #if DEAL_II_VERSION_GTE(9, 6, 0)
           this->mg_constrained_dofs.merge_constraints(

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -195,7 +195,8 @@ NavierStokesOperatorBase<dim, number>::reinit(
       std::vector<types::global_dof_index> interface_indices;
       IndexSet                             refinement_edge_indices;
       refinement_edge_indices = get_refinement_edges(this->matrix_free);
-      refinement_edge_indices.fill_index_vector(interface_indices);
+
+      interface_indices = refinement_edge_indices.get_index_vector();
 
       edge_constrained_indices.clear();
       edge_constrained_indices.reserve(interface_indices.size());
@@ -1260,7 +1261,7 @@ NavierStokesOperatorBase<dim, number>::do_boundary_face_integral_local(
           typename FEFaceIntegrator::value_type    value_result    = {};
           typename FEFaceIntegrator::gradient_type gradient_result = {};
 
-          const auto normal_vector = integrator.get_normal_vector(q);
+          const auto normal_vector = integrator.normal_vector(q);
 
           auto       value    = integrator.get_value(q);
           const auto gradient = integrator.get_gradient(q);
@@ -1303,7 +1304,7 @@ NavierStokesOperatorBase<dim, number>::do_boundary_face_integral_local(
         {
           typename FEFaceIntegrator::value_type value_result = {};
 
-          const auto normal_vector = integrator.get_normal_vector(q);
+          const auto normal_vector = integrator.normal_vector(q);
 
           auto value = integrator.get_value(q);
 

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -1352,7 +1352,8 @@ HeatTransfer<dim>::setup_dofs()
 
   {
     nonzero_constraints.clear();
-    nonzero_constraints.reinit(this->locally_relevant_dofs);
+    nonzero_constraints.reinit(this->locally_owned_dofs,
+                               this->locally_relevant_dofs);
     DoFTools::make_hanging_node_constraints(this->dof_handler,
                                             nonzero_constraints);
 
@@ -1397,7 +1398,8 @@ HeatTransfer<dim>::setup_dofs()
   // Boundary conditions for Newton correction
   {
     zero_constraints.clear();
-    zero_constraints.reinit(this->locally_relevant_dofs);
+    zero_constraints.reinit(this->locally_owned_dofs,
+                            this->locally_relevant_dofs);
     DoFTools::make_hanging_node_constraints(this->dof_handler,
                                             zero_constraints);
 
@@ -1481,7 +1483,8 @@ HeatTransfer<dim>::update_boundary_conditions()
     }
 
   nonzero_constraints.clear();
-  nonzero_constraints.reinit(this->locally_relevant_dofs);
+  nonzero_constraints.reinit(this->locally_owned_dofs,
+                             this->locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(this->dof_handler,
                                           nonzero_constraints);
 

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -1056,6 +1056,13 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
               // refine if at least refinement flag on one variable
               global_refine_flags[i] =
                 global_refine_flags[i] || current_refine_flags[i];
+            }
+
+          // for subsequent coarsen variables
+          for (std::vector<bool>::size_type i = 0;
+               i != global_coarsen_flags.size();
+               ++i)
+            {
               // coarsen if refinement flag on all variables
               global_coarsen_flags[i] =
                 global_coarsen_flags[i] && current_coarsen_flags[i];

--- a/source/solvers/postprocessors_smoothing.cc
+++ b/source/solvers/postprocessors_smoothing.cc
@@ -27,7 +27,7 @@ PostProcessorSmoothing<dim, VectorType>::generate_mass_matrix()
 
   locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
   constraints.clear();
-  constraints.reinit(locally_relevant_dofs);
+  constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
   constraints.close();
 

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -1226,7 +1226,7 @@ Tracer<dim>::setup_dofs()
 
   {
     nonzero_constraints.clear();
-    nonzero_constraints.reinit(this->locally_relevant_dofs);
+    nonzero_constraints.reinit(locally_owned_dofs, this->locally_relevant_dofs);
     DoFTools::make_hanging_node_constraints(this->dof_handler,
                                             nonzero_constraints);
 
@@ -1261,7 +1261,8 @@ Tracer<dim>::setup_dofs()
   // Boundary conditions for Newton correction
   {
     zero_constraints.clear();
-    zero_constraints.reinit(this->locally_relevant_dofs);
+    zero_constraints.reinit(this->locally_owned_dofs,
+                            this->locally_relevant_dofs);
     DoFTools::make_hanging_node_constraints(this->dof_handler,
                                             zero_constraints);
 
@@ -1341,7 +1342,8 @@ Tracer<dim>::update_boundary_conditions()
 
   double time = this->simulation_control->get_current_time();
   nonzero_constraints.clear();
-  nonzero_constraints.reinit(this->locally_relevant_dofs);
+  nonzero_constraints.reinit(this->locally_owned_dofs,
+                             this->locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(this->dof_handler,
                                           nonzero_constraints);
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

TODO: I still need to update the copyright headers years.

### Description

The introduction of the deal.II-9.8-pre version has marked some functions for being deprecated in the future. 
Furthermore, I have found a small bug with related to error estimation with multiple variables. When establishing the coarsen and the refine flag with multiple variables, a loop was made over the refine vector, but the index of this loop was made to calculate both the coarsen and the refine vector. This inherently assumes that the refine and the coarsen vector have the same length, which is not a given. I have thus used two loops instead.
Finally, the matrix_free_non_linear prototype was not running in parallel anymore since the solution within the multigrid was not adequately ghosted.

### Solution

1. I have fixed all of the warnings related to 9.8-pre
2. I have changed the looping logic to use two loops with the correct size instead of assuming both vectors had the same size
3. I have updated the ghost variables for the mg_solution vectors at every level.


### Testing

No tests should be changed by this procedure. However, this might "destroy" the deal.II 9.6 CI. Since deal.II 9.7 is very close to being released, if this is an issue I will just disable the 9.6 warning CI and prepare to introduce the 9.7 warning CI with the release of 9.7.

### Documentation

Nothing to document.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge