### PR TITLE
Allow compatibility with 64bit indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+### [Master] - 2025-07-16
+
+### CHange
+
+- MINOR Lethe could not be compiled when deal.II was using 64 bit indices due to some locations where unsigned int were used instead of types::global_dof_index. This PR fixes this by using the correct type. It compiles with deal.II with 64bit indices. [#1585](https://github.com/chaos-polymtl/lethe/pull/1585)
+
 ### [Master] - 2025-07-14
 
 ### Change

--- a/source/core/interface_tools.cc
+++ b/source/core/interface_tools.cc
@@ -491,7 +491,7 @@ InterfaceTools::SignedDistanceSolver<dim, VectorType>::
       /* Loop over all DoFs of the volume mesh belonging to an intersected
        * volume cell. This is more expensive, but it is required to have the
        * right signed distance approximation for the first neighbors.*/
-      for (const unsigned int &intersected_dof : intersected_dofs)
+      for (const types::global_dof_index &intersected_dof : intersected_dofs)
         {
           const Point<dim> y = dof_support_points.at(intersected_dof);
 

--- a/source/dem/particle_wall_broad_search.cc
+++ b/source/dem/particle_wall_broad_search.cc
@@ -59,7 +59,7 @@ template <int dim>
 void
 find_particle_floating_wall_contact_pairs(
   const std::unordered_map<
-    DEM::global_face_id,
+    types::global_dof_index,
     std::set<typename Triangulation<dim>::active_cell_iterator>>
                                         &boundary_cells_for_floating_walls,
   const Particles::ParticleHandler<dim> &particle_handler,

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -774,7 +774,7 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
                 .fix_pressure_constant &&
               level == this->minlevel)
             {
-              unsigned int min_index = numbers::invalid_unsigned_int;
+              types::global_dof_index min_index = numbers::invalid_unsigned_int;
 
               std::vector<types::global_dof_index> dof_indices;
 
@@ -1173,7 +1173,7 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
                 .fix_pressure_constant &&
               level == this->minlevel)
             {
-              unsigned int min_index = numbers::invalid_unsigned_int;
+              types::global_dof_index min_index = numbers::invalid_unsigned_int;
 
               std::vector<types::global_dof_index> dof_indices;
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The current version of Lethe does not compile with 64 bit indices because of a few errors where dof indices were assumed to be unsigned int.

### Solution

Fix this by using the appropriate type where needed.

### Testing

All test also pass in the 64bit indices version, so this is cool

### Documentation

If 64 bit indices work well on the clusters for very large stuff, I will make another PR with the documentation on how to enable them.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge