### PR TITLE
Fix workflow status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 [![Debug](https://github.com/chaos-polymtl/lethe/actions/workflows/debug.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/debug.yml)
 [![Release](https://github.com/chaos-polymtl/lethe/actions/workflows/release.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/release.yml)
 [![Warnings](https://github.com/chaos-polymtl/lethe/actions/workflows/warnings-gcc.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/warnings-gcc.yml)
-[![Tidy](https://github.com/chaos-polymtl/lethe/actions/workflows/clang-tidy.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/clang-tidy.yml)
+<!-- [![Tidy](https://github.com/chaos-polymtl/lethe/actions/workflows/clang-tidy.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/clang-tidy.yml)-->
 [![Examples](https://github.com/chaos-polymtl/lethe/actions/workflows/examples-parameter-files.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/examples-parameter-files.yml)
 [![Documentation](https://github.com/chaos-polymtl/lethe/actions/workflows/doc-github-pages.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/doc-github-pages.yml)
-[![Docker Image](https://github.com/chaos-polymtl/lethe/actions/workflows/docker.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/docker.yml)
+<!--[![Docker Image](https://github.com/chaos-polymtl/lethe/actions/workflows/docker.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/docker.yml)-->
 
 Lethe (pronounced /ˈliːθiː/) is an open-source computational fluid dynamics
 (CFD), discrete element method (DEM) and coupled CFD-DEM

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Debug](https://github.com/chaos-polymtl/lethe/actions/workflows/debug.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/debug.yml)
 [![Release](https://github.com/chaos-polymtl/lethe/actions/workflows/release.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/release.yml)
 [![Warnings](https://github.com/chaos-polymtl/lethe/actions/workflows/warnings-gcc.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/warnings-gcc.yml)
-[![Tidy](https://github.com/chaos-polymtl/lethe/actions/workflows/clang-tidy.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/debug.yml)
-[![Examples](https://github.com/chaos-polymtl/lethe/actions/workflows/examples-parameter-files.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/clang-tidy.yml)
+[![Tidy](https://github.com/chaos-polymtl/lethe/actions/workflows/clang-tidy.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/clang-tidy.yml)
+[![Examples](https://github.com/chaos-polymtl/lethe/actions/workflows/examples-parameter-files.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/examples-parameter-files.yml)
 [![Documentation](https://github.com/chaos-polymtl/lethe/actions/workflows/doc-github-pages.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/doc-github-pages.yml)
 [![Docker Image](https://github.com/chaos-polymtl/lethe/actions/workflows/docker.yml/badge.svg)](https://github.com/chaos-polymtl/lethe/actions/workflows/docker.yml)
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

The workflow status badge in the `README.md` file was not pointing to the correct workflow in two cases: the clang-tidy and the example parameter files. In addition, two workflows were recently disabled, so in this PR the corresponding workflow status badge is disabled as well. The lines were simply commented and in the future they can be easily enabled once again. 