### PR TITLE
Remove all Clang warnings from core library

### DIFF
--- a/include/core/evaporation_model.h
+++ b/include/core/evaporation_model.h
@@ -38,6 +38,11 @@ public:
   {}
 
   /**
+   * @brief Default virual destructor. Does not do anything.
+   */
+  virtual ~EvaporationModel(){};
+
+  /**
    * @brief Instantiates and returns a pointer to an EvaporationModel
    * object by casting it to the proper child class.
    *
@@ -397,8 +402,6 @@ public:
     , boiling_temperature_inv(1.0 / p_evaporation.boiling_temperature)
     , latent_heat_evaporation(p_evaporation.latent_heat_evaporation)
     , ambient_pressure(p_evaporation.ambient_pressure)
-    , ambient_gas_density_inv(1.0 / p_evaporation.ambient_gas_density)
-    , liquid_density_inv(1.0 / p_evaporation.liquid_density)
     , universal_gas_constant(p_evaporation.universal_gas_constant)
   {
     model_depends_on[field::temperature] = true;
@@ -729,8 +732,6 @@ private:
   const double boiling_temperature_inv;
   const double latent_heat_evaporation;
   const double ambient_pressure;
-  const double ambient_gas_density_inv;
-  const double liquid_density_inv;
 
   const double universal_gas_constant;
 };

--- a/include/core/interface_property_model.h
+++ b/include/core/interface_property_model.h
@@ -24,7 +24,7 @@ class InterfacePropertyModel
 {
 public:
   /**
-   * @brief class InterfacePropertyModel Default constructor. Set the model_depends_on to false for all variables.
+   * @brief class Default constructor. Set the model_depends_on to false for all variables.
    */
   InterfacePropertyModel()
   {
@@ -34,6 +34,11 @@ public:
     model_depends_on[pressure]                  = false;
     model_depends_on[phase_order_cahn_hilliard] = false;
   }
+
+  /**
+   * @brief  Default destructor.
+   */
+  virtual ~InterfacePropertyModel(){};
 
   /**
    * @brief Returns true if the InterfacePropertyModel depends on a field, false if not.

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -235,8 +235,9 @@ namespace Parameters
     };
 
     template <int dim>
-    struct InsertionInfo
+    class InsertionInfo
     {
+    public:
       // Insertion method
       enum class InsertionMethod
       {
@@ -296,8 +297,9 @@ namespace Parameters
     };
 
     template <int dim>
-    struct ModelParameters
+    class ModelParameters
     {
+    public:
       // Load balance method
       enum class LoadBalanceMethod
       {
@@ -585,8 +587,9 @@ namespace Parameters
     };
 
     template <int dim>
-    struct FloatingGrid
+    class FloatingGrid
     {
+    public:
       // Floating mesh motion information
       Parameters::Mesh mesh;
 

--- a/include/core/periodic_hills_grid.h
+++ b/include/core/periodic_hills_grid.h
@@ -119,10 +119,10 @@ PeriodicHillsGrid<dim, spacedim>::PeriodicHillsGrid(
     dealii::Utilities::string_to_double(arguments);
   spacing_y     = arguments_double[0];
   alpha         = arguments_double[1];
-  repetitions_x = arguments_double[2];
-  repetitions_y = arguments_double[3];
+  repetitions_x = static_cast<int>(arguments_double[2]);
+  repetitions_y = static_cast<int>(arguments_double[3]);
   if (dim == 3)
-    repetitions_z = arguments_double[4];
+    repetitions_z = static_cast<int>(arguments_double[4]);
 
   if (abs(alpha - 1) < 1e-6)
     alpha = int(alpha);

--- a/include/core/physical_property_model.h
+++ b/include/core/physical_property_model.h
@@ -75,7 +75,7 @@ class PhysicalPropertyModel
 {
 public:
   /**
-   * @brief PhysicalPropertyModel Default constructor. Set the model_depends_on to false for all variables.
+   * @brief Default constructor. Set the model_depends_on to false for all variables.
    */
   PhysicalPropertyModel()
   {
@@ -88,6 +88,11 @@ public:
     model_depends_on[levelset]                  = false;
     model_depends_on[tracer_concentration]      = false;
   }
+
+  /**
+   * @brief Default virtual destructor. Does not do anything.
+   */
+  virtual ~PhysicalPropertyModel(){};
 
   /**
    * @brief Returns true if the PhysicalPropertyModel depends on a field, false if not.

--- a/include/core/shape.h
+++ b/include/core/shape.h
@@ -225,8 +225,7 @@ public:
           {
             // Initialize variables used in the calculation.
             Point<dim> current_point = candidate_points[i];
-            Point<dim> dx{}, distance_gradient{}, previous_position{},
-              previous_gradient{};
+            Point<dim> dx{}, distance_gradient{}, previous_position{};
             // Initialize the iteration counter.
             unsigned int       iteration     = 0;
             const unsigned int iteration_max = 2e2;
@@ -321,7 +320,7 @@ public:
                         current_distance = best_dist;
                         current_point    = best_point;
                       }
-                    Point<dim> extra_guess;
+
                     // If none of the cartesian candidates are better, we use
                     // the value to find the point that minimizes the numerical
                     // gradient we evaluated with the cartesian guess.
@@ -528,8 +527,7 @@ public:
           {
             // Initialize variable used in the calculation.
             Point<dim> current_point = candidate_points[i];
-            Point<dim> dx{}, distance_gradient{}, previous_position{},
-              previous_gradient{};
+            Point<dim> dx{}, distance_gradient{}, previous_position{};
             // Initialize the iteration counter. We limit the number of
             // iterations to 200.
             unsigned int       iteration     = 0;
@@ -618,7 +616,7 @@ public:
                         current_distance = best_dist;
                         current_point    = best_point;
                       }
-                    Point<dim> extra_guess;
+
                     // If none of the cartesian candidates are better, we use
                     // the value to find the point that minimizes the numerical
                     // gradient we evaluated with the cartesian guess.
@@ -2142,7 +2140,8 @@ public:
         this->effective_radius =
           std::max(this->effective_radius, constituent->effective_radius);
         constituent->set_part_of_a_composite(true);
-        std::vector<Point<3>> component_bounding_box_vertex(std::pow(2, dim));
+        std::vector<Point<3>> component_bounding_box_vertex(
+          Utilities::fixed_power<dim>(2));
         // For each of the components update the bounding box.
         if constexpr (dim == 2)
           {

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -390,9 +390,9 @@ read_mesh_and_manifolds(
         {
           double minimal_cell_size =
             GridTools::minimal_cell_diameter(triangulation);
-          double       target_size = mesh_parameters.target_size;
-          unsigned int number_refinement =
-            floor(std::log(minimal_cell_size / target_size) / std::log(2));
+          double       target_size       = mesh_parameters.target_size;
+          unsigned int number_refinement = static_cast<unsigned int>(
+            floor(std::log(minimal_cell_size / target_size) / std::log(2)));
           triangulation.refine_global(number_refinement);
         }
       else if (!restart)
@@ -613,9 +613,9 @@ read_mesh_and_manifolds_for_stator_and_rotor(
         {
           const double minimal_cell_size =
             GridTools::minimal_cell_diameter(triangulation);
-          const double       target_size = mesh_parameters.target_size;
-          const unsigned int number_refinement =
-            floor(std::log(minimal_cell_size / target_size) / std::log(2));
+          const double       target_size       = mesh_parameters.target_size;
+          const unsigned int number_refinement = static_cast<unsigned int>(
+            floor(std::log(minimal_cell_size / target_size) / std::log(2)));
           triangulation.refine_global(number_refinement);
         }
       else if (!restart)

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -1528,7 +1528,7 @@ LetheGridTools::find_point_triangle_distance(
       const double         normal_norm = normal.norm();
       Tensor<1, dim>       normal_unit = normal / normal_norm;
       Tensor<1, 3>         normal_unit_3d;
-      Point<3>             pt_in_triangle_3d;
+      // Point<3>             pt_in_triangle_3d;
 
       const double a   = e_0.norm_square();
       const double b   = scalar_product(e_0, e_1);

--- a/source/core/mortar_coupling_manager.cc
+++ b/source/core/mortar_coupling_manager.cc
@@ -449,7 +449,7 @@ compute_n_subdivisions_and_radius(
   // Number of subdivisions per process
   unsigned int n_subdivisions_local = 0;
   // Number of vertices at the boundary per process
-  unsigned int n_vertices_local = 0;
+  [[maybe_unused]] unsigned int n_vertices_local = 0;
   // Tolerance for rotor radius computation
   const double tolerance = 1e-8;
   // Min and max values for rotor radius computation
@@ -577,7 +577,8 @@ Quadrature<dim>
 construct_quadrature(const Quadrature<dim>         &quadrature,
                      const Parameters::Mortar<dim> &mortar_parameters)
 {
-  const double oversampling_factor = mortar_parameters.oversampling_factor;
+  const int oversampling_factor =
+    static_cast<int>(mortar_parameters.oversampling_factor);
 
   for (unsigned int i = 1; i <= 10; ++i)
     if (quadrature == QGauss<dim>(i))

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3788,7 +3788,7 @@ namespace Parameters
         contact_search_frequency = prm.get_integer("contact search frequency");
         particle_nonlinear_tolerance =
           prm.get_double("particle nonlinear tolerance");
-        coupling_frequency       = prm.get_double("DEM coupling frequency");
+        coupling_frequency       = prm.get_integer("DEM coupling frequency");
         enable_lubrication_force = prm.get_bool("enable lubrication force");
         lubrication_range_max    = prm.get_double("lubrication range max");
         lubrication_range_min    = prm.get_double("lubrication range min");

--- a/source/core/parameters_multiphysics.cc
+++ b/source/core/parameters_multiphysics.cc
@@ -329,7 +329,7 @@ Parameters::VOF_InterfaceSharpening::parse_parameters(ParameterHandler &prm)
 
     // Parameters for adaptive sharpening
     threshold_max_deviation = prm.get_double("threshold max deviation");
-    max_iterations          = prm.get_double("max iterations");
+    max_iterations          = prm.get_integer("max iterations");
     monitoring              = prm.get_bool("monitoring");
     tolerance               = prm.get_double("tolerance");
 

--- a/source/core/shape.cc
+++ b/source/core/shape.cc
@@ -2061,7 +2061,6 @@ RBFShape<dim>::determine_likely_nodes_for_one_cell(
 
   double     distance, max_distance;
   double     cell_diameter = cell->diameter();
-  Point<dim> centered_support_point;
   Point<dim> temp_cell_barycenter;
   double     temp_cell_diameter;
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

When compiling Lethe with Clang, multiple warning arise throughout the code. We aim to remove these warnings so that Lethe compiles on both GCC and Clang without any warnings. This changes removes all the warning in the core library.

### Testing

None of the tests should be affected. 

### Documentation

Nothing to document here

### Miscellaneous (will be removed when merged)

I still need to find a way to make a CI that uses Clang, but I have not figured it out yet. Until then, this is the next best solution.


### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Copyright headers are present and up to date
- [ ] Lethe documentation is up to date
- [ ] The branch is rebased onto master
- [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [ ] If parameters are modified, the tests and the documentation of examples are up to date
- [ ] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [ ] No other PR is open related to this refactoring
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If any future works is planned, an issue is opened
- [ ] The PR description is cleaned and ready for merge