### PR TITLE
Fix checkpointing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
+- MINOR The checkpointing with TableHandler tables had some issues. When checkpointing and restarting, the tables were serialized and deserialized on all ranks. Since the tables were only owned on rank 0, this resulted in an overwriting of data in the tables, and data history was lost at restart. With this change, by default, only rank 0 serializes and deserializes the information. If wished in the future, with the current change it is also possible to serialize on multiple cores, by setting the default parameter `serialize_on_rank_zero`/`deserialize_on_rank_zero` to `false`. [#1652](https://github.com/chaos-polymtl/lethe/pull/1652)
+
 - MAJOR The rolling resistance models naming convention was redundant. Every option had an extra \"_resistance\" at the end, which was not necessary. Options are now "none", "constant", "viscous" and "epsd". The old naming convention is still compatible for now, but will be deprecated down the line. Currently, a warning message is shown when using the previous naming convention. [#1640](https://github.com/chaos-polymtl/lethe/pull/1640)
 
 ### [Master] - 2025-09-01

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -253,8 +253,8 @@ make_table_tensors_tensors(
  * @param[in] independent_column_names Vector of strings representing labels of
  * the independent tensor.
  *
- * @param[in] dependent_values Vector of of doubles containing
- * dependent variables values (e.g., force).
+ * @param[in] dependent_values Vector of doubles containing dependent variables
+ * values (e.g., force).
  *
  * @param[in] dependent_column_name Label of the dependent variable.
  *

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -479,7 +479,7 @@ announce_string(const ConditionalOStream &pcout,
  * will be saved.
  * @param[in] mpi_communicator The MPI communicator
  * @param[in] serialize_on_rank_zero Boolean indicating if the table should only
- * be serialized on rank 0 only. By default, it is set to true.
+ * be serialized on rank 0 only. By default, it is set to `true`.
  */
 inline void
 serialize_table(const TableHandler &table,
@@ -509,7 +509,7 @@ serialize_table(const TableHandler &table,
  * from.
  * @param[in] mpi_communicator The MPI communicator
  * @param[in] deserialize_on_rank_zero Boolean indicating if the table should
- * only be deserialized on rank 0 only. By default, it is set to true.
+ * only be deserialized on rank 0 only. By default, it is set to `true`.
  */
 inline void
 deserialize_table(TableHandler      &table,

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -477,13 +477,25 @@ announce_string(const ConditionalOStream &pcout,
  * @param[in] table The table to be serialized.
  * @param[in] filename Path to the file (including extension) where the table
  * will be saved.
+ * @param[in] mpi_communicator The MPI communicator
+ * @param[in] serialize_on_rank_zero Boolean indicating if the table should only
+ * be serialized on rank 0 only. By default, it is set to true.
  */
 inline void
-serialize_table(const TableHandler &table, const std::string &filename)
+serialize_table(const TableHandler &table,
+                const std::string  &filename,
+                const MPI_Comm     &mpi_communicator,
+                const bool          serialize_on_rank_zero = true)
 {
-  std::ofstream                 ofile(filename);
-  boost::archive::text_oarchive oa(ofile, boost::archive::no_header);
-  oa << table;
+  unsigned int this_mpi_process(
+    Utilities::MPI::this_mpi_process(mpi_communicator));
+
+  if (!serialize_on_rank_zero || this_mpi_process == 0)
+    {
+      std::ofstream                 ofile(filename);
+      boost::archive::text_oarchive oa(ofile, boost::archive::no_header);
+      oa << table;
+    }
 }
 
 
@@ -493,15 +505,27 @@ serialize_table(const TableHandler &table, const std::string &filename)
  * The filename should include the desired extension.
  *
  * @param[in,out] table    The table to be deserialized (will be overwritten).
- * @param[in]     filename Path to the file (including extension) to read the
- * table from.
+ * @param[in] filename Path to the file (including extension) to read the table
+ * from.
+ * @param[in] mpi_communicator The MPI communicator
+ * @param[in] deserialize_on_rank_zero Boolean indicating if the table should
+ * only be deserialized on rank 0 only. By default, it is set to true.
  */
 inline void
-deserialize_table(TableHandler &table, const std::string &filename)
+deserialize_table(TableHandler      &table,
+                  const std::string &filename,
+                  const MPI_Comm    &mpi_communicator,
+                  const bool         deserialize_on_rank_zero = true)
 {
-  std::ifstream                 ifile(filename);
-  boost::archive::text_iarchive ia(ifile, boost::archive::no_header);
-  ia >> table;
+  unsigned int this_mpi_process(
+    Utilities::MPI::this_mpi_process(mpi_communicator));
+
+  if (!deserialize_on_rank_zero || this_mpi_process == 0)
+    {
+      std::ifstream                 ifile(filename);
+      boost::archive::text_iarchive ia(ifile, boost::archive::no_header);
+      ia >> table;
+    }
 }
 
 /**

--- a/source/solvers/cahn_hilliard.cc
+++ b/source/solvers/cahn_hilliard.cc
@@ -940,6 +940,7 @@ template <int dim>
 void
 CahnHilliard<dim>::write_checkpoint()
 {
+  auto mpi_communicator = this->triangulation->get_mpi_communicator();
   std::vector<const GlobalVectorType *> sol_set_transfer;
 
   solution_transfer =
@@ -960,12 +961,14 @@ CahnHilliard<dim>::write_checkpoint()
     serialize_table(
       this->error_table,
       prefix + this->simulation_parameters.analytical_solution->get_filename() +
-        "_CH" + suffix);
+        "_CH" + suffix,
+      mpi_communicator);
   if (this->simulation_parameters.post_processing.calculate_phase_statistics)
     serialize_table(
       this->statistics_table,
       prefix + this->simulation_parameters.post_processing.phase_output_name +
-        suffix);
+        suffix,
+      mpi_communicator);
 }
 
 template <int dim>
@@ -1005,12 +1008,14 @@ CahnHilliard<dim>::read_checkpoint()
     deserialize_table(
       this->error_table,
       prefix + this->simulation_parameters.analytical_solution->get_filename() +
-        "_CH" + suffix);
+        "_CH" + suffix,
+      mpi_communicator);
   if (this->simulation_parameters.post_processing.calculate_phase_statistics)
     deserialize_table(
       this->statistics_table,
       prefix + this->simulation_parameters.post_processing.phase_output_name +
-        suffix);
+        suffix,
+      mpi_communicator);
 }
 
 

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -1171,6 +1171,7 @@ template <int dim>
 void
 HeatTransfer<dim>::write_checkpoint()
 {
+  auto mpi_communicator = this->triangulation->get_mpi_communicator();
   std::vector<const GlobalVectorType *> sol_set_transfer;
 
   solution_transfer =
@@ -1206,27 +1207,31 @@ HeatTransfer<dim>::write_checkpoint()
     serialize_table(
       this->error_table,
       prefix + this->simulation_parameters.analytical_solution->get_filename() +
-        "_HT" + suffix);
+        "_HT" + suffix,
+      mpi_communicator);
   if (this->simulation_parameters.post_processing.calculate_heat_flux)
     serialize_table(
       this->heat_flux_table,
       prefix +
         this->simulation_parameters.post_processing.heat_flux_output_name +
-        suffix);
+        suffix,
+      mpi_communicator);
   if (this->simulation_parameters.post_processing
         .calculate_temperature_statistics)
     serialize_table(
       this->statistics_table,
       prefix +
         this->simulation_parameters.post_processing.temperature_output_name +
-        suffix);
+        suffix,
+      mpi_communicator);
 
   if (this->simulation_parameters.post_processing.calculate_liquid_fraction)
     serialize_table(this->liquid_fraction_table,
                     prefix +
                       this->simulation_parameters.post_processing
                         .liquid_fraction_output_name +
-                      suffix);
+                      suffix,
+      mpi_communicator);
 }
 
 template <int dim>
@@ -1300,26 +1305,30 @@ HeatTransfer<dim>::read_checkpoint()
     deserialize_table(
       this->error_table,
       prefix + this->simulation_parameters.analytical_solution->get_filename() +
-        "_HT" + suffix);
+      "_HT" + suffix,
+    mpi_communicator);
   if (this->simulation_parameters.post_processing.calculate_heat_flux)
     deserialize_table(
       this->heat_flux_table,
       prefix +
         this->simulation_parameters.post_processing.heat_flux_output_name +
-        suffix);
+        suffix,
+      mpi_communicator);
   if (this->simulation_parameters.post_processing
         .calculate_temperature_statistics)
     deserialize_table(
       this->statistics_table,
       prefix +
         this->simulation_parameters.post_processing.temperature_output_name +
-        suffix);
+        suffix,
+      mpi_communicator);
   if (this->simulation_parameters.post_processing.calculate_liquid_fraction)
     deserialize_table(this->liquid_fraction_table,
                       prefix +
                         this->simulation_parameters.post_processing
                           .liquid_fraction_output_name +
-                        suffix);
+                          suffix,
+        mpi_communicator);
 }
 
 

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -1231,7 +1231,7 @@ HeatTransfer<dim>::write_checkpoint()
                       this->simulation_parameters.post_processing
                         .liquid_fraction_output_name +
                       suffix,
-      mpi_communicator);
+                    mpi_communicator);
 }
 
 template <int dim>
@@ -1305,8 +1305,8 @@ HeatTransfer<dim>::read_checkpoint()
     deserialize_table(
       this->error_table,
       prefix + this->simulation_parameters.analytical_solution->get_filename() +
-      "_HT" + suffix,
-    mpi_communicator);
+        "_HT" + suffix,
+      mpi_communicator);
   if (this->simulation_parameters.post_processing.calculate_heat_flux)
     deserialize_table(
       this->heat_flux_table,
@@ -1327,8 +1327,8 @@ HeatTransfer<dim>::read_checkpoint()
                       prefix +
                         this->simulation_parameters.post_processing
                           .liquid_fraction_output_name +
-                          suffix,
-        mpi_communicator);
+                        suffix,
+                      mpi_communicator);
 }
 
 

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2297,41 +2297,39 @@ NavierStokesBase<dim, VectorType, DofsType>::read_checkpoint()
     std::string suffix = ".checkpoint";
     if (post_processing.calculate_enstrophy)
       deserialize_table(this->enstrophy_table,
-                        prefix + post_processing.enstrophy_output_name +
-                        suffix,
-    mpi_communicator);
+                        prefix + post_processing.enstrophy_output_name + suffix,
+                        mpi_communicator);
     if (post_processing.calculate_pressure_power)
       deserialize_table(this->pressure_power_table,
                         prefix + post_processing.pressure_power_output_name +
-                        suffix,
-    mpi_communicator);
+                          suffix,
+                        mpi_communicator);
     if (post_processing.calculate_viscous_dissipation)
       deserialize_table(this->viscous_dissipation_table,
                         prefix +
                           post_processing.viscous_dissipation_output_name +
                           suffix,
-      mpi_communicator);
+                        mpi_communicator);
     if (post_processing.calculate_kinetic_energy)
       deserialize_table(this->kinetic_energy_table,
                         prefix + post_processing.kinetic_energy_output_name +
-                        suffix,
-    mpi_communicator);
+                          suffix,
+                        mpi_communicator);
     if (post_processing.calculate_apparent_viscosity)
       deserialize_table(this->apparent_viscosity_table,
                         prefix +
                           post_processing.apparent_viscosity_output_name +
                           suffix,
-      mpi_communicator);
+                        mpi_communicator);
     if (post_processing.calculate_flow_rate)
       deserialize_table(this->flow_rate_table,
-                        prefix + post_processing.flow_rate_output_name +
-                        suffix,
-    mpi_communicator);
+                        prefix + post_processing.flow_rate_output_name + suffix,
+                        mpi_communicator);
     if (post_processing.calculate_pressure_drop)
       deserialize_table(this->pressure_drop_table,
                         prefix + post_processing.pressure_drop_output_name +
-                        suffix,
-    mpi_communicator);
+                          suffix,
+                        mpi_communicator);
     if (this->simulation_parameters.forces_parameters.calculate_force)
       for (auto const &[id, type] :
            this->simulation_parameters.boundary_conditions.type)
@@ -2341,7 +2339,7 @@ NavierStokesBase<dim, VectorType, DofsType>::read_checkpoint()
             prefix +
               this->simulation_parameters.forces_parameters.force_output_name +
               "_" + Utilities::int_to_string(id, 2) + suffix,
-      mpi_communicator);
+            mpi_communicator);
         }
     if (this->simulation_parameters.forces_parameters.calculate_torque)
       for (auto const &[id, type] :
@@ -2352,7 +2350,7 @@ NavierStokesBase<dim, VectorType, DofsType>::read_checkpoint()
             prefix +
               this->simulation_parameters.forces_parameters.torque_output_name +
               "_" + Utilities::int_to_string(id, 2) + suffix,
-      mpi_communicator);
+            mpi_communicator);
         }
     if (this->simulation_parameters.analytical_solution->calculate_error())
       deserialize_table(
@@ -2360,7 +2358,7 @@ NavierStokesBase<dim, VectorType, DofsType>::read_checkpoint()
         prefix +
           this->simulation_parameters.analytical_solution->get_filename() +
           "_FD" + suffix,
-      mpi_communicator);
+        mpi_communicator);
   }
 }
 
@@ -3130,37 +3128,37 @@ NavierStokesBase<dim, VectorType, DofsType>::write_checkpoint()
     std::string suffix = ".checkpoint";
     if (post_processing.calculate_enstrophy)
       serialize_table(this->enstrophy_table,
-      prefix + post_processing.enstrophy_output_name + suffix,
-mpi_communicator);
+                      prefix + post_processing.enstrophy_output_name + suffix,
+                      mpi_communicator);
     if (post_processing.calculate_kinetic_energy)
       serialize_table(this->kinetic_energy_table,
                       prefix + post_processing.kinetic_energy_output_name +
-                      suffix,
-    mpi_communicator);
+                        suffix,
+                      mpi_communicator);
     if (post_processing.calculate_pressure_power)
       serialize_table(this->pressure_power_table,
                       prefix + post_processing.pressure_power_output_name +
-                      suffix,
-    mpi_communicator);
+                        suffix,
+                      mpi_communicator);
     if (post_processing.calculate_viscous_dissipation)
       serialize_table(this->viscous_dissipation_table,
                       prefix + post_processing.viscous_dissipation_output_name +
-                      suffix,
-    mpi_communicator);
+                        suffix,
+                      mpi_communicator);
     if (post_processing.calculate_apparent_viscosity)
       serialize_table(this->apparent_viscosity_table,
                       prefix + post_processing.apparent_viscosity_output_name +
-                      suffix,
-    mpi_communicator);
+                        suffix,
+                      mpi_communicator);
     if (post_processing.calculate_flow_rate)
       serialize_table(this->flow_rate_table,
-      prefix + post_processing.flow_rate_output_name + suffix,
-mpi_communicator);
+                      prefix + post_processing.flow_rate_output_name + suffix,
+                      mpi_communicator);
     if (post_processing.calculate_pressure_drop)
       serialize_table(this->pressure_drop_table,
                       prefix + post_processing.pressure_drop_output_name +
-                      suffix,
-    mpi_communicator);
+                        suffix,
+                      mpi_communicator);
     if (this->simulation_parameters.forces_parameters.calculate_force)
       for (auto const &[boundary_id, type] :
            this->simulation_parameters.boundary_conditions.type)
@@ -3170,7 +3168,7 @@ mpi_communicator);
             prefix +
               this->simulation_parameters.forces_parameters.force_output_name +
               "_" + Utilities::int_to_string(boundary_id, 2) + suffix,
-      mpi_communicator);
+            mpi_communicator);
         }
     if (this->simulation_parameters.forces_parameters.calculate_torque)
       for (auto const &[boundary_id, type] :
@@ -3181,7 +3179,7 @@ mpi_communicator);
             prefix +
               this->simulation_parameters.forces_parameters.torque_output_name +
               "_" + Utilities::int_to_string(boundary_id, 2) + suffix,
-      mpi_communicator);
+            mpi_communicator);
         }
     if (this->simulation_parameters.analytical_solution->calculate_error())
       serialize_table(
@@ -3189,7 +3187,7 @@ mpi_communicator);
         prefix +
           this->simulation_parameters.analytical_solution->get_filename() +
           "_FD" + suffix,
-      mpi_communicator);
+        mpi_communicator);
   }
 }
 

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2298,33 +2298,40 @@ NavierStokesBase<dim, VectorType, DofsType>::read_checkpoint()
     if (post_processing.calculate_enstrophy)
       deserialize_table(this->enstrophy_table,
                         prefix + post_processing.enstrophy_output_name +
-                          suffix);
+                        suffix,
+    mpi_communicator);
     if (post_processing.calculate_pressure_power)
       deserialize_table(this->pressure_power_table,
                         prefix + post_processing.pressure_power_output_name +
-                          suffix);
+                        suffix,
+    mpi_communicator);
     if (post_processing.calculate_viscous_dissipation)
       deserialize_table(this->viscous_dissipation_table,
                         prefix +
                           post_processing.viscous_dissipation_output_name +
-                          suffix);
+                          suffix,
+      mpi_communicator);
     if (post_processing.calculate_kinetic_energy)
       deserialize_table(this->kinetic_energy_table,
                         prefix + post_processing.kinetic_energy_output_name +
-                          suffix);
+                        suffix,
+    mpi_communicator);
     if (post_processing.calculate_apparent_viscosity)
       deserialize_table(this->apparent_viscosity_table,
                         prefix +
                           post_processing.apparent_viscosity_output_name +
-                          suffix);
+                          suffix,
+      mpi_communicator);
     if (post_processing.calculate_flow_rate)
       deserialize_table(this->flow_rate_table,
                         prefix + post_processing.flow_rate_output_name +
-                          suffix);
+                        suffix,
+    mpi_communicator);
     if (post_processing.calculate_pressure_drop)
       deserialize_table(this->pressure_drop_table,
                         prefix + post_processing.pressure_drop_output_name +
-                          suffix);
+                        suffix,
+    mpi_communicator);
     if (this->simulation_parameters.forces_parameters.calculate_force)
       for (auto const &[id, type] :
            this->simulation_parameters.boundary_conditions.type)
@@ -2333,7 +2340,8 @@ NavierStokesBase<dim, VectorType, DofsType>::read_checkpoint()
             this->forces_tables[id],
             prefix +
               this->simulation_parameters.forces_parameters.force_output_name +
-              "_" + Utilities::int_to_string(id, 2) + suffix);
+              "_" + Utilities::int_to_string(id, 2) + suffix,
+      mpi_communicator);
         }
     if (this->simulation_parameters.forces_parameters.calculate_torque)
       for (auto const &[id, type] :
@@ -2343,14 +2351,16 @@ NavierStokesBase<dim, VectorType, DofsType>::read_checkpoint()
             this->torques_tables[id],
             prefix +
               this->simulation_parameters.forces_parameters.torque_output_name +
-              "_" + Utilities::int_to_string(id, 2) + suffix);
+              "_" + Utilities::int_to_string(id, 2) + suffix,
+      mpi_communicator);
         }
     if (this->simulation_parameters.analytical_solution->calculate_error())
       deserialize_table(
         this->error_table,
         prefix +
           this->simulation_parameters.analytical_solution->get_filename() +
-          "_FD" + suffix);
+          "_FD" + suffix,
+      mpi_communicator);
   }
 }
 
@@ -3120,30 +3130,37 @@ NavierStokesBase<dim, VectorType, DofsType>::write_checkpoint()
     std::string suffix = ".checkpoint";
     if (post_processing.calculate_enstrophy)
       serialize_table(this->enstrophy_table,
-                      prefix + post_processing.enstrophy_output_name + suffix);
+      prefix + post_processing.enstrophy_output_name + suffix,
+mpi_communicator);
     if (post_processing.calculate_kinetic_energy)
       serialize_table(this->kinetic_energy_table,
                       prefix + post_processing.kinetic_energy_output_name +
-                        suffix);
+                      suffix,
+    mpi_communicator);
     if (post_processing.calculate_pressure_power)
       serialize_table(this->pressure_power_table,
                       prefix + post_processing.pressure_power_output_name +
-                        suffix);
+                      suffix,
+    mpi_communicator);
     if (post_processing.calculate_viscous_dissipation)
       serialize_table(this->viscous_dissipation_table,
                       prefix + post_processing.viscous_dissipation_output_name +
-                        suffix);
+                      suffix,
+    mpi_communicator);
     if (post_processing.calculate_apparent_viscosity)
       serialize_table(this->apparent_viscosity_table,
                       prefix + post_processing.apparent_viscosity_output_name +
-                        suffix);
+                      suffix,
+    mpi_communicator);
     if (post_processing.calculate_flow_rate)
       serialize_table(this->flow_rate_table,
-                      prefix + post_processing.flow_rate_output_name + suffix);
+      prefix + post_processing.flow_rate_output_name + suffix,
+mpi_communicator);
     if (post_processing.calculate_pressure_drop)
       serialize_table(this->pressure_drop_table,
                       prefix + post_processing.pressure_drop_output_name +
-                        suffix);
+                      suffix,
+    mpi_communicator);
     if (this->simulation_parameters.forces_parameters.calculate_force)
       for (auto const &[boundary_id, type] :
            this->simulation_parameters.boundary_conditions.type)
@@ -3152,7 +3169,8 @@ NavierStokesBase<dim, VectorType, DofsType>::write_checkpoint()
             this->forces_tables[boundary_id],
             prefix +
               this->simulation_parameters.forces_parameters.force_output_name +
-              "_" + Utilities::int_to_string(boundary_id, 2) + suffix);
+              "_" + Utilities::int_to_string(boundary_id, 2) + suffix,
+      mpi_communicator);
         }
     if (this->simulation_parameters.forces_parameters.calculate_torque)
       for (auto const &[boundary_id, type] :
@@ -3162,14 +3180,16 @@ NavierStokesBase<dim, VectorType, DofsType>::write_checkpoint()
             this->torques_tables[boundary_id],
             prefix +
               this->simulation_parameters.forces_parameters.torque_output_name +
-              "_" + Utilities::int_to_string(boundary_id, 2) + suffix);
+              "_" + Utilities::int_to_string(boundary_id, 2) + suffix,
+      mpi_communicator);
         }
     if (this->simulation_parameters.analytical_solution->calculate_error())
       serialize_table(
         this->error_table,
         prefix +
           this->simulation_parameters.analytical_solution->get_filename() +
-          "_FD" + suffix);
+          "_FD" + suffix,
+      mpi_communicator);
   }
 }
 

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -1146,14 +1146,14 @@ Tracer<dim>::write_checkpoint()
     serialize_table(
       this->error_table,
       prefix + this->simulation_parameters.analytical_solution->get_filename() +
-      "_tracer" + suffix,
-    mpi_communicator);
+        "_tracer" + suffix,
+      mpi_communicator);
   if (this->simulation_parameters.post_processing.calculate_tracer_statistics)
     serialize_table(
       this->statistics_table,
       prefix + this->simulation_parameters.post_processing.tracer_output_name +
-      suffix,
-    mpi_communicator);
+        suffix,
+      mpi_communicator);
 }
 
 template <int dim>
@@ -1193,14 +1193,14 @@ Tracer<dim>::read_checkpoint()
     deserialize_table(
       this->error_table,
       prefix + this->simulation_parameters.analytical_solution->get_filename() +
-      "_tracer" + suffix,
-    mpi_communicator);
+        "_tracer" + suffix,
+      mpi_communicator);
   if (this->simulation_parameters.post_processing.calculate_tracer_statistics)
     deserialize_table(
       this->statistics_table,
       prefix + this->simulation_parameters.post_processing.tracer_output_name +
-      suffix,
-    mpi_communicator);
+        suffix,
+      mpi_communicator);
 }
 
 

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -1125,6 +1125,7 @@ template <int dim>
 void
 Tracer<dim>::write_checkpoint()
 {
+  auto mpi_communicator = this->triangulation->get_mpi_communicator();
   std::vector<const GlobalVectorType *> sol_set_transfer;
 
   solution_transfer =
@@ -1145,12 +1146,14 @@ Tracer<dim>::write_checkpoint()
     serialize_table(
       this->error_table,
       prefix + this->simulation_parameters.analytical_solution->get_filename() +
-        "_tracer" + suffix);
+      "_tracer" + suffix,
+    mpi_communicator);
   if (this->simulation_parameters.post_processing.calculate_tracer_statistics)
     serialize_table(
       this->statistics_table,
       prefix + this->simulation_parameters.post_processing.tracer_output_name +
-        suffix);
+      suffix,
+    mpi_communicator);
 }
 
 template <int dim>
@@ -1190,12 +1193,14 @@ Tracer<dim>::read_checkpoint()
     deserialize_table(
       this->error_table,
       prefix + this->simulation_parameters.analytical_solution->get_filename() +
-        "_tracer" + suffix);
+      "_tracer" + suffix,
+    mpi_communicator);
   if (this->simulation_parameters.post_processing.calculate_tracer_statistics)
     deserialize_table(
       this->statistics_table,
       prefix + this->simulation_parameters.post_processing.tracer_output_name +
-        suffix);
+      suffix,
+    mpi_communicator);
 }
 
 

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -2134,6 +2134,10 @@ template <int dim>
 void
 VolumeOfFluid<dim>::write_checkpoint()
 {
+  auto         mpi_communicator = this->triangulation->get_mpi_communicator();
+  unsigned int this_mpi_process(
+    Utilities::MPI::this_mpi_process(mpi_communicator));
+
   std::vector<const GlobalVectorType *> sol_set_transfer;
 
   solution_transfer =
@@ -2146,36 +2150,43 @@ VolumeOfFluid<dim>::write_checkpoint()
     }
   this->solution_transfer->prepare_for_serialization(sol_set_transfer);
 
-  // Serialize tables
-  std::string prefix =
-    this->simulation_parameters.simulation_control.output_folder;
-  std::string suffix = ".checkpoint";
-  if (this->simulation_parameters.analytical_solution->calculate_error())
-    serialize_table(
-      this->error_table,
-      prefix + this->simulation_parameters.analytical_solution->get_filename() +
-        "_VOF" + suffix);
-  if (this->simulation_parameters.post_processing.calculate_mass_conservation)
+  if (this_mpi_process == 0)
     {
-      serialize_table(this->table_monitoring_vof,
-                      prefix +
-                        this->simulation_parameters.post_processing
-                          .mass_conservation_output_name +
-                        suffix);
+      // Serialize tables
+      std::string prefix =
+        this->simulation_parameters.simulation_control.output_folder;
+      std::string suffix = ".checkpoint";
+      if (this->simulation_parameters.analytical_solution->calculate_error())
+        serialize_table(
+          this->error_table,
+          prefix +
+            this->simulation_parameters.analytical_solution->get_filename() +
+            "_VOF" + suffix);
+      if (this->simulation_parameters.post_processing
+            .calculate_mass_conservation)
+        {
+          serialize_table(this->table_monitoring_vof,
+                          prefix +
+                            this->simulation_parameters.post_processing
+                              .mass_conservation_output_name +
+                            suffix);
+        }
+      if (this->simulation_parameters.post_processing.calculate_barycenter)
+        serialize_table(
+          this->table_barycenter,
+          prefix +
+            this->simulation_parameters.post_processing.barycenter_output_name +
+            suffix);
     }
-  if (this->simulation_parameters.post_processing.calculate_barycenter)
-    serialize_table(
-      this->table_barycenter,
-      prefix +
-        this->simulation_parameters.post_processing.barycenter_output_name +
-        suffix);
 }
 
 template <int dim>
 void
 VolumeOfFluid<dim>::read_checkpoint()
 {
-  auto mpi_communicator        = this->triangulation->get_mpi_communicator();
+  auto         mpi_communicator = this->triangulation->get_mpi_communicator();
+  unsigned int this_mpi_process(
+    Utilities::MPI::this_mpi_process(mpi_communicator));
   auto previous_solutions_size = this->previous_solutions.size();
   this->pcout << "Reading VOF checkpoint" << std::endl;
 
@@ -2205,42 +2216,47 @@ VolumeOfFluid<dim>::read_checkpoint()
   // Apply filter to phase fraction
   apply_phase_filter(this->present_solution, this->filtered_solution);
 
-  // Deserialize tables
-  const std::string prefix =
-    this->simulation_parameters.simulation_control.output_folder;
-  const std::string suffix = ".checkpoint";
-  if (this->simulation_parameters.analytical_solution->calculate_error())
-    deserialize_table(
-      this->error_table,
-      prefix + this->simulation_parameters.analytical_solution->get_filename() +
-        "_VOF" + suffix);
-  if (this->simulation_parameters.post_processing.calculate_mass_conservation)
+  if (this_mpi_process == 0)
     {
-      deserialize_table(this->table_monitoring_vof,
-                        prefix +
-                          this->simulation_parameters.post_processing
-                            .mass_conservation_output_name +
-                          suffix);
-    }
-  if (this->simulation_parameters.post_processing.calculate_barycenter)
-    deserialize_table(
-      this->table_barycenter,
-      prefix +
-        this->simulation_parameters.post_processing.barycenter_output_name +
-        suffix);
+      // Deserialize tables
+      const std::string prefix =
+        this->simulation_parameters.simulation_control.output_folder;
+      const std::string suffix = ".checkpoint";
+      if (this->simulation_parameters.analytical_solution->calculate_error())
+        deserialize_table(
+          this->error_table,
+          prefix +
+            this->simulation_parameters.analytical_solution->get_filename() +
+            "_VOF" + suffix);
+      if (this->simulation_parameters.post_processing
+            .calculate_mass_conservation)
+        {
+          deserialize_table(this->table_monitoring_vof,
+                            prefix +
+                              this->simulation_parameters.post_processing
+                                .mass_conservation_output_name +
+                              suffix);
+        }
+      if (this->simulation_parameters.post_processing.calculate_barycenter)
+        deserialize_table(
+          this->table_barycenter,
+          prefix +
+            this->simulation_parameters.post_processing.barycenter_output_name +
+            suffix);
 
-  if (this->simulation_parameters.multiphysics.vof_parameters
-        .regularization_method.sharpening.type ==
-      Parameters::SharpeningType::adaptive)
-    {
-      // Calculate volume and mass
-      calculate_volume_and_mass(
-        this->present_solution,
-        *multiphysics->get_solution(PhysicsID::fluid_dynamics),
-        this->simulation_parameters.multiphysics.vof_parameters
-          .regularization_method.sharpening.monitored_fluid);
+      if (this->simulation_parameters.multiphysics.vof_parameters
+            .regularization_method.sharpening.type ==
+          Parameters::SharpeningType::adaptive)
+        {
+          // Calculate volume and mass
+          calculate_volume_and_mass(
+            this->present_solution,
+            *multiphysics->get_solution(PhysicsID::fluid_dynamics),
+            this->simulation_parameters.multiphysics.vof_parameters
+              .regularization_method.sharpening.monitored_fluid);
 
-      this->mass_first_iteration = this->mass_monitored;
+          this->mass_first_iteration = this->mass_monitored;
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description of the Problem

The checkpointing with TableHandler tables had some issues. When checkpointing and restarting, the tables were serialized and deserialized on all ranks. Since the tables were only owned on rank 0, this resulted in an overwriting of data in the tables, and data history was lost at restart.

### Solution

The bug was fixed by adding two arguments to the serializing and deserializing functions:

- The MPI communicator
- A boolean indicating if the serialization/deserialization must be done on 1 rank (rank 0); this is set to `true` by default. 

If wished, in the future, with the current changes, it is also possible to serialize/deserialize on multiple cores, by setting the default parameter `serialize_on_rank_zero`/`deserialize_on_rank_zero` to `false`. Some slight modifications will be need to the functions to ensure correspondence between checkpoint files and processors.

### Testing

- Tested with a 3D rising bubble case on Rorqual.
- Waiting for CI

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge