### PR TITLE
Remove duplicated function in the QCM void fraction method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
-- Minor The QCM calculation method for the void fraction had multiple chunks of code which were duplicated. This PR refactors the QCM to make an additional use of functions and greatly simplifies the code. Nothing is changed in the way the calculations are made. [#1591](https://github.com/chaos-polymtl/lethe/pull/1591)
+- MINOR The QCM calculation method for the void fraction had multiple chunks of code which were duplicated. This PR refactors the QCM to make an additional use of functions and greatly simplifies the code. Nothing is changed in the way the calculations are made. [#1591](https://github.com/chaos-polymtl/lethe/pull/1591)
 
 ### [Master] - 2025-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+### [Master] - 2025-07-21
+
+### Changed
+
+- Minor The QCM calculation method for the void fraction had multiple chunks of code which were duplicated. This PR refactors the QCM to make an additional use of functions and greatly simplifies the code. Nothing is changed in the way the calculations are made. [#1591](https://github.com/chaos-polymtl/lethe/pull/1591)
+
 ### [Master] - 2025-07-20
 
 ### Fixed

--- a/include/fem-dem/void_fraction.h
+++ b/include/fem-dem/void_fraction.h
@@ -312,7 +312,7 @@ private:
    *
    * @param r_particle The radius of the particle
    * @param r_sphere The radius of the averaging sphere
-   * @param distance_between_spheres The distance between the spheres
+   * @param distance_between_spheres The distance between the centers of the spheres
    *
    * @return The intersection volume (in 3D) or area (in 2d)
    */

--- a/include/fem-dem/void_fraction.h
+++ b/include/fem-dem/void_fraction.h
@@ -450,8 +450,7 @@ private:
   /// Triangulation
   parallel::DistributedTriangulationBase<dim> *triangulation;
 
-public:
-  /// TODO: To move to private
+private:
   /// Parameters for the calculation of the void fraction
   /// Right now this is used for the VANS matrix-free solver
   /// to directly calculate the void fraction from the function itself.
@@ -459,7 +458,6 @@ public:
   std::shared_ptr<Parameters::VoidFractionParameters<dim>>
     void_fraction_parameters;
 
-private:
   /// Linear solvers for the calculation of the void fraction
   const Parameters::LinearSolver linear_solver_parameters;
 

--- a/source/fem-dem/void_fraction.cc
+++ b/source/fem-dem/void_fraction.cc
@@ -594,23 +594,6 @@ VoidFractionBase<dim>::calculate_void_fraction_quadrature_centered_method()
       calculate_reference_sphere_radius = false;
     }
 
-  // Lambda functions for calculating the radius of the reference sphere
-  // Calculate the radius by the volume (area in 2D) of sphere:
-  // r = (2*dim*V/pi)^(1/dim) / 2
-  auto radius_sphere_volume_cell = [](auto cell_measure) {
-    return 0.5 * pow(2.0 * dim * cell_measure / M_PI, 1.0 / double(dim));
-  };
-
-  // Calculate the radius is obtained from the volume of sphere based on
-  // R_s = h_omega:
-  // V_s = pi*(2*V_c^(1/dim))^(dim)/(2*dim) = pi*2^(dim)*V_c/(2*dim)
-  auto radius_h_omega = [&radius_sphere_volume_cell](double cell_measure) {
-    double reference_sphere_volume =
-      M_PI * Utilities::fixed_power<dim>(2.0) * cell_measure / (2.0 * dim);
-
-    return radius_sphere_volume_cell(reference_sphere_volume);
-  };
-
   system_rhs_void_fraction    = 0;
   system_matrix_void_fraction = 0;
 
@@ -697,21 +680,8 @@ VoidFractionBase<dim>::calculate_void_fraction_quadrature_centered_method()
                   // active cell
                   if (calculate_reference_sphere_radius)
                     {
-                      if (void_fraction_parameters
-                            ->qcm_sphere_equal_cell_volume == true)
-                        {
-                          // Get the radius by the volume of sphere which is
-                          // equal to the volume of cell
-                          r_sphere = radius_sphere_volume_cell(
-                            active_neighbors[n]->measure());
-                        }
-                      else
-                        {
-                          // The radius is obtained from the volume of sphere
-                          // based on R_s = h_omega
-                          r_sphere =
-                            radius_h_omega(active_neighbors[n]->measure());
-                        }
+                      r_sphere = calculate_qcm_radius_from_cell_measure(
+                        active_periodic_neighbors[n]->measure());
                     }
 
                   // Loop over quadrature points
@@ -768,21 +738,8 @@ VoidFractionBase<dim>::calculate_void_fraction_quadrature_centered_method()
                 {
                   if (calculate_reference_sphere_radius)
                     {
-                      if (void_fraction_parameters
-                            ->qcm_sphere_equal_cell_volume == true)
-                        {
-                          // Get the radius by the volume of sphere which is
-                          // equal to the volume of cell
-                          r_sphere = radius_sphere_volume_cell(
-                            active_periodic_neighbors[n]->measure());
-                        }
-                      else
-                        {
-                          // The radius is obtained from the volume of sphere
-                          // based on R_s = h_omega
-                          r_sphere = radius_h_omega(
-                            active_periodic_neighbors[n]->measure());
-                        }
+                      r_sphere = calculate_qcm_radius_from_cell_measure(
+                        active_periodic_neighbors[n]->measure());
                     }
 
                   // Loop over quadrature points
@@ -790,7 +747,7 @@ VoidFractionBase<dim>::calculate_void_fraction_quadrature_centered_method()
                     {
                       // Adjust the location of the particle in the cell to
                       // account for the periodicity. If the position of the
-                      // periodic cell if greater than the position of the
+                      // periodic cell is greater than the position of the
                       // current cell, the particle location needs a positive
                       // correction, and vice versa
                       const Point<dim> particle_location =
@@ -805,63 +762,20 @@ VoidFractionBase<dim>::calculate_void_fraction_quadrature_centered_method()
                         particle_location.distance(
                           periodic_neighbor_quadrature_point_location[n][k]);
 
-                      // Particle completely in the reference sphere
-                      if (periodic_neighbor_distance <= (r_sphere - r_particle))
-                        {
-                          particle_properties
-                            [DEM::CFDDEMProperties::PropertiesIndex::
-                               volumetric_contribution] +=
-                            M_PI *
-                            Utilities::fixed_power<dim>(
-                              particle_properties
-                                [DEM::CFDDEMProperties::PropertiesIndex::dp]) /
-                            (2.0 * dim);
-                        }
-
-                      // Particle partially in the reference sphere
-                      else if ((periodic_neighbor_distance >
-                                (r_sphere - r_particle)) &&
-                               (periodic_neighbor_distance <
-                                (r_sphere + r_particle)))
-                        {
-                          if constexpr (dim == 2)
-                            particle_properties
-                              [DEM::CFDDEMProperties::PropertiesIndex::
-                                 volumetric_contribution] +=
-                              particle_circle_intersection_2d(
-                                r_particle,
-                                r_sphere,
-                                periodic_neighbor_distance);
-
-                          else if constexpr (dim == 3)
-                            particle_properties
-                              [DEM::CFDDEMProperties::PropertiesIndex::
-                                 volumetric_contribution] +=
-                              particle_sphere_intersection_3d(
-                                r_particle,
-                                r_sphere,
-                                periodic_neighbor_distance);
-                        }
-
-                      // Particle completely outside the reference
-                      // sphere. Do absolutely nothing.
+                      // Add the intersection volume to the particle
+                      // contribution
+                      particle_properties
+                        [DEM::CFDDEMProperties::PropertiesIndex::
+                           volumetric_contribution] +=
+                        calculate_intersection_measure(
+                          r_particle, r_sphere, periodic_neighbor_distance);
                     }
                 }
             }
         }
     }
 
-  // BB Double check if this is still necessary or not.
-  // Update ghost particles
-  // if (load_balance_step)
-  //  {
-  //    particle_handler.sort_particles_into_subdomains_and_cells();
-  //    particle_handler.exchange_ghost_particles(true);
-  //  }
-  // else
-  //  {
   particle_handler->update_ghost_particles();
-  //  }
 
   // After the particles' contributions have been determined, calculate and
   // normalize the void fraction
@@ -885,19 +799,8 @@ VoidFractionBase<dim>::calculate_void_fraction_quadrature_centered_method()
           // averaging volume for the QCM
           if (calculate_reference_sphere_radius)
             {
-              if (void_fraction_parameters->qcm_sphere_equal_cell_volume ==
-                  true)
-                {
-                  // Get the radius by the volume of sphere which is
-                  // equal to the volume of cell
-                  r_sphere = radius_sphere_volume_cell(cell->measure());
-                }
-              else
-                {
-                  // The radius is obtained from the volume of sphere based
-                  // on R_s = h_omega
-                  r_sphere = radius_h_omega(cell->measure());
-                }
+              r_sphere =
+                calculate_qcm_radius_from_cell_measure(cell->measure());
             }
 
           // Array of real locations for the quadrature points
@@ -934,54 +837,20 @@ VoidFractionBase<dim>::calculate_void_fraction_quadrature_centered_method()
                         particle_properties
                           [DEM::CFDDEMProperties::PropertiesIndex::dp] *
                         0.5;
-                      double single_particle_volume =
-                        M_PI * Utilities::fixed_power<dim>(r_particle * 2.0) /
-                        (2 * dim);
 
                       // Distance between particle and quadrature point
                       // centers
                       distance = particle.get_location().distance(
                         quadrature_point_location[q]);
 
-                      // Particle completely in the reference sphere
-                      if (distance <= (r_sphere - r_particle))
-                        particles_volume_in_sphere +=
-                          (M_PI *
-                           Utilities::fixed_power<dim>(
-                             particle_properties
-                               [DEM::CFDDEMProperties::PropertiesIndex::dp]) /
-                           (2.0 * dim)) *
-                          single_particle_volume /
-                          particle_properties
-                            [DEM::CFDDEMProperties::PropertiesIndex::
-                               volumetric_contribution];
-
-                      // Particle partially in the reference sphere
-                      else if ((distance > (r_sphere - r_particle)) &&
-                               (distance < (r_sphere + r_particle)))
-                        {
-                          if (dim == 2)
-                            particles_volume_in_sphere +=
-                              particle_circle_intersection_2d(r_particle,
-                                                              r_sphere,
-                                                              distance) *
-                              single_particle_volume /
-                              particle_properties
-                                [DEM::CFDDEMProperties::PropertiesIndex::
-                                   volumetric_contribution];
-                          else if (dim == 3)
-                            particles_volume_in_sphere +=
-                              particle_sphere_intersection_3d(r_particle,
-                                                              r_sphere,
-                                                              distance) *
-                              single_particle_volume /
-                              particle_properties
-                                [DEM::CFDDEMProperties::PropertiesIndex::
-                                   volumetric_contribution];
-                        }
-
-                      // Particle completely outside the reference sphere. Do
-                      // absolutely nothing.
+                      // Calculate the normalized particle contribution
+                      particles_volume_in_sphere +=
+                        calculate_intersection_measure(r_particle,
+                                                       r_sphere,
+                                                       distance) /
+                        particle_properties
+                          [DEM::CFDDEMProperties::PropertiesIndex::
+                             volumetric_contribution];
                     }
                 }
 
@@ -1005,9 +874,6 @@ VoidFractionBase<dim>::calculate_void_fraction_quadrature_centered_method()
                         particle_properties
                           [DEM::CFDDEMProperties::PropertiesIndex::dp] *
                         0.5;
-                      double single_particle_volume =
-                        M_PI * Utilities::fixed_power<dim>(r_particle * 2) /
-                        (2 * dim);
 
                       // Adjust the location of the particle in the cell to
                       // account for the periodicity. If the position of the
@@ -1028,45 +894,14 @@ VoidFractionBase<dim>::calculate_void_fraction_quadrature_centered_method()
                       distance = particle_location.distance(
                         quadrature_point_location[q]);
 
-                      // Particle completely in the reference sphere
-                      if (distance <= (r_sphere - r_particle))
-                        particles_volume_in_sphere +=
-                          (M_PI *
-                           Utilities::fixed_power<dim>(
-                             particle_properties
-                               [DEM::CFDDEMProperties::PropertiesIndex::dp]) /
-                           (2.0 * dim)) *
-                          single_particle_volume /
-                          particle_properties
-                            [DEM::CFDDEMProperties::PropertiesIndex::
-                               volumetric_contribution];
-
-                      // Particle partially in the reference sphere
-                      else if ((distance > (r_sphere - r_particle)) &&
-                               (distance < (r_sphere + r_particle)))
-                        {
-                          if (dim == 2)
-                            particles_volume_in_sphere +=
-                              particle_circle_intersection_2d(r_particle,
-                                                              r_sphere,
-                                                              distance) *
-                              single_particle_volume /
-                              particle_properties
-                                [DEM::CFDDEMProperties::PropertiesIndex::
-                                   volumetric_contribution];
-                          else if (dim == 3)
-                            particles_volume_in_sphere +=
-                              particle_sphere_intersection_3d(r_particle,
-                                                              r_sphere,
-                                                              distance) *
-                              single_particle_volume /
-                              particle_properties
-                                [DEM::CFDDEMProperties::PropertiesIndex::
-                                   volumetric_contribution];
-                        }
-
-                      // Particle completely outside the reference sphere. Do
-                      // absolutely nothing.
+                      // Calculate the normalized particle contribution
+                      particles_volume_in_sphere +=
+                        calculate_intersection_measure(r_particle,
+                                                       r_sphere,
+                                                       distance) /
+                        particle_properties
+                          [DEM::CFDDEMProperties::PropertiesIndex::
+                             volumetric_contribution];
                     }
                 }
 

--- a/source/fem-dem/void_fraction.cc
+++ b/source/fem-dem/void_fraction.cc
@@ -813,7 +813,7 @@ VoidFractionBase<dim>::calculate_void_fraction_quadrature_centered_method()
                         0.5;
 
                       // Calculate the ratio between the particle volume and the
-                      // total volume it contribute
+                      // total volume it contributes to
                       const double particle_volume_ratio =
                         (M_PI * Utilities::fixed_power<dim>(r_particle * 2.0) /
                          (2 * dim)) /
@@ -876,7 +876,7 @@ VoidFractionBase<dim>::calculate_void_fraction_quadrature_centered_method()
                         quadrature_point_location[q]);
 
                       // Calculate the ratio between the particle volume and the
-                      // total volume it contribute
+                      // total volume it contributes to
                       const double particle_volume_ratio =
                         (M_PI * Utilities::fixed_power<dim>(r_particle * 2.0) /
                          (2 * dim)) /

--- a/source/fem-dem/void_fraction.cc
+++ b/source/fem-dem/void_fraction.cc
@@ -875,14 +875,21 @@ VoidFractionBase<dim>::calculate_void_fraction_quadrature_centered_method()
                       distance = particle_location.distance(
                         quadrature_point_location[q]);
 
-                      // Calculate the normalized particle contribution
-                      particles_volume_in_sphere +=
-                        calculate_intersection_measure(r_particle,
-                                                       r_sphere,
-                                                       distance) /
+                      // Calculate the ratio between the particle volume and the
+                      // total volume it contribute
+                      const double particle_volume_ratio =
+                        (M_PI * Utilities::fixed_power<dim>(r_particle * 2.0) /
+                         (2 * dim)) /
                         particle_properties
                           [DEM::CFDDEMProperties::PropertiesIndex::
                              volumetric_contribution];
+
+                      // Calculate the normalized particle contribution
+                      particles_volume_in_sphere +=
+                        particle_volume_ratio *
+                        calculate_intersection_measure(r_particle,
+                                                       r_sphere,
+                                                       distance);
                     }
                 }
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The QCM method to calculate the void fraction has some extensive repeated calculation. Since we wish to extend the method to other fields, it is necessary to clean this duplication before trying to add other fields. This PR cleans the implementation of the QCM void fraction by adding 3 small helper functions and removing code duplication.

### Testing

All previous tests should pass.

### Documentation

Nothing to document here this is mostly code.


### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge