### PR TITLE
Remove kokkos-related warnings in the prototypes

### DIFF
--- a/.github/workflows/warnings-gcc.yml
+++ b/.github/workflows/warnings-gcc.yml
@@ -18,13 +18,14 @@ concurrency:
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 env:
-  COMPILE_JOBS: 4
-  MULTI_CORE_TESTS_REGEX: "mpirun=2"
+  COMPILE_JOBS: 18
+  TEST_JOBS: 12
 
 jobs:
   build:
     name: Build (deal.ii:${{ matrix.dealii_version }})
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+
 
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+### [Master] - 2025-09-16
+
+### Changed
+
+- MINOR There was a warning that would be triggered in some of the Kokkos prototypes. These are now fixed by using the new syntax for the matrix-free operators. Furthermore, I took the opportunity to remove all the Clang warnings that would appear in prototypes. [#1679](https://github.com/chaos-polymtl/lethe/pull/1679)
+
 ### [Master] - 2025-09-13
 
 ### Changed

--- a/prototypes/direct_gls_navier_stokes/exactsolutions.h
+++ b/prototypes/direct_gls_navier_stokes/exactsolutions.h
@@ -53,15 +53,14 @@ void
 ExactSolutionTaylorCouette<dim>::vector_value(const Point<dim> &p,
                                               Vector<double>   &values) const
 {
-  const double a      = M_PI;
-  double       x      = p[0];
-  double       y      = p[1];
-  double       r      = std::sqrt(x * x + y * y);
-  double       theta  = std::atan2(y, x);
-  double       A      = -(eta_ * eta_) / (1. - eta_ * eta_);
-  double       B      = ri_ * ri_ / (1. - eta_ * eta_);
-  double       utheta = A * r + B / r;
-  values(0)           = -std::sin(theta) * utheta;
-  values(1)           = std::cos(theta) * utheta;
-  values(2)           = 0.;
+  double x      = p[0];
+  double y      = p[1];
+  double r      = std::sqrt(x * x + y * y);
+  double theta  = std::atan2(y, x);
+  double A      = -(eta_ * eta_) / (1. - eta_ * eta_);
+  double B      = ri_ * ri_ / (1. - eta_ * eta_);
+  double utheta = A * r + B / r;
+  values(0)     = -std::sin(theta) * utheta;
+  values(1)     = std::cos(theta) * utheta;
+  values(2)     = 0.;
 }

--- a/prototypes/direct_steady_navier_stokes/exactsolutions.h
+++ b/prototypes/direct_steady_navier_stokes/exactsolutions.h
@@ -53,15 +53,14 @@ void
 ExactSolutionTaylorCouette<dim>::vector_value(const Point<dim> &p,
                                               Vector<double>   &values) const
 {
-  const double a      = M_PI;
-  double       x      = p[0];
-  double       y      = p[1];
-  double       r      = std::sqrt(x * x + y * y);
-  double       theta  = std::atan2(y, x);
-  double       A      = -(eta_ * eta_) / (1. - eta_ * eta_);
-  double       B      = ri_ * ri_ / (1. - eta_ * eta_);
-  double       utheta = A * r + B / r;
-  values(0)           = -std::sin(theta) * utheta;
-  values(1)           = std::cos(theta) * utheta;
-  values(2)           = 0.;
+  double x      = p[0];
+  double y      = p[1];
+  double r      = std::sqrt(x * x + y * y);
+  double theta  = std::atan2(y, x);
+  double A      = -(eta_ * eta_) / (1. - eta_ * eta_);
+  double B      = ri_ * ri_ / (1. - eta_ * eta_);
+  double utheta = A * r + B / r;
+  values(0)     = -std::sin(theta) * utheta;
+  values(1)     = std::cos(theta) * utheta;
+  values(2)     = 0.;
 }

--- a/prototypes/kokkos_poisson/kokkos_poisson.cc
+++ b/prototypes/kokkos_poisson/kokkos_poisson.cc
@@ -131,7 +131,7 @@ public:
   }
 
 private:
-  const MGTransferMF<dim, Number, dealii::MemorySpace::Host> transfer;
+  const MGTransferMatrixFree<dim, Number, dealii::MemorySpace::Host> transfer;
 
   template <typename Number2>
   void

--- a/prototypes/kokkos_stokes/kokkos_stokes.cc
+++ b/prototypes/kokkos_stokes/kokkos_stokes.cc
@@ -134,7 +134,7 @@ public:
   }
 
 private:
-  const MGTransferMF<dim, Number, dealii::MemorySpace::Host> transfer;
+  const MGTransferMatrixFree<dim, Number, dealii::MemorySpace::Host> transfer;
 
   template <typename Number2>
   void

--- a/prototypes/matrix_based_non_linear_poisson/matrix_based_non_linear_poisson.cc
+++ b/prototypes/matrix_based_non_linear_poisson/matrix_based_non_linear_poisson.cc
@@ -833,9 +833,11 @@ MatrixBasedPoissonProblem<dim, fe_degree>::assemble_gmg_meshworker()
 
   for (unsigned int level = 0; level < triangulation.n_global_levels(); ++level)
     {
+      const IndexSet locally_owned_level_dofs =
+        this->dof_handler[level].locally_owned_mg_dofs(level);
       const IndexSet dof_set =
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
-      boundary_constraints[level].reinit(dof_set);
+      boundary_constraints[level].reinit(locally_owned_level_dofs, dof_set);
       boundary_constraints[level].add_lines(
         mg_constrained_dofs.get_refinement_edge_indices(level));
       boundary_constraints[level].add_lines(

--- a/prototypes/matrix_free_mortar_poisson_consistent_integration/matrix_free_mortar_poisson_consistent_integration.cc
+++ b/prototypes/matrix_free_mortar_poisson_consistent_integration/matrix_free_mortar_poisson_consistent_integration.cc
@@ -179,7 +179,7 @@ compute_quadrature(
 template <int dim,
           typename Number,
           typename VectorizedArrayType = VectorizedArray<Number>>
-class PoissonOperator : public Subscriptor
+class PoissonOperator : public EnableObserverPointer
 {
 public:
   using FECellIntegrator =

--- a/prototypes/matrix_free_navier_stokes/matrix_free_navier_stokes.cc
+++ b/prototypes/matrix_free_navier_stokes/matrix_free_navier_stokes.cc
@@ -444,7 +444,7 @@ evaluate_function(const Function<dim>                       &function,
 // Matrix-free differential operator for a vector-valued problem.
 // It "replaces" the traditional assemble_matrix() function.
 template <int dim, typename number>
-class NavierStokesOperator : public Subscriptor
+class NavierStokesOperator : public EnableObserverPointer
 {
 public:
   using FECellIntegrator = FEEvaluation<dim, -1, 0, dim + 1, number>;

--- a/prototypes/matrix_free_stokes/matrix_free_stokes.cc
+++ b/prototypes/matrix_free_stokes/matrix_free_stokes.cc
@@ -346,7 +346,7 @@ evaluate_function(const Function<dim>                       &function,
 // Matrix-free differential operator for a vector-valued problem.
 // It "replaces" the traditional assemble_matrix() function.
 template <int dim, typename number>
-class StokesOperator : public Subscriptor
+class StokesOperator : public EnableObserverPointer
 {
 public:
   using FECellIntegrator = FEEvaluation<dim, -1, 0, dim + 1, number>;

--- a/prototypes/template/prototype_template.cc
+++ b/prototypes/template/prototype_template.cc
@@ -7,6 +7,8 @@
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/tensor.h>
 
+#include <iostream>
+
 
 using namespace dealii;
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The CI-Warnings is crashing because some warnings occur in the kokkos prototypes due to a change in deal.II. This PR fixes these warnings but also fixes the Clang warnings at the same time.

### Testing

All test results should remain unchanged.

### Documentation

Nothing here.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge