### PR TITLE
Dem rolling resistance naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,24 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+<<<<<<< HEAD
 ### [Master] - 2025-09-01
 
 ### Added
 
 - MINOR Adds the capability to project the particle-fluid forces within the ParticleProjector class. This is still an experimental feature that is not usable from the parameter file. [#1642](https://github.com/chaos-polymtl/lethe/pull/1642)
 
+### [Master] - 2025-08-31
+
+### Changed
+
+- MAJOR The rolling resistance models naming convention was redundant. Every option had an extra \"_resistance\" at the end, which was not necessary. Options are now "none", "constant", "viscous" and "epsd". The old naming convention is still compatible for now, but will be deprecated down the line. Currently, a warning message is shown when using the previous naming convention. [#1640](https://github.com/chaos-polymtl/lethe/pull/1640)
+
 ### [Master] - 2025-08-30
 
 ### Changed
 
-- MINOR The `create_random_number_container`, previously only used during the volume insertion in the DEM, has been moved to the `utilities.h` file. This way, this function will be accessible outside of the volume insertion, which will limit duplicated code. [#1639](https://github.com/chaos-polymtl/lethe/pull/1639)
+- MINOR The `create_random_number_container`, previously only used during the volume insertion in the DEM, has been moved to the `utilities.h` file. This way, this function will be accessible outside the volume insertion, which will limit duplicated code. [#1639](https://github.com/chaos-polymtl/lethe/pull/1639)
 
 ### [Master] - 2025-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,17 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-<<<<<<< HEAD
+### [Master] - 2025-09-02
+
+### Changed
+
+- MAJOR The rolling resistance models naming convention was redundant. Every option had an extra \"_resistance\" at the end, which was not necessary. Options are now "none", "constant", "viscous" and "epsd". The old naming convention is still compatible for now, but will be deprecated down the line. Currently, a warning message is shown when using the previous naming convention. [#1640](https://github.com/chaos-polymtl/lethe/pull/1640)
+
 ### [Master] - 2025-09-01
 
 ### Added
 
 - MINOR Adds the capability to project the particle-fluid forces within the ParticleProjector class. This is still an experimental feature that is not usable from the parameter file. [#1642](https://github.com/chaos-polymtl/lethe/pull/1642)
-
-### [Master] - 2025-08-31
-
-### Changed
-
-- MAJOR The rolling resistance models naming convention was redundant. Every option had an extra \"_resistance\" at the end, which was not necessary. Options are now "none", "constant", "viscous" and "epsd". The old naming convention is still compatible for now, but will be deprecated down the line. Currently, a warning message is shown when using the previous naming convention. [#1640](https://github.com/chaos-polymtl/lethe/pull/1640)
 
 ### [Master] - 2025-08-30
 

--- a/applications_tests/lethe-fluid-particles/dynamic_contact_search.prm
+++ b/applications_tests/lethe-fluid-particles/dynamic_contact_search.prm
@@ -178,7 +178,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/generators/adaptative_sparse_contacts_generator_step1.prm
+++ b/applications_tests/lethe-fluid-particles/generators/adaptative_sparse_contacts_generator_step1.prm
@@ -40,7 +40,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
   subsection adaptive sparse contacts
     set enable adaptive sparse contacts = true

--- a/applications_tests/lethe-fluid-particles/generators/adaptative_sparse_contacts_generator_step2.prm
+++ b/applications_tests/lethe-fluid-particles/generators/adaptative_sparse_contacts_generator_step2.prm
@@ -41,7 +41,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
   subsection adaptive sparse contacts
     set enable adaptive sparse contacts = true

--- a/applications_tests/lethe-fluid-particles/generators/periodic_particles_qcm_generator.prm
+++ b/applications_tests/lethe-fluid-particles/generators/periodic_particles_qcm_generator.prm
@@ -42,7 +42,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   subsection load balancing
     set load balance method = none
   end

--- a/applications_tests/lethe-fluid-particles/generators/periodic_particles_qcm_opposite_flow_generator.prm
+++ b/applications_tests/lethe-fluid-particles/generators/periodic_particles_qcm_opposite_flow_generator.prm
@@ -42,7 +42,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   subsection load balancing
     set load balance method = none
   end

--- a/applications_tests/lethe-fluid-particles/generators/restart_particle_sedimentation_generator.prm
+++ b/applications_tests/lethe-fluid-particles/generators/restart_particle_sedimentation_generator.prm
@@ -177,7 +177,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_force
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/liquid_fluidized_bed.prm
+++ b/applications_tests/lethe-fluid-particles/liquid_fluidized_bed.prm
@@ -201,7 +201,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/particle_sedimentation.prm
@@ -178,7 +178,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_force
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/periodic_particles_qcm.prm
+++ b/applications_tests/lethe-fluid-particles/periodic_particles_qcm.prm
@@ -175,7 +175,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/periodic_particles_qcm_opposite_flow.disabled
+++ b/applications_tests/lethe-fluid-particles/periodic_particles_qcm_opposite_flow.disabled
@@ -175,7 +175,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/qcm_gauss_lobatto_particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/qcm_gauss_lobatto_particle_sedimentation.prm
@@ -182,7 +182,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_force
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/qcm_gauss_particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/qcm_gauss_particle_sedimentation.prm
@@ -182,7 +182,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_force
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/restart_particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/restart_particle_sedimentation.prm
@@ -178,7 +178,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_force
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-particles/ball_with_floating_walls.prm
+++ b/applications_tests/lethe-particles/ball_with_floating_walls.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_force
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = viscous_resistance
+  set rolling resistance torque method       = viscous
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/box_grid_rotation.prm
+++ b/applications_tests/lethe-particles/box_grid_rotation.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = viscous_resistance
+  set rolling resistance torque method       = viscous
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/box_grid_slide.prm
+++ b/applications_tests/lethe-particles/box_grid_slide.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/circle_with_floating_walls.prm
+++ b/applications_tests/lethe-particles/circle_with_floating_walls.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/deprecated_parameters.prm
+++ b/applications_tests/lethe-particles/deprecated_parameters.prm
@@ -46,7 +46,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/epsd_rolling_resistance_model.prm
+++ b/applications_tests/lethe-particles/epsd_rolling_resistance_model.prm
@@ -50,7 +50,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_force
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = epsd_resistance
+  set rolling resistance torque method       = epsd
   set f coefficient                          = 0.2
   set integration method                     = velocity_verlet
 end

--- a/applications_tests/lethe-particles/initial_value_insertion.prm
+++ b/applications_tests/lethe-particles/initial_value_insertion.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/insert_and_remove_with_files.prm
+++ b/applications_tests/lethe-particles/insert_and_remove_with_files.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/insert_file_3d.prm
+++ b/applications_tests/lethe-particles/insert_file_3d.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/insert_list_2d.prm
+++ b/applications_tests/lethe-particles/insert_list_2d.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/insert_list_3d.prm
+++ b/applications_tests/lethe-particles/insert_list_3d.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/insert_list_3d_default_velocities.prm
+++ b/applications_tests/lethe-particles/insert_list_3d_default_velocities.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/insert_plane_3d.prm
+++ b/applications_tests/lethe-particles/insert_plane_3d.prm
@@ -46,7 +46,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/insert_z-x-y.prm
+++ b/applications_tests/lethe-particles/insert_z-x-y.prm
@@ -46,7 +46,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/load_balancing_mobility_status.prm
+++ b/applications_tests/lethe-particles/load_balancing_mobility_status.prm
@@ -38,7 +38,7 @@ subsection model parameters
 
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 
   subsection adaptive sparse contacts

--- a/applications_tests/lethe-particles/load_balancing_solid_object.prm
+++ b/applications_tests/lethe-particles/load_balancing_solid_object.prm
@@ -32,7 +32,7 @@ subsection model parameters
     set frequency           = 1000
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = viscous_resistance
+  set rolling resistance torque method       = viscous
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
 end

--- a/applications_tests/lethe-particles/mobility_status.prm
+++ b/applications_tests/lethe-particles/mobility_status.prm
@@ -29,7 +29,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
   subsection adaptive sparse contacts
     set enable adaptive sparse contacts = true

--- a/applications_tests/lethe-particles/moving_solid_surface_dmt.prm
+++ b/applications_tests/lethe-particles/moving_solid_surface_dmt.prm
@@ -32,7 +32,7 @@ subsection model parameters
     set frequency           = 10000
   end
   set particle particle contact force method = DMT
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = DMT
   set integration method                     = velocity_verlet
 end

--- a/applications_tests/lethe-particles/moving_solid_surface_hmlo.prm
+++ b/applications_tests/lethe-particles/moving_solid_surface_hmlo.prm
@@ -32,7 +32,7 @@ subsection model parameters
     set frequency           = 10000
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
 end

--- a/applications_tests/lethe-particles/moving_solid_surface_jkr.prm
+++ b/applications_tests/lethe-particles/moving_solid_surface_jkr.prm
@@ -32,7 +32,7 @@ subsection model parameters
     set frequency           = 10000
   end
   set particle particle contact force method = hertz_JKR
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = JKR
   set integration method                     = velocity_verlet
 end

--- a/applications_tests/lethe-particles/outlet_boundary.prm
+++ b/applications_tests/lethe-particles/outlet_boundary.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = viscous_resistance
+  set rolling resistance torque method       = viscous
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/packing_in_ball.prm
+++ b/applications_tests/lethe-particles/packing_in_ball.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/packing_in_ball_demmp.prm
+++ b/applications_tests/lethe-particles/packing_in_ball_demmp.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
   set solver type                            = dem_mp
 end

--- a/applications_tests/lethe-particles/packing_in_ball_dynamic_contact.prm
+++ b/applications_tests/lethe-particles/packing_in_ball_dynamic_contact.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_force
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/packing_in_ball_dynamic_load_balance.prm
+++ b/applications_tests/lethe-particles/packing_in_ball_dynamic_load_balance.prm
@@ -50,7 +50,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/packing_in_box.prm
+++ b/applications_tests/lethe-particles/packing_in_box.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/packing_in_circle.prm
+++ b/applications_tests/lethe-particles/packing_in_circle.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/packing_in_cylinder.prm
+++ b/applications_tests/lethe-particles/packing_in_cylinder.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/packing_in_square.prm
+++ b/applications_tests/lethe-particles/packing_in_square.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/parallel_contacts_in_circle.prm
+++ b/applications_tests/lethe-particles/parallel_contacts_in_circle.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/periodic_boundary_collisions.prm
+++ b/applications_tests/lethe-particles/periodic_boundary_collisions.prm
@@ -50,7 +50,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-particles/perpendicular_rotation_to_wall.prm
+++ b/applications_tests/lethe-particles/perpendicular_rotation_to_wall.prm
@@ -44,7 +44,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/resize_containers.prm
+++ b/applications_tests/lethe-particles/resize_containers.prm
@@ -50,7 +50,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/restart_cell_weight_function.prm
+++ b/applications_tests/lethe-particles/restart_cell_weight_function.prm
@@ -61,7 +61,7 @@ subsection model parameters
     end
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
 end

--- a/applications_tests/lethe-particles/restart_circle.prm
+++ b/applications_tests/lethe-particles/restart_circle.prm
@@ -57,7 +57,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_force
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/restart_file_insertion.prm
+++ b/applications_tests/lethe-particles/restart_file_insertion.prm
@@ -57,7 +57,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/restart_generators/restart_cell_weight_function_generator.prm
+++ b/applications_tests/lethe-particles/restart_generators/restart_cell_weight_function_generator.prm
@@ -57,7 +57,7 @@ subsection model parameters
     set step                = 1
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
 end

--- a/applications_tests/lethe-particles/restart_generators/restart_circle_generator.prm
+++ b/applications_tests/lethe-particles/restart_generators/restart_circle_generator.prm
@@ -56,7 +56,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_force
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/restart_generators/restart_file_insertion_generator.prm
+++ b/applications_tests/lethe-particles/restart_generators/restart_file_insertion_generator.prm
@@ -56,7 +56,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/restart_generators/restart_moving_receptacle_generator.prm
+++ b/applications_tests/lethe-particles/restart_generators/restart_moving_receptacle_generator.prm
@@ -43,7 +43,7 @@ subsection model parameters
     set frequency           = 10000
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
 end

--- a/applications_tests/lethe-particles/restart_generators/restart_sliding_generator.prm
+++ b/applications_tests/lethe-particles/restart_generators/restart_sliding_generator.prm
@@ -55,7 +55,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/restart_moving_receptacle.prm
+++ b/applications_tests/lethe-particles/restart_moving_receptacle.prm
@@ -32,7 +32,7 @@ subsection model parameters
     set frequency           = 10000
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
 end

--- a/applications_tests/lethe-particles/restart_sliding.prm
+++ b/applications_tests/lethe-particles/restart_sliding.prm
@@ -54,7 +54,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/rolling_on_plane.prm
+++ b/applications_tests/lethe-particles/rolling_on_plane.prm
@@ -41,7 +41,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-particles/rotating_in_ball.prm
+++ b/applications_tests/lethe-particles/rotating_in_ball.prm
@@ -44,7 +44,7 @@ subsection model parameters
     set neighborhood threshold                 = 1.3
     set particle particle contact force method = hertz_mindlin_limit_overlap
     set particle wall contact force method     = nonlinear
-    set rolling resistance torque method       = constant_resistance
+    set rolling resistance torque method       = constant
     set integration method                     = velocity_verlet
   end
 

--- a/applications_tests/lethe-particles/rotating_in_circle.prm
+++ b/applications_tests/lethe-particles/rotating_in_circle.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/sliding_in_box.prm
+++ b/applications_tests/lethe-particles/sliding_in_box.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = viscous_resistance
+  set rolling resistance torque method       = viscous
   set integration method                     = velocity_verlet
 end
 

--- a/applications_tests/lethe-particles/solid_surface.prm
+++ b/applications_tests/lethe-particles/solid_surface.prm
@@ -38,7 +38,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-particles/two_types_packing_in_circle.prm
+++ b/applications_tests/lethe-particles/two_types_packing_in_circle.prm
@@ -45,7 +45,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_force
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
   set integration method                     = velocity_verlet
 end
 

--- a/doc/source/examples/dem-mp/heat-transfer-in-aligned-particles/heat-transfer-in-aligned-particles.rst
+++ b/doc/source/examples/dem-mp/heat-transfer-in-aligned-particles/heat-transfer-in-aligned-particles.rst
@@ -121,7 +121,7 @@ Model Parameters
         set neighborhood threshold                  = 1.3
       end
       set particle particle contact force method = hertz_mindlin_limit_overlap
-      set rolling resistance torque method       = constant_resistance
+      set rolling resistance torque method       = constant
       set particle wall contact force method     = nonlinear
       set integration method                     = velocity_verlet
       set solver type                            = dem_mp

--- a/doc/source/examples/dem-mp/heated-packed-bed/heated-packed-bed.rst
+++ b/doc/source/examples/dem-mp/heated-packed-bed/heated-packed-bed.rst
@@ -159,7 +159,7 @@ For the first two stages, the model parameters are defined as:
         set frequency           = 100000
       end
       set particle particle contact force method = hertz_mindlin_limit_overlap
-      set rolling resistance torque method       = constant_resistance
+      set rolling resistance torque method       = constant
       set particle wall contact force method     = nonlinear
       set integration method                     = velocity_verlet
       set solver type                            = dem_mp
@@ -176,7 +176,7 @@ For the heating of the particles, the parameter ``disable position integration``
         set neighborhood threshold                  = 1.3
       end
       set particle particle contact force method = hertz_mindlin_limit_overlap
-      set rolling resistance torque method       = constant_resistance
+      set rolling resistance torque method       = constant
       set particle wall contact force method     = nonlinear
       set integration method                     = velocity_verlet
       set solver type                            = dem_mp

--- a/doc/source/examples/dem/granuheap/granuheap.rst
+++ b/doc/source/examples/dem/granuheap/granuheap.rst
@@ -162,7 +162,7 @@ The JKR contact model is used in this case because it has be shown to correctly 
     end
 
     set particle particle contact force method = hertz_JKR
-      set rolling resistance torque method       = constant_resistance
+      set rolling resistance torque method       = constant
       set particle wall contact force method     = JKR
       set integration method                     = velocity_verlet
     end

--- a/doc/source/examples/dem/granular-dam-break/granular-dam-break.rst
+++ b/doc/source/examples/dem/granular-dam-break/granular-dam-break.rst
@@ -99,7 +99,7 @@ In this example, we use the ``frequent`` load balancing method to ensure that th
       set threshold                               = 1.3
     end
     set particle particle contact force method  = hertz_mindlin_limit_overlap
-    set rolling resistance torque method        = constant_resistance
+    set rolling resistance torque method        = constant
     set particle wall contact force method      = nonlinear
     set integration method                      = velocity_verlet
   end

--- a/doc/source/examples/dem/oblique-wall-impact/oblique-wall-impact.rst
+++ b/doc/source/examples/dem/oblique-wall-impact/oblique-wall-impact.rst
@@ -107,7 +107,7 @@ We use a non-linear wall contact force model based on Hertz law. Rolling resista
     set particle particle contact force method = hertz_mindlin_limit_overlap
     set particle wall contact force method     = nonlinear
     set integration method                     = velocity_verlet
-    set rolling resistance torque method       = no_resistance
+    set rolling resistance torque method       = none
   end
 
 

--- a/doc/source/examples/dem/packing-in-circle/packing-in-circle.rst
+++ b/doc/source/examples/dem/packing-in-circle/packing-in-circle.rst
@@ -147,7 +147,7 @@ In the ``model parameters`` subsection, DEM simulation parameters are defined.
       set particle particle contact force method    = hertz_mindlin_limit_overlap
       set particle wall contact force method        = nonlinear
       set integration method                        = velocity_verlet
-      set rolling resistance torque method          = constant_resistance
+      set rolling resistance torque method          = constant
     end
 
 These parameters include ``contact detection method`` and  the ``dynamic contact search size coefficient``, ``neighborhood threshold`` (which defines the contact neighbor list size: ``neighborhood threshold`` * ``particle diameter``), ``particle particle contact force method``, ``particle wall contact force method`` and ``integration method``. All the concepts, models, and choices are explained in `DEM parameters <../../../parameters/dem/dem.html>`_.

--- a/doc/source/examples/dem/plate-discharge/plate-discharge.rst
+++ b/doc/source/examples/dem/plate-discharge/plate-discharge.rst
@@ -223,7 +223,7 @@ The model parameters are quite standard for a DEM simulation with the non-linear
        set load balance method = none
      end
      set particle particle contact force method = hertz_mindlin_limit_overlap
-     set rolling resistance torque method       = constant_resistance
+     set rolling resistance torque method       = constant
      set particle wall contact force method     = nonlinear
      set integration method                     = velocity_verlet
      subsection adaptive sparse contacts
@@ -266,7 +266,7 @@ Here the ASC is enabled with a granular temperature threshold of :math:`0.0001 \
        set neighborhood threshold                  = 1.3
      end
      set particle particle contact force method = hertz_mindlin_limit_overlap
-     set rolling resistance torque method       = constant_resistance
+     set rolling resistance torque method       = constant
      set particle wall contact force method     = nonlinear
      set integration method                     = velocity_verlet
      subsection adaptive sparse contacts
@@ -299,7 +299,7 @@ Here, the dynamic load balancing checks if a load balancing is needed every :mat
        set neighborhood threshold                  = 1.3
      end
      set particle particle contact force method = hertz_mindlin_limit_overlap
-     set rolling resistance torque method       = constant_resistance
+     set rolling resistance torque method       = constant
      set particle wall contact force method     = nonlinear
      set integration method                     = velocity_verlet
      subsection adaptive sparse contacts
@@ -332,7 +332,7 @@ Here, we use the ASC with the dynamic load balancing, using the same load balanc
        set neighborhood threshold                  = 1.3
      end
      set particle particle contact force method = hertz_mindlin_limit_overlap
-     set rolling resistance torque method       = constant_resistance
+     set rolling resistance torque method       = constant
      set particle wall contact force method     = nonlinear
      set integration method                     = velocity_verlet
      subsection adaptive sparse contacts

--- a/doc/source/examples/dem/rectangular-hopper/rectangular-hopper.rst
+++ b/doc/source/examples/dem/rectangular-hopper/rectangular-hopper.rst
@@ -144,7 +144,7 @@ Model parameters are based on the `Silo example <../silo/silo.html>`_.
       end
       set particle particle contact force method    = hertz_mindlin_limit_overlap
       set particle wall contact force method        = nonlinear
-      set rolling resistance torque method          = constant_resistance
+      set rolling resistance torque method          = constant
       set integration method                        = velocity_verlet
     end
 

--- a/doc/source/examples/dem/rotating-drum/rotating-drum.rst
+++ b/doc/source/examples/dem/rotating-drum/rotating-drum.rst
@@ -115,7 +115,7 @@ In the rotating drum simulation, we use a ``frequent`` load-balancing method and
       end
       set particle particle contact force method    = hertz_mindlin_limit_overlap
       set particle wall contact force method        = nonlinear
-      set rolling resistance torque method          = no_resistance
+      set rolling resistance torque method          = none
       set integration method                        = velocity_verlet
     end
 

--- a/doc/source/examples/dem/rotation-of-box/rotation-of-box.rst
+++ b/doc/source/examples/dem/rotation-of-box/rotation-of-box.rst
@@ -104,7 +104,7 @@ Model Parameters
       end
       set particle particle contact force method    = hertz_mindlin_limit_overlap
       set particle wall contact force method        = nonlinear
-      set rolling resistance torque method          = constant_resistance
+      set rolling resistance torque method          = constant
       set integration method                        = velocity_verlet
     end
 

--- a/doc/source/examples/dem/sandpile-formation/sandpile-formation.rst
+++ b/doc/source/examples/dem/sandpile-formation/sandpile-formation.rst
@@ -137,7 +137,7 @@ Model Parameters
       set particle particle contact force method = hertz_mindlin_limit_overlap
       set particle wall contact force method     = nonlinear
       set integration method                     = velocity_verlet
-      set rolling resistance torque method       = epsd_resistance
+      set rolling resistance torque method       = epsd
       set f coefficient                          = 0.0 
     end
 
@@ -145,7 +145,7 @@ Model Parameters
 
   The ``f coefficient`` is only specified when the EPSD rolling resistance model is selected, in this case in prm file ``sandpile-epsd.prm``. 
   
-  In ``sandpile-viscous.prm`` and ``sandpile-constant.prm``, the ``rolling resistance torque method`` is set to ``viscous_resistance`` and ``constant_resistance``, respectively.
+  In ``sandpile-viscous.prm`` and ``sandpile-constant.prm``, the ``rolling resistance torque method`` is set to ``viscous`` and ``constant``, respectively.
   
   More information regarding the DEM model parameters is given in the Lethe documentation, i.e. `DEM Model Parameters <../../../parameters/dem/model_parameters.html>`_.
 

--- a/doc/source/examples/dem/small-scale-rotating-drum/small-scale-rotating-drum.rst
+++ b/doc/source/examples/dem/small-scale-rotating-drum/small-scale-rotating-drum.rst
@@ -122,7 +122,7 @@ In this example, we use the ``dynamic`` load balancing method. This method check
       end
       set particle particle contact force method    = hertz_mindlin_limit_overlap
       set particle wall contact force method        = nonlinear
-      set rolling resistance torque method          = constant_resistance
+      set rolling resistance torque method          = constant
       set integration method                        = velocity_verlet
     end
 

--- a/doc/source/examples/unresolved-cfd-dem/boycott-effect/boycott-effect.rst
+++ b/doc/source/examples/unresolved-cfd-dem/boycott-effect/boycott-effect.rst
@@ -95,7 +95,7 @@ The section on model parameters is explained in the DEM examples. We show the ch
         set neighborhood threshold   = 1.3
         set frequency                = 1
       end
-      set rolling resistance torque method       = constant_resistance
+      set rolling resistance torque method       = constant
       set particle particle contact force method = hertz_mindlin_limit_force
       set particle wall contact force method     = nonlinear
       set integration method                     = velocity_verlet

--- a/doc/source/examples/unresolved-cfd-dem/dense-pneumatic-conveying/dense-pneumatic-conveying.rst
+++ b/doc/source/examples/unresolved-cfd-dem/dense-pneumatic-conveying/dense-pneumatic-conveying.rst
@@ -261,7 +261,7 @@ The model parameters are quite standard for a DEM simulation with the non-linear
      set particle particle contact force method = hertz_mindlin_limit_overlap
      set particle wall contact force method     = nonlinear
      set integration method                     = velocity_verlet
-     set rolling resistance torque method       = constant_resistance
+     set rolling resistance torque method       = constant
      subsection adaptive sparse contacts
        set enable adaptive sparse contacts = true
        set enable particle advection       = false
@@ -417,7 +417,7 @@ Model parameters are the same as in the DEM simulation, but without load balanci
      set particle particle contact force method = hertz_mindlin_limit_overlap
      set particle wall contact force method     = nonlinear
      set integration method                     = velocity_verlet
-     set rolling resistance torque method       = constant_resistance
+     set rolling resistance torque method       = constant
    end
 
 Simulation Control

--- a/doc/source/parameters/dem/model_parameters.rst
+++ b/doc/source/parameters/dem/model_parameters.rst
@@ -49,9 +49,9 @@ In this subsection, contact detection, force models, time integration, load bala
     set integration method                     = velocity_verlet
 
     # Rolling resistance method
-    # Choices are no_resistance|constant_resistance|viscous_resistance|epsd_resistance
-    set rolling resistance torque method       = constant_resistance
-    set f coefficient                          = 0.0 # if rolling resistance torque method = epsd_resistance
+    # Choices are none|constant|viscous|epsd
+    set rolling resistance torque method       = constant
+    set f coefficient                          = 0.0 # if rolling resistance torque method = epsd
 
     subsection adaptive sparse contacts
       set enable adaptive sparse contacts = false
@@ -115,9 +115,9 @@ All contact force models are described in the :doc:`../../theory/multiphase/cfd_
 .. note::
     The ``neighborhood threshold`` has to be large enough to correctly consider all non contact forces.
 
-* ``rolling resistance method`` controls the rolling resistance model used. Three rolling resistance models are available: ``no_resistance``, ``constant_resistance``, ``viscous_resistance`` and ``epsd_resistance``
+* ``rolling resistance method`` controls the rolling resistance model used. Three rolling resistance models are available: ``none``, ``constant``, ``viscous`` and ``epsd``
 
-* ``f coefficient`` is a model parameter used for the ``epsd_resistance`` model which controls the proportion of the viscous damping applied when full mobilization is reached.
+* ``f coefficient`` is a model parameter used for the ``epsd`` model which controls the proportion of the viscous damping applied when full mobilization is reached.
 
 -----------------------
 Load Balancing

--- a/examples/dem-mp/3d-heat-transfer-in-aligned-particles/equilibrium.prm
+++ b/examples/dem-mp/3d-heat-transfer-in-aligned-particles/equilibrium.prm
@@ -30,7 +30,7 @@ subsection model parameters
     set neighborhood threshold                  = 1.3
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
   set solver type                            = dem_mp

--- a/examples/dem-mp/3d-heat-transfer-in-aligned-particles/wall-heating.prm
+++ b/examples/dem-mp/3d-heat-transfer-in-aligned-particles/wall-heating.prm
@@ -30,7 +30,7 @@ subsection model parameters
     set neighborhood threshold                  = 1.3
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
   set solver type                            = dem_mp

--- a/examples/dem-mp/3d-heated-packed-bed/flip-packed-bed.prm
+++ b/examples/dem-mp/3d-heated-packed-bed/flip-packed-bed.prm
@@ -34,7 +34,7 @@ subsection model parameters
     set frequency           = 100000
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
   set solver type                            = dem_mp

--- a/examples/dem-mp/3d-heated-packed-bed/heat-packed-bed.prm
+++ b/examples/dem-mp/3d-heated-packed-bed/heat-packed-bed.prm
@@ -30,7 +30,7 @@ subsection model parameters
     set neighborhood threshold                  = 1.3
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
   set solver type                            = dem_mp

--- a/examples/dem-mp/3d-heated-packed-bed/load-packed-bed.prm
+++ b/examples/dem-mp/3d-heated-packed-bed/load-packed-bed.prm
@@ -34,7 +34,7 @@ subsection model parameters
     set frequency           = 100000
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
   set solver type                            = dem_mp

--- a/examples/dem/2d-packing-in-circle/packing-in-circle.prm
+++ b/examples/dem/2d-packing-in-circle/packing-in-circle.prm
@@ -31,7 +31,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
 end
 
 #---------------------------------------------------

--- a/examples/dem/2d-sandpile-formation/sandpile-constant.prm
+++ b/examples/dem/2d-sandpile-formation/sandpile-constant.prm
@@ -49,7 +49,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
 end
 
 #---------------------------------------------------

--- a/examples/dem/2d-sandpile-formation/sandpile-epsd.prm
+++ b/examples/dem/2d-sandpile-formation/sandpile-epsd.prm
@@ -49,7 +49,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = epsd_resistance
+  set rolling resistance torque method       = epsd
   set f coefficient                          = 0.0
 end
 

--- a/examples/dem/2d-sandpile-formation/sandpile-viscous.prm
+++ b/examples/dem/2d-sandpile-formation/sandpile-viscous.prm
@@ -49,7 +49,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = viscous_resistance
+  set rolling resistance torque method       = viscous
 end
 
 #---------------------------------------------------

--- a/examples/dem/3d-bunny-drill/bunny-drill-loading.prm
+++ b/examples/dem/3d-bunny-drill/bunny-drill-loading.prm
@@ -42,7 +42,7 @@ subsection model parameters
     set frequency           = 10000
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
 end

--- a/examples/dem/3d-bunny-drill/bunny-drill.prm
+++ b/examples/dem/3d-bunny-drill/bunny-drill.prm
@@ -34,7 +34,7 @@ subsection model parameters
     set frequency           = 10000
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
 end

--- a/examples/dem/3d-dam-break/granular-dam-break-H-40cm.prm
+++ b/examples/dem/3d-dam-break/granular-dam-break-H-40cm.prm
@@ -34,7 +34,7 @@ subsection model parameters
     set frequency           = 5000
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
 end

--- a/examples/dem/3d-dam-break/granular-dam-break.prm
+++ b/examples/dem/3d-dam-break/granular-dam-break.prm
@@ -34,7 +34,7 @@ subsection model parameters
     set frequency           = 5000
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
 end

--- a/examples/dem/3d-granuheap/granuheap.prm
+++ b/examples/dem/3d-granuheap/granuheap.prm
@@ -43,7 +43,7 @@ subsection model parameters
     set frequency           = 10000
   end
   set particle particle contact force method = hertz_JKR
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = JKR
   set integration method                     = velocity_verlet
 end

--- a/examples/dem/3d-granuheap/granuheap_multicase.prm
+++ b/examples/dem/3d-granuheap/granuheap_multicase.prm
@@ -43,7 +43,7 @@ subsection model parameters
     set frequency           = 10000
   end
   set particle particle contact force method = hertz_JKR
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = JKR
   set integration method                     = velocity_verlet
 end

--- a/examples/dem/3d-grid-rotation-in-box/grid-rotation-box.prm
+++ b/examples/dem/3d-grid-rotation-in-box/grid-rotation-box.prm
@@ -29,7 +29,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/examples/dem/3d-oblique-wall-impact/oblique_wall_impact_template.tpl
+++ b/examples/dem/3d-oblique-wall-impact/oblique_wall_impact_template.tpl
@@ -25,7 +25,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
 
 end
 

--- a/examples/dem/3d-plate-discharge/data/plate-discharge_asc-lb.prm
+++ b/examples/dem/3d-plate-discharge/data/plate-discharge_asc-lb.prm
@@ -37,7 +37,7 @@ subsection model parameters
     set neighborhood threshold                  = 1.3
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
   subsection adaptive sparse contacts

--- a/examples/dem/3d-plate-discharge/data/plate-discharge_asc.prm
+++ b/examples/dem/3d-plate-discharge/data/plate-discharge_asc.prm
@@ -37,7 +37,7 @@ subsection model parameters
     set neighborhood threshold                  = 1.3
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
   subsection adaptive sparse contacts

--- a/examples/dem/3d-plate-discharge/data/plate-discharge_base.prm
+++ b/examples/dem/3d-plate-discharge/data/plate-discharge_base.prm
@@ -37,7 +37,7 @@ subsection model parameters
     set neighborhood threshold                  = 1.3
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
   subsection adaptive sparse contacts

--- a/examples/dem/3d-plate-discharge/data/plate-discharge_lb.prm
+++ b/examples/dem/3d-plate-discharge/data/plate-discharge_lb.prm
@@ -37,7 +37,7 @@ subsection model parameters
     set neighborhood threshold                  = 1.3
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
   subsection adaptive sparse contacts

--- a/examples/dem/3d-plate-discharge/performance/plate-discharge_asc-lb.prm
+++ b/examples/dem/3d-plate-discharge/performance/plate-discharge_asc-lb.prm
@@ -37,7 +37,7 @@ subsection model parameters
     set neighborhood threshold                  = 1.3
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
   subsection adaptive sparse contacts

--- a/examples/dem/3d-plate-discharge/performance/plate-discharge_asc.prm
+++ b/examples/dem/3d-plate-discharge/performance/plate-discharge_asc.prm
@@ -37,7 +37,7 @@ subsection model parameters
     set neighborhood threshold                  = 1.3
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
   subsection adaptive sparse contacts

--- a/examples/dem/3d-plate-discharge/performance/plate-discharge_base.prm
+++ b/examples/dem/3d-plate-discharge/performance/plate-discharge_base.prm
@@ -37,7 +37,7 @@ subsection model parameters
     set neighborhood threshold                  = 1.3
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
   subsection adaptive sparse contacts

--- a/examples/dem/3d-plate-discharge/performance/plate-discharge_lb.prm
+++ b/examples/dem/3d-plate-discharge/performance/plate-discharge_lb.prm
@@ -42,7 +42,7 @@ subsection model parameters
     set dynamic check frequency = 2500
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
   subsection adaptive sparse contacts

--- a/examples/dem/3d-rectangular-hopper/hopper.prm
+++ b/examples/dem/3d-rectangular-hopper/hopper.prm
@@ -36,7 +36,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/examples/dem/3d-rectangular-hopper/hopper_periodic.prm
+++ b/examples/dem/3d-rectangular-hopper/hopper_periodic.prm
@@ -36,7 +36,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/examples/dem/3d-rotating-drum/rotating-drum.prm
+++ b/examples/dem/3d-rotating-drum/rotating-drum.prm
@@ -34,7 +34,7 @@ subsection model parameters
     set frequency           = 20000
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
-  set rolling resistance torque method       = no_resistance
+  set rolling resistance torque method       = none
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
 end

--- a/examples/dem/3d-small-scale-rotating-drum/packing-rotating-drum.prm
+++ b/examples/dem/3d-small-scale-rotating-drum/packing-rotating-drum.prm
@@ -55,7 +55,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/examples/dem/3d-small-scale-rotating-drum/small-rotating-drum-dem.prm
+++ b/examples/dem/3d-small-scale-rotating-drum/small-rotating-drum-dem.prm
@@ -103,7 +103,7 @@ subsection model parameters
   end
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   set integration method                     = velocity_verlet
 end
 

--- a/examples/unresolved-cfd-dem/dense-pneumatic-conveying/loading-particles.prm
+++ b/examples/unresolved-cfd-dem/dense-pneumatic-conveying/loading-particles.prm
@@ -68,7 +68,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   subsection adaptive sparse contacts
     set enable adaptive sparse contacts = true
     set enable particle advection       = false

--- a/examples/unresolved-cfd-dem/dense-pneumatic-conveying/pneumatic-conveying.prm
+++ b/examples/unresolved-cfd-dem/dense-pneumatic-conveying/pneumatic-conveying.prm
@@ -171,7 +171,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
 end
 
 # --------------------------------------------------

--- a/examples/unresolved-cfd-dem/dense-pneumatic-conveying/settling-particles.prm
+++ b/examples/unresolved-cfd-dem/dense-pneumatic-conveying/settling-particles.prm
@@ -68,7 +68,7 @@ subsection model parameters
   set particle particle contact force method = hertz_mindlin_limit_overlap
   set particle wall contact force method     = nonlinear
   set integration method                     = velocity_verlet
-  set rolling resistance torque method       = constant_resistance
+  set rolling resistance torque method       = constant
   subsection adaptive sparse contacts
     set enable adaptive sparse contacts = true
     set enable particle advection       = false

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -35,10 +35,10 @@ namespace Parameters
 
     enum RollingResistanceMethod
     {
-      no_resistance,
-      constant_resistance,
-      viscous_resistance,
-      epsd_resistance
+      none,
+      constant,
+      viscous,
+      epsd
     };
 
     enum class SizeDistributionType

--- a/include/dem/particle_particle_contact_force.h
+++ b/include/dem/particle_particle_contact_force.h
@@ -575,14 +575,12 @@ private:
   {
     using namespace Parameters::Lagrangian;
 
-    if constexpr (rolling_friction_model ==
-                  RollingResistanceMethod::no_resistance)
+    if constexpr (rolling_friction_model == none)
       {
         return no_rolling_resistance_torque();
       }
 
-    if constexpr (rolling_friction_model ==
-                  RollingResistanceMethod::constant_resistance)
+    if constexpr (rolling_friction_model == constant)
       {
         return constant_rolling_resistance_torque<PropertiesIndex>(
           effective_radius,
@@ -592,7 +590,7 @@ private:
           normal_force_norm);
       }
 
-    if constexpr (rolling_friction_model == viscous_resistance)
+    if constexpr (rolling_friction_model == viscous)
       {
         return viscous_rolling_resistance_torque<PropertiesIndex>(
           effective_radius,
@@ -602,7 +600,7 @@ private:
           normal_force_norm,
           normal_unit_vector);
       }
-    if constexpr (rolling_friction_model == epsd_resistance)
+    if constexpr (rolling_friction_model == epsd)
       {
         return epsd_rolling_resistance_torque<dim, PropertiesIndex>(
           effective_radius,

--- a/include/dem/particle_wall_contact_force.h
+++ b/include/dem/particle_wall_contact_force.h
@@ -496,12 +496,12 @@ private:
   {
     using namespace Parameters::Lagrangian;
 
-    if constexpr (rolling_friction_model == RollingResistanceMethod::none)
+    if constexpr (rolling_friction_model == none)
       {
         return no_rolling_torque();
       }
 
-    if constexpr (rolling_friction_model == RollingResistanceMethod::constant)
+    if constexpr (rolling_friction_model == constant)
       {
         return constant_rolling_torque<PropertiesIndex>(particle_radius,
                                                         particle_properties,

--- a/include/dem/particle_wall_contact_force.h
+++ b/include/dem/particle_wall_contact_force.h
@@ -496,14 +496,12 @@ private:
   {
     using namespace Parameters::Lagrangian;
 
-    if constexpr (rolling_friction_model ==
-                  RollingResistanceMethod::no_resistance)
+    if constexpr (rolling_friction_model == RollingResistanceMethod::none)
       {
         return no_rolling_torque();
       }
 
-    if constexpr (rolling_friction_model ==
-                  RollingResistanceMethod::constant_resistance)
+    if constexpr (rolling_friction_model == RollingResistanceMethod::constant)
       {
         return constant_rolling_torque<PropertiesIndex>(particle_radius,
                                                         particle_properties,
@@ -511,7 +509,7 @@ private:
                                                         normal_force_norm);
       }
 
-    if constexpr (rolling_friction_model == viscous_resistance)
+    if constexpr (rolling_friction_model == viscous)
       {
         return viscous_rolling_torque<PropertiesIndex>(particle_radius,
                                                        particle_properties,
@@ -519,7 +517,7 @@ private:
                                                        normal_force_norm,
                                                        normal_unit_vector);
       }
-    if constexpr (rolling_friction_model == epsd_resistance)
+    if constexpr (rolling_friction_model == epsd)
       {
         return epsd_rolling_torque<dim, PropertiesIndex>(
           particle_radius,

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -1109,33 +1109,35 @@ namespace Parameters
         const std::string rolling_resistance_torque =
           prm.get("rolling resistance torque method");
 
-        if (rolling_resistance_torque == "no_resistance")
-          std::cout
-            << "Warning, the \"no_resistance\" entry to the \"rolling "
-               "resistance torque method\" parameter will be deprecated. "
-               "Please use \"none\" instead."
-            << std::endl;
+        if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+          {
+            if (rolling_resistance_torque == "no_resistance")
+              std::cout
+                << "Warning, the \"no_resistance\" entry to the \"rolling "
+                   "resistance torque method\" parameter will be deprecated. "
+                   "Please use \"none\" instead."
+                << std::endl;
 
-        if (rolling_resistance_torque == "constant_resistance")
-          std::cout
-            << "Warning, the \"constant_resistance\" entry to the \"rolling"
-               " resistance torque method\" parameter will be deprecated."
-               " Please use \"constant\" instead."
-            << std::endl;
+            if (rolling_resistance_torque == "constant_resistance")
+              std::cout
+                << "Warning, the \"constant_resistance\" entry to the \"rolling"
+                   " resistance torque method\" parameter will be deprecated."
+                   " Please use \"constant\" instead."
+                << std::endl;
 
-        if (rolling_resistance_torque == "viscous_resistance")
-          std::cout
-            << "Warning, the \"viscous_resistance\" entry to the \"rolling"
-               " resistance torque method\" parameter will be deprecated. "
-               "Please use \"viscous\" instead."
-            << std::endl;
-        if (rolling_resistance_torque == "epsd_resistance")
-          std::cout
-            << "Warning, the \"epsd_resistance\" entry to the \"rolling "
-               "resistance torque method\" parameter will be deprecated. "
-               "Please use \"epsd\" instead."
-            << std::endl;
-
+            if (rolling_resistance_torque == "viscous_resistance")
+              std::cout
+                << "Warning, the \"viscous_resistance\" entry to the \"rolling"
+                   " resistance torque method\" parameter will be deprecated. "
+                   "Please use \"viscous\" instead."
+                << std::endl;
+            if (rolling_resistance_torque == "epsd_resistance")
+              std::cout
+                << "Warning, the \"epsd_resistance\" entry to the \"rolling "
+                   "resistance torque method\" parameter will be deprecated. "
+                   "Please use \"epsd\" instead."
+                << std::endl;
+          }
         if (rolling_resistance_torque == "no_resistance" ||
             rolling_resistance_torque == "none")
           {

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -1158,12 +1158,6 @@ namespace Parameters
           {
             rolling_resistance_method = RollingResistanceMethod::epsd;
           }
-        else
-          {
-            throw(
-              std::runtime_error("Invalid rolling resistance torque method "));
-          }
-
 
 
         // Model parameter for the EPSD rolling resistance model

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -882,13 +882,14 @@ namespace Parameters
           "dmt cut-off threshold",
           "0.1",
           Patterns::Double(),
-          "Cut-off threshold above which the Van der Waal forces are ignored for the DMT model relative to the pull-off force");
+          "Cut-off threshold above which the Van der Waal forces are "
+          "ignored for the DMT model relative to the pull-off force");
 
         prm.declare_entry(
           "rolling resistance torque method",
-          "constant_resistance",
+          "constant",
           Patterns::Selection(
-            "no_resistance|constant_resistance|viscous_resistance|epsd_resistance"),
+            "none|no_resistance|constant|constant_resistance|viscous|viscous_resistance|epsd|epsd_resistance"),
           "Choosing rolling resistance torque model"
           "Choices are <no_resistance|constant_resistance|viscous_resistance|epsd_resistance>.");
 
@@ -1107,30 +1108,62 @@ namespace Parameters
 
         const std::string rolling_resistance_torque =
           prm.get("rolling resistance torque method");
+
         if (rolling_resistance_torque == "no_resistance")
+          std::cout
+            << "Warning, the \"no_resistance\" entry to the \"rolling "
+               "resistance torque method\" parameter will be deprecated. "
+               "Please use \"none\" instead."
+            << std::endl;
+
+        if (rolling_resistance_torque == "constant_resistance")
+          std::cout
+            << "Warning, the \"constant_resistance\" entry to the \"rolling"
+               " resistance torque method\" parameter will be deprecated."
+               " Please use \"constant\" instead."
+            << std::endl;
+
+        if (rolling_resistance_torque == "viscous_resistance")
+          std::cout
+            << "Warning, the \"viscous_resistance\" entry to the \"rolling"
+               " resistance torque method\" parameter will be deprecated. "
+               "Please use \"viscous\" instead."
+            << std::endl;
+        if (rolling_resistance_torque == "epsd_resistance")
+          std::cout
+            << "Warning, the \"epsd_resistance\" entry to the \"rolling "
+               "resistance torque method\" parameter will be deprecated. "
+               "Please use \"epsd\" instead."
+            << std::endl;
+
+        if (rolling_resistance_torque == "no_resistance" ||
+            rolling_resistance_torque == "none")
           {
-            rolling_resistance_method = RollingResistanceMethod::no_resistance;
+            rolling_resistance_method = RollingResistanceMethod::none;
           }
-        else if (rolling_resistance_torque == "constant_resistance")
+        else if (rolling_resistance_torque == "constant_resistance" ||
+                 rolling_resistance_torque == "constant")
           {
-            rolling_resistance_method =
-              RollingResistanceMethod::constant_resistance;
+            rolling_resistance_method = RollingResistanceMethod::constant;
           }
-        else if (rolling_resistance_torque == "viscous_resistance")
+        else if (rolling_resistance_torque == "viscous_resistance" ||
+                 rolling_resistance_torque == "viscous")
           {
-            rolling_resistance_method =
-              RollingResistanceMethod::viscous_resistance;
+            rolling_resistance_method = RollingResistanceMethod::viscous;
           }
-        else if (rolling_resistance_torque == "epsd_resistance")
+        else if (rolling_resistance_torque == "epsd_resistance" ||
+                 rolling_resistance_torque == "epsd")
           {
-            rolling_resistance_method =
-              RollingResistanceMethod::epsd_resistance;
+            rolling_resistance_method = RollingResistanceMethod::epsd;
           }
         else
           {
             throw(
               std::runtime_error("Invalid rolling resistance torque method "));
           }
+
+
+
         // Model parameter for the EPSD rolling resistance model
         f_coefficient_epsd = prm.get_double("f coefficient");
 

--- a/source/dem/force_chains_visualization.cc
+++ b/source/dem/force_chains_visualization.cc
@@ -162,237 +162,225 @@ ParticlesForceChains<dim,
 template class ParticlesForceChains<2,
                                     DEM::DEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::DMT,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 template class ParticlesForceChains<3,
                                     DEM::DEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::DMT,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 template class ParticlesForceChains<2,
                                     DEM::DEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::hertz,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 template class ParticlesForceChains<3,
                                     DEM::DEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::hertz,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<2,
                                     DEM::DEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::linear,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 template class ParticlesForceChains<3,
                                     DEM::DEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::linear,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 
 // Constant resistance
-template class ParticlesForceChains<
-  2,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticlesForceChains<
-  2,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::constant_resistance>;
+template class ParticlesForceChains<2,
+                                    DEM::DEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::DMT,
+                                    RollingResistanceMethod::constant>;
+template class ParticlesForceChains<3,
+                                    DEM::DEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::DMT,
+                                    RollingResistanceMethod::constant>;
+template class ParticlesForceChains<2,
+                                    DEM::DEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::hertz,
+                                    RollingResistanceMethod::constant>;
+template class ParticlesForceChains<3,
+                                    DEM::DEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::hertz,
+                                    RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticlesForceChains<
-  2,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
+template class ParticlesForceChains<2,
+                                    DEM::DEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::linear,
+                                    RollingResistanceMethod::constant>;
+template class ParticlesForceChains<3,
+                                    DEM::DEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::linear,
+                                    RollingResistanceMethod::constant>;
 
 // Viscous resistance
-template class ParticlesForceChains<
-  2,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticlesForceChains<
-  2,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::viscous_resistance>;
+template class ParticlesForceChains<2,
+                                    DEM::DEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::DMT,
+                                    RollingResistanceMethod::viscous>;
+template class ParticlesForceChains<3,
+                                    DEM::DEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::DMT,
+                                    RollingResistanceMethod::viscous>;
+template class ParticlesForceChains<2,
+                                    DEM::DEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::hertz,
+                                    RollingResistanceMethod::viscous>;
+template class ParticlesForceChains<3,
+                                    DEM::DEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::hertz,
+                                    RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticlesForceChains<
-  2,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
+template class ParticlesForceChains<2,
+                                    DEM::DEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::linear,
+                                    RollingResistanceMethod::viscous>;
+template class ParticlesForceChains<3,
+                                    DEM::DEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::linear,
+                                    RollingResistanceMethod::viscous>;
 
 // EPSD resistance
 template class ParticlesForceChains<2,
                                     DEM::DEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::DMT,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<3,
                                     DEM::DEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::DMT,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<2,
                                     DEM::DEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::hertz,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<3,
                                     DEM::DEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::hertz,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<2,
                                     DEM::DEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::linear,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<3,
                                     DEM::DEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::linear,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 
 
 //// DEM::CFDDEMProperties::PropertiesIndex
@@ -400,471 +388,447 @@ template class ParticlesForceChains<3,
 template class ParticlesForceChains<2,
                                     DEM::CFDDEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::DMT,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 template class ParticlesForceChains<3,
                                     DEM::CFDDEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::DMT,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 template class ParticlesForceChains<2,
                                     DEM::CFDDEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::hertz,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 template class ParticlesForceChains<3,
                                     DEM::CFDDEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::hertz,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<2,
                                     DEM::CFDDEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::linear,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 template class ParticlesForceChains<3,
                                     DEM::CFDDEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::linear,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 
 // Constant resistance
-template class ParticlesForceChains<
-  2,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticlesForceChains<
-  2,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::constant_resistance>;
+template class ParticlesForceChains<2,
+                                    DEM::CFDDEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::DMT,
+                                    RollingResistanceMethod::constant>;
+template class ParticlesForceChains<3,
+                                    DEM::CFDDEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::DMT,
+                                    RollingResistanceMethod::constant>;
+template class ParticlesForceChains<2,
+                                    DEM::CFDDEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::hertz,
+                                    RollingResistanceMethod::constant>;
+template class ParticlesForceChains<3,
+                                    DEM::CFDDEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::hertz,
+                                    RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticlesForceChains<
-  2,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
+template class ParticlesForceChains<2,
+                                    DEM::CFDDEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::linear,
+                                    RollingResistanceMethod::constant>;
+template class ParticlesForceChains<3,
+                                    DEM::CFDDEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::linear,
+                                    RollingResistanceMethod::constant>;
 
 // Viscous resistance
-template class ParticlesForceChains<
-  2,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticlesForceChains<
-  2,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::viscous_resistance>;
+template class ParticlesForceChains<2,
+                                    DEM::CFDDEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::DMT,
+                                    RollingResistanceMethod::viscous>;
+template class ParticlesForceChains<3,
+                                    DEM::CFDDEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::DMT,
+                                    RollingResistanceMethod::viscous>;
+template class ParticlesForceChains<2,
+                                    DEM::CFDDEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::hertz,
+                                    RollingResistanceMethod::viscous>;
+template class ParticlesForceChains<3,
+                                    DEM::CFDDEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::hertz,
+                                    RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticlesForceChains<
-  2,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
+template class ParticlesForceChains<2,
+                                    DEM::CFDDEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::linear,
+                                    RollingResistanceMethod::viscous>;
+template class ParticlesForceChains<3,
+                                    DEM::CFDDEMProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::linear,
+                                    RollingResistanceMethod::viscous>;
 
 // EPSD resistance
 template class ParticlesForceChains<2,
                                     DEM::CFDDEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::DMT,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<3,
                                     DEM::CFDDEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::DMT,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<2,
                                     DEM::CFDDEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::hertz,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<3,
                                     DEM::CFDDEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::hertz,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<2,
                                     DEM::CFDDEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::linear,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<3,
                                     DEM::CFDDEMProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::linear,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 
 //// DEM::SolverType::dem_mp
 // No resistance
 template class ParticlesForceChains<2,
                                     DEM::DEMMPProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::DMT,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 template class ParticlesForceChains<3,
                                     DEM::DEMMPProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::DMT,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 template class ParticlesForceChains<2,
                                     DEM::DEMMPProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::hertz,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 template class ParticlesForceChains<3,
                                     DEM::DEMMPProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::hertz,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticlesForceChains<2,
                                     DEM::DEMMPProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::linear,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 template class ParticlesForceChains<3,
                                     DEM::DEMMPProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::linear,
-                                    RollingResistanceMethod::no_resistance>;
+                                    RollingResistanceMethod::none>;
 
 // Constant resistance
-template class ParticlesForceChains<
-  2,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticlesForceChains<
-  2,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::constant_resistance>;
+template class ParticlesForceChains<2,
+                                    DEM::DEMMPProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::DMT,
+                                    RollingResistanceMethod::constant>;
+template class ParticlesForceChains<3,
+                                    DEM::DEMMPProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::DMT,
+                                    RollingResistanceMethod::constant>;
+template class ParticlesForceChains<2,
+                                    DEM::DEMMPProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::hertz,
+                                    RollingResistanceMethod::constant>;
+template class ParticlesForceChains<3,
+                                    DEM::DEMMPProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::hertz,
+                                    RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticlesForceChains<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticlesForceChains<
-  2,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
+template class ParticlesForceChains<2,
+                                    DEM::DEMMPProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::linear,
+                                    RollingResistanceMethod::constant>;
+template class ParticlesForceChains<3,
+                                    DEM::DEMMPProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::linear,
+                                    RollingResistanceMethod::constant>;
 
 // Viscous resistance
-template class ParticlesForceChains<
-  2,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticlesForceChains<
-  2,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::viscous_resistance>;
+template class ParticlesForceChains<2,
+                                    DEM::DEMMPProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::DMT,
+                                    RollingResistanceMethod::viscous>;
+template class ParticlesForceChains<3,
+                                    DEM::DEMMPProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::DMT,
+                                    RollingResistanceMethod::viscous>;
+template class ParticlesForceChains<2,
+                                    DEM::DEMMPProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::hertz,
+                                    RollingResistanceMethod::viscous>;
+template class ParticlesForceChains<3,
+                                    DEM::DEMMPProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::hertz,
+                                    RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticlesForceChains<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticlesForceChains<
-  2,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticlesForceChains<
-  3,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
+template class ParticlesForceChains<2,
+                                    DEM::DEMMPProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::linear,
+                                    RollingResistanceMethod::viscous>;
+template class ParticlesForceChains<3,
+                                    DEM::DEMMPProperties::PropertiesIndex,
+                                    ParticleParticleContactForceModel::linear,
+                                    RollingResistanceMethod::viscous>;
 
 // EPSD resistance
 template class ParticlesForceChains<2,
                                     DEM::DEMMPProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::DMT,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<3,
                                     DEM::DEMMPProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::DMT,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<2,
                                     DEM::DEMMPProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::hertz,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<3,
                                     DEM::DEMMPProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::hertz,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<2,
                                     DEM::DEMMPProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::linear,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;
 template class ParticlesForceChains<3,
                                     DEM::DEMMPProperties::PropertiesIndex,
                                     ParticleParticleContactForceModel::linear,
-                                    RollingResistanceMethod::epsd_resistance>;
+                                    RollingResistanceMethod::epsd>;

--- a/source/dem/particle_particle_contact_force.cc
+++ b/source/dem/particle_particle_contact_force.cc
@@ -106,248 +106,248 @@ template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 
 // Constant resistance
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 
 // Viscous resistance
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 
 // EPSD resistance
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 
 // cfd_dem
 // No resistance
@@ -355,248 +355,248 @@ template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 
 // Constant resistance
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 
 // Viscous resistance
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 
 // EPSD resistance
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 
 // dem_mp
 //  No resistance
@@ -604,245 +604,245 @@ template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 
 // Constant resistance
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 
 // Viscous resistance
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 
 // EPSD resistance
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::DMT,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_JKR,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_force,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleParticleContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleParticleContactForceModel::linear,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;

--- a/source/dem/particle_wall_contact_force.cc
+++ b/source/dem/particle_wall_contact_force.cc
@@ -556,486 +556,432 @@ ParticleWallContactForce<dim,
 template class ParticleWallContactForce<2,
                                         DEM::DEMProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::DMT,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<3,
                                         DEM::DEMProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::DMT,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<2,
                                         DEM::DEMProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::JKR,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<3,
                                         DEM::DEMProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::JKR,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<2,
                                         DEM::DEMProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::linear,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<3,
                                         DEM::DEMProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::linear,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleWallContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 
 // Constant resistance
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::constant>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::constant>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::constant>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::constant>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::constant>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::constant>;
 template class ParticleWallContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleWallContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 
 // Viscous resistance
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::viscous>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::viscous>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::viscous>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::viscous>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::viscous>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::viscous>;
 template class ParticleWallContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleWallContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 
 // EPSD resistance
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::epsd_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::epsd_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::epsd_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::epsd_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::epsd_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::epsd_resistance>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::epsd>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::epsd>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::epsd>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::epsd>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::epsd>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::epsd>;
 template class ParticleWallContactForce<
   2,
   DEM::DEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleWallContactForce<
   3,
   DEM::DEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 
 // cfd_dem
 // No resistance
 template class ParticleWallContactForce<2,
                                         DEM::CFDDEMProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::DMT,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<3,
                                         DEM::CFDDEMProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::DMT,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<2,
                                         DEM::CFDDEMProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::JKR,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<3,
                                         DEM::CFDDEMProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::JKR,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<2,
                                         DEM::CFDDEMProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::linear,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<3,
                                         DEM::CFDDEMProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::linear,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleWallContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 
 // Constant resistance
-template class ParticleWallContactForce<
-  2,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
+template class ParticleWallContactForce<2,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::constant>;
+template class ParticleWallContactForce<3,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::constant>;
+template class ParticleWallContactForce<2,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::constant>;
+template class ParticleWallContactForce<3,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::constant>;
+template class ParticleWallContactForce<2,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::constant>;
+template class ParticleWallContactForce<3,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::constant>;
 template class ParticleWallContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleWallContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 
 // Viscous resistance
-template class ParticleWallContactForce<
-  2,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
+template class ParticleWallContactForce<2,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::viscous>;
+template class ParticleWallContactForce<3,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::viscous>;
+template class ParticleWallContactForce<2,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::viscous>;
+template class ParticleWallContactForce<3,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::viscous>;
+template class ParticleWallContactForce<2,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::viscous>;
+template class ParticleWallContactForce<3,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::viscous>;
 template class ParticleWallContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleWallContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 
 // EPSD resistance
-template class ParticleWallContactForce<
-  2,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::epsd_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::epsd_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::epsd_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::epsd_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::epsd_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::CFDDEMProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::epsd_resistance>;
+template class ParticleWallContactForce<2,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::epsd>;
+template class ParticleWallContactForce<3,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::epsd>;
+template class ParticleWallContactForce<2,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::epsd>;
+template class ParticleWallContactForce<3,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::epsd>;
+template class ParticleWallContactForce<2,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::epsd>;
+template class ParticleWallContactForce<3,
+                                        DEM::CFDDEMProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::epsd>;
 template class ParticleWallContactForce<
   2,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleWallContactForce<
   3,
   DEM::CFDDEMProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 
 // dem_mp
 //  No resistance
 template class ParticleWallContactForce<2,
                                         DEM::DEMMPProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::DMT,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<3,
                                         DEM::DEMMPProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::DMT,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<2,
                                         DEM::DEMMPProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::JKR,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<3,
                                         DEM::DEMMPProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::JKR,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<2,
                                         DEM::DEMMPProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::linear,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<3,
                                         DEM::DEMMPProperties::PropertiesIndex,
                                         ParticleWallContactForceModel::linear,
-                                        RollingResistanceMethod::no_resistance>;
+                                        RollingResistanceMethod::none>;
 template class ParticleWallContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 template class ParticleWallContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::no_resistance>;
+  RollingResistanceMethod::none>;
 
 // Constant resistance
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::constant_resistance>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::constant>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::constant>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::constant>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::constant>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::constant>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::constant>;
 template class ParticleWallContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 template class ParticleWallContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::constant_resistance>;
+  RollingResistanceMethod::constant>;
 
 // Viscous resistance
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::viscous_resistance>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::viscous>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::viscous>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::viscous>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::viscous>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::viscous>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::viscous>;
 template class ParticleWallContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 template class ParticleWallContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::viscous_resistance>;
+  RollingResistanceMethod::viscous>;
 
 // EPSD resistance
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::epsd_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::DMT,
-  RollingResistanceMethod::epsd_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::epsd_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::JKR,
-  RollingResistanceMethod::epsd_resistance>;
-template class ParticleWallContactForce<
-  2,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::epsd_resistance>;
-template class ParticleWallContactForce<
-  3,
-  DEM::DEMMPProperties::PropertiesIndex,
-  ParticleWallContactForceModel::linear,
-  RollingResistanceMethod::epsd_resistance>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::epsd>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::DMT,
+                                        RollingResistanceMethod::epsd>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::epsd>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::JKR,
+                                        RollingResistanceMethod::epsd>;
+template class ParticleWallContactForce<2,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::epsd>;
+template class ParticleWallContactForce<3,
+                                        DEM::DEMMPProperties::PropertiesIndex,
+                                        ParticleWallContactForceModel::linear,
+                                        RollingResistanceMethod::epsd>;
 template class ParticleWallContactForce<
   2,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;
 template class ParticleWallContactForce<
   3,
   DEM::DEMMPProperties::PropertiesIndex,
   ParticleWallContactForceModel::nonlinear,
-  RollingResistanceMethod::epsd_resistance>;
+  RollingResistanceMethod::epsd>;

--- a/source/dem/set_particle_particle_contact_force_model.cc
+++ b/source/dem/set_particle_particle_contact_force_model.cc
@@ -101,44 +101,44 @@ set_rolling_resistance_model(
 
   switch (rolling_resistance_method)
     {
-      case RollingResistanceMethod::no_resistance:
+      case RollingResistanceMethod::none:
         {
-          particle_particle_contact_force_object =
-            std::make_shared<ParticleParticleContactForce<
-              dim,
-              PropertiesIndex,
-              particle_particle_contact_force_model,
-              RollingResistanceMethod::no_resistance>>(dem_parameters);
+          particle_particle_contact_force_object = std::make_shared<
+            ParticleParticleContactForce<dim,
+                                         PropertiesIndex,
+                                         particle_particle_contact_force_model,
+                                         RollingResistanceMethod::none>>(
+            dem_parameters);
           break;
         }
-      case RollingResistanceMethod::constant_resistance:
+      case RollingResistanceMethod::constant:
         {
-          particle_particle_contact_force_object =
-            std::make_shared<ParticleParticleContactForce<
-              dim,
-              PropertiesIndex,
-              particle_particle_contact_force_model,
-              RollingResistanceMethod::constant_resistance>>(dem_parameters);
+          particle_particle_contact_force_object = std::make_shared<
+            ParticleParticleContactForce<dim,
+                                         PropertiesIndex,
+                                         particle_particle_contact_force_model,
+                                         RollingResistanceMethod::constant>>(
+            dem_parameters);
           break;
         }
-      case RollingResistanceMethod::viscous_resistance:
+      case RollingResistanceMethod::viscous:
         {
-          particle_particle_contact_force_object =
-            std::make_shared<ParticleParticleContactForce<
-              dim,
-              PropertiesIndex,
-              particle_particle_contact_force_model,
-              RollingResistanceMethod::viscous_resistance>>(dem_parameters);
+          particle_particle_contact_force_object = std::make_shared<
+            ParticleParticleContactForce<dim,
+                                         PropertiesIndex,
+                                         particle_particle_contact_force_model,
+                                         RollingResistanceMethod::viscous>>(
+            dem_parameters);
           break;
         }
-      case RollingResistanceMethod::epsd_resistance:
+      case RollingResistanceMethod::epsd:
         {
-          particle_particle_contact_force_object =
-            std::make_shared<ParticleParticleContactForce<
-              dim,
-              PropertiesIndex,
-              particle_particle_contact_force_model,
-              RollingResistanceMethod::epsd_resistance>>(dem_parameters);
+          particle_particle_contact_force_object = std::make_shared<
+            ParticleParticleContactForce<dim,
+                                         PropertiesIndex,
+                                         particle_particle_contact_force_model,
+                                         RollingResistanceMethod::epsd>>(
+            dem_parameters);
           break;
         }
       default:
@@ -239,43 +239,43 @@ set_rolling_resistance_model(
 
   switch (rolling_resistance_method)
     {
-      case RollingResistanceMethod::no_resistance:
+      case RollingResistanceMethod::none:
         {
           particles_force_chains_object = std::make_shared<
             ParticlesForceChains<dim,
                                  PropertiesIndex,
                                  particle_particle_contact_force_model,
-                                 RollingResistanceMethod::no_resistance>>(
+                                 RollingResistanceMethod::none>>(
             dem_parameters);
           break;
         }
-      case RollingResistanceMethod::constant_resistance:
+      case RollingResistanceMethod::constant:
         {
           particles_force_chains_object = std::make_shared<
             ParticlesForceChains<dim,
                                  PropertiesIndex,
                                  particle_particle_contact_force_model,
-                                 RollingResistanceMethod::constant_resistance>>(
+                                 RollingResistanceMethod::constant>>(
             dem_parameters);
           break;
         }
-      case RollingResistanceMethod::viscous_resistance:
+      case RollingResistanceMethod::viscous:
         {
           particles_force_chains_object = std::make_shared<
             ParticlesForceChains<dim,
                                  PropertiesIndex,
                                  particle_particle_contact_force_model,
-                                 RollingResistanceMethod::viscous_resistance>>(
+                                 RollingResistanceMethod::viscous>>(
             dem_parameters);
           break;
         }
-      case RollingResistanceMethod::epsd_resistance:
+      case RollingResistanceMethod::epsd:
         {
           particles_force_chains_object = std::make_shared<
             ParticlesForceChains<dim,
                                  PropertiesIndex,
                                  particle_particle_contact_force_model,
-                                 RollingResistanceMethod::epsd_resistance>>(
+                                 RollingResistanceMethod::epsd>>(
             dem_parameters);
           break;
         }

--- a/source/dem/set_particle_wall_contact_force_model.cc
+++ b/source/dem/set_particle_wall_contact_force_model.cc
@@ -81,43 +81,43 @@ set_rolling_resistance_model(
 
   switch (rolling_resistance_method)
     {
-      case RollingResistanceMethod::no_resistance:
+      case RollingResistanceMethod::none:
         {
           particle_wall_contact_force_object = std::make_shared<
             ParticleWallContactForce<dim,
                                      PropertiesIndex,
                                      particle_wall_contact_force_model,
-                                     RollingResistanceMethod::no_resistance>>(
+                                     RollingResistanceMethod::none>>(
             dem_parameters);
           break;
         }
-      case RollingResistanceMethod::constant_resistance:
-        {
-          particle_wall_contact_force_object =
-            std::make_shared<ParticleWallContactForce<
-              dim,
-              PropertiesIndex,
-              particle_wall_contact_force_model,
-              RollingResistanceMethod::constant_resistance>>(dem_parameters);
-          break;
-        }
-      case RollingResistanceMethod::viscous_resistance:
-        {
-          particle_wall_contact_force_object =
-            std::make_shared<ParticleWallContactForce<
-              dim,
-              PropertiesIndex,
-              particle_wall_contact_force_model,
-              RollingResistanceMethod::viscous_resistance>>(dem_parameters);
-          break;
-        }
-      case RollingResistanceMethod::epsd_resistance:
+      case RollingResistanceMethod::constant:
         {
           particle_wall_contact_force_object = std::make_shared<
             ParticleWallContactForce<dim,
                                      PropertiesIndex,
                                      particle_wall_contact_force_model,
-                                     RollingResistanceMethod::epsd_resistance>>(
+                                     RollingResistanceMethod::constant>>(
+            dem_parameters);
+          break;
+        }
+      case RollingResistanceMethod::viscous:
+        {
+          particle_wall_contact_force_object = std::make_shared<
+            ParticleWallContactForce<dim,
+                                     PropertiesIndex,
+                                     particle_wall_contact_force_model,
+                                     RollingResistanceMethod::viscous>>(
+            dem_parameters);
+          break;
+        }
+      case RollingResistanceMethod::epsd:
+        {
+          particle_wall_contact_force_object = std::make_shared<
+            ParticleWallContactForce<dim,
+                                     PropertiesIndex,
+                                     particle_wall_contact_force_model,
+                                     RollingResistanceMethod::epsd>>(
             dem_parameters);
           break;
         }

--- a/tests/dem/normal_force.cc
+++ b/tests/dem/normal_force.cc
@@ -77,7 +77,7 @@ test()
   properties.rolling_viscous_damping_wall                    = 0.1;
   properties.density_particle[0]                             = 7850;
   dem_parameters.model_parameters.rolling_resistance_method =
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
+    Parameters::Lagrangian::RollingResistanceMethod::constant;
 
   // Initializing motion of boundaries
   Tensor<1, dim> translational_and_rotational_velocity;
@@ -147,7 +147,7 @@ test()
     dim,
     PropertiesIndex,
     Parameters::Lagrangian::ParticleWallContactForceModel::nonlinear,
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
+    Parameters::Lagrangian::RollingResistanceMethod::constant>
     particle_wall_force_object(dem_parameters);
   VelocityVerletIntegrator<dim, PropertiesIndex> integrator_object;
   double                                         distance;

--- a/tests/dem/particle_particle_contact_force_linear.cc
+++ b/tests/dem/particle_particle_contact_force_linear.cc
@@ -112,7 +112,7 @@ test()
     dim,
     PropertiesIndex,
     Parameters::Lagrangian::ParticleParticleContactForceModel::linear,
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
+    Parameters::Lagrangian::RollingResistanceMethod::constant>
     linear_force_object(dem_parameters);
   linear_force_object.calculate_particle_particle_contact(
     contact_manager.get_local_adjacent_particles(),

--- a/tests/dem/particle_particle_contact_force_nonlinear.cc
+++ b/tests/dem/particle_particle_contact_force_nonlinear.cc
@@ -46,7 +46,7 @@ test()
   lagrangian_prop.hamaker_constant_particle[0]                    = 0.;
   lagrangian_prop.density_particle[0]                             = 2500;
   model_param.rolling_resistance_method =
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
+    Parameters::Lagrangian::RollingResistanceMethod::constant;
 
   const double neighborhood_threshold = std::pow(1.3 * particle_diameter, 2);
 
@@ -115,7 +115,7 @@ test()
     PropertiesIndex,
     Parameters::Lagrangian::ParticleParticleContactForceModel::
       hertz_mindlin_limit_overlap,
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
+    Parameters::Lagrangian::RollingResistanceMethod::constant>
     nonlinear_force_object(dem_parameters);
   nonlinear_force_object.calculate_particle_particle_contact(
     contact_manager.get_local_adjacent_particles(),

--- a/tests/dem/particle_particle_contact_on_two_processors.cc
+++ b/tests/dem/particle_particle_contact_on_two_processors.cc
@@ -94,7 +94,7 @@ test()
     0.;
   dem_parameters.lagrangian_physical_properties.density_particle[0] = 2500;
   dem_parameters.model_parameters.rolling_resistance_method =
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
+    Parameters::Lagrangian::RollingResistanceMethod::constant;
 
   const double neighborhood_threshold = std::pow(1.3 * particle_diameter, 2);
 
@@ -117,7 +117,7 @@ test()
     PropertiesIndex,
     Parameters::Lagrangian::ParticleParticleContactForceModel::
       hertz_mindlin_limit_overlap,
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
+    Parameters::Lagrangian::RollingResistanceMethod::constant>
     nonlinear_force_object(dem_parameters);
   VelocityVerletIntegrator<dim, PropertiesIndex> integrator_object;
 

--- a/tests/dem/particle_particle_full_contact.cc
+++ b/tests/dem/particle_particle_full_contact.cc
@@ -72,7 +72,7 @@ test()
   lagrangian_prop.hamaker_constant_particle[0]                    = 0.;
   lagrangian_prop.density_particle[0]                             = 2500;
   model_param.rolling_resistance_method =
-    RollingResistanceMethod::constant_resistance;
+    RollingResistanceMethod::constant;
 
   const double neighborhood_threshold = std::pow(1.3 * particle_diameter, 2);
 
@@ -114,7 +114,7 @@ test()
     simulate_full_contact<dim,
                           PropertiesIndex,
                           ParticleParticleContactForceModel::linear,
-                          RollingResistanceMethod::constant_resistance>(
+                          RollingResistanceMethod::constant>(
       triangulation,
       particle_handler,
       contact_manager,
@@ -140,7 +140,7 @@ test()
     dim,
     PropertiesIndex,
     ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
-    RollingResistanceMethod::constant_resistance>(triangulation,
+    RollingResistanceMethod::constant>(triangulation,
                                                   particle_handler,
                                                   contact_manager,
                                                   dem_parameters,

--- a/tests/dem/particle_particle_full_contact.cc
+++ b/tests/dem/particle_particle_full_contact.cc
@@ -71,8 +71,7 @@ test()
   lagrangian_prop.surface_energy_particle[0]                      = 0.;
   lagrangian_prop.hamaker_constant_particle[0]                    = 0.;
   lagrangian_prop.density_particle[0]                             = 2500;
-  model_param.rolling_resistance_method =
-    RollingResistanceMethod::constant;
+  model_param.rolling_resistance_method = RollingResistanceMethod::constant;
 
   const double neighborhood_threshold = std::pow(1.3 * particle_diameter, 2);
 
@@ -141,16 +140,16 @@ test()
     PropertiesIndex,
     ParticleParticleContactForceModel::hertz_mindlin_limit_overlap,
     RollingResistanceMethod::constant>(triangulation,
-                                                  particle_handler,
-                                                  contact_manager,
-                                                  dem_parameters,
-                                                  particle_properties,
-                                                  g,
-                                                  dt,
-                                                  output_frequency,
-                                                  neighborhood_threshold,
-                                                  0,
-                                                  "hmlo");
+                                       particle_handler,
+                                       contact_manager,
+                                       dem_parameters,
+                                       particle_properties,
+                                       g,
+                                       dt,
+                                       output_frequency,
+                                       neighborhood_threshold,
+                                       0,
+                                       "hmlo");
 
   log_contact_output(hmlo_output);
 }

--- a/tests/dem/particle_particle_heat_transfer.cc
+++ b/tests/dem/particle_particle_heat_transfer.cc
@@ -48,7 +48,7 @@ test()
   properties.surface_energy_particle[0]                      = 0.;
   properties.hamaker_constant_particle[0]                    = 0.;
   model_param.rolling_resistance_method =
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
+    Parameters::Lagrangian::RollingResistanceMethod::constant;
 
   const double neighborhood_threshold = std::pow(1.3 * particle_diameter, 2);
 
@@ -140,7 +140,7 @@ test()
     PropertiesIndex,
     Parameters::Lagrangian::ParticleParticleContactForceModel::
       hertz_mindlin_limit_overlap,
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
+    Parameters::Lagrangian::RollingResistanceMethod::constant>
     nonlinear_force_object(dem_parameters);
   nonlinear_force_object.calculate_particle_particle_contact(
     contact_manager.get_local_adjacent_particles(),

--- a/tests/dem/particle_particle_thermal_resistances.cc
+++ b/tests/dem/particle_particle_thermal_resistances.cc
@@ -142,7 +142,7 @@ test()
     PropertiesIndex,
     Parameters::Lagrangian::ParticleParticleContactForceModel::
       hertz_mindlin_limit_overlap,
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
+    Parameters::Lagrangian::RollingResistanceMethod::constant>
     nonlinear_force_object(dem_parameters);
   nonlinear_force_object.calculate_particle_particle_contact(
     contact_manager.get_local_adjacent_particles(),

--- a/tests/dem/particle_wall_contact_force_linear.cc
+++ b/tests/dem/particle_wall_contact_force_linear.cc
@@ -75,7 +75,7 @@ test()
   properties.rolling_viscous_damping_wall                    = 0.1;
   properties.density_particle[0]                             = 2500;
   dem_parameters.model_parameters.rolling_resistance_method =
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
+    Parameters::Lagrangian::RollingResistanceMethod::constant;
 
   // Initializing motion of boundaries
   Tensor<1, dim> translational_and_rotational_velocity;
@@ -154,7 +154,7 @@ test()
     dim,
     PropertiesIndex,
     Parameters::Lagrangian::ParticleWallContactForceModel::linear,
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
+    Parameters::Lagrangian::RollingResistanceMethod::constant>
     force_object(dem_parameters);
   force_object.calculate_particle_wall_contact(
     particle_wall_contact_information, dt, contact_outcome);

--- a/tests/dem/particle_wall_contact_force_nonlinear.cc
+++ b/tests/dem/particle_wall_contact_force_nonlinear.cc
@@ -75,7 +75,7 @@ test()
   properties.rolling_viscous_damping_wall                    = 0.1;
   properties.density_particle[0]                             = 2500;
   dem_parameters.model_parameters.rolling_resistance_method =
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
+    Parameters::Lagrangian::RollingResistanceMethod::constant;
 
   // Initializing motion of boundaries
   Tensor<1, dim> translational_and_rotational_velocity;
@@ -154,7 +154,7 @@ test()
     dim,
     PropertiesIndex,
     Parameters::Lagrangian::ParticleWallContactForceModel::nonlinear,
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
+    Parameters::Lagrangian::RollingResistanceMethod::constant>
     force_object(dem_parameters);
   force_object.calculate_particle_wall_contact(
     particle_wall_contact_information, dt, contact_outcome);

--- a/tests/dem/particle_wall_thermal_conductance.cc
+++ b/tests/dem/particle_wall_thermal_conductance.cc
@@ -79,7 +79,7 @@ test()
   properties.rolling_viscous_damping_wall                    = 0.1;
   properties.density_particle[0]                             = 2500;
   dem_parameters.model_parameters.rolling_resistance_method =
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
+    Parameters::Lagrangian::RollingResistanceMethod::constant;
 
   // Defining parameters for thermal DEM
   const double equivalent_surface_roughness  = 1e-9;
@@ -173,7 +173,7 @@ test()
     dim,
     PropertiesIndex,
     Parameters::Lagrangian::ParticleWallContactForceModel::nonlinear,
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
+    Parameters::Lagrangian::RollingResistanceMethod::constant>
     nonlinear_force_object(dem_parameters);
   nonlinear_force_object.calculate_particle_wall_contact(
     particle_wall_pairs_in_contact, dt, contact_outcome);

--- a/tests/dem/post_collision_velocity.cc
+++ b/tests/dem/post_collision_velocity.cc
@@ -75,7 +75,7 @@ test(double coefficient_of_restitution)
   properties.rolling_friction_wall                           = 0.1;
   properties.density_particle[0]                             = 2500;
   dem_parameters.model_parameters.rolling_resistance_method =
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
+    Parameters::Lagrangian::RollingResistanceMethod::constant;
 
   // Initializing motion of boundaries
   Tensor<1, dim> translational_and_rotational_veclocity;
@@ -147,7 +147,7 @@ test(double coefficient_of_restitution)
     dim,
     PropertiesIndex,
     Parameters::Lagrangian::ParticleWallContactForceModel::nonlinear,
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
+    Parameters::Lagrangian::RollingResistanceMethod::constant>
     particle_wall_force_object(dem_parameters);
   VelocityVerletIntegrator<dim, PropertiesIndex> integrator_object;
 

--- a/tests/dem/test_particles_functions.h
+++ b/tests/dem/test_particles_functions.h
@@ -113,7 +113,7 @@ set_default_dem_parameters(const unsigned int        particle_type_number,
 
   // Rolling resistance method
   dem_parameters.model_parameters.rolling_resistance_method =
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
+    Parameters::Lagrangian::RollingResistanceMethod::constant;
 
   // Particle parameters
   for (unsigned int i = 0; i < particle_type_number; ++i)

--- a/tests/dem/two_particles_multiple_contacts_parallel.cc
+++ b/tests/dem/two_particles_multiple_contacts_parallel.cc
@@ -65,7 +65,7 @@ test()
   dem_parameters.lagrangian_physical_properties.density_particle[0] = 2500;
   double neighborhood_threshold = 1.3 * particle_diameter;
   dem_parameters.model_parameters.rolling_resistance_method =
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance;
+    Parameters::Lagrangian::RollingResistanceMethod::constant;
 
   Particles::ParticleHandler<dim> particle_handler(
     triangulation, mapping, PropertiesIndex::n_properties);
@@ -86,7 +86,7 @@ test()
     PropertiesIndex,
     Parameters::Lagrangian::ParticleParticleContactForceModel::
       hertz_mindlin_limit_overlap,
-    Parameters::Lagrangian::RollingResistanceMethod::constant_resistance>
+    Parameters::Lagrangian::RollingResistanceMethod::constant>
     nonlinear_force_object(dem_parameters);
   VelocityVerletIntegrator<dim, PropertiesIndex> integrator_object;
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The naming convention related to rolling resistance models is redundant. When setting the type of model : 

"set rolling resistance torque model = constant_resistance "

The "_resistance" is not necessary. This PR is resolve #1420 . 

### Testing
Every test are passing and I tested that the warning message informing the user that he is using a soon to be deprecated parameter naming convention appears when using the old versions. 

### Documentation

The documentation was updated using the new convention. 

### Miscellaneous (will be removed when merged)
N/A

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [X] If parameters are modified, the tests and the documentation of examples are up to date
- [X] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [X] No other PR is open related to this refactoring
- [X] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [X] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] If any future works is planned, an issue is opened
- [X] The PR description is cleaned and ready for merge