### PR TITLE
Fix issue by attaching dof_handler to DataOut instance + refactor structs to include cell data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
+- MAJOR This PR fixes the bug patched in [#1658](https://github.com/chaos-polymtl/lethe/pull/1658). It attaches a DoF handler to the DataOut instance, which prevents calls for add_solution_vector without DoF handler. This is a more robust solution than the previous one. More tests will be carried out, but this solution reproduces what the code had before the refactoring in [#1624](https://github.com/chaos-polymtl/lethe/pull/1624). [#1661](https://github.com/chaos-polymtl/lethe/pull/1661)
+
+### Fixed
+
 - MAJOR The sharp-edge solver used in resolved CFD-DEM would crash at the first VTU output produced. This is because no dof handler was being attached to the output hook. This PR temporarily fixes that by attaching the dof handler of the main problem. A better solution will be implemented soon. [#1658](https://github.com/chaos-polymtl/lethe/pull/1658)
 
 ### [Master] - 2025-09-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- MAJOR This PR fixes the bug patched in [#1658](https://github.com/chaos-polymtl/lethe/pull/1658). It attaches a DoF handler to the DataOut instance, which prevents calls for add_solution_vector without DoF handler. This is a more robust solution than the previous one. More tests will be carried out, but this solution reproduces what the code had before the refactoring in [#1624](https://github.com/chaos-polymtl/lethe/pull/1624). [#1661](https://github.com/chaos-polymtl/lethe/pull/1661)
+- MAJOR This PR fixes the bug patched in [#1658](https://github.com/chaos-polymtl/lethe/pull/1658). It attaches a DoF handler to the DataOut instance, which prevents calls for add_solution_vector without DoF handler. This is a more robust solution than the previous one. More tests will be carried out, but this solution reproduces what the code had before the refactoring in [#1624](https://github.com/chaos-polymtl/lethe/pull/1624). Additionally, this PR finishes the refactoring of the "write output" function, unifying cell and DoF output data into the same container of structs. [#1661](https://github.com/chaos-polymtl/lethe/pull/1661)
 
 ### Fixed
 

--- a/include/fem-dem/fluid_dynamics_sharp.h
+++ b/include/fem-dem/fluid_dynamics_sharp.h
@@ -282,9 +282,8 @@ private:
    * @brief output_field_hook
    * Adds the level set output field to the output
    */
-  virtual void
-  output_field_hook(std::vector<OutputStruct<dim, GlobalVectorType>>
-                      &solution_output_structs) override;
+  virtual std::vector<OutputStruct<dim, GlobalVectorType>>
+  get_output_struct_hook() override;
 
   /**
    * @brief

--- a/include/fem-dem/fluid_dynamics_sharp.h
+++ b/include/fem-dem/fluid_dynamics_sharp.h
@@ -279,11 +279,12 @@ private:
 
 
   /**
-   * @brief output_field_hook
-   * Adds the level set output field to the output
+   * @brief Adds levelset to output files.
+   *
+   * @return Vector of OutputStructs that will be used to write the output results as VTU files.
    */
   virtual std::vector<OutputStruct<dim, GlobalVectorType>>
-  get_output_struct_hook() override;
+  gather_output_hook() override;
 
   /**
    * @brief

--- a/include/fem-dem/fluid_dynamics_sharp.h
+++ b/include/fem-dem/fluid_dynamics_sharp.h
@@ -283,7 +283,8 @@ private:
    * Adds the level set output field to the output
    */
   virtual void
-  output_field_hook(DataOut<dim> &data_out) override;
+  output_field_hook(std::vector<OutputStruct<dim, GlobalVectorType>>
+                      &solution_output_structs) override;
 
   /**
    * @brief

--- a/include/fem-dem/fluid_dynamics_vans.h
+++ b/include/fem-dem/fluid_dynamics_vans.h
@@ -162,8 +162,8 @@ protected:
    * post_processing additional results
    */
   virtual void
-  output_field_hook(DataOut<dim> &data_out) override;
-
+  output_field_hook(std::vector<OutputStruct<dim, GlobalVectorType>>
+                      &solution_output_structs) override;
 
 
   /**

--- a/include/fem-dem/fluid_dynamics_vans.h
+++ b/include/fem-dem/fluid_dynamics_vans.h
@@ -158,11 +158,12 @@ protected:
     const StabilizedMethodsTensorCopyData<dim> &copy_data) override;
 
   /**
-   * @brief a function for adding data vectors to the data_out object for
-   * post_processing additional results
+   * @brief Add void fractio and particle velocity field to output files.
+   *
+   * @return Vector of OutputStructs that will be used to write the output results as VTU files.
    */
   virtual std::vector<OutputStruct<dim, GlobalVectorType>>
-  get_output_struct_hook() override;
+  gather_output_hook() override;
 
 
   /**

--- a/include/fem-dem/fluid_dynamics_vans.h
+++ b/include/fem-dem/fluid_dynamics_vans.h
@@ -161,9 +161,8 @@ protected:
    * @brief a function for adding data vectors to the data_out object for
    * post_processing additional results
    */
-  virtual void
-  output_field_hook(std::vector<OutputStruct<dim, GlobalVectorType>>
-                      &solution_output_structs) override;
+  virtual std::vector<OutputStruct<dim, GlobalVectorType>>
+  get_output_struct_hook() override;
 
 
   /**

--- a/include/fem-dem/fluid_dynamics_vans_matrix_free.h
+++ b/include/fem-dem/fluid_dynamics_vans_matrix_free.h
@@ -145,7 +145,8 @@ protected:
    * additional results. In this case, the void fraction field is added.
    */
   virtual void
-  output_field_hook(DataOut<dim> &data_out) override;
+  output_field_hook(std::vector<OutputStruct<dim, GlobalVectorType>>
+                      &solution_output_structs) override;
 
   /**
    * @brief Create geometric multigrid preconditioner.

--- a/include/fem-dem/fluid_dynamics_vans_matrix_free.h
+++ b/include/fem-dem/fluid_dynamics_vans_matrix_free.h
@@ -141,11 +141,12 @@ protected:
   finish_time_step_fd();
 
   /**
-   * @brief Add data vectors to the data_out object for post_processing
-   * additional results. In this case, the void fraction field is added.
+   * @brief Add void fraction field to output files.
+   *
+   * @return Vector of OutputStructs that will be used to write the output results as VTU files.
    */
   std::vector<OutputStruct<dim, LinearAlgebra::distributed::Vector<double>>>
-  get_output_struct_hook() override;
+  gather_output_hook() override;
 
   /**
    * @brief Create geometric multigrid preconditioner.
@@ -154,7 +155,7 @@ protected:
   create_GMG() override;
 
   /**
-   * Initializes (or re-initializes) geometric multigrid preconditioneré
+   * Initializes (or re-initializes) geometric multigrid preconditioner
    */
   void
   initialize_GMG() override;

--- a/include/fem-dem/fluid_dynamics_vans_matrix_free.h
+++ b/include/fem-dem/fluid_dynamics_vans_matrix_free.h
@@ -144,9 +144,8 @@ protected:
    * @brief Add data vectors to the data_out object for post_processing
    * additional results. In this case, the void fraction field is added.
    */
-  virtual void
-  output_field_hook(std::vector<OutputStruct<dim, GlobalVectorType>>
-                      &solution_output_structs) override;
+  std::vector<OutputStruct<dim, LinearAlgebra::distributed::Vector<double>>>
+  get_output_struct_hook() override;
 
   /**
    * @brief Create geometric multigrid preconditioner.

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -877,7 +877,8 @@ protected:
    * to each solver.
    */
   virtual void
-  output_field_hook(DataOut<dim> &);
+  output_field_hook(
+    std::vector<OutputStruct<dim, VectorType>> &solution_output_structs);
 
   /**
    * @brief Writes the forces per boundary condition to a text file output

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -876,9 +876,8 @@ protected:
    * @brief This function is to be redefined in specialized classes to adapt the output
    * to each solver.
    */
-  virtual void
-  output_field_hook(
-    std::vector<OutputStruct<dim, VectorType>> &solution_output_structs);
+  virtual std::vector<OutputStruct<dim, VectorType>>
+  get_output_struct_hook();
 
   /**
    * @brief Writes the forces per boundary condition to a text file output

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -852,10 +852,18 @@ protected:
   write_checkpoint();
 
   /**
+   * @brief Gather and return vector of output structs that are particular to some applications.
+   *
+   * @return Vector of OutputStructs that will be used to write the output results as VTU files.
+   */
+  virtual std::vector<OutputStruct<dim, VectorType>>
+  gather_output_hook();
+
+  /**
    * @brief Gather solution information to generate output results
    *
    * @param[in] solution Vector of present solution
-   * @param[out] solution_output_structs Vector of OutputStructs that will be
+   * @param[in,out] solution_output_structs Vector of OutputStructs that will be
    * used to write the output results as VTU files
    */
   void
@@ -871,13 +879,6 @@ protected:
    */
   void
   write_output_results(const VectorType &solution);
-
-  /**
-   * @brief This function is to be redefined in specialized classes to adapt the output
-   * to each solver.
-   */
-  virtual std::vector<OutputStruct<dim, VectorType>>
-  get_output_struct_hook();
 
   /**
    * @brief Writes the forces per boundary condition to a text file output

--- a/include/solvers/output_struct.h
+++ b/include/solvers/output_struct.h
@@ -82,7 +82,7 @@ struct OutputStructSolution
  * It is used to pass all the information required upon calling
  * add_data_vector() for the DataOut instance without losing track of its
  * attributes such as name and data component interpretation. This version of
- * the struct uses a cell based field parsed as a Vector and the solution name.
+ * the struct uses a cell-based field parsed as a Vector and the solution name.
  */
 struct OutputStructCellVector
 {

--- a/include/solvers/output_struct.h
+++ b/include/solvers/output_struct.h
@@ -78,12 +78,37 @@ struct OutputStructSolution
 };
 
 /**
+ * @brief Struct containing information about the solution output.
+ * It is used to pass all the information required upon calling
+ * add_data_vector() for the DataOut instance without losing track of its
+ * attributes such as name and data component interpretation. This version of
+ * the struct uses a cell based field parsed as a Vector and the solution name.
+ */
+struct OutputStructCellVector
+{
+  /**
+   * @brief Constructor for when data is not related to a data_postprocessor.
+   *
+   * @param[in] solution Solution Vector<float>, which is stored as a copy.
+   * @param[in] solution_name String containing solution name.
+   */
+  OutputStructCellVector(const Vector<float> &solution,
+                         const std::string   &solution_name)
+    : solution(solution)
+    , solution_name(solution_name)
+  {}
+  const Vector<float> solution;
+  const std::string   solution_name;
+};
+
+/**
  * @brief Variant handler of the two output structs (OutputStructPostprocessor and OutputStructDoFHandler).
  * This is used to allow the output of both postprocessors and DoF handlers in a
  * single vector of OutputStruct.
  */
 template <int dim, typename VectorType>
 using OutputStruct = std::variant<OutputStructPostprocessor<dim, VectorType>,
-                                  OutputStructSolution<dim, VectorType>>;
+                                  OutputStructSolution<dim, VectorType>,
+                                  OutputStructCellVector>;
 
 #endif

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -1680,7 +1680,7 @@ FluidDynamicsSharp<dim>::write_force_ib()
 
 template <int dim>
 std::vector<OutputStruct<dim, GlobalVectorType>>
-FluidDynamicsSharp<dim>::get_output_struct_hook()
+FluidDynamicsSharp<dim>::gather_output_hook()
 {
   std::vector<OutputStruct<dim, GlobalVectorType>> solution_output_structs;
   // If the particles have moved, the combined shapes will have been cleared by

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -1679,10 +1679,10 @@ FluidDynamicsSharp<dim>::write_force_ib()
 }
 
 template <int dim>
-void
-FluidDynamicsSharp<dim>::output_field_hook(
-  std::vector<OutputStruct<dim, GlobalVectorType>> &solution_output_structs)
+std::vector<OutputStruct<dim, GlobalVectorType>>
+FluidDynamicsSharp<dim>::get_output_struct_hook()
 {
+  std::vector<OutputStruct<dim, GlobalVectorType>> solution_output_structs;
   // If the particles have moved, the combined shapes will have been cleared by
   // the particle integration routines.
   levelset_postprocessor =
@@ -1752,6 +1752,7 @@ FluidDynamicsSharp<dim>::output_field_hook(
         this->present_solution,
         levelset_gradient_postprocessor);
     }
+  return solution_output_structs;
 }
 
 template <int dim>

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -1686,9 +1686,7 @@ FluidDynamicsSharp<dim>::output_field_hook(DataOut<dim> &data_out)
   // the particle integration routines.
   levelset_postprocessor =
     std::make_shared<LevelsetPostprocessor<dim>>(combined_shapes);
-  data_out.add_data_vector(this->dof_handler,
-                           this->present_solution,
-                           *levelset_postprocessor);
+  data_out.add_data_vector(this->present_solution, *levelset_postprocessor);
   Vector<float> cell_cuts(this->triangulation->n_active_cells());
   Vector<float> cell_overconstrained(this->triangulation->n_active_cells());
   const unsigned int                   dofs_per_cell = this->fe->dofs_per_cell;

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -680,10 +680,10 @@ FluidDynamicsVANS<dim>::copy_local_rhs_to_global_rhs(
 }
 
 template <int dim>
-void
-FluidDynamicsVANS<dim>::output_field_hook(
-  std::vector<OutputStruct<dim, GlobalVectorType>> &solution_output_structs)
+std::vector<OutputStruct<dim, GlobalVectorType>>
+FluidDynamicsVANS<dim>::get_output_struct_hook()
 {
+  std::vector<OutputStruct<dim, GlobalVectorType>> solution_output_structs;
   solution_output_structs.emplace_back(
     std::in_place_type<OutputStructSolution<dim, GlobalVectorType>>,
     particle_projector.dof_handler,
@@ -705,6 +705,7 @@ FluidDynamicsVANS<dim>::output_field_hook(
         names,
         data_interpretation);
     }
+  return solution_output_structs;
 }
 
 template <int dim>

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -681,11 +681,16 @@ FluidDynamicsVANS<dim>::copy_local_rhs_to_global_rhs(
 
 template <int dim>
 void
-FluidDynamicsVANS<dim>::output_field_hook(DataOut<dim> &data_out)
+FluidDynamicsVANS<dim>::output_field_hook(
+  std::vector<OutputStruct<dim, GlobalVectorType>> &solution_output_structs)
 {
-  data_out.add_data_vector(particle_projector.dof_handler,
-                           particle_projector.void_fraction_locally_relevant,
-                           "void_fraction");
+  solution_output_structs.emplace_back(
+    std::in_place_type<OutputStructSolution<dim, GlobalVectorType>>,
+    particle_projector.dof_handler,
+    particle_projector.void_fraction_locally_relevant,
+    std::vector<std::string>{"void_fraction"},
+    std::vector<DataComponentInterpretation::DataComponentInterpretation>{
+      DataComponentInterpretation::component_is_scalar});
   if (this->cfd_dem_simulation_parameters.void_fraction
         ->project_particle_velocity)
     {
@@ -693,9 +698,10 @@ FluidDynamicsVANS<dim>::output_field_hook(DataOut<dim> &data_out)
       std::vector<DataComponentInterpretation::DataComponentInterpretation>
         data_interpretation(
           dim, DataComponentInterpretation::component_is_part_of_vector);
-      data_out.add_data_vector(
+      solution_output_structs.emplace_back(
+        std::in_place_type<OutputStructSolution<dim, GlobalVectorType>>,
         particle_projector.particle_velocity.dof_handler,
-        particle_projector.particle_velocity.particle_field_solution,
+        particle_projector.particle_velocity.particle_field_locally_relevant,
         names,
         data_interpretation);
     }

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -681,7 +681,7 @@ FluidDynamicsVANS<dim>::copy_local_rhs_to_global_rhs(
 
 template <int dim>
 std::vector<OutputStruct<dim, GlobalVectorType>>
-FluidDynamicsVANS<dim>::get_output_struct_hook()
+FluidDynamicsVANS<dim>::gather_output_hook()
 {
   std::vector<OutputStruct<dim, GlobalVectorType>> solution_output_structs;
   solution_output_structs.emplace_back(

--- a/source/fem-dem/fluid_dynamics_vans_matrix_free.cc
+++ b/source/fem-dem/fluid_dynamics_vans_matrix_free.cc
@@ -275,20 +275,19 @@ FluidDynamicsVANSMatrixFree<dim>::finish_time_step_fd()
 }
 
 template <int dim>
-void
-FluidDynamicsVANSMatrixFree<dim>::output_field_hook(
-  std::vector<OutputStruct<dim, GlobalVectorType>> &solution_output_structs)
+std::vector<OutputStruct<dim, LinearAlgebra::distributed::Vector<double>>>
+FluidDynamicsVANSMatrixFree<dim>::get_output_struct_hook()
 {
   std::vector<std::string> name = {"void_fraction"};
   std::vector<DataComponentInterpretation::DataComponentInterpretation>
     component_interpretation = {
       DataComponentInterpretation::component_is_scalar};
-  solution_output_structs.emplace_back(
-    std::in_place_type < OutputStructSolution<dim, GlobalVectorType>,
-    particle_projector.dof_handler,
-    particle_projector.void_fraction_locally_relevant,
-    name,
-    component_interpretation);
+  OutputStructSolution<dim, LinearAlgebra::distributed::Vector<double>>
+    void_fraction_struct(particle_projector.dof_handler,
+                         particle_projector.void_fraction_solution,
+                         name,
+                         component_interpretation);
+  return {void_fraction_struct};
 }
 
 template <int dim>

--- a/source/fem-dem/fluid_dynamics_vans_matrix_free.cc
+++ b/source/fem-dem/fluid_dynamics_vans_matrix_free.cc
@@ -276,11 +276,19 @@ FluidDynamicsVANSMatrixFree<dim>::finish_time_step_fd()
 
 template <int dim>
 void
-FluidDynamicsVANSMatrixFree<dim>::output_field_hook(DataOut<dim> &data_out)
+FluidDynamicsVANSMatrixFree<dim>::output_field_hook(
+  std::vector<OutputStruct<dim, GlobalVectorType>> &solution_output_structs)
 {
-  data_out.add_data_vector(particle_projector.dof_handler,
-                           particle_projector.void_fraction_locally_relevant,
-                           "void_fraction");
+  std::vector<std::string> name = {"void_fraction"};
+  std::vector<DataComponentInterpretation::DataComponentInterpretation>
+    component_interpretation = {
+      DataComponentInterpretation::component_is_scalar};
+  solution_output_structs.emplace_back(
+    std::in_place_type < OutputStructSolution<dim, GlobalVectorType>,
+    particle_projector.dof_handler,
+    particle_projector.void_fraction_locally_relevant,
+    name,
+    component_interpretation);
 }
 
 template <int dim>

--- a/source/fem-dem/fluid_dynamics_vans_matrix_free.cc
+++ b/source/fem-dem/fluid_dynamics_vans_matrix_free.cc
@@ -276,7 +276,7 @@ FluidDynamicsVANSMatrixFree<dim>::finish_time_step_fd()
 
 template <int dim>
 std::vector<OutputStruct<dim, LinearAlgebra::distributed::Vector<double>>>
-FluidDynamicsVANSMatrixFree<dim>::get_output_struct_hook()
+FluidDynamicsVANSMatrixFree<dim>::gather_output_hook()
 {
   std::vector<std::string> name = {"void_fraction"};
   std::vector<DataComponentInterpretation::DataComponentInterpretation>

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2712,8 +2712,7 @@ template <int dim, typename VectorType, typename DofsType>
 std::vector<OutputStruct<dim, VectorType>>
 NavierStokesBase<dim, VectorType, DofsType>::get_output_struct_hook()
 {
-  std::vector<OutputStruct<dim, VectorType>> output_structs;
-  return output_structs;
+  return std::vector<OutputStruct<dim, VectorType>>();
 }
 
 template <int dim, typename VectorType, typename DofsType>
@@ -2933,11 +2932,12 @@ NavierStokesBase<dim, VectorType, DofsType>::gather_output_results(
   solution_output_structs.emplace_back(
     std::in_place_type<OutputStructCellVector>, subdomain, "subdomain");
 
+  // Add fields specific to other physics
   std::vector<OutputStruct<dim, VectorType>> additional_output_structs =
-    get_output_struct_hook();
+    this->get_output_struct_hook();
 
   for (const auto &output_struct : additional_output_structs)
-    solution_output_structs.push_back(output_struct);
+    solution_output_structs.emplace_back(output_struct);
 }
 
 template <int dim, typename VectorType, typename DofsType>

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2709,10 +2709,12 @@ NavierStokesBase<dim, VectorType, DofsType>::
 }
 
 template <int dim, typename VectorType, typename DofsType>
-void
-NavierStokesBase<dim, VectorType, DofsType>::output_field_hook(
-  std::vector<OutputStruct<dim, VectorType>> & /*solution_output_structs*/)
-{}
+std::vector<OutputStruct<dim, VectorType>>
+NavierStokesBase<dim, VectorType, DofsType>::get_output_struct_hook()
+{
+  std::vector<OutputStruct<dim, VectorType>> output_structs;
+  return output_structs;
+}
 
 template <int dim, typename VectorType, typename DofsType>
 void
@@ -2931,7 +2933,11 @@ NavierStokesBase<dim, VectorType, DofsType>::gather_output_results(
   solution_output_structs.emplace_back(
     std::in_place_type<OutputStructCellVector>, subdomain, "subdomain");
 
-  output_field_hook(solution_output_structs);
+  std::vector<OutputStruct<dim, VectorType>> additional_output_structs =
+    get_output_struct_hook();
+
+  for (const auto &output_struct : additional_output_structs)
+    solution_output_structs.push_back(output_struct);
 }
 
 template <int dim, typename VectorType, typename DofsType>

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2710,7 +2710,7 @@ NavierStokesBase<dim, VectorType, DofsType>::
 
 template <int dim, typename VectorType, typename DofsType>
 std::vector<OutputStruct<dim, VectorType>>
-NavierStokesBase<dim, VectorType, DofsType>::get_output_struct_hook()
+NavierStokesBase<dim, VectorType, DofsType>::gather_output_hook()
 {
   return std::vector<OutputStruct<dim, VectorType>>();
 }

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2953,6 +2953,9 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
     flags.write_higher_order_cells = true;
   data_out.set_flags(flags);
 
+  // Attach DoF handler to data output object
+  data_out.attach_dof_handler(this->dof_handler);
+
   // Fill data out object with solutions in structs
   for (const auto &solution_output_struct : solution_output_structs)
     {

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2934,7 +2934,7 @@ NavierStokesBase<dim, VectorType, DofsType>::gather_output_results(
 
   // Add fields specific to other physics
   std::vector<OutputStruct<dim, VectorType>> additional_output_structs =
-    this->get_output_struct_hook();
+    this->gather_output_hook();
 
   for (const auto &output_struct : additional_output_structs)
     solution_output_structs.emplace_back(output_struct);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

The output_field_hook functions were not working due to the last refactoring of the write output results, PR #1624. The reason is that we were not attaching a default DoF handler to the DataOut instance. Additionally, the inclusion of cell fields, mainly the subdomain field, was done without the struct.

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->

Call attach_dof_handler upon instantiating DataOut.
Refactor output_field_hook function to use the new struct.
Add a variant of the struct for the case of cell data.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

This was first observed when @blaisb was running a sharp example. I tested the "Sedimentation of One Particle" sharp example, and it worked just fine without the hotfix of PR #1658.

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

No need. Just a fix.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

This solves the issue related to it, but we want to also add a sharp validation case to both validate the code and test the output results.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge