### PR TITLE
Remove checks to deal.II versions which are not supported anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
-- MINOR At multiple locations, Lethe was still checking if deal.II was compiled with a version number larger than 9.4 for some features. Since we do not even compile with anything before deal.II 9.6, this PR removes all of these checks which are not relevant anymore. This increases readability and prevents confusion in terms of compatibility. [#1588](https://github.com/chaos-polymtl/lethe/pull/1588)
+- MINOR At multiple locations and for specific features, Lethe was still checking if deal.II was compiled with a version number larger than 9.4. Since we do not even compile with anything before deal.II 9.6, this PR removes all of these checks which are not relevant anymore. This increases readability and prevents confusion in terms of compatibility. [#1588](https://github.com/chaos-polymtl/lethe/pull/1588)
 
 ### [Master] - 2025-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MAJOR Deal.II-9.8pre deprecates some functions such as get_communicator and the parallel::distributed::SolutionTransfer class. This PR uses the modern version of these functions or classes following the new 9.8 release standard before they are deprecated. This PR officially deprecates the compatibility with deal.II 9.6.0.  [#1589](https://github.com/chaos-polymtl/lethe/pull/1589)
 
+### Changed
+
+- MINOR At multiple locations, Lethe was still checking if deal.II was compiled with a version number larger than 9.4 for some features. Since we do not even compile with anything before deal.II 9.6, this PR removes all of these checks which are not relevant anymore. This increases readability and prevents confusion in terms of compatibility. [#1588](https://github.com/chaos-polymtl/lethe/pull/1588)
+
 ### [Master] - 2025-07-17
 
 ### Added

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -26,10 +26,7 @@
 #  include <GProp_GProps.hxx>
 #endif
 
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-#else
-#  include <deal.II/base/function_signed_distance.h>
-#endif
+#include <deal.II/base/function_signed_distance.h>
 
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
@@ -1386,12 +1383,9 @@ public:
          const Tensor<1, 3> &orientation)
     : Shape<dim>(radius, position, orientation)
   {
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-#else
     sphere_function =
       std::make_shared<Functions::SignedDistance::Sphere<dim>>(position,
                                                                radius);
-#endif
     for (unsigned int d = 0; d < dim; ++d)
       {
         this->bounding_box_half_length[d] = radius;
@@ -1495,10 +1489,7 @@ public:
 
 
 private:
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-#else
   std::shared_ptr<Functions::SignedDistance::Sphere<dim>> sphere_function;
-#endif
 };
 
 

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2022-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_shape_h

--- a/include/dem/load_balancing.h
+++ b/include/dem/load_balancing.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2022-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_load_balancing_h

--- a/include/dem/load_balancing.h
+++ b/include/dem/load_balancing.h
@@ -251,24 +251,6 @@ public:
     // Clear and connect a new cell weight function
     triangulation->signals.weight.disconnect_all_slots();
 
-
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 6)
-    triangulation->signals.weight.connect(
-      [&](const typename Triangulation<dim>::cell_iterator &,
-          const typename Triangulation<dim>::CellStatus) -> unsigned int {
-        return cell_weight;
-      });
-
-    triangulation->signals.weight.connect(
-      [&](const typename parallel::distributed::Triangulation<
-            dim>::cell_iterator &cell,
-          const typename parallel::distributed::Triangulation<dim>::CellStatus
-            status) -> unsigned int {
-        return this->calculate_total_cell_weight_with_mobility_status(cell,
-                                                                      status);
-      });
-
-#else
     // Connect, or reconnect, the default cell weight function
     triangulation->signals.weight.connect(
       [&](const typename Triangulation<dim>::cell_iterator &,
@@ -281,49 +263,39 @@ public:
         return this->calculate_total_cell_weight_with_mobility_status(cell,
                                                                       status);
       });
-#endif
   }
 
 private:
-/**
- * @brief Indicates to the triangulation how much computational work is
- * expected to happen on this cell, and consequently how the domain needs to
- * be partitioned.
- *
- * Every MPI rank receives a roughly equal amount of work (potentially not an
- * equal number of cells). While the function is called from the outside,
- * it is connected to the corresponding signal from inside this class,
- * therefore it can be private. This function is the key component that allows
- * dynamically balance the computational load. The function attributes a
- * weight to every cell that represents the computational work on this cell.
- * Here the majority of work is expected to happen on the particles, therefore
- * the return value of this function is calculated based on the number of
- * particles in the current cell. The function is connected to the
- * cell_weight() signal inside the triangulation, and will be called once per
- * cell, whenever the triangulation repartition the domain between ranks.
- *
- * @param[in] cell The cell for which the load is calculated.
- *
- * @param[in] status The status of the cell related to the coarsening level.
- *
- * TODO: Remove preprocessor directives after deal.ii v.9.6 release
- *
- * @return The total weight of the cell.
- */
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 6)
-  unsigned int
-  calculate_total_cell_weight(
-    const typename parallel::distributed::Triangulation<dim>::cell_iterator
-                                                                        &cell,
-    const typename parallel::distributed::Triangulation<dim>::CellStatus status)
-    const;
-#else
+  /**
+   * @brief Indicates to the triangulation how much computational work is
+   * expected to happen on this cell, and consequently how the domain needs to
+   * be partitioned.
+   *
+   * Every MPI rank receives a roughly equal amount of work (potentially not an
+   * equal number of cells). While the function is called from the outside,
+   * it is connected to the corresponding signal from inside this class,
+   * therefore it can be private. This function is the key component that allows
+   * dynamically balance the computational load. The function attributes a
+   * weight to every cell that represents the computational work on this cell.
+   * Here the majority of work is expected to happen on the particles, therefore
+   * the return value of this function is calculated based on the number of
+   * particles in the current cell. The function is connected to the
+   * cell_weight() signal inside the triangulation, and will be called once per
+   * cell, whenever the triangulation repartition the domain between ranks.
+   *
+   * @param[in] cell The cell for which the load is calculated.
+   *
+   * @param[in] status The status of the cell related to the coarsening level.
+   *
+   * TODO: Remove preprocessor directives after deal.ii v.9.6 release
+   *
+   * @return The total weight of the cell.
+   */
   unsigned int
   calculate_total_cell_weight(
     const typename parallel::distributed::Triangulation<dim>::cell_iterator
                     &cell,
     const CellStatus status) const;
-#endif
 
   /**
    * @brief Indicates to the triangulation how much computational work is
@@ -340,27 +312,17 @@ private:
    * total cell weight = cell weight +
    *                     load balancing factor * n particles * particle weight
    *
-   * TODO: Remove preprocessor directives after deal.ii v.9.6 release
    *
    * @param[in] cell The cell for which the load is calculated
    * @param[in] status The status of the cell related to the coarsening level
    *
    * @return The total weight of the cell
    */
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 6)
-  unsigned int
-  calculate_total_cell_weight_with_mobility_status(
-    const typename parallel::distributed::Triangulation<dim>::cell_iterator
-                                                                        &cell,
-    const typename parallel::distributed::Triangulation<dim>::CellStatus status)
-    const;
-#else
   unsigned int
   calculate_total_cell_weight_with_mobility_status(
     const typename parallel::distributed::Triangulation<dim>::cell_iterator
                     &cell,
     const CellStatus status) const;
-#endif
 
   /**
    * @brief The load balancing method chosen by the user.

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -283,12 +283,7 @@ double
 Sphere<dim>::value(const Point<dim> &evaluation_point,
                    const unsigned int /*component*/) const
 {
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-  return evaluation_point.distance(this->position) - this->effective_radius -
-         this->layer_thickening;
-#else
   return sphere_function->value(evaluation_point) - this->layer_thickening;
-#endif
 }
 
 
@@ -315,13 +310,7 @@ Sphere<dim>::gradient(const Point<dim> &evaluation_point,
   if ((evaluation_point - this->position).norm() <
       1e-12 * this->effective_radius)
     return AutoDerivativeFunction<dim>::gradient(evaluation_point);
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-  const Tensor<1, dim> center_to_point = evaluation_point - this->position;
-  const Tensor<1, dim> grad = center_to_point / center_to_point.norm();
-  return grad;
-#else
   return sphere_function->gradient(evaluation_point);
-#endif
 }
 
 template <int dim>
@@ -351,11 +340,8 @@ void
 Sphere<dim>::set_position(const Point<dim> &position)
 {
   this->Shape<dim>::set_position(position);
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-#else
   sphere_function = std::make_shared<Functions::SignedDistance::Sphere<dim>>(
     position, this->effective_radius);
-#endif
 }
 
 template <int dim>
@@ -2080,7 +2066,7 @@ RBFShape<dim>::determine_likely_nodes_for_one_cell(
   double     temp_cell_diameter;
 
   likely_nodes_map[cell]          = std::make_shared<std::vector<
-    std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>>();
+             std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>>();
   const size_t number_of_portions = iterable_nodes.size();
   for (size_t portion_id = 0; portion_id < number_of_portions; portion_id++)
     {

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2022-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/shape.h>

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -2066,7 +2066,7 @@ RBFShape<dim>::determine_likely_nodes_for_one_cell(
   double     temp_cell_diameter;
 
   likely_nodes_map[cell]          = std::make_shared<std::vector<
-             std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>>();
+    std::tuple<Point<dim>, double, std::shared_ptr<std::vector<size_t>>>>>();
   const size_t number_of_portions = iterable_nodes.size();
   for (size_t portion_id = 0; portion_id < number_of_portions; portion_id++)
     {

--- a/source/dem/load_balancing.cc
+++ b/source/dem/load_balancing.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2022-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <dem/adaptive_sparse_contacts.h>

--- a/source/dem/load_balancing.cc
+++ b/source/dem/load_balancing.cc
@@ -139,20 +139,11 @@ LagrangianLoadBalancing<dim, PropertiesIndex>::
   connect_mobility_status_weight_signals();
 }
 
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 6)
-template <int dim, typename PropertiesIndex>
-unsigned int
-LagrangianLoadBalancing<dim, PropertiesIndex>::calculate_total_cell_weight(
-  const typename parallel::distributed::Triangulation<dim>::cell_iterator &cell,
-  const typename parallel::distributed::Triangulation<dim>::CellStatus status)
-  const
-#else
 template <int dim, typename PropertiesIndex>
 unsigned int
 LagrangianLoadBalancing<dim, PropertiesIndex>::calculate_total_cell_weight(
   const typename parallel::distributed::Triangulation<dim>::cell_iterator &cell,
   const CellStatus status) const
-#endif
 {
   // Assign no weight to cells we do not own.
   if (!cell->is_locally_owned())
@@ -160,32 +151,18 @@ LagrangianLoadBalancing<dim, PropertiesIndex>::calculate_total_cell_weight(
 
   switch (status)
     {
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 6)
-      case parallel::distributed::Triangulation<dim>::CELL_PERSIST:
-      case parallel::distributed::Triangulation<dim>::CELL_REFINE:
-#else
       case CellStatus::cell_will_persist:
       case CellStatus::cell_will_be_refined:
-#endif
         // If CELL_PERSIST, do as CELL_REFINE
         {
           const unsigned int n_particles_in_cell =
             particle_handler->n_particles_in_cell(cell);
           return n_particles_in_cell * particle_weight;
         }
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 6)
-      case parallel::distributed::Triangulation<dim>::CELL_INVALID:
-        break;
-#else
       case CellStatus::cell_invalid:
         break;
-#endif
 
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 6)
-      case parallel::distributed::Triangulation<dim>::CELL_COARSEN:
-#else
       case CellStatus::children_will_be_coarsened:
-#endif
         {
           unsigned int n_particles_in_cell = 0;
 
@@ -205,16 +182,6 @@ LagrangianLoadBalancing<dim, PropertiesIndex>::calculate_total_cell_weight(
   return 0;
 }
 
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 6)
-template <int dim, typename PropertiesIndex>
-unsigned int
-LagrangianLoadBalancing<dim, PropertiesIndex>::
-  calculate_total_cell_weight_with_mobility_status(
-    const typename parallel::distributed::Triangulation<dim>::cell_iterator
-                                                                        &cell,
-    const typename parallel::distributed::Triangulation<dim>::CellStatus status)
-    const
-#else
 template <int dim, typename PropertiesIndex>
 unsigned int
 LagrangianLoadBalancing<dim, PropertiesIndex>::
@@ -222,7 +189,6 @@ LagrangianLoadBalancing<dim, PropertiesIndex>::
     const typename parallel::distributed::Triangulation<dim>::cell_iterator
                     &cell,
     const CellStatus status) const
-#endif
 {
   // Assign no weight to cells we do not own.
   if (!cell->is_locally_owned())
@@ -252,30 +218,16 @@ LagrangianLoadBalancing<dim, PropertiesIndex>::
 
   switch (status)
     {
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 6)
-      case parallel::distributed::Triangulation<dim>::CELL_PERSIST:
-      case parallel::distributed::Triangulation<dim>::CELL_REFINE:
-#else
       case dealii::CellStatus::cell_will_persist:
       case dealii::CellStatus::cell_will_be_refined:
-#endif
         {
           const unsigned int n_particles_in_cell =
             particle_handler->n_particles_in_cell(cell);
           return alpha * n_particles_in_cell * particle_weight;
         }
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 6)
-      case parallel::distributed::Triangulation<dim>::CELL_INVALID:
-        break;
-#else
       case dealii::CellStatus::cell_invalid:
         break;
-#endif
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 6)
-      case parallel::distributed::Triangulation<dim>::CELL_COARSEN:
-#else
       case dealii::CellStatus::children_will_be_coarsened:
-#endif
         {
           unsigned int n_particles_in_cell = 0;
 

--- a/source/dem/particle_point_line_contact_force.cc
+++ b/source/dem/particle_point_line_contact_force.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/tensors_and_points_dimension_manipulation.h>

--- a/source/dem/particle_point_line_contact_force.cc
+++ b/source/dem/particle_point_line_contact_force.cc
@@ -118,11 +118,7 @@ ParticlePointLineForce<dim, PropertiesIndex>::
           Tensor<1, 3> total_force = spring_normal_force - dashpot_normal_force;
 
           // Getting force
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-          Tensor<1, 3> &particle_force = force[particle->get_id()];
-#else
           Tensor<1, 3> &particle_force = force[particle->get_local_index()];
-#endif
 
           // Updating the body force of particles in the particle handler
           particle_force += total_force;
@@ -247,11 +243,7 @@ ParticlePointLineForce<dim, PropertiesIndex>::
           Tensor<1, 3> total_force = spring_normal_force - dashpot_normal_force;
 
           // Getting force
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-          Tensor<1, 3> &particle_force = force[particle->get_id()];
-#else
           Tensor<1, 3> &particle_force = force[particle->get_local_index()];
-#endif
 
           // Updating the body force of particles in the particle handler
           particle_force += total_force;

--- a/source/solvers/fluid_dynamics_nitsche.cc
+++ b/source/solvers/fluid_dynamics_nitsche.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/bdf.h>

--- a/source/solvers/fluid_dynamics_nitsche.cc
+++ b/source/solvers/fluid_dynamics_nitsche.cc
@@ -250,11 +250,7 @@ FluidDynamicsNitsche<2, 3>::calculate_forces_on_solid(
   auto particle = solid_ph->begin();
   while (particle != solid_ph->end())
     {
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-      const auto &cell = particle->get_surrounding_cell(*this->triangulation);
-#else
       const auto &cell = particle->get_surrounding_cell();
-#endif
       const auto &dh_cell =
         typename DoFHandler<3>::cell_iterator(*cell, &this->dof_handler);
       dh_cell->get_dof_indices(fluid_dof_indices);
@@ -266,13 +262,8 @@ FluidDynamicsNitsche<2, 3>::calculate_forces_on_solid(
       // at the particle location
       auto &evaluation_point = this->evaluation_point;
 
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-      Functions::FEFieldFunction<3, DoFHandler<3, 3>, GlobalVectorType>
-        fe_field(this->dof_handler, evaluation_point);
-#else
       Functions::FEFieldFunction<3, GlobalVectorType> fe_field(
         this->dof_handler, evaluation_point);
-#endif
 
 
       fe_field.set_active_cell(dh_cell);
@@ -338,12 +329,8 @@ FluidDynamicsNitsche<dim, spacedim>::calculate_forces_on_solid(
   auto particle = solid_ph->begin();
   while (particle != solid_ph->end())
     {
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-      const auto &cell = particle->get_surrounding_cell(*this->triangulation);
-#else
       const auto &cell = particle->get_surrounding_cell();
-#endif
-      double h_cell =
+      double      h_cell =
         compute_cell_diameter<dim>(cell->measure(), this->velocity_fem_degree);
       const double penalty_parameter =
         1. / std::pow(h_cell * h_cell, double(dim) / double(spacedim));
@@ -422,12 +409,8 @@ FluidDynamicsNitsche<dim, spacedim>::calculate_torque_on_solid(
   auto particle = solid_ph->begin();
   while (particle != solid_ph->end())
     {
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-      const auto &cell = particle->get_surrounding_cell(*this->triangulation);
-#else
       const auto &cell = particle->get_surrounding_cell();
-#endif
-      double h_cell =
+      double      h_cell =
         compute_cell_diameter<dim>(cell->measure(), this->velocity_fem_degree);
       const double penalty_parameter =
         1. / std::pow(h_cell * h_cell, double(dim) / double(spacedim));
@@ -821,11 +804,7 @@ void
 FluidDynamicsNitsche<dim, spacedim>::output_solid_triangulation(
   const unsigned int i_solid)
 {
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-  DataOut<dim, DoFHandler<dim, spacedim>> data_out;
-#else
-  DataOut<dim, spacedim> data_out;
-#endif
+  DataOut<dim, spacedim>     data_out;
   DoFHandler<dim, spacedim> &solid_dh =
     solids[i_solid]->get_solid_dof_handler();
   data_out.attach_dof_handler(solid_dh);
@@ -841,18 +820,10 @@ FluidDynamicsNitsche<dim, spacedim>::output_solid_triangulation(
   GlobalVectorType &displacement_vector =
     solids[i_solid]->get_displacement_vector();
 
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-  data_out.add_data_vector(
-    displacement_vector,
-    solution_names,
-    DataOut<dim, DoFHandler<dim, spacedim>>::type_dof_data,
-    data_component_interpretation);
-#else
   data_out.add_data_vector(displacement_vector,
                            solution_names,
                            DataOut<dim, spacedim>::type_dof_data,
                            data_component_interpretation);
-#endif
 
 
 

--- a/tests/core/lethe_grid_tool_mesh_cut_by_flat_3.cc
+++ b/tests/core/lethe_grid_tool_mesh_cut_by_flat_3.cc
@@ -98,16 +98,10 @@ test()
               << " is cut " << std::endl;
     }
 
-    // Printing the final position for all the vertices
+  // Printing the final position for all the vertices
 
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-  Legacy::DataOut<3>                   data_out;
-  Legacy::DataOut<2, DoFHandler<2, 3>> flat_data_out;
-#else
   DataOut<3>    data_out;
   DataOut<2, 3> flat_data_out;
-#endif
-
 
   data_out.attach_dof_handler(dof_handler);
   data_out.add_data_vector(subdomain, "subdomain");

--- a/tests/dem/integration_schemes_accuracy.cc
+++ b/tests/dem/integration_schemes_accuracy.cc
@@ -98,16 +98,7 @@ test()
   std::vector<double>       MOI;
 
   particle_handler.sort_particles_into_subdomains_and_cells();
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-  {
-    unsigned int max_particle_id = 0;
-    for (const auto &particle : particle_handler)
-      max_particle_id = std::max(max_particle_id, particle.get_id());
-    force.resize(max_particle_id + 1);
-  }
-#else
   force.resize(particle_handler.get_max_local_particle_index());
-#endif
   torque.resize(force.size());
   MOI.resize(force.size());
   MOI[0] = 1.;

--- a/tests/dem/integration_schemes_accuracy.cc
+++ b/tests/dem/integration_schemes_accuracy.cc
@@ -142,16 +142,7 @@ test()
     particle_mass;
 
   particle_handler.sort_particles_into_subdomains_and_cells();
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-  {
-    unsigned int max_particle_id = 0;
-    for (const auto &particle : particle_handler)
-      max_particle_id = std::max(max_particle_id, particle.get_id());
-    force.resize(max_particle_id + 1);
-  }
-#else
   force.resize(particle_handler.get_max_local_particle_index());
-#endif
   torque.resize(force.size());
   MOI.resize(force.size());
 
@@ -251,16 +242,7 @@ test()
     particle_mass;
 
   particle_handler.sort_particles_into_subdomains_and_cells();
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-  {
-    unsigned int max_particle_id = 0;
-    for (const auto &particle : particle_handler)
-      max_particle_id = std::max(max_particle_id, particle.get_id());
-    force.resize(max_particle_id + 1);
-  }
-#else
   force.resize(particle_handler.get_max_local_particle_index());
-#endif
   torque.resize(force.size());
   MOI.resize(force.size());
 
@@ -271,11 +253,8 @@ test()
     {
       t = 0;
 
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-      force[particle_iterator->get_id()][dim - 1] = -x0;
-#else
+
       force[particle_iterator->get_local_index()][dim - 1] = -x0;
-#endif
       velocity_verlet_object.integrate_half_step_location(
         particle_handler, g, dt2, torque, force, MOI);
       t += dt2;
@@ -285,11 +264,7 @@ test()
           Tensor<1, dim> force_tensor;
           force_tensor[dim - 1] =
             -spring_constant * particle_iterator->get_location()[dim - 1];
-#if (DEAL_II_VERSION_MAJOR < 10 && DEAL_II_VERSION_MINOR < 4)
-          force[particle_iterator->get_id()] = force_tensor;
-#else
           force[particle_iterator->get_local_index()] = force_tensor;
-#endif
 
           velocity_verlet_object.integrate(
             particle_handler, g, dt2, torque, force, MOI);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

In the past, we had to introduce numerous checks for deal.II versions, notably when we introduced the parallel particle architectures. These tests check if the deal.II version if superior to version 9.3 or 9.4, which are versions that we do not even support anymore. Consequently, this PR removes these checks and only keeps the one which are related to deal.II 9.6 and 9.7. Once the official deal.II 9.7 release is finished, I will also remove support to deal.II 9.6 and move support to deal.II 9.7 as a minimum

### Testing

This refactoring does not include new tests. Old tests should still pass as if nothing has changed.

### Documentation

This does not require any modifications to the documentation.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [ ] The PR description is cleaned and ready for merge