### PR TITLE
Hotfix sharp output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+### [Master] - 2025-09-04
+
+### Fixed
+
+- MAJOR The sharp-edge solver used in resolved CFD-DEM would crash at the first VTU output produced. This is because no dof handler was being attached to the output hook. This PR temporarily fixes that by attaching the dof handler of the main problem. A better solution will be implemented soon. [#1658](https://github.com/chaos-polymtl/lethe/pull/1658)
+
 ### [Master] - 2025-09-03
 
 ### Fixed

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -1686,7 +1686,9 @@ FluidDynamicsSharp<dim>::output_field_hook(DataOut<dim> &data_out)
   // the particle integration routines.
   levelset_postprocessor =
     std::make_shared<LevelsetPostprocessor<dim>>(combined_shapes);
-  data_out.add_data_vector(this->present_solution, *levelset_postprocessor);
+  data_out.add_data_vector(this->dof_handler,
+                           this->present_solution,
+                           *levelset_postprocessor);
   Vector<float> cell_cuts(this->triangulation->n_active_cells());
   Vector<float> cell_overconstrained(this->triangulation->n_active_cells());
   const unsigned int                   dofs_per_cell = this->fe->dofs_per_cell;


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The sharp-edge solver used in resolved CFD-DEM would crash at the first VTU output produced. This is because no dof handler was being attached to the output hook.

### Solution

This PR temporarily fixes that by attaching the dof handler of the main problem. A better solution will be implemented by leveraging the full mechanisms that @voferreira implemented with the struct. @voferreira I'll let you do that in a follow-up PR.

### Testing

Tested on any of the examples and now they run.

### Documentation

Nothing to document here.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge