### PR TITLE
Initialize VOF using geometric redistanciation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 # Change Log
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
+### [Master] - 2025-07-31
+
+### Added
+
+- MINOR Refactors the way the initial conditions smoothing for VOF can be applied. On top of the diffusive smoothing, a new approach can be used to set-up the initial condition using geometric redistanciation. This is great when using the geometric redistanciation strategy since the interface remains defined coherently throughout the simulation. [#1602](https://github.com/chaos-polymtl/lethe/pull/1602)
 
 ### [Master] - 2025-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- MINOR Refactors the way the initial conditions smoothing for VOF can be applied. On top of the diffusive smoothing, a new approach can be used to set-up the initial condition using geometric redistanciation. This is great when using the geometric redistanciation strategy since the interface remains defined coherently throughout the simulation. [#1602](https://github.com/chaos-polymtl/lethe/pull/1602)
+- MINOR Refactors the way the initial conditions smoothing for VOF can be applied. On top of the diffusive smoothing, a new approach can be used to set up the initial condition using geometric redistanciation. This is great when using the geometric redistanciation strategy since the interface remains defined coherently throughout the simulation. [#1602](https://github.com/chaos-polymtl/lethe/pull/1602)
 
 ### [Master] - 2025-08-01
 

--- a/applications_tests/lethe-fluid/cavity_ht_average_velocity_as_initial_condition.prm
+++ b/applications_tests/lethe-fluid/cavity_ht_average_velocity_as_initial_condition.prm
@@ -27,11 +27,8 @@ subsection initial conditions
 
   subsection VOF
     set Function expression = if (x<0.5, 1, 0)
-
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
 end
 

--- a/applications_tests/lethe-fluid/cavity_ht_average_velocity_as_initial_condition.prm
+++ b/applications_tests/lethe-fluid/cavity_ht_average_velocity_as_initial_condition.prm
@@ -27,8 +27,8 @@ subsection initial conditions
 
   subsection VOF
     set Function expression = if (x<0.5, 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
 end
 

--- a/applications_tests/lethe-fluid/evaporation_static_droplet_constant_mass_flux.prm
+++ b/applications_tests/lethe-fluid/evaporation_static_droplet_constant_mass_flux.prm
@@ -47,10 +47,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (x^2 + y^2 < 0.5^2 , 1, 0)
-    subsection projection step
-      set enable           = true
+    set smoothing type = diffusive
       set diffusion factor = 1
-    end
   end
 end
 

--- a/applications_tests/lethe-fluid/evaporation_static_droplet_constant_mass_flux.prm
+++ b/applications_tests/lethe-fluid/evaporation_static_droplet_constant_mass_flux.prm
@@ -47,8 +47,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (x^2 + y^2 < 0.5^2 , 1, 0)
-    set smoothing type = diffusive
-      set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
 end
 

--- a/applications_tests/lethe-fluid/gls_vof_dirichlet_boundary_condition.prm
+++ b/applications_tests/lethe-fluid/gls_vof_dirichlet_boundary_condition.prm
@@ -39,8 +39,8 @@ subsection initial conditions
 
   subsection VOF
     set Function expression = if (y>0.0, 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
 end
 

--- a/applications_tests/lethe-fluid/gls_vof_dirichlet_boundary_condition.prm
+++ b/applications_tests/lethe-fluid/gls_vof_dirichlet_boundary_condition.prm
@@ -39,11 +39,8 @@ subsection initial conditions
 
   subsection VOF
     set Function expression = if (y>0.0, 1, 0)
-
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
 end
 

--- a/applications_tests/lethe-fluid/gls_vof_periodic_boundary_condition.prm
+++ b/applications_tests/lethe-fluid/gls_vof_periodic_boundary_condition.prm
@@ -39,8 +39,8 @@ subsection initial conditions
 
   subsection VOF
     set Function expression = if (y<0.5 , 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
 end
 

--- a/applications_tests/lethe-fluid/gls_vof_periodic_boundary_condition.prm
+++ b/applications_tests/lethe-fluid/gls_vof_periodic_boundary_condition.prm
@@ -39,11 +39,8 @@ subsection initial conditions
 
   subsection VOF
     set Function expression = if (y<0.5 , 1, 0)
-
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
 end
 

--- a/applications_tests/lethe-fluid/heat_transfer_vof_lpbf_benchmark_box_ref.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_vof_lpbf_benchmark_box_ref.prm
@@ -158,8 +158,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (y<0.43 , 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
   subsection temperature
     set Function expression = 298

--- a/applications_tests/lethe-fluid/heat_transfer_vof_lpbf_benchmark_box_ref.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_vof_lpbf_benchmark_box_ref.prm
@@ -158,10 +158,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (y<0.43 , 1, 0)
-    subsection projection step
-      set enable           = false
-      set diffusion factor = 1
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
   subsection temperature
     set Function expression = 298

--- a/applications_tests/lethe-fluid/heat_transfer_vof_lpbf_benchmark_rotated_laser.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_vof_lpbf_benchmark_rotated_laser.prm
@@ -223,10 +223,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (y<0.43 , 1, 0)
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
   subsection temperature
     set Function expression = 298

--- a/applications_tests/lethe-fluid/heat_transfer_vof_lpbf_benchmark_rotated_laser.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_vof_lpbf_benchmark_rotated_laser.prm
@@ -223,8 +223,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (y<0.43 , 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
   subsection temperature
     set Function expression = 298

--- a/applications_tests/lethe-fluid/liquid_thermocapillary_droplet.prm
+++ b/applications_tests/lethe-fluid/liquid_thermocapillary_droplet.prm
@@ -53,8 +53,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (x*x + y*y < 1.0*1.0 , 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
   subsection temperature
     set Function expression = x+3

--- a/applications_tests/lethe-fluid/liquid_thermocapillary_droplet.prm
+++ b/applications_tests/lethe-fluid/liquid_thermocapillary_droplet.prm
@@ -53,10 +53,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (x*x + y*y < 1.0*1.0 , 1, 0)
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1.0
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
   subsection temperature
     set Function expression = x+3

--- a/applications_tests/lethe-fluid/solid_thermocapillary_droplet.prm
+++ b/applications_tests/lethe-fluid/solid_thermocapillary_droplet.prm
@@ -53,8 +53,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (x*x + y*y < 1.0*1.0 , 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
   subsection temperature
     set Function expression = x+3

--- a/applications_tests/lethe-fluid/solid_thermocapillary_droplet.prm
+++ b/applications_tests/lethe-fluid/solid_thermocapillary_droplet.prm
@@ -53,10 +53,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (x*x + y*y < 1.0*1.0 , 1, 0)
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1.0
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
   subsection temperature
     set Function expression = x+3

--- a/applications_tests/lethe-fluid/uniform_mesh_adapt_limit.prm
+++ b/applications_tests/lethe-fluid/uniform_mesh_adapt_limit.prm
@@ -88,9 +88,9 @@ end
 #---------------------------------------------------
 
 subsection mesh adaptation
-  set type                    = uniform
-  set frequency               = 2
-  set max refinement level    = 3
+  set type                 = uniform
+  set frequency            = 2
+  set max refinement level = 3
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle-bdf2-frequency-check.prm
+++ b/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle-bdf2-frequency-check.prm
@@ -55,10 +55,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if(((x*x+y*y)<=0.75^2), 1, 0)
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 2
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 2
   end
 end
 

--- a/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle-bdf2-frequency-check.prm
+++ b/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle-bdf2-frequency-check.prm
@@ -55,8 +55,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if(((x*x+y*y)<=0.75^2), 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 2
+    set smoothing type      = diffusive
+    set diffusion factor    = 2
   end
 end
 

--- a/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle.prm
+++ b/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle.prm
@@ -48,8 +48,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if(((x*x+y*y)<=0.75^2), 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 2
+    set smoothing type      = diffusive
+    set diffusion factor    = 2
   end
 end
 

--- a/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle.prm
+++ b/applications_tests/lethe-fluid/vof-algebraic-interface-reinitialization-advected-circle.prm
@@ -48,10 +48,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if(((x*x+y*y)<=0.75^2), 1, 0)
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 2
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 2
   end
 end
 

--- a/applications_tests/lethe-fluid/vof-geometric-interface-reinitialization-swirling-flow.prm
+++ b/applications_tests/lethe-fluid/vof-geometric-interface-reinitialization-swirling-flow.prm
@@ -72,10 +72,7 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = 0.5 - 0.5*tanh((sqrt((0.5-x)*(0.5-x) +(0.75-y)*(0.75-y))-0.15)/0.04)
-    subsection projection step
-      set enable           = false
-      set diffusion factor = 1
-    end
+    set smoothing type = none
   end
 end
 

--- a/applications_tests/lethe-fluid/vof-geometric-interface-reinitialization-swirling-flow.prm
+++ b/applications_tests/lethe-fluid/vof-geometric-interface-reinitialization-swirling-flow.prm
@@ -72,7 +72,7 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = 0.5 - 0.5*tanh((sqrt((0.5-x)*(0.5-x) +(0.75-y)*(0.75-y))-0.15)/0.04)
-    set smoothing type = none
+    set smoothing type      = none
   end
 end
 

--- a/doc/source/parameters/cfd/initial_conditions.rst
+++ b/doc/source/parameters/cfd/initial_conditions.rst
@@ -64,7 +64,7 @@ It is often necessary to set-up complex initial conditions when simulating trans
 
   * The ``smoothing type`` allows to smooth the VOF initial condition and avoid a staircase definition of the free surface.
 
-    * When the parameter ``smoothing type = diffusive``, the initial condition is projected following :
+    * When the parameter ``smoothing type = diffusive``, the initial condition is projected following:
 
     .. math::
       \psi(\Omega_K) = \int_{\Omega_K} \phi d\Omega

--- a/doc/source/parameters/cfd/initial_conditions.rst
+++ b/doc/source/parameters/cfd/initial_conditions.rst
@@ -19,11 +19,8 @@ It is often necessary to set-up complex initial conditions when simulating trans
 
     subsection VOF
       set Function expression = if (x<0.5 & y<1, 1, 0)
-
-      subsection projection step
-        set enable           = false
-        set diffusion factor = 1
-      end
+      set smoothing type = none # <none|diffusive|geometric>
+      set diffusion factor = 1
     end
 
     subsection temperature
@@ -65,9 +62,9 @@ It is often necessary to set-up complex initial conditions when simulating trans
   .. note::
     The ``Function expression`` can be used to establish an even more complex free surface initial geometry. For example, one can create a circle of fluid : ``if ( (x^2+y^2)<=(r)^2 ,1,0)``
 
-  * The ``subsection projection step`` allows to smooth the VOF initial condition using a projection step and avoid a staircase definition of the free surface.
+  * The ``smoothing type`` allows to smooth the VOF initial condition and avoid a staircase definition of the free surface.
 
-    * When the parameter ``enable`` is set to ``true``, the initial condition is projected following :
+    * When the parameter ``smoothing type = diffusive``, the initial condition is projected following :
 
     .. math::
       \psi(\Omega_K) = \int_{\Omega_K} \phi d\Omega
@@ -76,6 +73,8 @@ It is often necessary to set-up complex initial conditions when simulating trans
       \int_\Omega \left( \psi^* v + \eta_\psi \nabla \psi^* \cdot \nabla v  \right) d\Omega = \int_\Omega \psi v  d\Omega
 
     where :math:`\psi(\Omega_K)` corresponds to a color function value on the Kth element, :math:`\phi` is the phase fraction, :math:`\psi^*` is the smoothed phase fraction, :math:`\eta_\psi = \alpha h^2` with :math:`\alpha` corresponding to the ``diffusion factor`` and :math:`h` to the cell size, and :math:`v` is a test function.
+    
+    * When the parameter ``smoothing type = geometric``, the initial condition is smoothed using a geometric redistanciation method. 
 
 * The ``subsection cahn hilliard`` defines the areas where both fluids lay at the initial state (see section :doc:`multiphysics`). It works similarly to the ``subsection VOF`` for the first component, which corresponds to the phase order parameter. The user also has the choice to specify initial conditions for the chemical potential, although it is often more suitable to leave it at :math:`0`.
 * The ``subsection temperature`` allows the user to define an initial temperature for the fluid domain (if ``set heat tranfer = true`` in :doc:`multiphysics`).

--- a/examples/multiphysics/3d-dam-break/3d-dam-break.prm
+++ b/examples/multiphysics/3d-dam-break/3d-dam-break.prm
@@ -79,11 +79,7 @@ subsection initial conditions
 
   subsection VOF
     set Function expression = if (x>1.992 & z<0.55 & y>=-0.5, 1, 0)
-
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1
-    end
+    set smoothing type      = diffusive
   end
 end
 

--- a/examples/multiphysics/capillary-wave/capillary-wave-TSM-0_95.prm
+++ b/examples/multiphysics/capillary-wave/capillary-wave-TSM-0_95.prm
@@ -55,8 +55,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (y<=1e-6*cos(2*3.14159/1e-4*x), min(0.5-(y-1e-6*cos(2*3.14159/1e-4*x))/1e-6,1), max(0.5-(y-1e-6*cos(2*3.14159/1e-4*x))/1e-6,0))
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
 end
 

--- a/examples/multiphysics/capillary-wave/capillary-wave-TSM-0_95.prm
+++ b/examples/multiphysics/capillary-wave/capillary-wave-TSM-0_95.prm
@@ -55,10 +55,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (y<=1e-6*cos(2*3.14159/1e-4*x), min(0.5-(y-1e-6*cos(2*3.14159/1e-4*x))/1e-6,1), max(0.5-(y-1e-6*cos(2*3.14159/1e-4*x))/1e-6,0))
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
 end
 

--- a/examples/multiphysics/capillary-wave/capillary-wave.tpl
+++ b/examples/multiphysics/capillary-wave/capillary-wave.tpl
@@ -55,8 +55,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (y<=1e-6*cos(2*3.14159/1e-4*x), min(0.5-(y-1e-6*cos(2*3.14159/1e-4*x))/1e-6,1), max(0.5-(y-1e-6*cos(2*3.14159/1e-4*x))/1e-6,0))
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
 end
 

--- a/examples/multiphysics/capillary-wave/capillary-wave.tpl
+++ b/examples/multiphysics/capillary-wave/capillary-wave.tpl
@@ -55,10 +55,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (y<=1e-6*cos(2*3.14159/1e-4*x), min(0.5-(y-1e-6*cos(2*3.14159/1e-4*x))/1e-6,1), max(0.5-(y-1e-6*cos(2*3.14159/1e-4*x))/1e-6,0))
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
 end
 

--- a/examples/multiphysics/rayleigh-plateau-instability/3D-delta0_30/rayleigh-plateau-J1-3D.prm
+++ b/examples/multiphysics/rayleigh-plateau-instability/3D-delta0_30/rayleigh-plateau-J1-3D.prm
@@ -65,8 +65,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if((y^2 + z^2) <= 1.3110e-6, 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
 end
 
@@ -148,7 +148,7 @@ end
 #---------------------------------------------------
 
 subsection boundary conditions VOF
-  set number = 3
+  set number         = 3
   set time dependent = true
   subsection bc 0
     set id   = 1

--- a/examples/multiphysics/rayleigh-plateau-instability/3D-delta0_30/rayleigh-plateau-J1-3D.prm
+++ b/examples/multiphysics/rayleigh-plateau-instability/3D-delta0_30/rayleigh-plateau-J1-3D.prm
@@ -65,9 +65,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if((y^2 + z^2) <= 1.3110e-6, 1, 0)
-    subsection projection step
-      set enable = true
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
 end
 
@@ -150,6 +149,7 @@ end
 
 subsection boundary conditions VOF
   set number = 3
+  set time dependent = true
   subsection bc 0
     set id   = 1
     set type = dirichlet

--- a/examples/multiphysics/rayleigh-plateau-instability/rayleigh-plateau-J1-We020-Oh0_10.tpl
+++ b/examples/multiphysics/rayleigh-plateau-instability/rayleigh-plateau-J1-We020-Oh0_10.tpl
@@ -64,9 +64,7 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if(y^2 <= 1.3110e-6, 1, 0)
-    subsection projection step
-      set enable = true
-    end
+    set smoothing type      = diffusive
   end
 end
 

--- a/examples/multiphysics/rayleigh-plateau-instability/rayleigh-plateau-J1-We020-Oh0_10_delta0_20/rayleigh-plateau-J1-We020-Oh0_10_delta0_20.prm
+++ b/examples/multiphysics/rayleigh-plateau-instability/rayleigh-plateau-J1-We020-Oh0_10_delta0_20/rayleigh-plateau-J1-We020-Oh0_10_delta0_20.prm
@@ -64,7 +64,7 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if(y^2 <= 1.3110e-6, 1, 0)
-    set smoothing type = diffusive
+    set smoothing type      = diffusive
   end
 end
 

--- a/examples/multiphysics/rayleigh-plateau-instability/rayleigh-plateau-J1-We020-Oh0_10_delta0_20/rayleigh-plateau-J1-We020-Oh0_10_delta0_20.prm
+++ b/examples/multiphysics/rayleigh-plateau-instability/rayleigh-plateau-J1-We020-Oh0_10_delta0_20/rayleigh-plateau-J1-We020-Oh0_10_delta0_20.prm
@@ -64,9 +64,7 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if(y^2 <= 1.3110e-6, 1, 0)
-    subsection projection step
-      set enable = true
-    end
+    set smoothing type = diffusive
   end
 end
 

--- a/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability-adaptive-sharpening.prm
+++ b/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability-adaptive-sharpening.prm
@@ -42,10 +42,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (y>(0.5 + 0.1 * 0.25 * cos(2 *3.1415 * x / 0.25)) , 1, 0)
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
 end
 

--- a/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability-adaptive-sharpening.prm
+++ b/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability-adaptive-sharpening.prm
@@ -42,8 +42,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (y>(0.5 + 0.1 * 0.25 * cos(2 *3.1415 * x / 0.25)) , 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
 end
 

--- a/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability-constant-sharpening.prm
+++ b/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability-constant-sharpening.prm
@@ -42,10 +42,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (y>(0.5 + 0.1 * 0.25 * cos(2 *3.1415 * x / 0.25)) , 1, 0)
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
 end
 

--- a/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability-constant-sharpening.prm
+++ b/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability-constant-sharpening.prm
@@ -42,8 +42,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (y>(0.5 + 0.1 * 0.25 * cos(2 *3.1415 * x / 0.25)) , 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
 end
 

--- a/examples/multiphysics/rising-bubble/rising-bubble-alge.prm
+++ b/examples/multiphysics/rising-bubble/rising-bubble-alge.prm
@@ -71,10 +71,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if ((x-0.5) * (x-0.5) + (y-0.5) * (y-0.5) < 0.25 * 0.25 , 1, 0)
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
 end
 

--- a/examples/multiphysics/rising-bubble/rising-bubble-alge.prm
+++ b/examples/multiphysics/rising-bubble/rising-bubble-alge.prm
@@ -71,8 +71,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if ((x-0.5) * (x-0.5) + (y-0.5) * (y-0.5) < 0.25 * 0.25 , 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
 end
 

--- a/examples/multiphysics/rising-bubble/rising-bubble-geo.prm
+++ b/examples/multiphysics/rising-bubble/rising-bubble-geo.prm
@@ -72,10 +72,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if ((x-0.5) * (x-0.5) + (y-0.5) * (y-0.5) < 0.25 * 0.25 , 1, 0)
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
 end
 

--- a/examples/multiphysics/rising-bubble/rising-bubble-geo.prm
+++ b/examples/multiphysics/rising-bubble/rising-bubble-geo.prm
@@ -72,8 +72,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if ((x-0.5) * (x-0.5) + (y-0.5) * (y-0.5) < 0.25 * 0.25 , 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
 end
 

--- a/examples/multiphysics/rising-bubble/rising-bubble-proj.prm
+++ b/examples/multiphysics/rising-bubble/rising-bubble-proj.prm
@@ -72,10 +72,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if ((x-0.5) * (x-0.5) + (y-0.5) * (y-0.5) < 0.25 * 0.25 , 1, 0)
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
 end
 

--- a/examples/multiphysics/rising-bubble/rising-bubble-proj.prm
+++ b/examples/multiphysics/rising-bubble/rising-bubble-proj.prm
@@ -72,8 +72,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if ((x-0.5) * (x-0.5) + (y-0.5) * (y-0.5) < 0.25 * 0.25 , 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
 end
 

--- a/examples/multiphysics/static-bubble/static-bubble.prm
+++ b/examples/multiphysics/static-bubble/static-bubble.prm
@@ -50,8 +50,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (x^2 + y^2 < 0.5^2 , 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
 end
 

--- a/examples/multiphysics/static-bubble/static-bubble.prm
+++ b/examples/multiphysics/static-bubble/static-bubble.prm
@@ -50,10 +50,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (x^2 + y^2 < 0.5^2 , 1, 0)
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
 end
 

--- a/examples/multiphysics/static-irradiation/2D/static-irradiation.prm
+++ b/examples/multiphysics/static-irradiation/2D/static-irradiation.prm
@@ -178,7 +178,7 @@ subsection initial conditions
   subsection VOF
     set Function expression = if (y<0.43 , 1, 0)
     set smoothing type      = diffusive
-    set diffusion factor = 1
+    set diffusion factor    = 1
   end
   subsection temperature
     set Function expression = 298

--- a/examples/multiphysics/static-irradiation/2D/static-irradiation.prm
+++ b/examples/multiphysics/static-irradiation/2D/static-irradiation.prm
@@ -177,10 +177,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (y<0.43 , 1, 0)
-    subsection projection step
-      set enable           = false
-      set diffusion factor = 1
-    end
+    set smoothing type      = diffusive
+    set diffusion factor = 1
   end
   subsection temperature
     set Function expression = 298

--- a/examples/multiphysics/thermocapillary-droplet/thermocapillary-droplet.prm
+++ b/examples/multiphysics/thermocapillary-droplet/thermocapillary-droplet.prm
@@ -61,8 +61,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (x*x + y*y + z*z < 0.25 * 0.25 , 1, 0)
-    set smoothing type = diffusive
-    set diffusion factor = 1
+    set smoothing type      = diffusive
+    set diffusion factor    = 1
   end
   subsection temperature
     set Function expression = x+3

--- a/examples/multiphysics/thermocapillary-droplet/thermocapillary-droplet.prm
+++ b/examples/multiphysics/thermocapillary-droplet/thermocapillary-droplet.prm
@@ -61,10 +61,8 @@ subsection initial conditions
   end
   subsection VOF
     set Function expression = if (x*x + y*y + z*z < 0.25 * 0.25 , 1, 0)
-    subsection projection step
-      set enable           = true
-      set diffusion factor = 1
-    end
+    set smoothing type = diffusive
+    set diffusion factor = 1
   end
   subsection temperature
     set Function expression = x+3

--- a/include/solvers/fluid_dynamics_block.h
+++ b/include/solvers/fluid_dynamics_block.h
@@ -172,8 +172,8 @@ private:
 
   virtual void
   set_initial_condition_fd(
-    Parameters::InitialConditionType initial_condition_type,
-    bool                             restart = false) override;
+    Parameters::FluidDynamicsInitialConditionType initial_condition_type,
+    bool                                          restart = false) override;
 
   void
   set_solution_vector(double value);

--- a/include/solvers/fluid_dynamics_matrix_based.h
+++ b/include/solvers/fluid_dynamics_matrix_based.h
@@ -68,8 +68,8 @@ protected:
    **/
   virtual void
   set_initial_condition_fd(
-    Parameters::InitialConditionType initial_condition_type,
-    bool                             restart = false) override;
+    Parameters::FluidDynamicsInitialConditionType initial_condition_type,
+    bool                                          restart = false) override;
 
 protected:
   /**

--- a/include/solvers/fluid_dynamics_matrix_free.h
+++ b/include/solvers/fluid_dynamics_matrix_free.h
@@ -440,8 +440,8 @@ protected:
    **/
   virtual void
   set_initial_condition_fd(
-    Parameters::InitialConditionType initial_condition_type,
-    bool                             restart = false) override;
+    Parameters::FluidDynamicsInitialConditionType initial_condition_type,
+    bool                                          restart = false) override;
 
   /**
    * @brief Assemble the matrix associated with the solver. Only required for

--- a/include/solvers/initial_conditions.h
+++ b/include/solvers/initial_conditions.h
@@ -14,8 +14,8 @@ using namespace dealii;
 
 namespace Parameters
 {
-  // Type of initial conditions
-  enum class InitialConditionType
+  // Type of initial conditions for fluid dynamics
+  enum class FluidDynamicsInitialConditionType
   {
     none,
     L2projection,
@@ -23,6 +23,14 @@ namespace Parameters
     nodal,
     ramp,
     average_velocity_profile
+  };
+
+  // Type of initial conditions for VOF
+  enum class VOFInitialConditionType
+  {
+    none,      // Uses the function as is
+    diffusive, // Uses a L2 projection with a smoothing coefficient
+    geometric  // Uses geometric redistanciation
   };
 
   struct Ramp_n
@@ -68,7 +76,7 @@ namespace Parameters
       : uvwp(dim + 1)
     {}
 
-    InitialConditionType type;
+    FluidDynamicsInitialConditionType type;
 
     // Velocity components
     Functions::ParsedFunction<dim> uvwp;
@@ -84,10 +92,10 @@ namespace Parameters
 
     // VOF
     Functions::ParsedFunction<dim> VOF;
-    // Bool to apply a Galerkin projection (with a diffusion term) to the VOF
-    // initial condition
-    bool   enable_projection_step;
-    double projection_step_diffusion_factor;
+
+
+    VOFInitialConditionType vof_initial_condition_smoothing;
+    double                  projection_step_diffusion_factor;
 
     // Non-Newtonian
     Ramp ramp;
@@ -105,132 +113,6 @@ namespace Parameters
     void
     parse_parameters(ParameterHandler &prm);
   };
-
-  template <int dim>
-  void
-  InitialConditions<dim>::declare_parameters(ParameterHandler &prm)
-  {
-    prm.enter_subsection("initial conditions");
-    {
-      prm.declare_entry(
-        "type",
-        "nodal",
-        Patterns::Selection(
-          "L2projection|viscous|nodal|ramp|average_velocity_profile"),
-        "Type of initial condition"
-        "Choices are <L2projection|viscous|nodal|ramp|average_velocity_profile>.");
-      prm.enter_subsection("uvwp");
-      uvwp.declare_parameters(prm, dim + 1);
-      prm.leave_subsection();
-
-      prm.declare_entry("kinematic viscosity",
-                        "1",
-                        Patterns::Double(),
-                        "Kinematic viscosity for viscous initial conditions");
-
-
-      prm.enter_subsection("temperature");
-      temperature.declare_parameters(prm);
-      prm.leave_subsection();
-
-      prm.enter_subsection("tracer");
-      tracer.declare_parameters(prm);
-      prm.leave_subsection();
-
-      prm.enter_subsection("VOF");
-      VOF.declare_parameters(prm);
-      prm.enter_subsection("projection step");
-      prm.declare_entry(
-        "enable",
-        "false",
-        Patterns::Bool(),
-        "Apply a projection step with diffusion to smooth the VOF initial condition");
-      prm.declare_entry(
-        "diffusion factor",
-        "1",
-        Patterns::Double(),
-        "Factor applied to the diffusion term in the projection step");
-      prm.leave_subsection();
-      prm.leave_subsection();
-
-      prm.enter_subsection("cahn hilliard");
-      cahn_hilliard.declare_parameters(prm, 2);
-      prm.leave_subsection();
-
-      prm.enter_subsection("average velocity profile");
-      prm.declare_entry(
-        "checkpoint folder",
-        "./",
-        Patterns::FileName(),
-        "the path leading to the checkpointed average velocity profile");
-      prm.declare_entry("checkpoint file name",
-                        "restart",
-                        Patterns::FileName(),
-                        "checkpoint file name");
-      prm.leave_subsection();
-
-      ramp.declare_parameters(prm);
-    }
-    prm.leave_subsection();
-  }
-
-  template <int dim>
-  void
-  InitialConditions<dim>::parse_parameters(ParameterHandler &prm)
-  {
-    prm.enter_subsection("initial conditions");
-    {
-      const std::string op = prm.get("type");
-      if (op == "L2projection")
-        type = InitialConditionType::L2projection;
-      else if (op == "viscous")
-        type = InitialConditionType::viscous;
-      else if (op == "nodal")
-        type = InitialConditionType::nodal;
-      else if (op == "ramp")
-        type = InitialConditionType::ramp;
-      else if (op == "average_velocity_profile")
-        type = InitialConditionType::average_velocity_profile;
-
-      kinematic_viscosity = prm.get_double("kinematic viscosity");
-      prm.enter_subsection("uvwp");
-      uvwp.parse_parameters(prm);
-      prm.leave_subsection();
-
-      prm.enter_subsection("temperature");
-      temperature.parse_parameters(prm);
-      prm.leave_subsection();
-
-      prm.enter_subsection("tracer");
-      tracer.parse_parameters(prm);
-      prm.leave_subsection();
-
-      prm.enter_subsection("VOF");
-      {
-        VOF.parse_parameters(prm);
-        prm.enter_subsection("projection step");
-        {
-          enable_projection_step           = prm.get_bool("enable");
-          projection_step_diffusion_factor = prm.get_double("diffusion factor");
-        }
-        prm.leave_subsection();
-      }
-      prm.leave_subsection();
-
-      ramp.parse_parameters(prm);
-
-      prm.enter_subsection("cahn hilliard");
-      cahn_hilliard.parse_parameters(prm);
-      prm.leave_subsection();
-
-      prm.enter_subsection("average velocity profile");
-      average_velocity_folder    = prm.get("checkpoint folder");
-      average_velocity_file_name = prm.get("checkpoint file name");
-
-      prm.leave_subsection();
-    }
-    prm.leave_subsection();
-  }
 } // namespace Parameters
 
 #endif

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -230,8 +230,9 @@ protected:
    **/
 
   virtual void
-  set_initial_condition(Parameters::InitialConditionType initial_condition_type,
-                        bool                             restart = false)
+  set_initial_condition(
+    Parameters::FluidDynamicsInitialConditionType initial_condition_type,
+    bool                                          restart = false)
   {
     unsigned int ref_iter = 0;
     do
@@ -325,8 +326,8 @@ protected:
 
   virtual void
   set_initial_condition_fd(
-    Parameters::InitialConditionType initial_condition_type,
-    bool                             restart = false) = 0;
+    Parameters::FluidDynamicsInitialConditionType initial_condition_type,
+    bool                                          restart = false) = 0;
 
   /**
    * End of key physics components for fluid dynamics

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -500,7 +500,8 @@ private:
         // Check if the post processed variable needs to be calculated with the
         // average velocity profile or the fluid solution.
         if (this->simulation_parameters.initial_condition->type ==
-              Parameters::InitialConditionType::average_velocity_profile &&
+              Parameters::FluidDynamicsInitialConditionType::
+                average_velocity_profile &&
             !this->simulation_parameters.multiphysics.fluid_dynamics &&
             simulation_control->get_current_time() >
               this->simulation_parameters.post_processing
@@ -529,7 +530,8 @@ private:
         // Check if the post processed variable needs to be calculated with the
         // average velocity profile or the fluid solution.
         if (this->simulation_parameters.initial_condition->type ==
-              Parameters::InitialConditionType::average_velocity_profile &&
+              Parameters::FluidDynamicsInitialConditionType::
+                average_velocity_profile &&
             !this->simulation_parameters.multiphysics.fluid_dynamics &&
             simulation_control->get_current_time() >
               this->simulation_parameters.post_processing

--- a/source/core/interface_tools.cc
+++ b/source/core/interface_tools.cc
@@ -328,7 +328,7 @@ InterfaceTools::SignedDistanceSolver<dim, VectorType>::solve()
   interface_reconstruction_cells.clear();
   intersected_dofs.clear();
 
-  // Initialize local distance vetors.
+  // Initialize local distance vectors.
   initialize_distance();
 
   // Identify intersected cells and compute the interface reconstruction.

--- a/source/solvers/cahn_hilliard.cc
+++ b/source/solvers/cahn_hilliard.cc
@@ -729,7 +729,8 @@ CahnHilliard<dim>::postprocess(bool first_iteration)
           // Check if the post processed variable needs to be calculated with
           // the average velocity profile or the fluid solution.
           if (this->simulation_parameters.initial_condition->type ==
-                Parameters::InitialConditionType::average_velocity_profile &&
+                Parameters::FluidDynamicsInitialConditionType::
+                  average_velocity_profile &&
               !this->simulation_parameters.multiphysics.fluid_dynamics &&
               simulation_control->get_current_time() >
                 this->simulation_parameters.post_processing
@@ -753,7 +754,8 @@ CahnHilliard<dim>::postprocess(bool first_iteration)
           // Check if the post processed variable needs to be calculated with
           // the average velocity profile or the fluid solution.
           if (this->simulation_parameters.initial_condition->type ==
-                Parameters::InitialConditionType::average_velocity_profile &&
+                Parameters::FluidDynamicsInitialConditionType::
+                  average_velocity_profile &&
               !this->simulation_parameters.multiphysics.fluid_dynamics &&
               simulation_control->get_current_time() >
                 this->simulation_parameters.post_processing

--- a/source/solvers/fluid_dynamics_block.cc
+++ b/source/solvers/fluid_dynamics_block.cc
@@ -700,8 +700,8 @@ FluidDynamicsBlock<dim>::set_solution_vector(double value)
 template <int dim>
 void
 FluidDynamicsBlock<dim>::set_initial_condition_fd(
-  Parameters::InitialConditionType initial_condition_type,
-  bool                             restart)
+  Parameters::FluidDynamicsInitialConditionType initial_condition_type,
+  bool                                          restart)
 {
   if (restart)
     {
@@ -711,20 +711,22 @@ FluidDynamicsBlock<dim>::set_initial_condition_fd(
       this->read_checkpoint();
     }
   else if (initial_condition_type ==
-           Parameters::InitialConditionType::L2projection)
+           Parameters::FluidDynamicsInitialConditionType::L2projection)
     {
       assemble_L2_projection();
       solve_L2_system(true, 1e-15, 1e-15);
       this->present_solution = this->newton_update;
       this->finish_time_step();
     }
-  else if (initial_condition_type == Parameters::InitialConditionType::nodal)
+  else if (initial_condition_type ==
+           Parameters::FluidDynamicsInitialConditionType::nodal)
     {
       this->set_nodal_values();
       this->finish_time_step();
     }
 
-  else if (initial_condition_type == Parameters::InitialConditionType::viscous)
+  else if (initial_condition_type ==
+           Parameters::FluidDynamicsInitialConditionType::viscous)
     {
       this->set_nodal_values();
       std::shared_ptr<RheologicalModel> original_viscosity_model =

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -134,7 +134,7 @@ FluidDynamicsMatrixBased<dim>::setup_dofs_fd()
   if (this->simulation_parameters.post_processing
         .calculate_average_velocities ||
       this->simulation_parameters.initial_condition->type ==
-        Parameters::InitialConditionType::average_velocity_profile)
+        Parameters::FluidDynamicsInitialConditionType::average_velocity_profile)
     {
       this->average_velocities->initialize_vectors(
         this->locally_owned_dofs,
@@ -171,7 +171,7 @@ FluidDynamicsMatrixBased<dim>::update_multiphysics_time_average_solution()
   if (this->simulation_parameters.post_processing
         .calculate_average_velocities ||
       this->simulation_parameters.initial_condition->type ==
-        Parameters::InitialConditionType::average_velocity_profile)
+        Parameters::FluidDynamicsInitialConditionType::average_velocity_profile)
     {
       this->multiphysics->set_time_average_solution(
         PhysicsID::fluid_dynamics,
@@ -956,8 +956,8 @@ FluidDynamicsMatrixBased<dim>::copy_local_rhs_to_global_rhs(
 template <int dim>
 void
 FluidDynamicsMatrixBased<dim>::set_initial_condition_fd(
-  Parameters::InitialConditionType initial_condition_type,
-  bool                             restart)
+  Parameters::FluidDynamicsInitialConditionType initial_condition_type,
+  bool                                          restart)
 {
   if (restart)
     {
@@ -967,7 +967,7 @@ FluidDynamicsMatrixBased<dim>::set_initial_condition_fd(
       this->read_checkpoint();
     }
   else if (initial_condition_type ==
-           Parameters::InitialConditionType::L2projection)
+           Parameters::FluidDynamicsInitialConditionType::L2projection)
     {
       assemble_L2_projection();
       setup_preconditioner();
@@ -980,12 +980,14 @@ FluidDynamicsMatrixBased<dim>::set_initial_condition_fd(
       this->present_solution = this->newton_update;
       this->finish_time_step();
     }
-  else if (initial_condition_type == Parameters::InitialConditionType::nodal)
+  else if (initial_condition_type ==
+           Parameters::FluidDynamicsInitialConditionType::nodal)
     {
       this->set_nodal_values();
       this->finish_time_step();
     }
-  else if (initial_condition_type == Parameters::InitialConditionType::viscous)
+  else if (initial_condition_type ==
+           Parameters::FluidDynamicsInitialConditionType::viscous)
     {
       this->set_nodal_values();
       std::shared_ptr<RheologicalModel> original_viscosity_model =
@@ -1008,7 +1010,8 @@ FluidDynamicsMatrixBased<dim>::set_initial_condition_fd(
       this->simulation_parameters.physical_properties_manager.set_rheology(
         original_viscosity_model);
     }
-  else if (initial_condition_type == Parameters::InitialConditionType::ramp)
+  else if (initial_condition_type ==
+           Parameters::FluidDynamicsInitialConditionType::ramp)
     {
       this->pcout << "*********************************" << std::endl;
       this->pcout << " Initial condition using ramp " << std::endl;
@@ -1106,7 +1109,8 @@ FluidDynamicsMatrixBased<dim>::set_initial_condition_fd(
         }
     }
   else if (initial_condition_type ==
-           Parameters::InitialConditionType::average_velocity_profile)
+           Parameters::FluidDynamicsInitialConditionType::
+             average_velocity_profile)
     {
       announce_string(this->pcout,
                       "Initial condition using average velocity profile");

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -2359,8 +2359,8 @@ FluidDynamicsMatrixFree<dim>::setup_dofs_fd()
 template <int dim>
 void
 FluidDynamicsMatrixFree<dim>::set_initial_condition_fd(
-  Parameters::InitialConditionType initial_condition_type,
-  bool                             restart)
+  Parameters::FluidDynamicsInitialConditionType initial_condition_type,
+  bool                                          restart)
 {
   if (restart)
     {
@@ -2369,13 +2369,15 @@ FluidDynamicsMatrixFree<dim>::set_initial_condition_fd(
       this->pcout << "************************" << std::endl;
       this->read_checkpoint();
     }
-  else if (initial_condition_type == Parameters::InitialConditionType::nodal)
+  else if (initial_condition_type ==
+           Parameters::FluidDynamicsInitialConditionType::nodal)
     {
       this->set_nodal_values();
       this->present_solution.update_ghost_values();
       this->finish_time_step();
     }
-  else if (initial_condition_type == Parameters::InitialConditionType::viscous)
+  else if (initial_condition_type ==
+           Parameters::FluidDynamicsInitialConditionType::viscous)
     {
       // Set the nodal values to have an initial condition that is adequate
       this->set_nodal_values();
@@ -2403,7 +2405,8 @@ FluidDynamicsMatrixFree<dim>::set_initial_condition_fd(
       // Reset original rheology for the system operator
       this->physical_properties_manager->set_rheology(original_viscosity_model);
     }
-  else if (initial_condition_type == Parameters::InitialConditionType::ramp)
+  else if (initial_condition_type ==
+           Parameters::FluidDynamicsInitialConditionType::ramp)
     {
       this->pcout << "*********************************" << std::endl;
       this->pcout << " Initial condition using ramp " << std::endl;

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -479,7 +479,8 @@ HeatTransfer<dim>::assemble_local_system_matrix(
       // Check if the post processed variable needs to be calculated with the
       // average velocity profile or the fluid solution.
       if (this->simulation_parameters.initial_condition->type ==
-            Parameters::InitialConditionType::average_velocity_profile &&
+            Parameters::FluidDynamicsInitialConditionType::
+              average_velocity_profile &&
           !this->simulation_parameters.multiphysics.fluid_dynamics &&
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing
@@ -505,7 +506,8 @@ HeatTransfer<dim>::assemble_local_system_matrix(
       // Check if the post processed variable needs to be calculated with the
       // average velocity profile or the fluid solution.
       if (this->simulation_parameters.initial_condition->type ==
-            Parameters::InitialConditionType::average_velocity_profile &&
+            Parameters::FluidDynamicsInitialConditionType::
+              average_velocity_profile &&
           !this->simulation_parameters.multiphysics.fluid_dynamics &&
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing
@@ -648,7 +650,8 @@ HeatTransfer<dim>::assemble_local_system_rhs(
       // Check if the post processed variable needs to be calculated with the
       // average velocity profile or the fluid solution.
       if (this->simulation_parameters.initial_condition->type ==
-            Parameters::InitialConditionType::average_velocity_profile &&
+            Parameters::FluidDynamicsInitialConditionType::
+              average_velocity_profile &&
           !this->simulation_parameters.multiphysics.fluid_dynamics &&
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing
@@ -675,7 +678,8 @@ HeatTransfer<dim>::assemble_local_system_rhs(
       // Check if the post processed variable needs to be calculated with the
       // average velocity profile or the fluid solution.
       if (this->simulation_parameters.initial_condition->type ==
-            Parameters::InitialConditionType::average_velocity_profile &&
+            Parameters::FluidDynamicsInitialConditionType::
+              average_velocity_profile &&
           !this->simulation_parameters.multiphysics.fluid_dynamics &&
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing

--- a/source/solvers/initial_conditions.cc
+++ b/source/solvers/initial_conditions.cc
@@ -101,7 +101,144 @@ namespace Parameters
     prm.leave_subsection();
   }
 
+  template <int dim>
+  void
+  InitialConditions<dim>::declare_parameters(ParameterHandler &prm)
+  {
+    prm.enter_subsection("initial conditions");
+    {
+      prm.declare_entry(
+        "type",
+        "nodal",
+        Patterns::Selection(
+          "L2projection|viscous|nodal|ramp|average_velocity_profile"),
+        "Type of initial condition"
+        "Choices are <L2projection|viscous|nodal|ramp|average_velocity_profile>.");
+      prm.enter_subsection("uvwp");
+      uvwp.declare_parameters(prm, dim + 1);
+      prm.leave_subsection();
 
-  extern template class InitialConditions<2>;
-  extern template class InitialConditions<3>;
+      prm.declare_entry("kinematic viscosity",
+                        "1",
+                        Patterns::Double(),
+                        "Kinematic viscosity for viscous initial conditions");
+
+
+      prm.enter_subsection("temperature");
+      temperature.declare_parameters(prm);
+      prm.leave_subsection();
+
+      prm.enter_subsection("tracer");
+      tracer.declare_parameters(prm);
+      prm.leave_subsection();
+
+      prm.enter_subsection("VOF");
+      VOF.declare_parameters(prm);
+      prm.declare_entry(
+        "smoothing type",
+        "none",
+        Patterns::Selection("none|diffusive|geometric"),
+        "Apply a projection step with diffusion to smooth the VOF initial condition");
+
+      prm.enter_subsection("projection step");
+      prm.declare_entry(
+        "diffusion factor",
+        "1",
+        Patterns::Double(),
+        "Factor applied to the diffusion term in the projection step");
+      prm.leave_subsection();
+      prm.leave_subsection();
+
+      prm.enter_subsection("cahn hilliard");
+      cahn_hilliard.declare_parameters(prm, 2);
+      prm.leave_subsection();
+
+      prm.enter_subsection("average velocity profile");
+      prm.declare_entry(
+        "checkpoint folder",
+        "./",
+        Patterns::FileName(),
+        "the path leading to the checkpointed average velocity profile");
+      prm.declare_entry("checkpoint file name",
+                        "restart",
+                        Patterns::FileName(),
+                        "checkpoint file name");
+      prm.leave_subsection();
+
+      ramp.declare_parameters(prm);
+    }
+    prm.leave_subsection();
+  }
+
+  template <int dim>
+  void
+  InitialConditions<dim>::parse_parameters(ParameterHandler &prm)
+  {
+    prm.enter_subsection("initial conditions");
+    {
+      const std::string op = prm.get("type");
+      if (op == "L2projection")
+        type = FluidDynamicsInitialConditionType::L2projection;
+      else if (op == "viscous")
+        type = FluidDynamicsInitialConditionType::viscous;
+      else if (op == "nodal")
+        type = FluidDynamicsInitialConditionType::nodal;
+      else if (op == "ramp")
+        type = FluidDynamicsInitialConditionType::ramp;
+      else if (op == "average_velocity_profile")
+        type = FluidDynamicsInitialConditionType::average_velocity_profile;
+
+      kinematic_viscosity = prm.get_double("kinematic viscosity");
+      prm.enter_subsection("uvwp");
+      uvwp.parse_parameters(prm);
+      prm.leave_subsection();
+
+      prm.enter_subsection("temperature");
+      temperature.parse_parameters(prm);
+      prm.leave_subsection();
+
+      prm.enter_subsection("tracer");
+      tracer.parse_parameters(prm);
+      prm.leave_subsection();
+
+      prm.enter_subsection("VOF");
+      {
+        VOF.parse_parameters(prm);
+        const std::string op = prm.get("smoothing type");
+        if (op == "none")
+          vof_initial_condition_smoothing = VOFInitialConditionType::none;
+        else if (op == "diffusive")
+          vof_initial_condition_smoothing = VOFInitialConditionType::diffusive;
+        else if (op == "geometric")
+          vof_initial_condition_smoothing = VOFInitialConditionType::geometric;
+        else
+          throw(
+            std::runtime_error("Unknown VOF initial condition smoothing type"));
+
+        prm.enter_subsection("projection step");
+        {
+          projection_step_diffusion_factor = prm.get_double("diffusion factor");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+
+      ramp.parse_parameters(prm);
+
+      prm.enter_subsection("cahn hilliard");
+      cahn_hilliard.parse_parameters(prm);
+      prm.leave_subsection();
+
+      prm.enter_subsection("average velocity profile");
+      average_velocity_folder    = prm.get("checkpoint folder");
+      average_velocity_file_name = prm.get("checkpoint file name");
+
+      prm.leave_subsection();
+    }
+    prm.leave_subsection();
+  }
+
+
+  template class InitialConditions<2>;
+  template class InitialConditions<3>;
 } // namespace Parameters

--- a/source/solvers/initial_conditions.cc
+++ b/source/solvers/initial_conditions.cc
@@ -140,13 +140,11 @@ namespace Parameters
         Patterns::Selection("none|diffusive|geometric"),
         "Apply a projection step with diffusion to smooth the VOF initial condition");
 
-      prm.enter_subsection("projection step");
       prm.declare_entry(
         "diffusion factor",
         "1",
         Patterns::Double(),
         "Factor applied to the diffusion term in the projection step");
-      prm.leave_subsection();
       prm.leave_subsection();
 
       prm.enter_subsection("cahn hilliard");
@@ -215,11 +213,7 @@ namespace Parameters
           throw(
             std::runtime_error("Unknown VOF initial condition smoothing type"));
 
-        prm.enter_subsection("projection step");
-        {
-          projection_step_diffusion_factor = prm.get_double("diffusion factor");
-        }
-        prm.leave_subsection();
+        projection_step_diffusion_factor = prm.get_double("diffusion factor");
       }
       prm.leave_subsection();
 

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -186,7 +186,7 @@ NavierStokesBase<dim, VectorType, DofsType>::NavierStokesBase(
   if (this->simulation_parameters.post_processing
         .calculate_average_velocities ||
       this->simulation_parameters.initial_condition->type ==
-        Parameters::InitialConditionType::average_velocity_profile)
+        Parameters::FluidDynamicsInitialConditionType::average_velocity_profile)
     average_velocities =
       std::make_shared<AverageVelocities<dim, VectorType, DofsType>>(
         dof_handler);
@@ -618,7 +618,8 @@ NavierStokesBase<dim, VectorType, DofsType>::iterate()
       multiphysics->percolate_time_vectors(false);
 
       if (this->simulation_parameters.initial_condition->type ==
-          Parameters::InitialConditionType::average_velocity_profile)
+          Parameters::FluidDynamicsInitialConditionType::
+            average_velocity_profile)
         {
           // We get the solution via the average solution
           this->local_evaluation_point =
@@ -1145,7 +1146,7 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh_kelly()
   if (this->simulation_parameters.post_processing
         .calculate_average_velocities ||
       this->simulation_parameters.initial_condition->type ==
-        Parameters::InitialConditionType::average_velocity_profile)
+        Parameters::FluidDynamicsInitialConditionType::average_velocity_profile)
     average_velocities->prepare_for_mesh_adaptation();
 
   tria.execute_coarsening_and_refinement();
@@ -1245,7 +1246,7 @@ NavierStokesBase<dim, VectorType, DofsType>::transfer_solution(
   if (this->simulation_parameters.post_processing
         .calculate_average_velocities ||
       this->simulation_parameters.initial_condition->type ==
-        Parameters::InitialConditionType::average_velocity_profile)
+        Parameters::FluidDynamicsInitialConditionType::average_velocity_profile)
     average_velocities->post_mesh_adaptation();
 
   // Only needed if other physics apart from fluid dynamics are enabled.
@@ -2282,7 +2283,7 @@ NavierStokesBase<dim, VectorType, DofsType>::set_solution_from_checkpoint(
 
   if (simulation_parameters.post_processing.calculate_average_velocities ||
       this->simulation_parameters.initial_condition->type ==
-        Parameters::InitialConditionType::average_velocity_profile)
+        Parameters::FluidDynamicsInitialConditionType::average_velocity_profile)
     {
       std::vector<VectorType *> sum_vectors =
         this->average_velocities->read(checkpoint_file_prefix);
@@ -2302,7 +2303,7 @@ NavierStokesBase<dim, VectorType, DofsType>::set_solution_from_checkpoint(
   // average velocity profile.
   if (simulation_parameters.post_processing.calculate_average_velocities &
       (this->simulation_parameters.initial_condition->type !=
-       Parameters::InitialConditionType::average_velocity_profile))
+       Parameters::FluidDynamicsInitialConditionType::average_velocity_profile))
     {
       if ((this->simulation_parameters.post_processing
              .initial_time_for_average_velocities +
@@ -2318,7 +2319,7 @@ NavierStokesBase<dim, VectorType, DofsType>::set_solution_from_checkpoint(
 
   if (simulation_parameters.post_processing.calculate_average_velocities ||
       this->simulation_parameters.initial_condition->type ==
-        Parameters::InitialConditionType::average_velocity_profile)
+        Parameters::FluidDynamicsInitialConditionType::average_velocity_profile)
     {
       this->average_velocities->sanitize_after_restart();
     }
@@ -2613,7 +2614,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
   if (this->simulation_parameters.post_processing
         .calculate_average_velocities ||
       this->simulation_parameters.initial_condition->type ==
-        Parameters::InitialConditionType::average_velocity_profile)
+        Parameters::FluidDynamicsInitialConditionType::average_velocity_profile)
     {
       // Add the interpretation of the average solution. The dim first
       // components are the average velocity vectors and the following one is
@@ -2932,7 +2933,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_checkpoint()
 
   if (simulation_parameters.post_processing.calculate_average_velocities ||
       this->simulation_parameters.initial_condition->type ==
-        Parameters::InitialConditionType::average_velocity_profile)
+        Parameters::FluidDynamicsInitialConditionType::average_velocity_profile)
     {
       std::vector<const VectorType *> av_set_transfer =
         this->average_velocities->save(prefix);

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -283,7 +283,8 @@ Tracer<dim>::assemble_local_system_matrix(
       // Check if the post processed variable needs to be calculated with the
       // average velocity profile or the fluid solution.
       if (this->simulation_parameters.initial_condition->type ==
-            Parameters::InitialConditionType::average_velocity_profile &&
+            Parameters::FluidDynamicsInitialConditionType::
+              average_velocity_profile &&
           !this->simulation_parameters.multiphysics.fluid_dynamics &&
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing
@@ -310,7 +311,8 @@ Tracer<dim>::assemble_local_system_matrix(
       // Check if the post processed variable needs to be calculated with the
       // average velocity profile or the fluid solution.
       if (this->simulation_parameters.initial_condition->type ==
-            Parameters::InitialConditionType::average_velocity_profile &&
+            Parameters::FluidDynamicsInitialConditionType::
+              average_velocity_profile &&
           !this->simulation_parameters.multiphysics.fluid_dynamics &&
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing
@@ -570,7 +572,8 @@ Tracer<dim>::assemble_local_system_rhs(
       // Check if the post processed variable needs to be calculated with the
       // average velocity profile or the fluid solution.
       if (this->simulation_parameters.initial_condition->type ==
-            Parameters::InitialConditionType::average_velocity_profile &&
+            Parameters::FluidDynamicsInitialConditionType::
+              average_velocity_profile &&
           !this->simulation_parameters.multiphysics.fluid_dynamics &&
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing
@@ -597,7 +600,8 @@ Tracer<dim>::assemble_local_system_rhs(
       // Check if the post processed variable needs to be calculated with the
       // average velocity profile or the fluid solution.
       if (this->simulation_parameters.initial_condition->type ==
-            Parameters::InitialConditionType::average_velocity_profile &&
+            Parameters::FluidDynamicsInitialConditionType::
+              average_velocity_profile &&
           !this->simulation_parameters.multiphysics.fluid_dynamics &&
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -364,7 +364,8 @@ VolumeOfFluid<dim>::assemble_local_system_matrix(
       // Check if the post processed variable needs to be calculated with the
       // average velocity profile or the fluid solution.
       if (this->simulation_parameters.initial_condition->type ==
-            Parameters::InitialConditionType::average_velocity_profile &&
+            Parameters::FluidDynamicsInitialConditionType::
+              average_velocity_profile &&
           !this->simulation_parameters.multiphysics.fluid_dynamics &&
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing
@@ -393,7 +394,8 @@ VolumeOfFluid<dim>::assemble_local_system_matrix(
       // Check if the post-processed variable needs to be calculated with the
       // average velocity profile or the fluid solution.
       if (this->simulation_parameters.initial_condition->type ==
-            Parameters::InitialConditionType::average_velocity_profile &&
+            Parameters::FluidDynamicsInitialConditionType::
+              average_velocity_profile &&
           !this->simulation_parameters.multiphysics.fluid_dynamics &&
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing
@@ -607,7 +609,8 @@ VolumeOfFluid<dim>::assemble_local_system_rhs(
       // Check if the post-processed variable needs to be calculated with the
       // average velocity profile or the fluid solution.
       if (this->simulation_parameters.initial_condition->type ==
-            Parameters::InitialConditionType::average_velocity_profile &&
+            Parameters::FluidDynamicsInitialConditionType::
+              average_velocity_profile &&
           !this->simulation_parameters.multiphysics.fluid_dynamics &&
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing
@@ -636,7 +639,8 @@ VolumeOfFluid<dim>::assemble_local_system_rhs(
       // Check if the post-processed variable needs to be calculated with the
       // average velocity profile or the fluid solution.
       if (this->simulation_parameters.initial_condition->type ==
-            Parameters::InitialConditionType::average_velocity_profile &&
+            Parameters::FluidDynamicsInitialConditionType::
+              average_velocity_profile &&
           !this->simulation_parameters.multiphysics.fluid_dynamics &&
           simulation_control->get_current_time() >
             this->simulation_parameters.post_processing
@@ -1446,7 +1450,8 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
           // Check if the post processed variable needs to be calculated with
           // the average velocity profile or the fluid solution.
           if (this->simulation_parameters.initial_condition->type ==
-                Parameters::InitialConditionType::average_velocity_profile &&
+                Parameters::FluidDynamicsInitialConditionType::
+                  average_velocity_profile &&
               !this->simulation_parameters.multiphysics.fluid_dynamics &&
               simulation_control->get_current_time() >
                 this->simulation_parameters.post_processing
@@ -1470,7 +1475,8 @@ VolumeOfFluid<dim>::postprocess(bool first_iteration)
           // Check if the post processed variable needs to be calculated with
           // the average velocity profile or the fluid solution.
           if (this->simulation_parameters.initial_condition->type ==
-                Parameters::InitialConditionType::average_velocity_profile &&
+                Parameters::FluidDynamicsInitialConditionType::
+                  average_velocity_profile &&
               !this->simulation_parameters.multiphysics.fluid_dynamics &&
               simulation_control->get_current_time() >
                 this->simulation_parameters.post_processing
@@ -2478,8 +2484,16 @@ VolumeOfFluid<dim>::set_initial_conditions()
   this->nonzero_constraints.distribute(this->newton_update);
   this->present_solution = this->newton_update;
 
-  if (simulation_parameters.initial_condition->enable_projection_step)
+
+  if (simulation_parameters.initial_condition
+        ->vof_initial_condition_smoothing ==
+      Parameters::VOFInitialConditionType::diffusive)
     smooth_phase_fraction(this->present_solution);
+
+  else if (simulation_parameters.initial_condition
+             ->vof_initial_condition_smoothing ==
+           Parameters::VOFInitialConditionType::geometric)
+    reinitialize_interface_with_geometric_method();
 
   apply_phase_filter(this->present_solution, this->filtered_solution);
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The VOF model initial condition had a projection step capability to generate a smooth initial condition. However, it is also interestsing to be able to define an initial condition using the geometric redistanciation. This PR adds this capability. I also took the opportunity of moving the implementation of the initial conditions class to the .cc

### Testing

All tests results remain unchanged. I am not sure a new test is required, but if you think it's necessary I can add one.

### Documentation

The new parameter is discussed in the documentation.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge