### PR TITLE
Added the same check as the CFD-DEM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+### [Master] - 2025-07-23
+
+### Fixed
+
+- MINOR The default insertion frequency was causing a segmentation fault when using the DEM solver (division by zero when set unchanged). This PR adds an "if" statement that checks if this insertion frequency is equal to 0. [#1593](https://github.com/chaos-polymtl/lethe/pull/1593)
+
 ### [Master] - 2025-07-21
 
 ### Changed

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -505,6 +505,11 @@ template <int dim, typename PropertiesIndex>
 void
 DEMSolver<dim, PropertiesIndex>::insert_particles()
 {
+  // If the insertion frequency is set to 0, then no particles are going
+  // to be inserted
+  if (parameters.insertion_info.insertion_frequency == 0)
+    return;
+
   if ((simulation_control->get_step_number() %
        parameters.insertion_info.insertion_frequency) == 1 ||
       simulation_control->get_step_number() == 1)


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

In #1576 , the default insertion frequency was changed to 0. When not defined in a prm file (like for the rotation drum example, which uses two prm files with a restart), a division by zero would occur with the modulo. 

This wasn't a problem in the CFD-DEM, since a "if" statement verifying if the insertion frequency was equal to zero was added. 

### Solution
Added the same "if" statement in the DEM. 

### Testing

The rotation drum example works now. 

### Documentation

N/A

### Miscellaneous (will be removed when merged)

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [X] Lethe documentation is up to date
- [X] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [X] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] If the fix is temporary, an issue is opened
- [X ] The PR description is cleaned and ready for merge