### PR TITLE
Add two warnings for apt installs

### DIFF
--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -27,6 +27,9 @@ Lethe requires a modern version of the `deal.II library <https://www.dealii.org/
 Installing deal.II using apt 
 -----------------------------------------
 
+::warning::
+  The master version of Lethe does not support deal.II 9.6 anymore. Until an apt release of deal.II 9.7 is available, you should use the 1.0.1 version of Lethe if you wish to use the deal.II 9.6 package.
+
 This is done following `this procedure <https://www.dealii.org/download.html#:~:text=page%20for%20details.-,Linux%20distributions,-Arch%20Linux>`_.
 
 In case you are using Ubuntu, you will need to `update the backports <https://launchpad.net/~ginggs/+archive/ubuntu/deal.ii-9.6.0-backports>`_:

--- a/doc/source/installation/windows_wsl.rst
+++ b/doc/source/installation/windows_wsl.rst
@@ -95,6 +95,9 @@ The following step is to install deal.II. This can be done through
 Installing deal.II using apt (Step #1)
 -----------------------------------------
 
+::warning::
+  The master version of Lethe does not support deal.II 9.6 anymore. Until an apt release of deal.II 9.7 is available, you should use the 1.0.1 version of Lethe if you wish to use the deal.II 9.6 package.
+
 This is done following `this procedure <https://www.dealii.org/download.html#:~:text=page%20for%20details.-,Linux%20distributions,-Arch%20Linux>`_.
 
 1. |linux_shell| In case you are using Ubuntu, you will need to `update the backports <https://launchpad.net/~ginggs/+archive/ubuntu/deal.ii-9.6.0-backports>`_:


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The current master version of Lethe does not support deal.II 9.6 anymore, but we do not discuss this in the documentation anywhere. This means that our current installation instruction that use the "apt" install on both Linux and Windows just do not work if people use them. This PR adds a warning that specifies that the deal.II 9.6 version should only be used with the latest stable release of Lethe ( v1.0.1 which is our latest release)

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Copyright headers are present and up to date
- [ ] Lethe documentation is up to date
- [ ] The branch is rebased onto master
- [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If any future works is planned, an issue is opened
- [ ] The PR description is cleaned and ready for merge