### PR TITLE
Change prm file and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,23 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-### [Master] - 2025-08-08
+### [Master] - 2025-08-19
+
+### Fixed
+
+- MINOR The matrix-free version of the TGV example did not use the fix pressure constant option. This prevented the prm file from being robust if you modified the CFL, the order or anything similar. I have added the fix pressure constant option to the exampel to ensure that it is now robust. [#1625](https://github.com/chaos-polymtl/lethe/pull/1625)
+
+### [Master] - 2025-08-18
 
 ### Fixed
 
 - MAJOR Add check for heat transfer request when solving multiphysics simulations with the matrix-free solver. This is a tiny change, but without this check an error was triggered upon running a multiphysics simulation without heat transfer.[#1622](https://github.com/chaos-polymtl/lethe/pull/1622)
 
+### [Master] - 2025-08-14
+
 ### Changed
 
 - MINOR The geometric reinitialization method was really expensive in terms of computational time. This PR improves the performances by reducing the number of cells in the layer's loop (only the cells in a corona around the interface are visited) and the number of calls to FEPointEvaluation.reinit(). [#1621](https://github.com/chaos-polymtl/lethe/pull/1621)
-
-### [Master] - 2025-08-14
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- MINOR The matrix-free version of the TGV example did not use the fix pressure constant option. This prevented the prm file from being robust if you modified the CFL, the order or anything similar. I have added the fix pressure constant option to the exampel to ensure that it is now robust. [#1625](https://github.com/chaos-polymtl/lethe/pull/1625)
+- MINOR The matrix-free version of the TGV example did not use the fix pressure constant option. This prevented the prm file from being robust if you modified the CFL, the order or anything similar. I have added the fix pressure constant option to the example to ensure that it is now robust. [#1625](https://github.com/chaos-polymtl/lethe/pull/1625)
 
 ### [Master] - 2025-08-18
 

--- a/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
+++ b/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
@@ -82,7 +82,8 @@ The ``boundary conditions`` subsection establishes the constraints on different 
 .. code-block:: text
 
   subsection boundary conditions
-    set number = 3
+    set number                = 3
+    set fix pressure constant = true
     subsection bc 0
       set type               = periodic
       set id                 = 0
@@ -104,6 +105,10 @@ The ``boundary conditions`` subsection establishes the constraints on different 
   end
 
 First, the ``number`` of boundary conditions to be applied must be specified. For each boundary condition, the ``id`` of the boundary as well as its ``type`` must be specified. All boundaries are ``periodic``. The ``x-`` boundary (id=0) is periodic with the ``x+`` boundary (id=1), the ``y-`` boundary (id=2) is periodic with the ``y+`` boundary (id=3) and so on and so forth. For each periodic boundary condition, the periodic direction must be specified. A periodic direction of ``0`` implies that the normal direction of the wall is the :math:`\mathbf{e}_x` vector, ``1`` implies that it's the :math:`\mathbf{e}_y`.
+
+.. warning::
+
+  When using periodic boundary conditions and the ``lethe-fluid-matrix-free`` solver, it is important to set ``fix pressure constant = true`` to prevent the pressure from drifting by an arbitrary constant between the grids of the multigrid hierarchy. This is not required in the ``lethe-fluid`` solver.
 
 Physical Properties
 ~~~~~~~~~~~~~~~~~~~

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
@@ -95,7 +95,8 @@ end
 #---------------------------------------------------
 
 subsection boundary conditions
-  set number = 3
+  set number                = 3
+  set fix pressure constant = true
   subsection bc 0
     set type               = periodic
     set id                 = 0


### PR DESCRIPTION


### Description

@etiennemarin found a bug in which the tgv example provided with the matrix-free solver did not work correctly. This is indeed true. The reason is that the prm file provided with the example did not fix the pressure constant in the multigrid preconditioner (something that we do in both the validation test case and in the taylor-couette problem). Amazing find @etiennemarin !!! 

### Solution

I added the fix pressure constant = true in the example and in the documentation. I also added a warning that explains why this option is necessary.

### Testing

Ran the example with this and it is a lot more robust (and better)


### Documentation

This fixes the example itself, nothing special.


### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge