### PR TITLE
Add missing space

### DIFF
--- a/contrib/utilities/relaunch_simulations.sh
+++ b/contrib/utilities/relaunch_simulations.sh
@@ -382,7 +382,7 @@ do
             echo " Re-running failed simulation"
 
             # Check if restart parameter should be set to "true"
-            if [ "$set_restart_true" == "true"]
+            if [ "$set_restart_true" == "true" ]
             then
               # Get prm file
               prm_file=$(ls | grep "\.prm$")


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

A small bug was introduce at the last commit of PR #1636. A missing space in the script did not allow the user to change the restart to `true` for failed simulations. 

### Solution

The missing space has been added.

### Testing

Tested with a failed 3D rising bubble simulation on Rorqual.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Copyright headers are present and up to date
- [ ] Lethe documentation is up to date
- [ ] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [ ] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge