### PR TITLE
Fix and streamline the particle-fluid assemblers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
-- MINOR The constructor for some of the particle-fluid force assemblers were taking as an argument the lagrangian particle properties, but never using them. As part of a refactor, these constructors have been cleaned out and streamlined to not take any argument. Furthermore, the buoyancy constructor took the full particle parameters whereas it only need the particle gravity acceleration. This has also been fixed. [#1633](https://github.com/chaos-polymtl/lethe/pull/1633)
+- MINOR The constructor for some of the particle-fluid force assemblers were taking as an argument the lagrangian particle properties, but never using them. As part of a refactor, these constructors have been cleaned out and streamlined to not take any argument. Furthermore, the buoyancy constructor took the full particle parameters whereas it only needs the particle gravity acceleration. This has also been fixed. [#1633](https://github.com/chaos-polymtl/lethe/pull/1633)
 
 ### [Master] - 2025-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+### [Master] - 2025-08-27
+
+### Changed
+
+- MINOR The constructor for some of the particle-fluid force assemblers were taking as an argument the lagrangian particle properties, but never using them. As part of a refactor, these constructors have been cleaned out and streamlined to not take any argument. Furthermore, the buoyancy constructor took the full particle parameters whereas it only need the particle gravity acceleration. This has also been fixed. [#1633](https://github.com/chaos-polymtl/lethe/pull/1633)
+
 ### [Master] - 2025-08-25
 
 ### Added

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -569,7 +569,7 @@ public:
   /**
    * @brief Constructor. Keeps an internal copy of the gravity.
    *
-   * @param gravity the gravity applied to the particles.
+   * @param[in] gravity the gravity applied to the particles.
    */
 
   VANSAssemblerBuoyancy(const Tensor<1, 3> &p_gravity)

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -475,7 +475,7 @@ public:
   {}
 
   /**
-   * @brief calculate_particle_fluid_interactions calculates the magnus force.
+   * @brief calculate_particle_fluid_interactions calculates the Magnus force.
    * @param scratch_data (see base class)
    * @param copy_data (see base class)
    */

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2021-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/simulation_control.h>

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -572,7 +572,7 @@ public:
    * @param gravity the gravity applied to the particles.
    */
 
-  VANSAssemblerBuoyancy(Tensor<1, 3> &p_gravity)
+  VANSAssemblerBuoyancy(const Tensor<1, 3> &p_gravity)
     : gravity(p_gravity)
 
   {}

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -443,7 +443,7 @@ public:
   {}
 
   /**
-   * @brief calculate_particle_fluid_interactions calculates the saffman force.
+   * @brief calculate_particle_fluid_interactions calculates the Saffman force.
    * @param scratch_data (see base class)
    * @param copy_data (see base class)
    */

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -443,7 +443,7 @@ public:
   {}
 
   /**
-   * @brief calculate_particle_fluid_interactions calculates the buoyancy force
+   * @brief calculate_particle_fluid_interactions calculates the saffman force.
    * @param scratch_data (see base class)
    * @param copy_data (see base class)
    */
@@ -475,7 +475,7 @@ public:
   {}
 
   /**
-   * @brief calculate_particle_fluid_interactions calculates the buoyancy force
+   * @brief calculate_particle_fluid_interactions calculates the magnus force.
    * @param scratch_data (see base class)
    * @param copy_data (see base class)
    */
@@ -578,7 +578,7 @@ public:
   {}
 
   /**
-   * @brief calculate_particle_fluid_interactions calculates the buoyancy force
+   * @brief calculate_particle_fluid_interactions calculates the buoyancy force.
    * @param scratch_data (see base class)
    * @param copy_data (see base class)
    */
@@ -587,13 +587,13 @@ public:
     NavierStokesScratchData<dim> &scratch_data) override;
 
   /// Gravity acceleration applied to the particles
-  Tensor<1, 3> gravity;
+  const Tensor<1, 3> gravity;
 };
 
 
 /**
  * @brief Class that assembles the particle pressure force that will then
- * be added to particle_fluid_interactions
+ * be added to particle_fluid_interactions.
  *
  * @tparam dim An integer that denotes the number of spatial dimensions
  *

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -436,10 +436,10 @@ template <int dim>
 class VANSAssemblerSaffmanMei : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VANSAssemblerSaffmanMei(Parameters::Lagrangian::LagrangianPhysicalProperties
-                            lagrangian_physical_properties)
-    : lagrangian_physical_properties(lagrangian_physical_properties)
-
+  /**
+   * @brief Constructor. Does not do anything.
+   */
+  VANSAssemblerSaffmanMei()
   {}
 
   /**
@@ -450,9 +450,6 @@ public:
   virtual void
   calculate_particle_fluid_interactions(
     NavierStokesScratchData<dim> &scratch_data) override;
-
-  Parameters::Lagrangian::LagrangianPhysicalProperties
-    lagrangian_physical_properties;
 };
 
 
@@ -471,10 +468,10 @@ template <int dim>
 class VANSAssemblerMagnus : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VANSAssemblerMagnus(Parameters::Lagrangian::LagrangianPhysicalProperties
-                        lagrangian_physical_properties)
-    : lagrangian_physical_properties(lagrangian_physical_properties)
-
+  /**
+   * @brief Constructor. Does not do anything.
+   */
+  VANSAssemblerMagnus()
   {}
 
   /**
@@ -485,9 +482,6 @@ public:
   virtual void
   calculate_particle_fluid_interactions(
     NavierStokesScratchData<dim> &scratch_data) override;
-
-  Parameters::Lagrangian::LagrangianPhysicalProperties
-    lagrangian_physical_properties;
 };
 
 /**
@@ -508,11 +502,10 @@ template <int dim>
 class VANSAssemblerViscousTorque : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VANSAssemblerViscousTorque(
-    Parameters::Lagrangian::LagrangianPhysicalProperties
-      lagrangian_physical_properties)
-    : lagrangian_physical_properties(lagrangian_physical_properties)
-
+  /**
+   * @brief Constructor. Does not do anything.
+   */
+  VANSAssemblerViscousTorque()
   {}
 
   /**
@@ -523,9 +516,6 @@ public:
   virtual void
   calculate_particle_fluid_interactions(
     NavierStokesScratchData<dim> &scratch_data) override;
-
-  Parameters::Lagrangian::LagrangianPhysicalProperties
-    lagrangian_physical_properties;
 };
 
 /**
@@ -545,11 +535,10 @@ template <int dim>
 class VANSAssemblerVorticalTorque : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VANSAssemblerVorticalTorque(
-    Parameters::Lagrangian::LagrangianPhysicalProperties
-      lagrangian_physical_properties)
-    : lagrangian_physical_properties(lagrangian_physical_properties)
-
+  /**
+   * @brief Constructor. Does not do anything.
+   */
+  VANSAssemblerVorticalTorque()
   {}
 
   /**
@@ -560,9 +549,6 @@ public:
   virtual void
   calculate_particle_fluid_interactions(
     NavierStokesScratchData<dim> &scratch_data) override;
-
-  Parameters::Lagrangian::LagrangianPhysicalProperties
-    lagrangian_physical_properties;
 };
 
 /**
@@ -580,9 +566,14 @@ template <int dim>
 class VANSAssemblerBuoyancy : public ParticleFluidAssemblerBase<dim>
 {
 public:
-  VANSAssemblerBuoyancy(Parameters::Lagrangian::LagrangianPhysicalProperties
-                          lagrangian_physical_properties)
-    : lagrangian_physical_properties(lagrangian_physical_properties)
+  /**
+   * @brief Constructor. Keeps an internal copy of the gravity.
+   *
+   * @param gravity the gravity applied to the particles.
+   */
+
+  VANSAssemblerBuoyancy(Tensor<1, 3> &p_gravity)
+    : gravity(p_gravity)
 
   {}
 
@@ -595,8 +586,8 @@ public:
   calculate_particle_fluid_interactions(
     NavierStokesScratchData<dim> &scratch_data) override;
 
-  Parameters::Lagrangian::LagrangianPhysicalProperties
-    lagrangian_physical_properties;
+  /// Gravity acceleration applied to the particles
+  Tensor<1, 3> gravity;
 };
 
 

--- a/include/fem-dem/vans_assemblers.h
+++ b/include/fem-dem/vans_assemblers.h
@@ -578,7 +578,7 @@ public:
   {}
 
   /**
-   * @brief calculate_particle_fluid_interactions calculates the buoyancy force.
+   * @brief Calculate the buoyancy force.
    * @param scratch_data (see base class)
    * @param copy_data (see base class)
    */

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -293,39 +293,31 @@ FluidDynamicsVANS<dim>::setup_assemblers()
   if (this->cfd_dem_simulation_parameters.cfd_dem.saffman_lift_force == true)
     // Saffman Mei Lift Force Assembler
     particle_fluid_assemblers.push_back(
-      std::make_shared<VANSAssemblerSaffmanMei<dim>>(
-        this->cfd_dem_simulation_parameters.dem_parameters
-          .lagrangian_physical_properties));
+      std::make_shared<VANSAssemblerSaffmanMei<dim>>());
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.magnus_lift_force == true)
     // Magnus Lift Force Assembler
     particle_fluid_assemblers.push_back(
-      std::make_shared<VANSAssemblerMagnus<dim>>(
-        this->cfd_dem_simulation_parameters.dem_parameters
-          .lagrangian_physical_properties));
+      std::make_shared<VANSAssemblerMagnus<dim>>());
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.rotational_viscous_torque ==
       true)
     // Viscous Torque Assembler
     particle_fluid_assemblers.push_back(
-      std::make_shared<VANSAssemblerViscousTorque<dim>>(
-        this->cfd_dem_simulation_parameters.dem_parameters
-          .lagrangian_physical_properties));
+      std::make_shared<VANSAssemblerViscousTorque<dim>>());
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.vortical_viscous_torque ==
       true)
     // Vortical Torque Assembler
     particle_fluid_assemblers.push_back(
-      std::make_shared<VANSAssemblerVorticalTorque<dim>>(
-        this->cfd_dem_simulation_parameters.dem_parameters
-          .lagrangian_physical_properties));
+      std::make_shared<VANSAssemblerVorticalTorque<dim>>());
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.buoyancy_force == true)
     // Buoyancy Force Assembler
     particle_fluid_assemblers.push_back(
       std::make_shared<VANSAssemblerBuoyancy<dim>>(
         this->cfd_dem_simulation_parameters.dem_parameters
-          .lagrangian_physical_properties));
+          .lagrangian_physical_properties.g));
 
   if (this->cfd_dem_simulation_parameters.cfd_dem.pressure_force == true)
     // Pressure Force

--- a/source/fem-dem/vans_assemblers.cc
+++ b/source/fem-dem/vans_assemblers.cc
@@ -1819,7 +1819,7 @@ VANSAssemblerBuoyancy<dim>::calculate_particle_fluid_interactions(
 
       // Buoyancy Force
       buoyancy_force =
-        -lagrangian_physical_properties.g * (4.0 / 3) * M_PI *
+        -gravity * (4.0 / 3) * M_PI *
         Utilities::fixed_power<3>(
           (particle_properties[DEM::CFDDEMProperties::PropertiesIndex::dp] /
            2.0));


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

Some of the particle-fluid force constructor were taking into argument parameters that they did not require such as the full lagrangian particle properties objectif. This makes it really invasive for the matrix-free stuff I am trying to achieve. This PR cleans this up.

### Testing

All the tests should be non-affected by this.

### Documentation

Nothing to document here. I took the opportunity to improve the doxygen of this part of the code.


### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge