### PR TITLE
Refactor VoidFractionManager to become ParticleProjector and enable projection of other fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+### [Master] - 2025-08-12
+
+### Added
+
+- MAJOR The void fraction manager has been refactored to become the particle_projector. This class now manages not only the calculation of the void fraction, but it can also project other particle fields onto the triangulation. Right now the only field that can be projected is the particle velocity, but additional fields can be easily added to the method. [#1614](https://github.com/chaos-polymtl/lethe/pull/1614)
+
 ### [Master] - 2025-08-11
 
 ### Added

--- a/include/fem-dem/fluid_dynamics_vans.h
+++ b/include/fem-dem/fluid_dynamics_vans.h
@@ -193,7 +193,7 @@ protected:
 
   Particles::ParticleHandler<dim, dim> particle_handler;
 
-  ParticleProjector<dim> void_fraction_manager;
+  ParticleProjector<dim> particle_projector;
 
   bool           has_periodic_boundaries;
   Tensor<1, dim> periodic_offset;

--- a/include/fem-dem/fluid_dynamics_vans.h
+++ b/include/fem-dem/fluid_dynamics_vans.h
@@ -12,8 +12,8 @@
 
 #include <dem/dem.h>
 #include <fem-dem/cfd_dem_simulation_parameters.h>
+#include <fem-dem/particle_projector.h>
 #include <fem-dem/vans_assemblers.h>
-#include <fem-dem/void_fraction.h>
 
 #include <deal.II/fe/mapping_q.h>
 

--- a/include/fem-dem/fluid_dynamics_vans.h
+++ b/include/fem-dem/fluid_dynamics_vans.h
@@ -193,7 +193,7 @@ protected:
 
   Particles::ParticleHandler<dim, dim> particle_handler;
 
-  VoidFractionBase<dim> void_fraction_manager;
+  ParticleProjector<dim> void_fraction_manager;
 
   bool           has_periodic_boundaries;
   Tensor<1, dim> periodic_offset;

--- a/include/fem-dem/fluid_dynamics_vans_matrix_free.h
+++ b/include/fem-dem/fluid_dynamics_vans_matrix_free.h
@@ -7,7 +7,7 @@
 #include <solvers/fluid_dynamics_matrix_free.h>
 
 #include <fem-dem/cfd_dem_simulation_parameters.h>
-#include <fem-dem/void_fraction.h>
+#include <fem-dem/particle_projector.h>
 
 
 /**

--- a/include/fem-dem/fluid_dynamics_vans_matrix_free.h
+++ b/include/fem-dem/fluid_dynamics_vans_matrix_free.h
@@ -65,8 +65,8 @@ public:
   initialize(const std::shared_ptr<SimulationControl> &simulation_control,
              FlowControl<dim>                         &flow_control,
              const VectorType                         &present_solution,
-             const VectorType            &time_derivative_previous_solutions,
-             const VoidFractionBase<dim> &void_fraction_manager);
+             const VectorType             &time_derivative_previous_solutions,
+             const ParticleProjector<dim> &void_fraction_manager);
 
 private:
   /// Reference to the simulation parameters
@@ -170,7 +170,7 @@ protected:
 
   /// Object that manages the void fraction calculation from functions
   /// or from parameters.
-  VoidFractionBase<dim> void_fraction_manager;
+  ParticleProjector<dim> void_fraction_manager;
 
   /// Member variables which are used to manage boundary conditions
   bool           has_periodic_boundaries;

--- a/include/fem-dem/fluid_dynamics_vans_matrix_free_operators.h
+++ b/include/fem-dem/fluid_dynamics_vans_matrix_free_operators.h
@@ -6,7 +6,7 @@
 
 #include <solvers/fluid_dynamics_matrix_free_operators.h>
 
-#include <fem-dem/void_fraction.h>
+#include <fem-dem/particle_projector.h>
 
 using namespace dealii;
 

--- a/include/fem-dem/parameters_cfd_dem.h
+++ b/include/fem-dem/parameters_cfd_dem.h
@@ -80,6 +80,7 @@ namespace Parameters
     bool                           qcm_sphere_equal_cell_volume;
     VoidFractionQuadratureRule     quadrature_rule;
     unsigned int                   n_quadrature_points;
+    bool                           project_particle_velocity;
   };
 
   struct CFDDEM

--- a/include/fem-dem/particle_projector.h
+++ b/include/fem-dem/particle_projector.h
@@ -97,11 +97,11 @@ particle_sphere_intersection_3d(double r_particle,
  *
  * @tparam dim An integer that denotes the number of spatial dimensions.
  *
- * @tparam component_start An integer that indicates at which particle property the field starts
+ * @tparam property_start_index An integer that indicates at which particle property the field starts
  *
  * @tparam n_components The number of components in the field. This number should be either 1 (a scalar) or dim (a Tensor<1,dim>)
  */
-template <int dim, int component_start, int n_components>
+template <int dim, int property_start_index, int n_components>
 class ParticleFieldQCM
 {
 public:
@@ -512,7 +512,7 @@ private:
   /**
   * @brief Calculates the projection of a particle field onto the mesh.
   *
-  * @tparam component_start An integer for the particle_property that will be projected
+  * @tparam property_start_index An integer for the particle_property that will be projected
   *
   * @tparam n_components The number of components of the field. This should be either 1 (scalar) or dim (a Tensor<1,dim>).
   *
@@ -520,10 +520,10 @@ private:
 
    *
    */
-  template <int component_start, int n_components>
+  template <int property_start_index, int n_components>
   void
   calculate_field_projection(
-    ParticleFieldQCM<dim, component_start, n_components> &field_qcm)
+    ParticleFieldQCM<dim, property_start_index, n_components> &field_qcm)
   {
     AssertThrow(
       n_components == 1 || n_components == dim,
@@ -645,7 +645,7 @@ private:
                           {
                             particles_velocity_in_sphere[d] +=
                               particle_volume_in_sphere *
-                              particle_properties[component_start + d];
+                              particle_properties[property_start_index + d];
                           }
                       }
                   }
@@ -701,7 +701,7 @@ private:
                           {
                             particles_velocity_in_sphere[d] +=
                               particle_volume_in_sphere *
-                              particle_properties[component_start + d];
+                              particle_properties[property_start_index + d];
                           }
                       }
                   }

--- a/include/fem-dem/void_fraction.h
+++ b/include/fem-dem/void_fraction.h
@@ -505,7 +505,15 @@ private:
   virtual void
   solve_void_fraction_linear_system() override;
 
-  /*
+  /**
+  * @brief Calculates the projection of a particle field onto the mesh.
+  *
+  * @tparam component_start An integer for the particle_property that will be projected
+  *
+  * @tparam n_components The number of components of the field. This should be either 1 (scalar) or dim (a Tensor<1,dim>).
+  *
+  * @param field_qcm The container for the field that will be projected.
+
    *
    */
   template <int component_start, int n_components>

--- a/include/fem-dem/void_fraction.h
+++ b/include/fem-dem/void_fraction.h
@@ -137,11 +137,11 @@ public:
 
   /// System matrix used to assemble the smoothed L2 projection of the void
   /// fraction
-  TrilinosWrappers::SparseMatrix system_matrix_particle_velocity;
+  TrilinosWrappers::SparseMatrix system_matrix;
 
   /// Right-hand side used to assemble the smoothed L2 projection of the void
   /// fraction
-  GlobalVectorType system_rhs_particle_velocity;
+  GlobalVectorType system_rhs;
 
   /// Constraints used for the boundary conditions of the void fraction.
   /// Currently, this is only used to establish periodic void fractions. This
@@ -155,19 +155,6 @@ public:
    */
   void
   setup_dofs();
-
-
-  // void
-  // project_particle_velocity(Particles::ParticleHandler<dim>
-  // *particle_handler);
-
-  /**
-   * @brief Assemble the linear system and the right-hand-side of the equations
-   *
-   */
-  void
-  assemble_system_matrix_and_rhs(
-    Particles::ParticleHandler<dim> *particle_handler);
 };
 
 
@@ -476,6 +463,12 @@ private:
    */
   virtual void
   solve_linear_system_and_update_solution() override;
+
+  /*
+   *
+   */
+  void
+  calculate_velocity_projection();
 
   /**
    * @brief Calculate and return the periodic offset distance vector of the domain which is needed

--- a/include/fem-dem/void_fraction.h
+++ b/include/fem-dem/void_fraction.h
@@ -96,6 +96,10 @@ particle_sphere_intersection_3d(double r_particle,
  * called to establish new particle fields.
  *
  * @tparam dim An integer that denotes the number of spatial dimensions.
+ *
+ * @tparam component_start An integer that indicates at which particle property the field starts
+ *
+ * @tparam n_components The number of components in the field. This number should be either 1 (a scalar) or dim (a Tensor<1,dim>)
  */
 template <int dim, int component_start, int n_components>
 class ParticleFieldQCM

--- a/include/solvers/physics_subequations_solver.h
+++ b/include/solvers/physics_subequations_solver.h
@@ -60,7 +60,7 @@ protected:
    * the equation is already linear.
    */
   virtual void
-  solve_linear_system_and_update_solution() = 0;
+  solve_void_fraction_linear_system() = 0;
 
 
   const ConditionalOStream pcout;

--- a/include/solvers/vof_linear_subequations_solver.h
+++ b/include/solvers/vof_linear_subequations_solver.h
@@ -107,7 +107,7 @@ protected:
    * for the partial differential equation.
    */
   void
-  solve_linear_system_and_update_solution() override;
+  solve_void_fraction_linear_system() override;
 
   /**
    * @brief Check if the solutions on which the subequation depends on are

--- a/source/fem-dem/CMakeLists.txt
+++ b/source/fem-dem/CMakeLists.txt
@@ -8,9 +8,9 @@ add_library(lethe-fem-dem
   fluid_dynamics_vans_matrix_free_operators.cc
   ib_particles_dem.cc
   parameters_cfd_dem.cc
+  particle_projector.cc
   postprocessing_cfd_dem.cc
   vans_assemblers.cc
-  void_fraction.cc
   # Headers
   ../../include/fem-dem/cfd_dem_coupling.h
   ../../include/fem-dem/cfd_dem_simulation_parameters.h
@@ -20,9 +20,9 @@ add_library(lethe-fem-dem
   ../../include/fem-dem/fluid_dynamics_vans_matrix_free_operators.h
   ../../include/fem-dem/ib_particles_dem.h
   ../../include/fem-dem/parameters_cfd_dem.h
+  ../../include/fem-dem/particle_projector.h
   ../../include/fem-dem/postprocessing_cfd_dem.h
-  ../../include/fem-dem/vans_assemblers.h
-  ../../include/fem-dem/void_fraction.h)
+  ../../include/fem-dem/vans_assemblers.h)
 
 deal_ii_setup_target(lethe-fem-dem)
 target_link_libraries(lethe-fem-dem lethe-core lethe-dem lethe-solvers)

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -284,7 +284,7 @@ CFDDEMSolver<dim>::initialize_dem_parameters()
 
   // Set up the local and ghost cells (if ASC enabled)
   sparse_contacts_object.update_local_and_ghost_cell_set(
-    this->void_fraction_manager.dof_handler);
+    this->particle_projector.dof_handler);
 
   particle_wall_contact_force_object = set_particle_wall_contact_force_model<
     dim,
@@ -335,7 +335,7 @@ CFDDEMSolver<dim>::initialize_dem_parameters()
       dem_action_manager->check_sparse_contacts_enabled())
     {
       sparse_contacts_object.map_periodic_nodes(
-        this->void_fraction_manager.void_fraction_constraints);
+        this->particle_projector.void_fraction_constraints);
     }
 
   this->pcout << "Finished initializing DEM parameters" << std::endl
@@ -496,20 +496,20 @@ CFDDEMSolver<dim>::write_checkpoint()
   // Void Fraction
   std::vector<const GlobalVectorType *> vf_set_transfer;
   vf_set_transfer.push_back(
-    &this->void_fraction_manager.void_fraction_locally_relevant);
+    &this->particle_projector.void_fraction_locally_relevant);
   for (unsigned int i = 0;
-       i < this->void_fraction_manager.previous_void_fraction.size();
+       i < this->particle_projector.previous_void_fraction.size();
        ++i)
     {
       vf_set_transfer.push_back(
-        &this->void_fraction_manager.previous_void_fraction[i]);
+        &this->particle_projector.previous_void_fraction[i]);
     }
 
   this->multiphysics->write_checkpoint();
 
   // Prepare for Serialization
   SolutionTransfer<dim, GlobalVectorType> vf_system_trans_vectors(
-    this->void_fraction_manager.dof_handler);
+    this->particle_projector.dof_handler);
   vf_system_trans_vectors.prepare_for_serialization(vf_set_transfer);
 
   if (auto parallel_triangulation =
@@ -585,7 +585,7 @@ CFDDEMSolver<dim>::read_checkpoint()
       dem_action_manager->check_sparse_contacts_enabled())
     {
       sparse_contacts_object.map_periodic_nodes(
-        this->void_fraction_manager.void_fraction_constraints);
+        this->particle_projector.void_fraction_constraints);
     }
 
   // Velocity Vectors
@@ -628,40 +628,40 @@ CFDDEMSolver<dim>::read_checkpoint()
 
   // Void Fraction Vectors
   std::vector<GlobalVectorType *> vf_system(
-    1 + this->void_fraction_manager.previous_void_fraction.size());
+    1 + this->particle_projector.previous_void_fraction.size());
 
   GlobalVectorType vf_distributed_system(
-    this->void_fraction_manager.locally_owned_dofs, this->mpi_communicator);
+    this->particle_projector.locally_owned_dofs, this->mpi_communicator);
 
   vf_system[0] = &(vf_distributed_system);
 
   std::vector<GlobalVectorType> vf_distributed_previous_solutions;
 
   vf_distributed_previous_solutions.reserve(
-    this->void_fraction_manager.previous_void_fraction.size());
+    this->particle_projector.previous_void_fraction.size());
 
   for (unsigned int i = 0;
-       i < this->void_fraction_manager.previous_void_fraction.size();
+       i < this->particle_projector.previous_void_fraction.size();
        ++i)
     {
       vf_distributed_previous_solutions.emplace_back(
-        GlobalVectorType(this->void_fraction_manager.locally_owned_dofs,
+        GlobalVectorType(this->particle_projector.locally_owned_dofs,
                          this->mpi_communicator));
       vf_system[i + 1] = &vf_distributed_previous_solutions[i];
     }
 
   SolutionTransfer<dim, GlobalVectorType> vf_system_trans_vectors(
-    this->void_fraction_manager.dof_handler);
+    this->particle_projector.dof_handler);
 
   vf_system_trans_vectors.deserialize(vf_system);
 
-  this->void_fraction_manager.void_fraction_locally_relevant =
+  this->particle_projector.void_fraction_locally_relevant =
     vf_distributed_system;
   for (unsigned int i = 0;
-       i < this->void_fraction_manager.previous_void_fraction.size();
+       i < this->particle_projector.previous_void_fraction.size();
        ++i)
     {
-      this->void_fraction_manager.previous_void_fraction[i] =
+      this->particle_projector.previous_void_fraction[i] =
         vf_distributed_previous_solutions[i];
     }
 
@@ -739,18 +739,18 @@ CFDDEMSolver<dim>::load_balance()
   // Void Fraction
   std::vector<const GlobalVectorType *> vf_set_transfer;
   vf_set_transfer.push_back(
-    &this->void_fraction_manager.void_fraction_locally_relevant);
+    &this->particle_projector.void_fraction_locally_relevant);
   for (unsigned int i = 0;
-       i < this->void_fraction_manager.previous_void_fraction.size();
+       i < this->particle_projector.previous_void_fraction.size();
        ++i)
     {
       vf_set_transfer.push_back(
-        &this->void_fraction_manager.previous_void_fraction[i]);
+        &this->particle_projector.previous_void_fraction[i]);
     }
 
   // Prepare for Serialization
   SolutionTransfer<dim, GlobalVectorType> vf_system_trans_vectors(
-    this->void_fraction_manager.dof_handler);
+    this->particle_projector.dof_handler);
   vf_system_trans_vectors.prepare_for_coarsening_and_refinement(
     vf_set_transfer);
 
@@ -810,12 +810,12 @@ CFDDEMSolver<dim>::load_balance()
       dem_action_manager->check_sparse_contacts_enabled())
     {
       sparse_contacts_object.map_periodic_nodes(
-        this->void_fraction_manager.void_fraction_constraints);
+        this->particle_projector.void_fraction_constraints);
     }
 
   // Update the local and ghost cells (if ASC enabled)
   sparse_contacts_object.update_local_and_ghost_cell_set(
-    this->void_fraction_manager.dof_handler);
+    this->particle_projector.dof_handler);
 
   // Velocity Vectors
   std::vector<GlobalVectorType *> x_system(1 + this->previous_solutions.size());
@@ -848,37 +848,37 @@ CFDDEMSolver<dim>::load_balance()
 
   // Void Fraction Vectors
   std::vector<GlobalVectorType *> vf_system(
-    1 + this->void_fraction_manager.previous_void_fraction.size());
+    1 + this->particle_projector.previous_void_fraction.size());
 
   GlobalVectorType vf_distributed_system(
-    this->void_fraction_manager.locally_owned_dofs, this->mpi_communicator);
+    this->particle_projector.locally_owned_dofs, this->mpi_communicator);
 
   vf_system[0] = &(vf_distributed_system);
 
   std::vector<GlobalVectorType> vf_distributed_previous_solutions;
 
   vf_distributed_previous_solutions.reserve(
-    this->void_fraction_manager.previous_void_fraction.size());
+    this->particle_projector.previous_void_fraction.size());
 
   for (unsigned int i = 0;
-       i < this->void_fraction_manager.previous_void_fraction.size();
+       i < this->particle_projector.previous_void_fraction.size();
        ++i)
     {
       vf_distributed_previous_solutions.emplace_back(
-        GlobalVectorType(this->void_fraction_manager.locally_owned_dofs,
+        GlobalVectorType(this->particle_projector.locally_owned_dofs,
                          this->mpi_communicator));
       vf_system[i + 1] = &vf_distributed_previous_solutions[i];
     }
 
   vf_system_trans_vectors.interpolate(vf_system);
 
-  this->void_fraction_manager.void_fraction_locally_relevant =
+  this->particle_projector.void_fraction_locally_relevant =
     vf_distributed_system;
   for (unsigned int i = 0;
-       i < this->void_fraction_manager.previous_void_fraction.size();
+       i < this->particle_projector.previous_void_fraction.size();
        ++i)
     {
-      this->void_fraction_manager.previous_void_fraction[i] =
+      this->particle_projector.previous_void_fraction[i] =
         vf_distributed_previous_solutions[i];
     }
 
@@ -1216,8 +1216,8 @@ CFDDEMSolver<dim>::postprocess_cfd_dem()
       double             total_volume_fluid, total_volume_particles;
       std::tie(total_volume_fluid, total_volume_particles) =
         calculate_fluid_and_particle_volumes(
-          this->void_fraction_manager.dof_handler,
-          this->void_fraction_manager.void_fraction_locally_relevant,
+          this->particle_projector.dof_handler,
+          this->particle_projector.void_fraction_locally_relevant,
           *this->cell_quadrature,
           *this->mapping);
       this->table_phase_volumes.add_value(
@@ -1278,9 +1278,9 @@ CFDDEMSolver<dim>::dynamic_flow_control()
         this->simulation_parameters.flow_control.flow_direction;
       double average_velocity = calculate_average_velocity(
         this->dof_handler,
-        this->void_fraction_manager.dof_handler,
+        this->particle_projector.dof_handler,
         this->present_solution,
-        this->void_fraction_manager.void_fraction_locally_relevant,
+        this->particle_projector.void_fraction_locally_relevant,
         flow_direction,
         *this->cell_quadrature,
         *this->mapping);
@@ -1475,7 +1475,7 @@ CFDDEMSolver<dim>::dem_contact_build(unsigned int counter)
 
       // Identify the mobility status of particles (if ASC enabled)
       sparse_contacts_object.identify_mobility_status(
-        this->void_fraction_manager.dof_handler,
+        this->particle_projector.dof_handler,
         this->particle_handler,
         (*this->triangulation).n_active_cells(),
         this->mpi_communicator);
@@ -1562,7 +1562,7 @@ CFDDEMSolver<dim>::solve()
   // Calculate first instance of void fraction once particles are set-up
   this->vertices_cell_mapping();
   if (!dem_action_manager->check_restart_simulation())
-    this->void_fraction_manager.initialize_void_fraction(
+    this->particle_projector.initialize_void_fraction(
       this->simulation_control->get_current_time());
 
   while (this->simulation_control->integrate())
@@ -1613,7 +1613,7 @@ CFDDEMSolver<dim>::solve()
                       // Output mobility status vector
                       visualization_object.print_intermediate_format(
                         mobility_status,
-                        this->void_fraction_manager.dof_handler,
+                        this->particle_projector.dof_handler,
                         this->mpi_communicator);
                     }
                   break;

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -6,7 +6,7 @@
 
 #include <dem/particle_handler_conversion.h>
 #include <fem-dem/fluid_dynamics_vans.h>
-#include <fem-dem/void_fraction.h>
+#include <fem-dem/particle_projector.h>
 
 #include <deal.II/base/work_stream.h>
 

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -591,12 +591,19 @@ FluidDynamicsVANS<dim>::output_field_hook(DataOut<dim> &data_out)
   data_out.add_data_vector(void_fraction_manager.dof_handler,
                            void_fraction_manager.void_fraction_locally_relevant,
                            "void_fraction");
-  if (this->cfd_dem_simulation_parameters.void_fraction->mode ==
-      Parameters::VoidFractionMode::qcm)
-    data_out.add_data_vector(
-      void_fraction_manager.particle_velocity_qcm.dof_handler,
-      void_fraction_manager.particle_velocity_qcm.particle_field_solution,
-      "particle_velocity");
+  if (this->cfd_dem_simulation_parameters.void_fraction
+        ->project_particle_velocity)
+    {
+      std::vector<std::string> names(dim, "particle_velocity");
+      std::vector<DataComponentInterpretation::DataComponentInterpretation>
+        data_interpretation(
+          dim, DataComponentInterpretation::component_is_part_of_vector);
+      data_out.add_data_vector(
+        void_fraction_manager.particle_velocity.dof_handler,
+        void_fraction_manager.particle_velocity.particle_field_solution,
+        names,
+        data_interpretation);
+    }
 }
 
 template <int dim>

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -595,7 +595,7 @@ FluidDynamicsVANS<dim>::output_field_hook(DataOut<dim> &data_out)
       Parameters::VoidFractionMode::qcm)
     data_out.add_data_vector(
       void_fraction_manager.particle_velocity_qcm.dof_handler,
-      void_fraction_manager.particle_velocity_qcm.particle_velocity_solution,
+      void_fraction_manager.particle_velocity_qcm.particle_field_solution,
       "particle_velocity");
 }
 

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -20,7 +20,7 @@ FluidDynamicsVANS<dim>::FluidDynamicsVANS(
   , particle_handler(*this->triangulation,
                      particle_mapping,
                      DEM::CFDDEMProperties::n_properties)
-  , void_fraction_manager(
+  , particle_projector(
       &(*this->triangulation),
       nsparam.void_fraction,
       this->cfd_dem_simulation_parameters.cfd_parameters.linear_solver.at(
@@ -63,8 +63,8 @@ FluidDynamicsVANS<dim>::setup_dofs()
 {
   FluidDynamicsMatrixBased<dim>::setup_dofs();
 
-  void_fraction_manager.setup_dofs();
-  void_fraction_manager.setup_constraints(
+  particle_projector.setup_dofs();
+  particle_projector.setup_constraints(
     this->cfd_dem_simulation_parameters.cfd_parameters.boundary_conditions);
 }
 
@@ -74,7 +74,7 @@ FluidDynamicsVANS<dim>::finish_time_step_fd()
 {
   // Void fraction percolation must be done before the time step is finished to
   // ensure that the checkpointed information is correct
-  void_fraction_manager.percolate_void_fraction();
+  particle_projector.percolate_void_fraction();
 
   FluidDynamicsMatrixBased<dim>::finish_time_step();
 }
@@ -166,7 +166,7 @@ void
 FluidDynamicsVANS<dim>::calculate_void_fraction(const double time)
 {
   TimerOutput::Scope t(this->computing_timer, "Calculate void fraction");
-  void_fraction_manager.calculate_void_fraction(time);
+  particle_projector.calculate_void_fraction(time);
 }
 
 template <int dim>
@@ -176,12 +176,12 @@ FluidDynamicsVANS<dim>::vertices_cell_mapping()
   // Find all the cells around each vertex
   TimerOutput::Scope t(this->computing_timer, "Map vertices to cell");
 
-  LetheGridTools::vertices_cell_mapping(this->void_fraction_manager.dof_handler,
+  LetheGridTools::vertices_cell_mapping(this->particle_projector.dof_handler,
                                         vertices_to_cell);
 
   if (has_periodic_boundaries)
     LetheGridTools::vertices_cell_mapping_with_periodic_boundaries(
-      this->void_fraction_manager.dof_handler, vertices_to_periodic_cell);
+      this->particle_projector.dof_handler, vertices_to_periodic_cell);
 }
 
 // Do an iteration with the NavierStokes Solver
@@ -383,7 +383,7 @@ FluidDynamicsVANS<dim>::assemble_system_matrix()
       *this->mapping,
       *this->face_quadrature);
 
-    scratch_data.enable_void_fraction(*void_fraction_manager.fe,
+    scratch_data.enable_void_fraction(*particle_projector.fe,
                                       *this->cell_quadrature,
                                       *this->mapping);
 
@@ -427,21 +427,21 @@ FluidDynamicsVANS<dim>::assemble_local_system_matrix(
     &(*(this->triangulation)),
     cell->level(),
     cell->index(),
-    &this->void_fraction_manager.dof_handler);
+    &this->particle_projector.dof_handler);
 
   scratch_data.reinit_void_fraction(
     void_fraction_cell,
-    void_fraction_manager.void_fraction_locally_relevant,
-    void_fraction_manager.previous_void_fraction);
+    particle_projector.void_fraction_locally_relevant,
+    particle_projector.previous_void_fraction);
 
   scratch_data.reinit_particle_fluid_interactions(
     cell,
     this->evaluation_point,
     this->previous_solutions[0],
-    this->void_fraction_manager.void_fraction_locally_relevant,
+    this->particle_projector.void_fraction_locally_relevant,
     particle_handler,
     this->dof_handler,
-    void_fraction_manager.dof_handler);
+    particle_projector.dof_handler);
 
   scratch_data.calculate_physical_properties();
   copy_data.reset();
@@ -491,7 +491,7 @@ FluidDynamicsVANS<dim>::assemble_system_rhs()
     *this->mapping,
     *this->face_quadrature);
 
-  scratch_data.enable_void_fraction(*void_fraction_manager.fe,
+  scratch_data.enable_void_fraction(*particle_projector.fe,
                                     *this->cell_quadrature,
                                     *this->mapping);
 
@@ -538,21 +538,21 @@ FluidDynamicsVANS<dim>::assemble_local_system_rhs(
     &(*(this->triangulation)),
     cell->level(),
     cell->index(),
-    &this->void_fraction_manager.dof_handler);
+    &this->particle_projector.dof_handler);
 
   scratch_data.reinit_void_fraction(
     void_fraction_cell,
-    void_fraction_manager.void_fraction_locally_relevant,
-    void_fraction_manager.previous_void_fraction);
+    particle_projector.void_fraction_locally_relevant,
+    particle_projector.previous_void_fraction);
 
   scratch_data.reinit_particle_fluid_interactions(
     cell,
     this->evaluation_point,
     this->previous_solutions[0],
-    void_fraction_manager.void_fraction_locally_relevant,
+    particle_projector.void_fraction_locally_relevant,
     particle_handler,
     this->dof_handler,
-    void_fraction_manager.dof_handler);
+    particle_projector.dof_handler);
 
   scratch_data.calculate_physical_properties();
   copy_data.reset();
@@ -588,8 +588,8 @@ template <int dim>
 void
 FluidDynamicsVANS<dim>::output_field_hook(DataOut<dim> &data_out)
 {
-  data_out.add_data_vector(void_fraction_manager.dof_handler,
-                           void_fraction_manager.void_fraction_locally_relevant,
+  data_out.add_data_vector(particle_projector.dof_handler,
+                           particle_projector.void_fraction_locally_relevant,
                            "void_fraction");
   if (this->cfd_dem_simulation_parameters.void_fraction
         ->project_particle_velocity)
@@ -599,8 +599,8 @@ FluidDynamicsVANS<dim>::output_field_hook(DataOut<dim> &data_out)
         data_interpretation(
           dim, DataComponentInterpretation::component_is_part_of_vector);
       data_out.add_data_vector(
-        void_fraction_manager.particle_velocity.dof_handler,
-        void_fraction_manager.particle_velocity.particle_field_solution,
+        particle_projector.particle_velocity.dof_handler,
+        particle_projector.particle_velocity.particle_field_solution,
         names,
         data_interpretation);
     }
@@ -620,7 +620,7 @@ FluidDynamicsVANS<dim>::monitor_mass_conservation()
                             update_hessians);
 
   FEValues<dim> fe_values_void_fraction(*this->mapping,
-                                        *this->void_fraction_manager.fe,
+                                        *this->particle_projector.fe,
                                         quadrature_formula,
                                         update_values |
                                           update_quadrature_points |
@@ -664,15 +664,15 @@ FluidDynamicsVANS<dim>::monitor_mass_conservation()
             &(*this->triangulation),
             cell->level(),
             cell->index(),
-            &this->void_fraction_manager.dof_handler);
+            &this->particle_projector.dof_handler);
           fe_values_void_fraction.reinit(void_fraction_cell);
 
           // Gather void fraction (values, gradient)
           fe_values_void_fraction.get_function_values(
-            void_fraction_manager.void_fraction_locally_relevant,
+            particle_projector.void_fraction_locally_relevant,
             present_void_fraction_values);
           fe_values_void_fraction.get_function_gradients(
-            void_fraction_manager.void_fraction_locally_relevant,
+            particle_projector.void_fraction_locally_relevant,
             present_void_fraction_gradients);
 
           fe_values.reinit(cell);
@@ -698,19 +698,19 @@ FluidDynamicsVANS<dim>::monitor_mass_conservation()
               Parameters::SimulationControl::TimeSteppingMethod::steady)
             {
               fe_values_void_fraction.get_function_values(
-                void_fraction_manager.previous_void_fraction[0],
+                particle_projector.previous_void_fraction[0],
                 p1_void_fraction_values);
 
               if (scheme ==
                   Parameters::SimulationControl::TimeSteppingMethod::bdf2)
                 fe_values_void_fraction.get_function_values(
-                  void_fraction_manager.previous_void_fraction[1],
+                  particle_projector.previous_void_fraction[1],
                   p2_void_fraction_values);
 
               if (scheme ==
                   Parameters::SimulationControl::TimeSteppingMethod::bdf3)
                 fe_values_void_fraction.get_function_values(
-                  void_fraction_manager.previous_void_fraction[2],
+                  particle_projector.previous_void_fraction[2],
                   p3_void_fraction_values);
             }
 
@@ -825,7 +825,7 @@ FluidDynamicsVANS<dim>::solve()
       if (this->simulation_control->is_at_start())
         {
           vertices_cell_mapping();
-          void_fraction_manager.initialize_void_fraction(
+          particle_projector.initialize_void_fraction(
             this->simulation_control->get_current_time());
           this->iterate();
         }

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -591,6 +591,12 @@ FluidDynamicsVANS<dim>::output_field_hook(DataOut<dim> &data_out)
   data_out.add_data_vector(void_fraction_manager.dof_handler,
                            void_fraction_manager.void_fraction_locally_relevant,
                            "void_fraction");
+  if (this->cfd_dem_simulation_parameters.void_fraction->mode ==
+      Parameters::VoidFractionMode::qcm)
+    data_out.add_data_vector(
+      void_fraction_manager.particle_velocity_qcm.dof_handler,
+      void_fraction_manager.particle_velocity_qcm.particle_velocity_solution,
+      "particle_velocity");
 }
 
 template <int dim>

--- a/source/fem-dem/fluid_dynamics_vans_matrix_free.cc
+++ b/source/fem-dem/fluid_dynamics_vans_matrix_free.cc
@@ -44,7 +44,7 @@ MFNavierStokesVANSPreconditionGMG<dim>::initialize(
   FlowControl<dim>                         &flow_control,
   const VectorType                         &present_solution,
   const VectorType                         &time_derivative_previous_solutions,
-  const VoidFractionBase<dim>              &void_fraction_manager)
+  const ParticleProjector<dim>             &void_fraction_manager)
 {
   if (this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
         .preconditioner == Parameters::LinearSolver::PreconditionerType::lsmg)

--- a/source/fem-dem/fluid_dynamics_vans_matrix_free_operators.cc
+++ b/source/fem-dem/fluid_dynamics_vans_matrix_free_operators.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <fem-dem/fluid_dynamics_vans_matrix_free_operators.h>
-#include <fem-dem/void_fraction.h>
+#include <fem-dem/particle_projector.h>
 
 template <int dim, typename number>
 void

--- a/source/fem-dem/parameters_cfd_dem.cc
+++ b/source/fem-dem/parameters_cfd_dem.cc
@@ -55,6 +55,11 @@ namespace Parameters
       "0",
       Patterns::Integer(),
       "Number of quadrature points per cell used in the QCM void fraction scheme");
+    prm.declare_entry(
+      "project particle velocity",
+      "false",
+      Patterns::Bool(),
+      "Specify whether the particle velocity is projected using QCM");
     prm.leave_subsection();
   }
 
@@ -95,6 +100,9 @@ namespace Parameters
         "Invalid quadrature rule for the void fraction calculation scheme. Options are 'gauss' or 'gauss-lobatto'"));
 
     n_quadrature_points = prm.get_integer("n quadrature points");
+
+    project_particle_velocity = prm.get_bool("project particle velocity");
+
 
     prm.leave_subsection();
   }

--- a/source/fem-dem/particle_projector.cc
+++ b/source/fem-dem/particle_projector.cc
@@ -193,7 +193,7 @@ ParticleProjector<dim>::setup_constraints(
 
   AssertThrow(
     has_periodic_boundaries == false ||
-      void_fraction_parameters->project_particle_velocity,
+      void_fraction_parameters->project_particle_velocity == false,
     ExcMessage(
       "The projection of particle velocity is currently not supported for periodic boundary conditions"));
 

--- a/source/fem-dem/particle_projector.cc
+++ b/source/fem-dem/particle_projector.cc
@@ -4,7 +4,7 @@
 #include <core/lethe_grid_tools.h>
 #include <core/vector.h>
 
-#include <fem-dem/void_fraction.h>
+#include <fem-dem/particle_projector.h>
 
 #include <deal.II/base/timer.h>
 

--- a/source/fem-dem/particle_projector.cc
+++ b/source/fem-dem/particle_projector.cc
@@ -191,6 +191,12 @@ ParticleProjector<dim>::setup_constraints(
     }
   void_fraction_constraints.close();
 
+  AssertThrow(
+    has_periodic_boundaries == false ||
+      void_fraction_parameters->project_particle_velocity,
+    ExcMessage(
+      "The projection of particle velocity is currently not supported for periodic boundary conditions"));
+
 
   // Reinit system matrix
 

--- a/source/fem-dem/void_fraction.cc
+++ b/source/fem-dem/void_fraction.cc
@@ -75,7 +75,7 @@ ParticleFieldQCM<dim, component_start, n_components>::setup_dofs()
 
 template <int dim>
 void
-VoidFractionBase<dim>::setup_dofs()
+ParticleProjector<dim>::setup_dofs()
 {
   // Get a constant copy of the communicator since it is used extensively to
   // establish the void fraction vectors
@@ -142,13 +142,13 @@ VoidFractionBase<dim>::setup_dofs()
   // Vertices to cell mapping
   LetheGridTools::vertices_cell_mapping(this->dof_handler, vertices_to_cell);
 
-  particle_velocity_qcm.setup_dofs();
+  particle_velocity.setup_dofs();
 }
 
 
 template <int dim>
 void
-VoidFractionBase<dim>::setup_constraints(
+ParticleProjector<dim>::setup_constraints(
   const BoundaryConditions::NSBoundaryConditions<dim> &boundary_conditions)
 {
   has_periodic_boundaries = false;
@@ -215,7 +215,7 @@ VoidFractionBase<dim>::setup_constraints(
 
 template <int dim>
 void
-VoidFractionBase<dim>::calculate_void_fraction(const double time)
+ParticleProjector<dim>::calculate_void_fraction(const double time)
 {
   announce_string(this->pcout, "Void Fraction");
 
@@ -243,17 +243,17 @@ VoidFractionBase<dim>::calculate_void_fraction(const double time)
       calculate_void_fraction_satellite_point_method();
     }
 
-  solve_linear_system_and_update_solution();
+  solve_void_fraction_linear_system();
 
-  if (void_fraction_parameters->mode == Parameters::VoidFractionMode::qcm)
+  if (void_fraction_parameters->project_particle_velocity)
     {
-      // calculate_velocity_projection();
+      calculate_field_projection(particle_velocity);
     }
 }
 
 template <int dim>
 void
-VoidFractionBase<dim>::calculate_void_fraction_function(const double time)
+ParticleProjector<dim>::calculate_void_fraction_function(const double time)
 {
   // The current time of the function is set for time-dependant functions
   void_fraction_parameters->void_fraction.set_time(time);
@@ -282,7 +282,7 @@ VoidFractionBase<dim>::calculate_void_fraction_function(const double time)
 
 template <int dim>
 void
-VoidFractionBase<dim>::calculate_void_fraction_particle_centered_method()
+ParticleProjector<dim>::calculate_void_fraction_particle_centered_method()
 {
   FEValues<dim> fe_values_void_fraction(*mapping,
                                         *fe,
@@ -381,7 +381,7 @@ VoidFractionBase<dim>::calculate_void_fraction_particle_centered_method()
 
 template <int dim>
 void
-VoidFractionBase<dim>::calculate_void_fraction_satellite_point_method()
+ParticleProjector<dim>::calculate_void_fraction_satellite_point_method()
 {
   FEValues<dim> fe_values_void_fraction(*mapping,
                                         *fe,
@@ -621,7 +621,7 @@ VoidFractionBase<dim>::calculate_void_fraction_satellite_point_method()
 
 template <int dim>
 void
-VoidFractionBase<dim>::calculate_void_fraction_quadrature_centered_method()
+ParticleProjector<dim>::calculate_void_fraction_quadrature_centered_method()
 {
   FEValues<dim> fe_values_void_fraction(*mapping,
                                         *fe,
@@ -1002,7 +1002,7 @@ VoidFractionBase<dim>::calculate_void_fraction_quadrature_centered_method()
 
 template <int dim>
 void
-VoidFractionBase<dim>::solve_linear_system_and_update_solution()
+ParticleProjector<dim>::solve_void_fraction_linear_system()
 {
   // Solve the L2 projection system
   const double linear_solver_tolerance =
@@ -1068,5 +1068,5 @@ VoidFractionBase<dim>::solve_linear_system_and_update_solution()
 // Pre-compile the 2D and 3D VoidFractionBase solver to ensure that the
 // library is valid before we actually compile the solver This greatly
 // helps with debugging
-template class VoidFractionBase<2>;
-template class VoidFractionBase<3>;
+template class ParticleProjector<2>;
+template class ParticleProjector<3>;

--- a/source/fem-dem/void_fraction.cc
+++ b/source/fem-dem/void_fraction.cc
@@ -467,9 +467,10 @@ VoidFractionBase<dim>::calculate_velocity_projection()
 
 #ifndef LETHE_USE_LDV
   // Perform copy between two vector types to ensure there is a deal.II vector
-  convert_vector_trilinos_to_dealii(this->void_fraction_solution,
-                                    void_fraction_locally_relevant);
-  void_fraction_solution.update_ghost_values();
+  convert_vector_trilinos_to_dealii(
+    particle_velocity_qcm.particle_velocity_solution,
+    particle_velocity_qcm.particle_velocity_locally_relevant);
+  particle_velocity_qcm.particle_velocity_solution.update_ghost_values();
 #else
   void_fraction_solution = void_fraction_locally_relevant;
 #endif

--- a/source/fem-dem/void_fraction.cc
+++ b/source/fem-dem/void_fraction.cc
@@ -21,10 +21,9 @@
 
 using namespace dealii;
 
-
-template <int dim>
+template <int dim, int component_start, int n_components>
 void
-ParticleVelocityQCM<dim>::setup_dofs()
+ParticleFieldQCM<dim, component_start, n_components>::setup_dofs()
 {
   // Get a constant copy of the communicator since it is used extensively to
   // establish the void fraction vectors
@@ -35,30 +34,29 @@ ParticleVelocityQCM<dim>::setup_dofs()
 
   locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
 
-  particle_velocity_locally_relevant.reinit(locally_owned_dofs,
-                                            locally_relevant_dofs,
-                                            mpi_communicator);
+  particle_field_locally_relevant.reinit(locally_owned_dofs,
+                                         locally_relevant_dofs,
+                                         mpi_communicator);
 
-  particle_velocity_locally_owned.reinit(locally_owned_dofs, mpi_communicator);
+  particle_field_locally_owned.reinit(locally_owned_dofs, mpi_communicator);
 
   // deal.II vector that will also hold the solution
-  this->particle_velocity_solution.reinit(dof_handler.locally_owned_dofs(),
-                                          DoFTools::extract_locally_active_dofs(
-                                            dof_handler),
-                                          mpi_communicator);
+  this->particle_field_solution.reinit(dof_handler.locally_owned_dofs(),
+                                       DoFTools::extract_locally_active_dofs(
+                                         dof_handler),
+                                       mpi_communicator);
 
-  particle_velocity_constraints.clear();
-  particle_velocity_constraints.reinit(locally_owned_dofs,
-                                       locally_relevant_dofs);
+  particle_field_constraints.clear();
+  particle_field_constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler,
-                                          particle_velocity_constraints);
+                                          particle_field_constraints);
 
-  particle_velocity_constraints.close();
+  particle_field_constraints.close();
 
   DynamicSparsityPattern dsp(locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(dof_handler,
                                   dsp,
-                                  particle_velocity_constraints,
+                                  particle_field_constraints,
                                   false);
 
   SparsityTools::distribute_sparsity_pattern(dsp,
@@ -74,408 +72,6 @@ ParticleVelocityQCM<dim>::setup_dofs()
 
   system_rhs.reinit(locally_owned_dofs, mpi_communicator);
 }
-
-template <int dim>
-void
-VoidFractionBase<dim>::calculate_velocity_projection()
-{
-  FEValues<dim> fe_values_velocity(*mapping,
-                                   *particle_velocity_qcm.fe,
-                                   *quadrature,
-                                   update_values | update_quadrature_points |
-                                     update_JxW_values | update_gradients);
-
-  FEValuesExtractors::Vector velocities;
-  velocities.first_vector_component = 0;
-
-  const unsigned int dofs_per_cell = particle_velocity_qcm.fe->dofs_per_cell;
-  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
-  const unsigned int                   n_q_points = quadrature->size();
-  FullMatrix<double>          local_matrix(dofs_per_cell, dofs_per_cell);
-  Vector<double>              local_rhs(dofs_per_cell);
-  std::vector<Tensor<1, dim>> phi_vf(dofs_per_cell);
-  std::vector<Tensor<2, dim>> grad_phi_vf(dofs_per_cell);
-
-  double         r_sphere = 0.0;
-  double         total_volume_of_particle_in_sphere;
-  Tensor<1, dim> particles_velocity_in_sphere;
-  double qcm_sphere_diameter = void_fraction_parameters->qcm_sphere_diameter;
-
-  // If the reference sphere diameter is user-defined, the radius is
-  // calculated from it, otherwise, the value must be calculated while looping
-  // over the cells.
-  bool calculate_reference_sphere_radius = true;
-  if (qcm_sphere_diameter > 1e-16)
-    {
-      r_sphere                          = 0.5 * qcm_sphere_diameter;
-      calculate_reference_sphere_radius = false;
-    }
-
-  // Lambda functions for calculating the radius of the reference sphere
-  // Calculate the radius by the volume (area in 2D) of sphere:
-  // r = (2*dim*V/pi)^(1/dim) / 2
-  auto radius_sphere_volume_cell = [](auto cell_measure) {
-    return 0.5 * pow(2.0 * dim * cell_measure / M_PI, 1.0 / double(dim));
-  };
-
-  // Calculate the radius is obtained from the volume of sphere based on
-  // R_s = h_omega:
-  // V_s = pi*(2*V_c^(1/dim))^(dim)/(2*dim) = pi*2^(dim)*V_c/(2*dim)
-  auto radius_h_omega = [&radius_sphere_volume_cell](double cell_measure) {
-    double reference_sphere_volume =
-      M_PI * Utilities::fixed_power<dim>(2.0) * cell_measure / (2.0 * dim);
-
-    return radius_sphere_volume_cell(reference_sphere_volume);
-  };
-
-  particle_velocity_qcm.system_rhs    = 0;
-  particle_velocity_qcm.system_matrix = 0;
-
-
-  for (const auto &cell :
-       particle_velocity_qcm.dof_handler.active_cell_iterators())
-    {
-      if (cell->is_locally_owned())
-        {
-          fe_values_velocity.reinit(cell);
-
-          local_matrix = 0;
-          local_rhs    = 0;
-
-          // Array of real locations for the quadrature points
-          std::vector<Point<dim>> quadrature_point_location;
-
-          quadrature_point_location =
-            fe_values_velocity.get_quadrature_points();
-
-          // Active neighbors include the current cell as well
-          auto active_neighbors =
-            LetheGridTools::find_cells_around_cell<dim>(vertices_to_cell, cell);
-
-          // Periodic neighbors of the current cell
-          auto active_periodic_neighbors =
-            LetheGridTools::find_cells_around_cell<dim>(
-              vertices_to_periodic_cell, cell);
-
-          // Define the volume of the reference sphere to be used as the
-          // averaging volume for the QCM
-          if (calculate_reference_sphere_radius)
-            {
-              if (void_fraction_parameters->qcm_sphere_equal_cell_volume ==
-                  true)
-                {
-                  // Get the radius by the volume of sphere which is
-                  // equal to the volume of cell
-                  r_sphere = radius_sphere_volume_cell(cell->measure());
-                }
-              else
-                {
-                  // The radius is obtained from the volume of sphere based
-                  // on R_s = h_omega
-                  r_sphere = radius_h_omega(cell->measure());
-                }
-            }
-
-          for (unsigned int q = 0; q < n_q_points; ++q)
-            {
-              total_volume_of_particle_in_sphere = 0;
-              particles_velocity_in_sphere       = 0;
-
-              for (unsigned int m = 0; m < active_neighbors.size(); m++)
-                {
-                  // Loop over particles in neighbor cell
-                  // Begin and end iterator for particles in neighbor cell
-                  const auto pic =
-                    particle_handler->particles_in_cell(active_neighbors[m]);
-                  for (auto &particle : pic)
-                    {
-                      double distance            = 0;
-                      auto   particle_properties = particle.get_properties();
-                      const double r_particle =
-                        particle_properties
-                          [DEM::CFDDEMProperties::PropertiesIndex::dp] *
-                        0.5;
-                      double single_particle_volume =
-                        M_PI * Utilities::fixed_power<dim>(r_particle * 2.0) /
-                        (2 * dim);
-
-                      // Distance between particle and quadrature point
-                      // centers
-                      distance = particle.get_location().distance(
-                        quadrature_point_location[q]);
-
-                      // Particle completely in the reference sphere
-                      if (distance <= (r_sphere - r_particle))
-                        {
-                          const double particle_volume = single_particle_volume;
-
-                          total_volume_of_particle_in_sphere += particle_volume;
-                          for (unsigned int d = 0; d < dim; ++d)
-                            {
-                              particles_velocity_in_sphere[d] +=
-                                particle_volume *
-                                particle_properties
-                                  [DEM::CFDDEMProperties::PropertiesIndex::v_x +
-                                   d];
-                            }
-                        }
-
-                      // Particle partially in the reference sphere
-                      else if ((distance > (r_sphere - r_particle)) &&
-                               (distance < (r_sphere + r_particle)))
-                        {
-                          if (dim == 2)
-                            {
-                              const double particle_volume =
-                                particle_circle_intersection_2d(r_particle,
-                                                                r_sphere,
-                                                                distance);
-
-                              total_volume_of_particle_in_sphere +=
-                                particle_volume;
-
-                              for (unsigned int d = 0; d < dim; ++d)
-                                {
-                                  particles_velocity_in_sphere[d] +=
-                                    particle_volume *
-                                    particle_properties[DEM::CFDDEMProperties::
-                                                          PropertiesIndex::v_x +
-                                                        d];
-                                }
-                            }
-                          else if (dim == 3)
-                            {
-                              const double particle_volume =
-                                particle_sphere_intersection_3d(r_particle,
-                                                                r_sphere,
-                                                                distance);
-                              total_volume_of_particle_in_sphere +=
-                                particle_volume;
-
-                              for (unsigned int d = 0; d < dim; ++d)
-                                {
-                                  particles_velocity_in_sphere[d] +=
-                                    particle_volume *
-                                    particle_properties[DEM::CFDDEMProperties::
-                                                          PropertiesIndex::v_x +
-                                                        d];
-                                }
-                            }
-                        }
-
-                      // Particle completely outside the reference sphere. Do
-                      // absolutely nothing.
-                    }
-                }
-
-              // Execute same operations for periodic neighbors, if the
-              // simulation has no periodic boundaries, the container is
-              // empty. Also, those operations cannot be done in the previous
-              // loop because the particles on the periodic side need a
-              // correction with an offset for the distance with the
-              // quadrature point
-              for (unsigned int m = 0; m < active_periodic_neighbors.size();
-                   m++)
-                {
-                  // Loop over particles in periodic neighbor cell
-                  const auto pic = particle_handler->particles_in_cell(
-                    active_periodic_neighbors[m]);
-                  for (auto &particle : pic)
-                    {
-                      double distance            = 0;
-                      auto   particle_properties = particle.get_properties();
-                      const double r_particle =
-                        particle_properties
-                          [DEM::CFDDEMProperties::PropertiesIndex::dp] *
-                        0.5;
-                      double single_particle_volume =
-                        M_PI * Utilities::fixed_power<dim>(r_particle * 2) /
-                        (2 * dim);
-
-                      // Adjust the location of the particle in the cell to
-                      // account for the periodicity. If the position of the
-                      // periodic cell if greater than the position of the
-                      // current cell, the particle location needs a negative
-                      // correction, and vice versa. Since the particle is in
-                      // the periodic cell, this correction is the inverse of
-                      // the correction for the volumetric contribution
-                      const Point<dim> particle_location =
-                        (active_periodic_neighbors[m]
-                           ->center()[periodic_direction] >
-                         cell->center()[periodic_direction]) ?
-                          particle.get_location() - periodic_offset :
-                          particle.get_location() + periodic_offset;
-
-                      // Distance between particle and quadrature point
-                      // centers
-                      distance = particle_location.distance(
-                        quadrature_point_location[q]);
-
-                      // Particle completely in the reference sphere
-                      if (distance <= (r_sphere - r_particle))
-                        {
-                          const double particle_volume = single_particle_volume;
-                          total_volume_of_particle_in_sphere += particle_volume;
-                          for (unsigned int d = 0; d < dim; ++d)
-                            {
-                              particles_velocity_in_sphere[d] +=
-                                particle_volume *
-                                particle_properties
-                                  [DEM::CFDDEMProperties::PropertiesIndex::v_x +
-                                   d];
-                            }
-                        }
-
-                      // Particle partially in the reference sphere
-                      else if ((distance > (r_sphere - r_particle)) &&
-                               (distance < (r_sphere + r_particle)))
-                        {
-                          if (dim == 2)
-                            {
-                              const double particle_volume =
-                                particle_circle_intersection_2d(r_particle,
-                                                                r_sphere,
-                                                                distance);
-
-                              total_volume_of_particle_in_sphere +=
-                                particle_volume;
-
-                              for (unsigned int d = 0; d < dim; ++d)
-                                {
-                                  particles_velocity_in_sphere[d] +=
-                                    particle_volume *
-                                    particle_properties[DEM::CFDDEMProperties::
-                                                          PropertiesIndex::v_x +
-                                                        d];
-                                }
-                            }
-                          else if (dim == 3)
-                            {
-                              const double particle_volume =
-                                particle_sphere_intersection_3d(r_particle,
-                                                                r_sphere,
-                                                                distance);
-                              total_volume_of_particle_in_sphere +=
-                                particle_volume;
-
-                              for (unsigned int d = 0; d < dim; ++d)
-                                {
-                                  particles_velocity_in_sphere[d] +=
-                                    particle_volume *
-                                    particle_properties[DEM::CFDDEMProperties::
-                                                          PropertiesIndex::v_x +
-                                                        d];
-                                }
-                            }
-                        }
-
-
-                      // Particle completely outside the reference sphere. Do
-                      // absolutely nothing.
-                    }
-                }
-
-              for (unsigned int k = 0; k < dofs_per_cell; ++k)
-                {
-                  phi_vf[k] = fe_values_velocity[velocities].value(k, q);
-                  grad_phi_vf[k] =
-                    fe_values_velocity[velocities].gradient(k, q);
-                }
-
-              for (unsigned int i = 0; i < dofs_per_cell; ++i)
-                {
-                  // Assemble L2 projection
-                  // Matrix assembly
-                  for (unsigned int j = 0; j < dofs_per_cell; ++j)
-                    {
-                      local_matrix(i, j) +=
-                        ((phi_vf[j] * phi_vf[i]) +
-                         (this->l2_smoothing_factor *
-                          scalar_product(grad_phi_vf[j], grad_phi_vf[i]))) *
-                        fe_values_velocity.JxW(q);
-                    }
-
-                  if (total_volume_of_particle_in_sphere > 0)
-                    {
-                      local_rhs(i) += phi_vf[i] * particles_velocity_in_sphere /
-                                      total_volume_of_particle_in_sphere *
-                                      fe_values_velocity.JxW(q);
-                    }
-                }
-            }
-
-          cell->get_dof_indices(local_dof_indices);
-          particle_velocity_qcm.particle_velocity_constraints
-            .distribute_local_to_global(local_matrix,
-                                        local_rhs,
-                                        local_dof_indices,
-                                        particle_velocity_qcm.system_matrix,
-                                        particle_velocity_qcm.system_rhs);
-        }
-    }
-
-  particle_velocity_qcm.system_matrix.compress(VectorOperation::add);
-  particle_velocity_qcm.system_rhs.compress(VectorOperation::add);
-
-  // Solve the L2 projection system
-  const double linear_solver_tolerance =
-    linear_solver_parameters.minimum_residual;
-
-  if (linear_solver_parameters.verbosity != Parameters::Verbosity::quiet)
-    {
-      this->pcout << "  -Tolerance of iterative solver is : "
-                  << linear_solver_tolerance << std::endl;
-    }
-
-  SolverControl solver_control(linear_solver_parameters.max_iterations,
-                               linear_solver_tolerance,
-                               true,
-                               true);
-
-  TrilinosWrappers::SolverCG solver(solver_control);
-
-  //**********************************************
-  // Trillinos Wrapper ILU Preconditioner
-  //*********************************************
-  const double ilu_fill = linear_solver_parameters.ilu_precond_fill;
-  const double ilu_atol = linear_solver_parameters.ilu_precond_atol;
-  const double ilu_rtol = linear_solver_parameters.ilu_precond_rtol;
-
-  TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
-    ilu_fill, ilu_atol, ilu_rtol, 0);
-
-  ilu_preconditioner = std::make_shared<TrilinosWrappers::PreconditionILU>();
-
-  ilu_preconditioner->initialize(particle_velocity_qcm.system_matrix,
-                                 preconditionerOptions);
-
-  solver.solve(particle_velocity_qcm.system_matrix,
-               particle_velocity_qcm.particle_velocity_locally_owned,
-               particle_velocity_qcm.system_rhs,
-               *ilu_preconditioner);
-
-  if (linear_solver_parameters.verbosity != Parameters::Verbosity::quiet)
-    {
-      this->pcout << "  -Iterative solver took : " << solver_control.last_step()
-                  << " steps " << std::endl;
-    }
-
-  particle_velocity_qcm.particle_velocity_constraints.distribute(
-    particle_velocity_qcm.particle_velocity_locally_owned);
-  particle_velocity_qcm.particle_velocity_locally_relevant =
-    particle_velocity_qcm.particle_velocity_locally_owned;
-
-#ifndef LETHE_USE_LDV
-  // Perform copy between two vector types to ensure there is a deal.II vector
-  convert_vector_trilinos_to_dealii(
-    particle_velocity_qcm.particle_velocity_solution,
-    particle_velocity_qcm.particle_velocity_locally_relevant);
-  particle_velocity_qcm.particle_velocity_solution.update_ghost_values();
-#else
-  void_fraction_solution = void_fraction_locally_relevant;
-#endif
-}
-
 
 template <int dim>
 void
@@ -651,7 +247,7 @@ VoidFractionBase<dim>::calculate_void_fraction(const double time)
 
   if (void_fraction_parameters->mode == Parameters::VoidFractionMode::qcm)
     {
-      calculate_velocity_projection();
+      // calculate_velocity_projection();
     }
 }
 

--- a/source/fem-dem/void_fraction.cc
+++ b/source/fem-dem/void_fraction.cc
@@ -77,6 +77,8 @@ template <int dim>
 void
 ParticleProjector<dim>::setup_dofs()
 {
+  // First we setup the dofs related to the void fraction
+
   // Get a constant copy of the communicator since it is used extensively to
   // establish the void fraction vectors
   const MPI_Comm mpi_communicator = dof_handler.get_mpi_communicator();
@@ -142,7 +144,10 @@ ParticleProjector<dim>::setup_dofs()
   // Vertices to cell mapping
   LetheGridTools::vertices_cell_mapping(this->dof_handler, vertices_to_cell);
 
-  particle_velocity.setup_dofs();
+  // If particle projection is enabled, we also setup the dofs for the particle
+  // velocity
+  if (void_fraction_parameters->project_particle_velocity)
+    particle_velocity.setup_dofs();
 }
 
 

--- a/source/solvers/vof_linear_subequations_solver.cc
+++ b/source/solvers/vof_linear_subequations_solver.cc
@@ -95,7 +95,7 @@ VOFLinearSubequationsSolver<dim>::setup_dofs()
 
 template <int dim>
 void
-VOFLinearSubequationsSolver<dim>::solve_linear_system_and_update_solution()
+VOFLinearSubequationsSolver<dim>::solve_void_fraction_linear_system()
 {
   auto mpi_communicator = this->triangulation->get_mpi_communicator();
 
@@ -184,7 +184,7 @@ VOFLinearSubequationsSolver<dim>::solve()
 {
   check_dependencies_validity();
   assemble_system_matrix_and_rhs();
-  solve_linear_system_and_update_solution();
+  solve_void_fraction_linear_system();
   this->subequations_interface.set_solution_valid(this->subequation_id);
 }
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

In the current work towards matrix-free CFD-DEM, it becomes relevant to be able to project particle-laden information onto the CFD mesh. This PR enables this features by creating a new mechanism that can project an arbitrary particle-laden field onto the CFD mesh.
Since the void fraction manager is not just for void fraction anymore, this class has been renamed to become the particle projector, which essentially projects particle information onto the CFD mesh.


### Testing

This is a bit difficult to test with a meaningful test. I will work in future PR to add unit tests for theses functionnalities instead of relying on simulation. This feature is not enabled by default and I don't plan on exposing it to the users for a while, so I'm not overly worried about this.

### Documentation

The particle velocity projection parameter is documented.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Copyright headers are present and up to date
- [ ] Lethe documentation is up to date
- [ ] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [ ] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge