### PR TITLE
Make Lethe work adequately without metis and fix some issues with null pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Change Log
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
+
+### [Master] - 2025-08-07
+
+### Fixed
+
+- MINOR Although Lethe can be configured without METIS, there would be nothing to indicate to the user that a parallel simulation without METIS would not work if a simplex mesh was used. This PR adds this assertion and also fixes some issues with some nullptr that were lying around there and there and could prevent compilation. [#1610](https://github.com/chaos-polymtl/lethe/pull/1610)
+
 ### [Master] - 2025-07-31
 
 ### Added

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -746,7 +746,7 @@ NavierStokesBase<dim, VectorType, DofsType>::box_refine_mesh(const bool restart)
 
 
           auto construction_data = TriangulationDescription::Utilities::
-            create_description_from_triangulation(basetria, nullptr);
+            create_description_from_triangulation(basetria, mpi_communicator);
 
           triangulation->create_triangulation(construction_data);
         }

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -796,7 +796,7 @@ NavierStokesBase<dim, VectorType, DofsType>::box_refine_mesh(const bool restart)
           auto construction_data = TriangulationDescription::Utilities::
             create_description_from_triangulation(
               temporary_tri_triangulation,
-              nullptr,
+              mpi_communicator,
               TriangulationDescription::Settings::
                 construct_multigrid_hierarchy);
           box_to_refine.create_triangulation(construction_data);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

Although Lethe does not require METIS, the solver will hang if a simulation is ran in parallel with a simplex triangulation. This PR addresses this issue by adding correct assertion.
Furthermore, Lethe struggles to compile on GCC 15.+, due to some nullptr that are not necessary. 

### Solution

- Check if deal.II is actually compiled with METIS, if not, check if Zoltan is available, if not, throw with an adequate error message
- Replace the nullptr with the appropriate mpi_communicator for the distributed triangulations used in the box refinement.

### Testing

All tests should pass as usual.

### Documentation

Does not modify anything in the documentation

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge