### PR TITLE
Remove warnings out of a few tests

### DIFF
--- a/tests/core/lethe_grid_tool_mesh_cut_by_flat_2.cc
+++ b/tests/core/lethe_grid_tool_mesh_cut_by_flat_2.cc
@@ -40,7 +40,7 @@ test()
   DoFHandler<2>    dof_handler;
   DoFHandler<1, 2> flat_dof_handler;
 
-  FlatManifold<1, 2> flat_manifold();
+  FlatManifold<1, 2> flat_manifold;
 
 
   // Mesh

--- a/tests/mortar/manager_03.cc
+++ b/tests/mortar/manager_03.cc
@@ -217,7 +217,7 @@ main(int argc, char **argv)
       TrilinosWrappers::SparsityPattern dsp;
 
       dsp.reinit(dof_handler.locally_owned_dofs(),
-                 dof_handler.get_communicator());
+                 dof_handler.get_mpi_communicator());
 
       DoFTools::make_flux_sparsity_pattern(dof_handler, dsp, constraints);
 
@@ -367,7 +367,7 @@ main(int argc, char **argv)
       TrilinosWrappers::SparsityPattern dsp;
 
       dsp.reinit(dof_handler.locally_owned_dofs(),
-                 dof_handler.get_communicator());
+                 dof_handler.get_mpi_communicator());
 
       DoFTools::make_flux_sparsity_pattern(dof_handler, dsp, constraints);
       coupling_operator.add_sparsity_pattern_entries(dsp);

--- a/tests/mortar/manager_04.cc
+++ b/tests/mortar/manager_04.cc
@@ -190,7 +190,7 @@ main(int argc, char **argv)
       TrilinosWrappers::SparsityPattern dsp;
 
       dsp.reinit(dof_handler.locally_owned_dofs(),
-                 dof_handler.get_communicator());
+                 dof_handler.get_mpi_communicator());
 
       DoFTools::make_flux_sparsity_pattern(dof_handler, dsp, constraints);
 
@@ -326,7 +326,7 @@ main(int argc, char **argv)
       TrilinosWrappers::SparsityPattern dsp;
 
       dsp.reinit(dof_handler.locally_owned_dofs(),
-                 dof_handler.get_communicator());
+                 dof_handler.get_mpi_communicator());
 
       DoFTools::make_flux_sparsity_pattern(dof_handler, dsp, constraints);
       coupling_operator.add_sparsity_pattern_entries(dsp);

--- a/tests/mortar/plot_01.cc
+++ b/tests/mortar/plot_01.cc
@@ -47,7 +47,7 @@ output_mesh(const Triangulation<dim, spacedim> &tria,
   data_out.attach_triangulation(tria);
 
   Vector<double> vector(tria.n_active_cells());
-  vector = Utilities::MPI::this_mpi_process(tria.get_communicator());
+  vector = Utilities::MPI::this_mpi_process(tria.get_mpi_communicator());
   data_out.add_data_vector(vector, "ranks");
 
   data_out.build_patches(
@@ -55,7 +55,7 @@ output_mesh(const Triangulation<dim, spacedim> &tria,
     mapping_degree + 1,
     DataOut<dim, spacedim>::CurvedCellRegion::curved_inner_cells);
 
-  data_out.write_vtu_in_parallel(file_name, tria.get_communicator());
+  data_out.write_vtu_in_parallel(file_name, tria.get_mpi_communicator());
 }
 
 template <int dim, int spacedim>

--- a/tests/mortar/tests.h
+++ b/tests/mortar/tests.h
@@ -610,7 +610,7 @@ public:
         TrilinosWrappers::SparsityPattern dsp;
 
         dsp.reinit(dof_handler.locally_owned_dofs(),
-                   dof_handler.get_communicator());
+                   dof_handler.get_mpi_communicator());
 
         DoFTools::make_sparsity_pattern(dof_handler, dsp, *constraints);
 
@@ -1022,7 +1022,7 @@ public:
         TrilinosWrappers::SparsityPattern dsp;
 
         dsp.reinit(dof_handler.locally_owned_dofs(),
-                   dof_handler.get_communicator());
+                   dof_handler.get_mpi_communicator());
 
         DoFTools::make_sparsity_pattern(dof_handler, dsp, *constraints);
 
@@ -1390,7 +1390,7 @@ public:
         TrilinosWrappers::SparsityPattern dsp;
 
         dsp.reinit(dof_handler.locally_owned_dofs(),
-                   dof_handler.get_communicator());
+                   dof_handler.get_mpi_communicator());
 
         DoFTools::make_flux_sparsity_pattern(dof_handler, dsp, *constraints);
 
@@ -1823,7 +1823,7 @@ public:
         TrilinosWrappers::SparsityPattern dsp;
 
         dsp.reinit(dof_handler.locally_owned_dofs(),
-                   dof_handler.get_communicator());
+                   dof_handler.get_mpi_communicator());
 
         DoFTools::make_flux_sparsity_pattern(dof_handler, dsp, *constraints);
 

--- a/tests/solvers/physical_properties_manager_01.cc
+++ b/tests/solvers/physical_properties_manager_01.cc
@@ -23,6 +23,7 @@ test()
   physical_properties.number_of_fluids                = 1;
   physical_properties.number_of_solids                = 0;
   physical_properties.number_of_material_interactions = 0;
+  physical_properties.reference_temperature           = 0;
   physical_properties.fluids.resize(1);
   physical_properties.fluids[0].density_model =
     Parameters::Material::DensityModel::constant;

--- a/tests/solvers/physical_properties_manager_02.cc
+++ b/tests/solvers/physical_properties_manager_02.cc
@@ -24,6 +24,7 @@ test()
   physical_properties.number_of_fluids                = 1;
   physical_properties.number_of_solids                = 1;
   physical_properties.number_of_material_interactions = 1;
+  physical_properties.reference_temperature           = 0;
 
 
   // Generate fluid properties

--- a/tests/solvers/physical_properties_manager_03.cc
+++ b/tests/solvers/physical_properties_manager_03.cc
@@ -25,6 +25,7 @@ test()
   physical_properties.number_of_fluids                = 2;
   physical_properties.number_of_solids                = 2;
   physical_properties.number_of_material_interactions = 5;
+  physical_properties.reference_temperature           = 0;
 
   physical_properties.fluids.resize(2);
   physical_properties.solids.resize(2);

--- a/tests/solvers/restart_01.cc
+++ b/tests/solvers/restart_01.cc
@@ -104,7 +104,7 @@ RestartNavierStokes<dim>::run()
   this->exact_solution   = new ExactSolutionMMS<dim>;
   this->forcing_function = std::make_shared<MMSSineForcingFunction<dim>>();
   Parameters::PhysicalProperties physical_properties;
-  physical_properties.fluids.emplace_back(Parameters::Material());
+  physical_properties.fluids.resize(1);
   physical_properties.number_of_fluids = 1;
   physical_properties.fluids[0].rheological_model =
     Parameters::Material::RheologicalModel::newtonian;


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

There were still some warnings in some of the unit tests. I found them while compiling with warning as error. 

### Solution

Eliminates a bunch of warnings in the tests. Nothing special

### Testing

All tests still pass, nothing has changed.

### Documentation

Nothing to change here

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Copyright headers are present and up to date
- [ ] Lethe documentation is up to date
- [ ] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [ ] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge