### PR TITLE
Stabilized ALE Mortar Assembler 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MINOR The `create_random_number_container`, previously only used during the volume insertion in the DEM, has been moved to the `utilities.h` file. This way, this function will be accessible outside the volume insertion, which will limit duplicated code. [#1639](https://github.com/chaos-polymtl/lethe/pull/1639)
 
+## [Master] - 2025-08-29
+
+### Fixed
+
+- MINOR The ALE mortar assembler did not account for changes in the stabilization terms due to the introduction of the ALE velocity. This PR fixes this.[#1638](https://github.com/chaos-polymtl/lethe/pull/1638)
+
 ### [Master] - 2025-08-28
 
 ### Added

--- a/applications_tests/lethe-fluid/mortar_tgv.mpirun=3.output
+++ b/applications_tests/lethe-fluid/mortar_tgv.mpirun=3.output
@@ -1,0 +1,131 @@
+Running on 3 MPI rank(s)...
+Mortar - Rotor grid angle is: 0 rad 
+         Rotor grid velocity is: 0.03 rad/time 
+
+   Number of active cells:       1280
+   Number of degrees of freedom: 6691
+   Volume of triangulation:      39.4784
+Enstrophy: 0.578839
+Kinetic energy: 0.249999
+
+*******************************************************************************
+Transient iteration: 1        Time: 0.04     Time step: 0.04     CFL: 1.43871 
+*******************************************************************************
+Mortar - Rotor grid angle is: 0.0012 rad 
+         Rotor grid velocity is: 0.03 rad/time 
+
+Enstrophy: 0.429193
+Kinetic energy: 0.214264
+L2 error velocity: 0.0120331
+
+*******************************************************************************
+Transient iteration: 2        Time: 0.1      Time step: 0.06     CFL: 0.532788
+*******************************************************************************
+Mortar - Rotor grid angle is: 0.003 rad 
+         Rotor grid velocity is: 0.03 rad/time 
+
+Enstrophy: 0.338548
+Kinetic energy: 0.169012
+L2 error velocity: 0.0157848
+
+*******************************************************************************
+Transient iteration: 3        Time: 0.2      Time step: 0.1      CFL: 0.709792
+*******************************************************************************
+Mortar - Rotor grid angle is: 0.006 rad 
+         Rotor grid velocity is: 0.03 rad/time 
+
+Enstrophy: 0.226713
+Kinetic energy: 0.113181
+L2 error velocity: 0.0117455
+
+*******************************************************************************
+Transient iteration: 4        Time: 0.3      Time step: 0.1      CFL: 0.968151
+*******************************************************************************
+Mortar - Rotor grid angle is: 0.009 rad 
+         Rotor grid velocity is: 0.03 rad/time 
+
+Enstrophy: 0.151272
+Kinetic energy: 0.0755188
+L2 error velocity: 0.00499781
+
+*******************************************************************************
+Transient iteration: 5        Time: 0.4      Time step: 0.1      CFL: 0.790963
+*******************************************************************************
+Mortar - Rotor grid angle is: 0.012 rad 
+         Rotor grid velocity is: 0.03 rad/time 
+
+Enstrophy: 0.100773
+Kinetic energy: 0.0503085
+L2 error velocity: 0.00472433
+
+*******************************************************************************
+Transient iteration: 6        Time: 0.5      Time step: 0.1      CFL: 0.645724
+*******************************************************************************
+Mortar - Rotor grid angle is: 0.015 rad 
+         Rotor grid velocity is: 0.03 rad/time 
+
+Enstrophy: 0.067084
+Kinetic energy: 0.0334902
+L2 error velocity: 0.00893645
+
+*******************************************************************************
+Transient iteration: 7        Time: 0.6      Time step: 0.1      CFL: 0.526988
+*******************************************************************************
+Mortar - Rotor grid angle is: 0.018 rad 
+         Rotor grid velocity is: 0.03 rad/time 
+
+Enstrophy: 0.0446433
+Kinetic energy: 0.0222872
+L2 error velocity: 0.0120341
+
+*******************************************************************************
+Transient iteration: 8        Time: 0.7      Time step: 0.1      CFL: 0.43003 
+*******************************************************************************
+Mortar - Rotor grid angle is: 0.021 rad 
+         Rotor grid velocity is: 0.03 rad/time 
+
+Enstrophy: 0.029705
+Kinetic energy: 0.0148297
+L2 error velocity: 0.0138445
+
+*******************************************************************************
+Transient iteration: 9        Time: 0.8      Time step: 0.1      CFL: 0.350894
+*******************************************************************************
+Mortar - Rotor grid angle is: 0.024 rad 
+         Rotor grid velocity is: 0.03 rad/time 
+
+Enstrophy: 0.0197639
+Kinetic energy: 0.0098668
+L2 error velocity: 0.0146446
+
+*******************************************************************************
+Transient iteration: 10       Time: 0.9      Time step: 0.1      CFL: 0.286318
+*******************************************************************************
+Mortar - Rotor grid angle is: 0.027 rad 
+         Rotor grid velocity is: 0.03 rad/time 
+
+Enstrophy: 0.0131493
+Kinetic energy: 0.00656456
+L2 error velocity: 0.0147143
+
+*******************************************************************************
+Transient iteration: 11       Time: 1        Time step: 0.1      CFL: 0.233628
+*******************************************************************************
+Mortar - Rotor grid angle is: 0.03 rad 
+         Rotor grid velocity is: 0.03 rad/time 
+
+Enstrophy: 0.00874824
+Kinetic energy: 0.00436743
+L2 error velocity: 0.0142833
+ time  error_velocity 
+0.0400   1.203312e-02 
+0.1000   1.578481e-02 
+0.2000   1.174553e-02 
+0.3000   4.997815e-03 
+0.4000   4.724331e-03 
+0.5000   8.936454e-03 
+0.6000   1.203406e-02 
+0.7000   1.384451e-02 
+0.8000   1.464456e-02 
+0.9000   1.471434e-02 
+1.0000   1.428333e-02 

--- a/applications_tests/lethe-fluid/mortar_tgv.prm
+++ b/applications_tests/lethe-fluid/mortar_tgv.prm
@@ -14,7 +14,6 @@ subsection simulation control
   set method           = bdf2
   set time step        = 0.1
   set time end         = 1
-  set output name      = tgv
   set output frequency = 0
 end
 
@@ -155,7 +154,6 @@ subsection linear solver
   subsection fluid dynamics
     set verbosity                             = quiet
     set method                                = gmres
-    set max iters                             = 5000
     set relative residual                     = 1e-4
     set minimum residual                      = 1e-9
     set preconditioner                        = ilu

--- a/applications_tests/lethe-fluid/mortar_tgv.prm
+++ b/applications_tests/lethe-fluid/mortar_tgv.prm
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method           = bdf2
+  set time step        = 0.1
+  set time end         = 1
+  set output name      = tgv
+  set output frequency = 0
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+
+subsection FEM
+  set enable bubble function velocity = true
+  set velocity order                  = 1
+  set pressure order                  = 1
+end
+
+#---------------------------------------------------
+# Initial condition
+#---------------------------------------------------
+
+subsection initial conditions
+  set type = L2projection
+  subsection uvwp
+    set Function expression = cos(x)*sin(y); -sin(x)*cos(y); -1./4*(cos(2*x)+cos(2*y));
+  end
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  set number of fluids = 1
+  subsection fluid 0
+    set kinematic viscosity = 1.0
+  end
+end
+
+#---------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+
+subsection analytical solution
+  set verbosity = verbose
+  set enable    = true
+  subsection uvwp
+    set Function constants  = viscosity=1.0
+    set Function expression = exp(-2*viscosity*t)*   cos(x) * sin(y) ; -sin(x) * cos(y) * exp(-2*viscosity*t); 0
+  end
+end
+
+#---------------------------------------------------
+# Post-Processing
+#---------------------------------------------------
+
+subsection post-processing
+  set verbosity                = verbose
+  set calculate enstrophy      = true
+  set calculate kinetic energy = true
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = hyper_cube_with_cylindrical_hole
+  set grid arguments     = 2.0 : 3.141592654 : 1 : 1 : true
+  set initial refinement = 3
+end
+
+#---------------------------------------------------
+# Mortar
+#---------------------------------------------------
+
+subsection mortar
+  set enable = true
+  subsection mesh
+    set type           = dealii
+    set grid type      = hyper_ball_balanced
+    set grid arguments = 0, 0 : 2.0
+  end
+  set rotor boundary id  = 5
+  set stator boundary id = 4
+  set center of rotation = 0, 0
+  subsection rotor rotation angle
+    set Function expression = 0.03*t
+  end
+  subsection rotor angular velocity
+    set Function expression = 0.03
+  end
+  set verbosity = verbose
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions
+  set number = 4
+  subsection bc 0
+    set type               = periodic
+    set id                 = 0
+    set periodic_id        = 1
+    set periodic_direction = 0
+  end
+  subsection bc 1
+    set type               = periodic
+    set id                 = 2
+    set periodic_id        = 3
+    set periodic_direction = 1
+  end
+  subsection bc 2
+    set type = none
+    set id   = 4
+  end
+  subsection bc 3
+    set type = none
+    set id   = 5
+  end
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection fluid dynamics
+    set verbosity      = quiet
+    set tolerance      = 1e-6
+    set max iterations = 10
+  end
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection fluid dynamics
+    set verbosity                             = quiet
+    set method                                = gmres
+    set max iters                             = 5000
+    set relative residual                     = 1e-4
+    set minimum residual                      = 1e-9
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 0
+    set ilu preconditioner absolute tolerance = 1e-10
+    set ilu preconditioner relative tolerance = 1.00
+  end
+end

--- a/source/core/mortar_coupling_manager.cc
+++ b/source/core/mortar_coupling_manager.cc
@@ -451,7 +451,7 @@ compute_n_subdivisions_and_radius(
   // Number of vertices at the boundary per process
   unsigned int n_vertices_local = 0;
   // Tolerance for rotor radius computation
-  const double tolerance = 1e-4;
+  const double tolerance = 1e-8;
   // Min and max values for rotor radius computation
   double radius_min = std::numeric_limits<double>::max();
   double radius_max = 0;

--- a/source/core/mortar_coupling_manager.cc
+++ b/source/core/mortar_coupling_manager.cc
@@ -451,7 +451,7 @@ compute_n_subdivisions_and_radius(
   // Number of vertices at the boundary per process
   unsigned int n_vertices_local = 0;
   // Tolerance for rotor radius computation
-  const double tolerance = 1e-8;
+  const double tolerance = 1e-4;
   // Min and max values for rotor radius computation
   double radius_min = std::numeric_limits<double>::max();
   double radius_max = 0;

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -592,6 +592,8 @@ FluidDynamicsMatrixBased<dim>::setup_assemblers()
     }
 
   // Mortar ALE
+  // This assembler is added last because it needs access to the strong
+  // Jacobian term computed in the core default assembler
   if (this->simulation_parameters.mortar_parameters.enable)
     {
       this->assemblers.emplace_back(

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -379,15 +379,6 @@ FluidDynamicsMatrixBased<dim>::setup_assemblers()
           this->simulation_control, this->simulation_parameters.ale));
     }
 
-  // Mortar ALE
-  if (this->simulation_parameters.mortar_parameters.enable)
-    {
-      this->assemblers.emplace_back(
-        std::make_shared<NavierStokesAssemblerMortarALE<dim>>(
-          this->simulation_control,
-          this->simulation_parameters.mortar_parameters));
-    }
-
   if (this->simulation_parameters.multiphysics.cahn_hilliard)
     {
       // Time-stepping schemes
@@ -598,6 +589,15 @@ FluidDynamicsMatrixBased<dim>::setup_assemblers()
               "Using the GLS solver with a stabilization other than the pspg_supg or gls "
               "stabilization will lead to an unstable solver that is unable to converge");
         }
+    }
+
+  // Mortar ALE
+  if (this->simulation_parameters.mortar_parameters.enable)
+    {
+      this->assemblers.emplace_back(
+        std::make_shared<NavierStokesAssemblerMortarALE<dim>>(
+          this->simulation_control,
+          this->simulation_parameters.mortar_parameters));
     }
 }
 

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -2858,7 +2858,7 @@ NavierStokesAssemblerMortarALE<dim>::assemble_matrix(
               const auto &strong_jac     = strong_jacobian_vec[q][j];
               const auto &strong_jac_ale = strong_jac_ale_vec[q][j];
 
-              // ALE term: -u_ALE * gradu
+              // ALE term: -u_ale·∇δu
               local_matrix(i, j) +=
                 -phi_u_i * (grad_phi_u_j * velocity_ale) * JxW;
 

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -2791,14 +2791,13 @@ NavierStokesAssemblerMortarALE<dim>::assemble_matrix(
   const double dt  = time_steps_vector[0];
   const double sdt = 1. / dt;
 
-  // Mortar ALE components
-  const auto &velocity_ale = scratch_data.rotor_linear_velocity_values;
-
   // assembling local matrix and right hand side
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
       // Gather into local variables the relevant fields
       const Tensor<1, dim> &velocity = scratch_data.velocity_values[q];
+      const Tensor<1, dim> &velocity_ale =
+        scratch_data.rotor_linear_velocity_values[q];
       const Tensor<2, dim> &velocity_gradient =
         scratch_data.velocity_gradients[q];
 
@@ -2822,7 +2821,8 @@ NavierStokesAssemblerMortarALE<dim>::assemble_matrix(
             u_mag, viscosity_for_stabilization_vector[q], h, sdt);
 
       // Calculate strong residual for GLS stabilization
-      auto strong_residual = -velocity_gradient * velocity_ale[q];
+      //  QUESTION: do I need toinclude + strong_residual_vec[q] here?
+      auto strong_residual = -velocity_gradient * velocity_ale;
 
       std::vector<Tensor<1, dim>> grad_phi_u_j_x_velocity(n_dofs);
       std::vector<Tensor<1, dim>> velocity_gradient_x_phi_u_j(n_dofs);
@@ -2833,10 +2833,10 @@ NavierStokesAssemblerMortarALE<dim>::assemble_matrix(
           const auto &phi_u_j      = scratch_data.phi_u[q][j];
           const auto &grad_phi_u_j = scratch_data.grad_phi_u[q][j];
 
-          strong_jacobian_vec[q][j] += -grad_phi_u_j * velocity_ale[q];
+          strong_jacobian_vec[q][j] += -grad_phi_u_j * velocity_ale;
 
           // Store these temporary products in auxiliary variables for speed
-          grad_phi_u_j_x_velocity[j]     = grad_phi_u_j * velocity;
+          grad_phi_u_j_x_velocity[j] = grad_phi_u_j * (velocity - velocity_ale);
           velocity_gradient_x_phi_u_j[j] = velocity_gradient * phi_u_j;
         }
 
@@ -2847,7 +2847,8 @@ NavierStokesAssemblerMortarALE<dim>::assemble_matrix(
           const auto &grad_phi_p_i = scratch_data.grad_phi_p[q][i];
 
           // Store these temporary products in auxiliary variables for speed
-          const auto grad_phi_u_i_x_velocity = grad_phi_u_i * velocity;
+          const auto grad_phi_u_i_x_velocity =
+            grad_phi_u_i * (velocity - velocity_ale);
           const auto strong_residual_x_grad_phi_u_i =
             strong_residual * grad_phi_u_i;
 
@@ -2857,17 +2858,18 @@ NavierStokesAssemblerMortarALE<dim>::assemble_matrix(
               const auto &grad_phi_u_j = scratch_data.grad_phi_u[q][j];
               const auto &strong_jac   = strong_jacobian_vec[q][j];
 
-              // Weak form for : -u_ALE * gradu
+              // ALE term: -u_ALE * gradu
               local_matrix(i, j) +=
-                -phi_u_i * (grad_phi_u_j * velocity_ale[q]) * JxW;
+                -phi_u_i * (grad_phi_u_j * velocity_ale) * JxW;
 
-              // PSPG term
-              local_matrix(i, j) += tau * (strong_jac * grad_phi_p_i);
+              // ALE-PSPG term
+              local_matrix(i, j) += tau * (strong_jac * grad_phi_p_i) * JxW;
 
-              // SUPG term
-              local_matrix(i, j) +=
-                tau * (strong_jac * grad_phi_u_i_x_velocity +
-                       strong_residual_x_grad_phi_u_i * phi_u_j);
+              // ALE-SUPG term
+              local_matrix(i, j) += tau *
+                                    (strong_jac * grad_phi_u_i_x_velocity +
+                                     strong_residual_x_grad_phi_u_i * phi_u_j) *
+                                    JxW;
             }
         }
 
@@ -2880,33 +2882,75 @@ NavierStokesAssemblerMortarALE<dim>::assemble_rhs(
   const NavierStokesScratchData<dim>   &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
+  /// Physical properties
+  const std::vector<double> &viscosity_for_stabilization_vector =
+    scratch_data.kinematic_viscosity_for_stabilization;
+
   // Loop and quadrature informations
   const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
+  const double       h          = scratch_data.cell_size;
 
   // Copy data elements
   auto &strong_residual_vec = copy_data.strong_residual;
   auto &local_rhs           = copy_data.local_rhs;
 
-  // ALE components
-  const auto velocity_ale = scratch_data.rotor_linear_velocity_values;
+  // Time steps and inverse time steps which is used for stabilization constant
+  std::vector<double> time_steps_vector =
+    this->simulation_control->get_time_steps_vector();
+  const double dt  = time_steps_vector[0];
+  const double sdt = 1. / dt;
 
   // assembling local matrix and right hand side
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
+      const Tensor<1, dim> &velocity = scratch_data.velocity_values[q];
+      const Tensor<1, dim> &velocity_ale =
+        scratch_data.rotor_linear_velocity_values[q];
+      const Tensor<2, dim> &velocity_gradient =
+        scratch_data.velocity_gradients[q];
+
+      // Calculation of the magnitude of the
+      // velocity for the stabilization parameter
+      const double u_mag = std::max(velocity.norm(), 1e-12);
+
       // Store JxW in local variable for faster access
       const double JxW = JxW_vec[q];
 
-      // Calculate strong residual vector
-      strong_residual_vec[q] +=
-        -scratch_data.velocity_gradients[q] * velocity_ale[q];
+      // Calculation of the GLS stabilization parameter. The
+      // stabilization parameter used is different if the simulation
+      // is steady or unsteady. In the unsteady case it includes the
+      // value of the time-step
+      const double tau =
+        this->simulation_control->get_assembly_method() ==
+            Parameters::SimulationControl::TimeSteppingMethod::steady ?
+          calculate_navier_stokes_gls_tau_steady(
+            u_mag, viscosity_for_stabilization_vector[q], h) :
+          calculate_navier_stokes_gls_tau_transient(
+            u_mag, viscosity_for_stabilization_vector[q], h, sdt);
+
+      // Calculate the strong residual for GLS stabilization
+      auto strong_residual =
+        -velocity_gradient * velocity_ale + strong_residual_vec[q];
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
+          const auto &phi_u_i      = scratch_data.phi_u[q][i];
+          const auto &grad_phi_u_i = scratch_data.grad_phi_u[q][i];
+          const auto &grad_phi_p_i = scratch_data.grad_phi_p[q][i];
+
+          // ALE term: -u_ALE * gradu
           local_rhs[i] +=
-            (scratch_data.phi_u[q][i] *
-             (scratch_data.velocity_gradients[q] * velocity_ale[q])) *
+            (velocity_gradient * velocity_ale * phi_u_i) * JxW;
+
+          // ALE-PSPG term
+          local_rhs[i] += -tau * (strong_residual * grad_phi_p_i) * JxW;
+
+          // ALE-SUPG term
+          local_rhs[i] +=
+            -tau *
+            (strong_residual * (grad_phi_u_i * (velocity - velocity_ale))) *
             JxW;
         }
     } // end loop on quadrature points

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -2770,48 +2770,104 @@ NavierStokesAssemblerMortarALE<dim>::assemble_matrix(
   const NavierStokesScratchData<dim>   &scratch_data,
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
+  /// Physical properties
+  const std::vector<double> &viscosity_for_stabilization_vector =
+    scratch_data.kinematic_viscosity_for_stabilization;
+
   /// Loop and quadrature informations
   const auto        &JxW_vec    = scratch_data.JxW;
   const unsigned int n_q_points = scratch_data.n_q_points;
   const unsigned int n_dofs     = scratch_data.n_dofs;
+  const double       h          = scratch_data.cell_size;
 
   // Copy data elements
   auto &strong_residual_vec = copy_data.strong_residual;
   auto &strong_jacobian_vec = copy_data.strong_jacobian;
   auto &local_matrix        = copy_data.local_matrix;
 
+  // Time steps and inverse time steps which is used for stabilization constant
+  std::vector<double> time_steps_vector =
+    this->simulation_control->get_time_steps_vector();
+  const double dt  = time_steps_vector[0];
+  const double sdt = 1. / dt;
+
   // Mortar ALE components
-  const auto velocity_ale = scratch_data.rotor_linear_velocity_values;
+  const auto &velocity_ale = scratch_data.rotor_linear_velocity_values;
 
   // assembling local matrix and right hand side
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
+      // Gather into local variables the relevant fields
+      const Tensor<1, dim> &velocity = scratch_data.velocity_values[q];
+      const Tensor<2, dim> &velocity_gradient =
+        scratch_data.velocity_gradients[q];
+
       // Store JxW in local variable for faster access
       const double JxW = JxW_vec[q];
 
-      // Calculate strong residual vector
-      strong_residual_vec[q] +=
-        -scratch_data.velocity_gradients[q] * velocity_ale[q];
+      // Calculation of the magnitude of the velocity for the
+      // stabilization parameter
+      const double u_mag = std::max(velocity.norm(), 1e-12);
+
+      // Calculation of the GLS stabilization parameter. The
+      // stabilization parameter used is different if the simulation
+      // is steady or unsteady. In the unsteady case it includes the
+      // value of the time-step
+      const double tau =
+        this->simulation_control->get_assembly_method() ==
+            Parameters::SimulationControl::TimeSteppingMethod::steady ?
+          calculate_navier_stokes_gls_tau_steady(
+            u_mag, viscosity_for_stabilization_vector[q], h) :
+          calculate_navier_stokes_gls_tau_transient(
+            u_mag, viscosity_for_stabilization_vector[q], h, sdt);
+
+      // Calculate strong residual for GLS stabilization
+      auto strong_residual = -velocity_gradient * velocity_ale[q];
+
+      std::vector<Tensor<1, dim>> grad_phi_u_j_x_velocity(n_dofs);
+      std::vector<Tensor<1, dim>> velocity_gradient_x_phi_u_j(n_dofs);
 
       // Strong residual jacobian calculation
       for (unsigned int j = 0; j < n_dofs; ++j)
         {
-          strong_jacobian_vec[q][j] +=
-            -scratch_data.grad_phi_u[q][j] * velocity_ale[q];
+          const auto &phi_u_j      = scratch_data.phi_u[q][j];
+          const auto &grad_phi_u_j = scratch_data.grad_phi_u[q][j];
+
+          strong_jacobian_vec[q][j] += -grad_phi_u_j * velocity_ale[q];
+
+          // Store these temporary products in auxiliary variables for speed
+          grad_phi_u_j_x_velocity[j]     = grad_phi_u_j * velocity;
+          velocity_gradient_x_phi_u_j[j] = velocity_gradient * phi_u_j;
         }
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
-          const auto phi_u_i = scratch_data.phi_u[q][i];
+          const auto &phi_u_i      = scratch_data.phi_u[q][i];
+          const auto &grad_phi_u_i = scratch_data.grad_phi_u[q][i];
+          const auto &grad_phi_p_i = scratch_data.grad_phi_p[q][i];
+
+          // Store these temporary products in auxiliary variables for speed
+          const auto grad_phi_u_i_x_velocity = grad_phi_u_i * velocity;
+          const auto strong_residual_x_grad_phi_u_i =
+            strong_residual * grad_phi_u_i;
 
           for (unsigned int j = 0; j < n_dofs; ++j)
             {
-              const Tensor<2, dim> &grad_phi_u_j =
-                scratch_data.grad_phi_u[q][j];
+              const auto &phi_u_j      = scratch_data.phi_u[q][j];
+              const auto &grad_phi_u_j = scratch_data.grad_phi_u[q][j];
+              const auto &strong_jac   = strong_jacobian_vec[q][j];
 
               // Weak form for : -u_ALE * gradu
               local_matrix(i, j) +=
                 -phi_u_i * (grad_phi_u_j * velocity_ale[q]) * JxW;
+
+              // PSPG term
+              local_matrix(i, j) += tau * (strong_jac * grad_phi_p_i);
+
+              // SUPG term
+              local_matrix(i, j) +=
+                tau * (strong_jac * grad_phi_u_i_x_velocity +
+                       strong_residual_x_grad_phi_u_i * phi_u_j);
             }
         }
 

--- a/source/solvers/navier_stokes_assemblers.cc
+++ b/source/solvers/navier_stokes_assemblers.cc
@@ -261,7 +261,7 @@ PSPGSUPGNavierStokesAssemblerCore<dim>::assemble_rhs(
       auto strong_residual = velocity_gradient * velocity + pressure_gradient -
                              kinematic_viscosity * velocity_laplacian - force +
                              mass_source * velocity + strong_residual_vec[q];
-
+      std::cout << "strong residual before " << strong_residual << std::endl;
       // Assembly of the right-hand side
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
@@ -2781,9 +2781,10 @@ NavierStokesAssemblerMortarALE<dim>::assemble_matrix(
   const double       h          = scratch_data.cell_size;
 
   // Copy data elements
-  auto &strong_residual_vec = copy_data.strong_residual;
+  // auto &strong_residual_vec = copy_data.strong_residual;
   auto &strong_jacobian_vec = copy_data.strong_jacobian;
   auto &local_matrix        = copy_data.local_matrix;
+  Tensor<1, dim> strong_jac_ale;
 
   // Time steps and inverse time steps which is used for stabilization constant
   std::vector<double> time_steps_vector =
@@ -2821,24 +2822,26 @@ NavierStokesAssemblerMortarALE<dim>::assemble_matrix(
             u_mag, viscosity_for_stabilization_vector[q], h, sdt);
 
       // Calculate strong residual for GLS stabilization
-      //  QUESTION: do I need toinclude + strong_residual_vec[q] here?
-      auto strong_residual = -velocity_gradient * velocity_ale;
+      // auto strong_residual = -velocity_gradient * velocity_ale
+      //                        + strong_residual_vec[q];
 
+      // ALE contribution to the strong residual
+      const auto strong_residual_ale = -velocity_gradient * velocity_ale;
+      
       std::vector<Tensor<1, dim>> grad_phi_u_j_x_velocity(n_dofs);
+      std::vector<Tensor<1, dim>> grad_phi_u_j_x_velocity_ale(n_dofs);
       std::vector<Tensor<1, dim>> velocity_gradient_x_phi_u_j(n_dofs);
-
-      // Strong residual jacobian calculation
+      
+      // We loop over the column first to prevent recalculation
+      // of the strong jacobian in the inner loop
       for (unsigned int j = 0; j < n_dofs; ++j)
-        {
-          const auto &phi_u_j      = scratch_data.phi_u[q][j];
-          const auto &grad_phi_u_j = scratch_data.grad_phi_u[q][j];
+      {
+        // const auto &phi_u_j      = scratch_data.phi_u[q][j];
+        const auto &grad_phi_u_j = scratch_data.grad_phi_u[q][j];  
 
-          strong_jacobian_vec[q][j] += -grad_phi_u_j * velocity_ale;
-
-          // Store these temporary products in auxiliary variables for speed
-          grad_phi_u_j_x_velocity[j] = grad_phi_u_j * (velocity - velocity_ale);
-          velocity_gradient_x_phi_u_j[j] = velocity_gradient * phi_u_j;
-        }
+        // ALE contribution to strong Jacobian
+        strong_jac_ale = -grad_phi_u_j * velocity_ale;        
+      }
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
@@ -2848,28 +2851,33 @@ NavierStokesAssemblerMortarALE<dim>::assemble_matrix(
 
           // Store these temporary products in auxiliary variables for speed
           const auto grad_phi_u_i_x_velocity =
-            grad_phi_u_i * (velocity - velocity_ale);
-          const auto strong_residual_x_grad_phi_u_i =
-            strong_residual * grad_phi_u_i;
+            grad_phi_u_i * velocity;
+          const auto grad_phi_u_i_x_velocity_ale =
+            grad_phi_u_i * velocity_ale;
+          const auto strong_residual_ale_x_grad_phi_u_i =
+            strong_residual_ale * grad_phi_u_i;
 
           for (unsigned int j = 0; j < n_dofs; ++j)
             {
               const auto &phi_u_j      = scratch_data.phi_u[q][j];
               const auto &grad_phi_u_j = scratch_data.grad_phi_u[q][j];
               const auto &strong_jac   = strong_jacobian_vec[q][j];
+              // const auto &strong_jac_ale = strong_jacobian_ale[q][j];
 
               // ALE term: -u_ALE * gradu
               local_matrix(i, j) +=
                 -phi_u_i * (grad_phi_u_j * velocity_ale) * JxW;
 
               // ALE-PSPG term
-              local_matrix(i, j) += tau * (strong_jac * grad_phi_p_i) * JxW;
+              // local_matrix(i, j) += tau * (strong_jac_ale * grad_phi_p_i) * JxW;
 
               // ALE-SUPG term
-              local_matrix(i, j) += tau *
-                                    (strong_jac * grad_phi_u_i_x_velocity +
-                                     strong_residual_x_grad_phi_u_i * phi_u_j) *
-                                    JxW;
+              // local_matrix(i, j) += tau *
+              //                       (strong_jac_ale * grad_phi_u_i_x_velocity -
+              //                         strong_jac_ale * grad_phi_u_i_x_velocity_ale -
+              //                         strong_jac * grad_phi_u_i_x_velocity_ale +
+              //                        strong_residual_ale_x_grad_phi_u_i * phi_u_j) *
+              //                       JxW;
             }
         }
 
@@ -2883,6 +2891,8 @@ NavierStokesAssemblerMortarALE<dim>::assemble_rhs(
   StabilizedMethodsTensorCopyData<dim> &copy_data)
 {
   /// Physical properties
+  const std::vector<double> &viscosity_vector =
+    scratch_data.kinematic_viscosity;
   const std::vector<double> &viscosity_for_stabilization_vector =
     scratch_data.kinematic_viscosity_for_stabilization;
 
@@ -2905,12 +2915,26 @@ NavierStokesAssemblerMortarALE<dim>::assemble_rhs(
   // assembling local matrix and right hand side
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
+      // Physical properties
+      const double kinematic_viscosity = viscosity_vector[q];
+      
+      // Velocity
       const Tensor<1, dim> &velocity = scratch_data.velocity_values[q];
       const Tensor<1, dim> &velocity_ale =
         scratch_data.rotor_linear_velocity_values[q];
       const Tensor<2, dim> &velocity_gradient =
         scratch_data.velocity_gradients[q];
+      const Tensor<1, dim> &velocity_laplacian =
+        scratch_data.velocity_laplacians[q];
 
+      // Pressure
+      const Tensor<1, dim> pressure_gradient =
+        scratch_data.pressure_gradients[q];
+
+      // Forcing term
+      const Tensor<1, dim> force       = scratch_data.force[q];
+      double               mass_source = scratch_data.mass_source[q];
+      
       // Calculation of the magnitude of the
       // velocity for the stabilization parameter
       const double u_mag = std::max(velocity.norm(), 1e-12);
@@ -2930,9 +2954,15 @@ NavierStokesAssemblerMortarALE<dim>::assemble_rhs(
           calculate_navier_stokes_gls_tau_transient(
             u_mag, viscosity_for_stabilization_vector[q], h, sdt);
 
-      // Calculate the strong residual for GLS stabilization
-      auto strong_residual =
-        -velocity_gradient * velocity_ale + strong_residual_vec[q];
+      // Strong residual
+      auto strong_residual = velocity_gradient * velocity + pressure_gradient -
+                             kinematic_viscosity * velocity_laplacian - force +
+                             mass_source * velocity + strong_residual_vec[q];
+      std::cout << "strong residual " << strong_residual << std::endl;
+      
+      // ALE contribution to the strong residual
+      const auto strong_residual_ale = -velocity_gradient * velocity_ale;
+      std::cout << "strong residual ALE " << strong_residual_ale << std::endl;
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
@@ -2940,19 +2970,24 @@ NavierStokesAssemblerMortarALE<dim>::assemble_rhs(
           const auto &grad_phi_u_i = scratch_data.grad_phi_u[q][i];
           const auto &grad_phi_p_i = scratch_data.grad_phi_p[q][i];
 
+          // std::cout << "local RHS before " << local_rhs[i] << " ";
           // ALE term: -u_ALE * gradu
           local_rhs[i] +=
             (velocity_gradient * velocity_ale * phi_u_i) * JxW;
 
           // ALE-PSPG term
-          local_rhs[i] += -tau * (strong_residual * grad_phi_p_i) * JxW;
+          local_rhs[i] += -tau * (strong_residual_ale * grad_phi_p_i) * JxW;
 
           // ALE-SUPG term
           local_rhs[i] +=
             -tau *
-            (strong_residual * (grad_phi_u_i * (velocity - velocity_ale))) *
+            (strong_residual_ale * grad_phi_u_i * velocity -
+            strong_residual * grad_phi_u_i * velocity_ale -
+            strong_residual_ale * grad_phi_u_i * velocity_ale) *
             JxW;
+          // std::cout << "local RHS after " << local_rhs[i] << " ";
         }
+        std::cout << std::endl;
     } // end loop on quadrature points
 }
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

The ALE mortar assembler did not account for changes in the stabilization terms due to the introduction of the ALE velocity. This PR fixes this.

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->

The PSPG/SUPG ALE stabilization terms have been added in the mortar assembler.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

A new application test for a TGV problem has been added.

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge