### PR TITLE
Clang warnings solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- Minor When compiling Lethe with Clang, multiple warning arise throughout the code. In the long term, we aim to remove these warnings so that Lethe compiles on both GCC and Clang without any warnings. All of the warnings of the solver library were removed. The majority of the warnings were related to some virtual classes not having a virtual distructors and some odd integers to double or double to integers conversions that were implicit. The type for the fill level in the ILU preconditioners was changed from double to integer since this is the actualy type required by the Trilinos library. [#AAA](https://github.com/chaos-polymtl/lethe/pull/AAAA)
+- MINOR When compiling Lethe with Clang, multiple warning arise throughout the code. In the long term, we aim to remove these warnings so that Lethe compiles on both GCC and Clang without any warnings. All of the warnings of the solver library were removed. The majority of the warnings were related to some virtual classes not having a virtual distructors and some odd integers to double or double to integers conversions that were implicit. The type for the fill level in the ILU preconditioners was changed from double to integer since this is the actualy type required by the Trilinos library. [#1672](https://github.com/chaos-polymtl/lethe/pull/1672)
 
 ### [Master] - 2025-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+### [Master] - 2025-09-10
+
+### Fixed
+
+- Minor When compiling Lethe with Clang, multiple warning arise throughout the code. In the long term, we aim to remove these warnings so that Lethe compiles on both GCC and Clang without any warnings. All of the warnings of the solver library were removed. The majority of the warnings were related to some virtual classes not having a virtual distructors and some odd integers to double or double to integers conversions that were implicit. The type for the fill level in the ILU preconditioners was changed from double to integer since this is the actualy type required by the Trilinos library. [#AAA](https://github.com/chaos-polymtl/lethe/pull/AAAA)
+
 ### [Master] - 2025-09-08
 
 ### Fixed

--- a/include/core/mortar_coupling_manager.h
+++ b/include/core/mortar_coupling_manager.h
@@ -42,7 +42,7 @@ public:
   /**
    * @brief Default destructor.
    */
-  virtual ~MortarManagerBase()=default;
+  virtual ~MortarManagerBase() = default;
 
   /**
    * @brief Verify if cells of the inner and outer domains are aligned
@@ -876,7 +876,7 @@ public:
   /**
    *    @brief Default destructor.
    */
-  virtual ~NavierStokesCouplingEvaluation()=default;
+  virtual ~NavierStokesCouplingEvaluation() = default;
 
   unsigned int
   data_size() const override;

--- a/include/core/mortar_coupling_manager.h
+++ b/include/core/mortar_coupling_manager.h
@@ -40,6 +40,11 @@ public:
                     const double                     rotation_angle);
 
   /**
+   * @brief Default destructor.
+   */
+  virtual ~MortarManagerBase()=default;
+
+  /**
    * @brief Verify if cells of the inner and outer domains are aligned
    */
   bool
@@ -867,6 +872,11 @@ public:
   NavierStokesCouplingEvaluation(const Mapping<dim>    &mapping,
                                  const DoFHandler<dim> &dof_handler,
                                  const double           kinematic_viscosity);
+
+  /**
+   *    @brief Default destructor.
+   */
+  virtual ~NavierStokesCouplingEvaluation()=default;
 
   unsigned int
   data_size() const override;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1243,7 +1243,7 @@ namespace Parameters
     PreconditionerType preconditioner;
 
     /// ILU or ILUT fill
-    double ilu_precond_fill;
+    unsigned int ilu_precond_fill;
 
     /// ILU or ILUT absolute tolerance
     double ilu_precond_atol;
@@ -1255,7 +1255,7 @@ namespace Parameters
     /// preconditioner of a coarse-grid solver for LSMG or GCMG
 
     /// ILU or ILUT fill for smoother
-    double amg_precond_ilu_fill;
+    unsigned int amg_precond_ilu_fill;
 
     /// ILU or ILUT absolute tolerance for smoother
     double amg_precond_ilu_atol;

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -146,6 +146,12 @@ public:
 
   SimulationControl(const Parameters::SimulationControl &param);
 
+  /**
+ * @brief Default destructor.
+ **/
+
+  virtual ~SimulationControl()=default;
+
 
   /**
    * @brief Return the number of stages associated with the time-stepping method.

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -147,10 +147,10 @@ public:
   SimulationControl(const Parameters::SimulationControl &param);
 
   /**
- * @brief Default destructor.
- **/
+   * @brief Default destructor.
+   **/
 
-  virtual ~SimulationControl()=default;
+  virtual ~SimulationControl() = default;
 
 
   /**

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -747,7 +747,7 @@ identify_minimum_cell_size(const Mapping<dim>    &mapping,
   double h = DBL_MAX;
 
   // Element degree
-  const double degree = double(fe_values.get_fe().degree);
+  const unsigned int degree = fe_values.get_fe().degree;
 
   for (const auto &cell : dof_handler.active_cell_iterators())
     {

--- a/include/solvers/cahn_hilliard_filter.h
+++ b/include/solvers/cahn_hilliard_filter.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_cahn_hilliard_filter_h

--- a/include/solvers/cahn_hilliard_filter.h
+++ b/include/solvers/cahn_hilliard_filter.h
@@ -16,6 +16,11 @@ public:
   {}
 
   /**
+   * @brief Default destructor.
+   */
+  virtual ~CahnHilliardFilterBase() = default;
+
+  /**
    * @brief Instantiate and return a pointer to a CahnHilliardFilterBase
    * object by casting it to the proper child class.
    *

--- a/include/solvers/fluid_dynamics_block.h
+++ b/include/solvers/fluid_dynamics_block.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2019-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2019-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_fluid_dynamics_block_h

--- a/include/solvers/fluid_dynamics_block.h
+++ b/include/solvers/fluid_dynamics_block.h
@@ -23,7 +23,7 @@
 using namespace dealii;
 
 template <class BSPreconditioner>
-class BlockSchurPreconditioner : public Subscriptor
+class BlockSchurPreconditioner : public EnableObserverPointer
 {
 public:
   BlockSchurPreconditioner(double gamma,
@@ -335,7 +335,7 @@ BlockSchurPreconditioner<BSPreconditioner>::vmult(
 
 
 template <class PreconditionerMp>
-class BlockDiagPreconditioner : public Subscriptor
+class BlockDiagPreconditioner : public EnableObserverPointer
 {
 public:
   BlockDiagPreconditioner(const TrilinosWrappers::BlockSparseMatrix &S,

--- a/include/solvers/fluid_dynamics_matrix_free.h
+++ b/include/solvers/fluid_dynamics_matrix_free.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2023-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_fluid_dynamics_matrix_free_h

--- a/include/solvers/fluid_dynamics_matrix_free.h
+++ b/include/solvers/fluid_dynamics_matrix_free.h
@@ -105,6 +105,12 @@ public:
     const DoFHandler<dim>           &dof_handler_fe_q_iso_q1);
 
   /**
+   * @brief Default destructor.
+   */
+
+  virtual ~MFNavierStokesPreconditionGMGBase() = default;
+
+  /**
    * @brief Initializes geometric multigrid preconditioner and pre-calculate terms that are constant.
    *
    * @param[in] mapping Describes the transformations from unit to real cell.

--- a/include/solvers/fluid_dynamics_matrix_free_operators.h
+++ b/include/solvers/fluid_dynamics_matrix_free_operators.h
@@ -114,7 +114,7 @@ evaluate_function(const Function<dim>                       &function,
  * @tparam number Abstract type for number across the class (i.e., double).
  */
 template <int dim, typename number>
-class NavierStokesOperatorBase : public Subscriptor
+class NavierStokesOperatorBase : public EnableObserverPointer
 {
 public:
   using FECellIntegrator = FEEvaluation<dim, -1, 0, dim + 1, number>;

--- a/include/solvers/fluid_dynamics_matrix_free_operators.h
+++ b/include/solvers/fluid_dynamics_matrix_free_operators.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2023-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_fluid_dynamics_matrix_free_operators_h

--- a/include/solvers/physics_assemblers.h
+++ b/include/solvers/physics_assemblers.h
@@ -44,6 +44,12 @@ public:
   virtual void
   assemble_rhs(const ScratchDataType &scratch_data,
                CopyDataType          &copy_data) = 0;
+
+  /**
+   * @brief Default destructor
+   */
+
+  virtual ~PhysicsAssemblerBase() = default;
 };
 
 
@@ -87,6 +93,12 @@ public:
   virtual void
   assemble_rhs(const ScratchDataType &scratch_data,
                CopyDataType          &copy_data) = 0;
+
+  /**
+   * @brief Default destructor
+   */
+
+  virtual ~PhysicsFaceAssemblerBase() = default;
 };
 
 #endif

--- a/include/solvers/signed_distance_transformation.h
+++ b/include/solvers/signed_distance_transformation.h
@@ -15,6 +15,12 @@ class SignedDistanceTransformationBase
 {
 public:
   /**
+   * @brief Default destructor.
+   */
+virtual ~SignedDistanceTransformationBase()=default;
+
+
+  /**
    * @brief Instantiate and return a pointer to a
    * SignedDistanceTransformationBase object by casting it to the proper child
    * class.

--- a/include/solvers/signed_distance_transformation.h
+++ b/include/solvers/signed_distance_transformation.h
@@ -17,7 +17,7 @@ public:
   /**
    * @brief Default destructor.
    */
-virtual ~SignedDistanceTransformationBase()=default;
+  virtual ~SignedDistanceTransformationBase() = default;
 
 
   /**

--- a/include/solvers/tracer_assemblers.h
+++ b/include/solvers/tracer_assemblers.h
@@ -24,7 +24,7 @@ using TracerAssemblerBase =
   PhysicsAssemblerBase<TracerScratchData<dim>, StabilizedMethodsCopyData>;
 
 /**
-* @brief A pure virtual class that serves as an interface for boundary and
+ * @brief A pure virtual class that serves as an interface for boundary and
  * internal faces that occur when using a discontinuous Galerkin discretization.
  * The main difference between the TracerFaceAssembler and the TracerAssembler
  * is that the TracerFaceAssembler assembles the matrix and rhs for internal
@@ -92,11 +92,10 @@ template <int dim>
 class TracerAssemblerDGCore : public TracerAssemblerBase<dim>
 {
 public:
-
   /**
    * @brief Default destructor.
    */
-  virtual ~TracerAssemblerDGCore()=default;
+  virtual ~TracerAssemblerDGCore() = default;
 
   /**
    * @brief Assembles the matrix

--- a/include/solvers/tracer_assemblers.h
+++ b/include/solvers/tracer_assemblers.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2021-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_tracer_assemblers_h

--- a/include/solvers/tracer_assemblers.h
+++ b/include/solvers/tracer_assemblers.h
@@ -23,6 +23,20 @@ template <int dim>
 using TracerAssemblerBase =
   PhysicsAssemblerBase<TracerScratchData<dim>, StabilizedMethodsCopyData>;
 
+/**
+* @brief A pure virtual class that serves as an interface for boundary and
+ * internal faces that occur when using a discontinuous Galerkin discretization.
+ * The main difference between the TracerFaceAssembler and the TracerAssembler
+ * is that the TracerFaceAssembler assembles the matrix and rhs for internal
+ * faces and thus requires the StabilizedDGMethodsCopyData class.
+ *
+ * @tparam dim An integer that denotes the number of spatial dimensions
+ *
+ * @ingroup assemblers
+ */
+template <int dim>
+using TracerFaceAssemblerBase =
+  PhysicsFaceAssemblerBase<TracerScratchData<dim>, StabilizedDGMethodsCopyData>;
 
 /**
  * @brief Class that assembles the core of the Tracer equation.
@@ -78,8 +92,11 @@ template <int dim>
 class TracerAssemblerDGCore : public TracerAssemblerBase<dim>
 {
 public:
-  TracerAssemblerDGCore()
-  {}
+
+  /**
+   * @brief Default destructor.
+   */
+  virtual ~TracerAssemblerDGCore()=default;
 
   /**
    * @brief Assembles the matrix
@@ -144,51 +161,6 @@ public:
   const std::shared_ptr<SimulationControl> simulation_control;
 };
 
-
-/**
- * @brief A pure virtual class that serves as an interface for boundary and
- * internal faces that occur when using a discontinuous Galerkin discretization.
- * The main difference between the TracerFaceAssembler and the TracerAssembler
- * is that the TracerFaceAssembler assembles the matrix and rhs for internal
- * faces and thus requires the StabilizedDGMethodsCopyData class.
- *
- * @tparam dim An integer that denotes the number of spatial dimensions
- *
- * @ingroup assemblers
- */
-template <int dim>
-class TracerFaceAssembler
-{
-public:
-  /**
-   * @brief Interface for the call to matrix assembly
-   * @param[in]  scratch_data Scratch data containing the Tracer
-   * information. It is important to note that the scratch data has to have been
-   * re-inited before calling for matrix assembly.
-   * @param[in,out]  copy_data Destination where the local_rhs and local_matrix
-   * should be copied
-   */
-
-  virtual void
-  assemble_matrix(const TracerScratchData<dim> &scratch_data,
-                  StabilizedDGMethodsCopyData  &copy_data) = 0;
-
-
-  /**
-   * @brief Interface for the call to rhs
-   * @param[in]  scratch_data Scratch data containing the Tracer
-   * information. It is important to note that the scratch data has to have been
-   * re-inited before calling for matrix assembly.
-   * @param[in,out] copy_data Destination where the local_rhs and local_matrix
-   * should be copied
-   */
-
-  virtual void
-  assemble_rhs(const TracerScratchData<dim> &scratch_data,
-               StabilizedDGMethodsCopyData  &copy_data) = 0;
-};
-
-
 /**
  * @brief Assembles the symmetric interior penalty (SIPG) method (or
  * Nitsche's method) for internal faces. This assembler is only required
@@ -200,7 +172,7 @@ public:
  * @ingroup assemblers
  */
 template <int dim>
-class TracerAssemblerSIPG : public TracerFaceAssembler<dim>
+class TracerAssemblerSIPG : public TracerFaceAssemblerBase<dim>
 {
 public:
   TracerAssemblerSIPG()
@@ -243,7 +215,7 @@ public:
  * @ingroup assemblers
  */
 template <int dim>
-class TracerAssemblerBoundaryNitsche : public TracerFaceAssembler<dim>
+class TracerAssemblerBoundaryNitsche : public TracerFaceAssemblerBase<dim>
 {
 public:
   TracerAssemblerBoundaryNitsche(

--- a/include/solvers/vof_filter.h
+++ b/include/solvers/vof_filter.h
@@ -15,6 +15,11 @@ class VolumeOfFluidFilterBase
 {
 public:
   /**
+   * @brief Default destructor.
+   */
+  virtual ~VolumeOfFluidFilterBase() = default;
+
+  /**
    * @brief Instantiate and return a pointer to a VolumeOfFluidFilterBase
    * object by casting it to the proper child class.
    *

--- a/include/solvers/vof_filter.h
+++ b/include/solvers/vof_filter.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2023-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_vof_filter_h

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -2904,13 +2904,13 @@ namespace Parameters
             "Error, invalid preconditioner type. Choices are amg, ilu, lsmg or gcmg.");
 
 
-        ilu_precond_fill = prm.get_double("ilu preconditioner fill");
+        ilu_precond_fill = prm.get_integer("ilu preconditioner fill");
         ilu_precond_atol =
           prm.get_double("ilu preconditioner absolute tolerance");
         ilu_precond_rtol =
           prm.get_double("ilu preconditioner relative tolerance");
 
-        amg_precond_ilu_fill = prm.get_double("amg preconditioner ilu fill");
+        amg_precond_ilu_fill = prm.get_integer("amg preconditioner ilu fill");
         amg_precond_ilu_atol =
           prm.get_double("amg preconditioner ilu absolute tolerance");
         amg_precond_ilu_rtol =

--- a/source/solvers/cahn_hilliard.cc
+++ b/source/solvers/cahn_hilliard.cc
@@ -1025,9 +1025,6 @@ CahnHilliard<dim>::setup_dofs()
 {
   verify_consistency_of_boundary_conditions();
 
-  FEValuesExtractors::Scalar phase_order(0);
-  FEValuesExtractors::Scalar chemical_potential(1);
-
   dof_handler.distribute_dofs(*fe);
   DoFRenumbering::Cuthill_McKee(this->dof_handler);
 
@@ -1280,9 +1277,9 @@ CahnHilliard<dim>::solve_linear_system(const bool initial_step,
                   << linear_solver_tolerance << std::endl;
     }
 
-  const double ilu_fill =
+  const unsigned int ilu_fill = static_cast<unsigned int>(
     simulation_parameters.linear_solver.at(PhysicsID::cahn_hilliard)
-      .ilu_precond_fill;
+      .ilu_precond_fill);
   const double ilu_atol =
     simulation_parameters.linear_solver.at(PhysicsID::cahn_hilliard)
       .ilu_precond_atol;
@@ -1435,8 +1432,6 @@ CahnHilliard<dim>::apply_phase_filter()
                           *cell_quadrature,
                           update_values | update_gradients |
                             update_quadrature_points | update_JxW_values);
-
-  const FEValuesExtractors::Scalar phase_order(0);
 
   GlobalVectorType filtered_solution_owned(this->locally_owned_dofs,
                                            mpi_communicator);

--- a/source/solvers/fluid_dynamics_block.cc
+++ b/source/solvers/fluid_dynamics_block.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2019-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2019-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/bdf.h>

--- a/source/solvers/fluid_dynamics_block.cc
+++ b/source/solvers/fluid_dynamics_block.cc
@@ -580,8 +580,6 @@ FluidDynamicsBlock<dim>::setup_dofs_fd()
   this->locally_relevant_dofs[1] =
     locally_relevant_dofs_acquisition.get_view(dof_u, dof_u + dof_p);
 
-  FEValuesExtractors::Vector velocities(0);
-
   // Non-zero constraints
   this->define_non_zero_constraints();
 
@@ -823,7 +821,7 @@ FluidDynamicsBlock<dim>::setup_ILU()
   //**********************************************
   // Trillinos Wrapper ILU Preconditioner
   //*********************************************
-  const double ilu_fill =
+  const unsigned int ilu_fill =
     this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
       .ilu_precond_fill;
   const double ilu_atol =
@@ -1109,7 +1107,7 @@ FluidDynamicsBlock<dim>::solve_L2_system(const bool initial_step,
   //**********************************************
   // Trillinos Wrapper ILU Preconditioner
   //*********************************************
-  const double ilu_fill =
+  const unsigned int ilu_fill =
     this->simulation_parameters.linear_solver.at(PhysicsID::fluid_dynamics)
       .ilu_precond_fill;
   const double ilu_atol =

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -76,8 +76,6 @@ FluidDynamicsMatrixBased<dim>::setup_dofs_fd()
   this->locally_relevant_dofs =
     DoFTools::extract_locally_relevant_dofs(this->dof_handler);
 
-  FEValuesExtractors::Vector velocities(0);
-
   // If enabled, rotate rotor mapping
   this->rotate_rotor_mapping(false);
 
@@ -89,7 +87,6 @@ FluidDynamicsMatrixBased<dim>::setup_dofs_fd()
 
   // If enabled, create mortar operators
   this->reinit_mortar_operators();
-
 
   // Operations on the following vectors (addition, multiplication, etc.) can
   // only be done if these are reinitialized WITHOUT locally_relevant_dofs. This

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -35,7 +35,7 @@
  * @brief A base class of preconditioners used by the smoother.
  */
 template <typename VectorType>
-class PreconditionBase : public Subscriptor
+class PreconditionBase : public EnableObserverPointer
 {
 public:
   /**

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/bdf.h>

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -1574,7 +1574,7 @@ HeatTransfer<dim>::solve_linear_system(const bool initial_step,
                   << linear_solver_tolerance << std::endl;
     }
 
-  const double ilu_fill =
+  const unsigned int ilu_fill =
     simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
       .ilu_precond_fill;
   const double ilu_atol =

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -997,8 +997,6 @@ NavierStokesBase<dim, VectorType, DofsType>::box_refine_mesh(const bool restart)
 
 
       Vector<float> estimated_error_per_cell(tria.n_active_cells());
-      const FEValuesExtractors::Vector velocity(0);
-      const FEValuesExtractors::Scalar pressure(dim);
       auto &present_solution = this->present_solution;
 
       const auto &cell_iterator =
@@ -2842,7 +2840,7 @@ NavierStokesBase<dim, VectorType, DofsType>::gather_output_results(
     this->simulation_parameters.physical_properties_manager
       .get_rheology_vector();
 
-  const double n_fluids = this->simulation_parameters
+  const unsigned int n_fluids = this->simulation_parameters
                             .physical_properties_manager.get_number_of_fluids();
 
   std::vector<std::shared_ptr<DensityPostprocessor<dim>>>

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -997,7 +997,7 @@ NavierStokesBase<dim, VectorType, DofsType>::box_refine_mesh(const bool restart)
 
 
       Vector<float> estimated_error_per_cell(tria.n_active_cells());
-      auto &present_solution = this->present_solution;
+      auto         &present_solution = this->present_solution;
 
       const auto &cell_iterator =
         box_to_refine_dof_handler.active_cell_iterators();
@@ -2840,8 +2840,9 @@ NavierStokesBase<dim, VectorType, DofsType>::gather_output_results(
     this->simulation_parameters.physical_properties_manager
       .get_rheology_vector();
 
-  const unsigned int n_fluids = this->simulation_parameters
-                            .physical_properties_manager.get_number_of_fluids();
+  const unsigned int n_fluids =
+    this->simulation_parameters.physical_properties_manager
+      .get_number_of_fluids();
 
   std::vector<std::shared_ptr<DensityPostprocessor<dim>>>
     density_postprocessors;

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -562,7 +562,7 @@ PhaseChangeDarcyVOFAssembler<dim>::assemble_rhs(
   auto &local_rhs       = copy_data.local_rhs;
   auto &strong_residual = copy_data.strong_residual;
 
-  const unsigned int        number_of_fluids = phase_change_parameters_vector.size();
+  const unsigned int  number_of_fluids = phase_change_parameters_vector.size();
   std::vector<double> liquid_fractions;
   std::vector<double> darcy_penalties;
   liquid_fractions.reserve(number_of_fluids);

--- a/source/solvers/navier_stokes_vof_assemblers.cc
+++ b/source/solvers/navier_stokes_vof_assemblers.cc
@@ -562,7 +562,7 @@ PhaseChangeDarcyVOFAssembler<dim>::assemble_rhs(
   auto &local_rhs       = copy_data.local_rhs;
   auto &strong_residual = copy_data.strong_residual;
 
-  const double        number_of_fluids = phase_change_parameters_vector.size();
+  const unsigned int        number_of_fluids = phase_change_parameters_vector.size();
   std::vector<double> liquid_fractions;
   std::vector<double> darcy_penalties;
   liquid_fractions.reserve(number_of_fluids);

--- a/source/solvers/postprocessing_cfd.cc
+++ b/source/solvers/postprocessing_cfd.cc
@@ -254,7 +254,7 @@ calculate_CFL(const DoFHandler<dim> &dof_handler,
   double h;
 
   // Element degree
-  double degree = double(fe.degree);
+  const unsigned int degree = fe.degree;
 
   // CFL
   double CFL = 0;
@@ -1070,8 +1070,7 @@ calculate_torques(
   Tensor<2, dim>                   shear_rate;
   Tensor<2, dim>                   fluid_stress;
   Tensor<2, dim>                   fluid_pressure;
-  // torque tensor had to be considered in 3D at all time...
-  Tensor<1, 3> torque;
+
 
   std::map<types::boundary_id, Tensor<1, 3>> torque_map;
 
@@ -1564,7 +1563,6 @@ calculate_average_velocity(const DoFHandler<dim> &dof_handler,
   const unsigned int               n_q_points = quadrature_formula.size();
   const FEValuesExtractors::Vector velocities(0);
   std::vector<Tensor<1, dim>>      velocity_values(n_q_points);
-  Tensor<1, dim>                   normal_vector;
 
   FEValues<dim> fe_values(mapping,
                           fe,

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -1455,7 +1455,7 @@ Tracer<dim>::solve_linear_system(const bool initial_step,
                   << linear_solver_tolerance << std::endl;
     }
 
-  const double ilu_fill =
+  const unsigned int ilu_fill =
     simulation_parameters.linear_solver.at(PhysicsID::tracer).ilu_precond_fill;
   const double ilu_atol =
     simulation_parameters.linear_solver.at(PhysicsID::tracer).ilu_precond_atol;

--- a/source/solvers/vof.cc
+++ b/source/solvers/vof.cc
@@ -2026,7 +2026,7 @@ VolumeOfFluid<dim>::solve_projection_phase_fraction(GlobalVectorType &solution)
 
   TrilinosWrappers::SolverCG solver(solver_control);
 
-  const double ilu_fill =
+  const unsigned int ilu_fill =
     this->simulation_parameters.linear_solver.at(PhysicsID::VOF)
       .ilu_precond_fill;
   const double ilu_atol =
@@ -2606,7 +2606,7 @@ VolumeOfFluid<dim>::solve_linear_system(const bool initial_step,
                   << linear_solver_tolerance << std::endl;
     }
 
-  const double ilu_fill =
+  const unsigned int ilu_fill =
     simulation_parameters.linear_solver.at(PhysicsID::VOF).ilu_precond_fill;
   const double ilu_atol =
     simulation_parameters.linear_solver.at(PhysicsID::VOF).ilu_precond_atol;
@@ -2850,7 +2850,7 @@ VolumeOfFluid<dim>::solve_interface_sharpening(GlobalVectorType &solution)
   //**********************************************
   // Trillinos Wrapper ILU Preconditioner
   //*********************************************
-  const double ilu_fill =
+  const unsigned int ilu_fill =
     this->simulation_parameters.linear_solver.at(PhysicsID::VOF)
       .ilu_precond_fill;
   const double ilu_atol =

--- a/source/solvers/vof_algebraic_interface_reinitialization.cc
+++ b/source/solvers/vof_algebraic_interface_reinitialization.cc
@@ -230,9 +230,9 @@ VOFAlgebraicInterfaceReinitialization<dim>::assemble_system_matrix()
                                                update_values);
 
   // Initialize size of arrays
-  const double n_q_points =
+  const unsigned int n_q_points =
     fe_values_algebraic_reinitialization.get_quadrature().size();
-  const double n_dofs_per_cell =
+  const unsigned int n_dofs_per_cell =
     fe_values_algebraic_reinitialization.get_fe().n_dofs_per_cell();
 
   // Initialize local matrix
@@ -425,9 +425,9 @@ VOFAlgebraicInterfaceReinitialization<dim>::assemble_system_rhs()
                                                update_values);
 
   // Initialize size of arrays
-  const double n_q_points =
+  const unsigned int n_q_points =
     fe_values_algebraic_reinitialization.get_quadrature().size();
-  const double n_dofs_per_cell =
+  const unsigned int n_dofs_per_cell =
     fe_values_algebraic_reinitialization.get_fe().n_dofs_per_cell();
 
   //  Initialize local rhs
@@ -629,7 +629,7 @@ VOFAlgebraicInterfaceReinitialization<dim>::solve_linear_system(
     }
 
   // ILU preconditioner
-  const double ilu_fill =
+  const unsigned int ilu_fill =
     this->simulation_parameters.vof_subequations_linear_solvers
       .at(VOFSubequationsID::algebraic_interface_reinitialization)
       .ilu_precond_fill;

--- a/source/solvers/vof_curvature_projection.cc
+++ b/source/solvers/vof_curvature_projection.cc
@@ -30,9 +30,9 @@ VOFCurvatureProjection<dim>::assemble_system_matrix_and_rhs()
     update_values);
 
   // Initialize size of arrays
-  const double n_q_points =
+  const unsigned int n_q_points =
     fe_values_curvature_projection.get_quadrature().size();
-  const double n_dofs_per_cell =
+  const unsigned int n_dofs_per_cell =
     fe_values_curvature_projection.get_fe().n_dofs_per_cell();
 
   // Initialize local matrix and rhs

--- a/source/solvers/vof_linear_subequations_solver.cc
+++ b/source/solvers/vof_linear_subequations_solver.cc
@@ -130,7 +130,7 @@ VOFLinearSubequationsSolver<dim>::solve_void_fraction_linear_system()
     }
 
   // ILU preconditioner
-  const double ilu_fill =
+  const unsigned int ilu_fill =
     this->simulation_parameters.linear_solver.at(PhysicsID::VOF)
       .ilu_precond_fill;
   const double ilu_atol =

--- a/source/solvers/vof_phase_gradient_projection.cc
+++ b/source/solvers/vof_phase_gradient_projection.cc
@@ -28,9 +28,9 @@ VOFPhaseGradientProjection<dim>::assemble_system_matrix_and_rhs()
                               update_gradients);
 
   // Initialize size of arrays
-  const double n_q_points =
+  const unsigned int n_q_points =
     fe_values_phase_gradient_projection.get_quadrature().size();
-  const double n_dofs_per_cell =
+  const unsigned int n_dofs_per_cell =
     fe_values_phase_gradient_projection.get_fe().n_dofs_per_cell();
 
   // Initialize local matrix and rhs


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

When compiling Lethe with Clang, multiple warning arise throughout the code. In the long term, we aim to remove these warnings so that Lethe compiles on both GCC and Clang without any warnings. All of the warnings of the solver library were removed. The majority of the warnings were related to some virtual classes not having a virtual distructors and some odd integers to double or double to integers conversions that were implicit. The type for the fill level in the ILU preconditioners was changed from double to integer since this is the actualy type required by the Trilinos library. This PR closes #1649.

### Testing

All of the tests should pass without any issue. Nothing has changed there.

### Documentation

This does not require documentation

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge