### PR TITLE
Fix the typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### [Master] - 2025-09-16
 
+## Fixed
+
+- MINOR There was a typo in the code when load balancing. "Repartitioning" was written with two "n". [#1681](https://github.com/chaos-polymtl/lethe/pull/1681)
+
 ### Changed
 
 - MINOR Remove dealii 9.6 version checks in matrix-free solver. [#1680](https://github.com/chaos-polymtl/lethe/pull/1680)

--- a/applications_tests/lethe-fluid-particles/spouted_bed_load_balancing.mpirun=2.output
+++ b/applications_tests/lethe-fluid-particles/spouted_bed_load_balancing.mpirun=2.output
@@ -28,7 +28,7 @@ Volume-Averaged Fluid Dynamics
 ----
 DEM
 ----
--->Repartitionning triangulation
+-->Repartitioning triangulation
 
 Warning: There are diamond-shaped cells in the input triangulation. It is strongly recommended to use a different triangulation without such cells. It should be mentioned that these cells are not detected if you have grid motion
 Load balance finished

--- a/applications_tests/lethe-particles/load_balancing_mobility_status.mpirun=2.output
+++ b/applications_tests/lethe-particles/load_balancing_mobility_status.mpirun=2.output
@@ -52,7 +52,7 @@ Transient iteration: 400      Time: 0.4      Time step: 0.001
 | Angular velocity magnitude   | 1.6006e-02 | 2.6957e+01 | 4.2493e+00 | 5.6091e+02 | 
 | Translational kinetic energy | 2.1064e-07 | 1.1348e-01 | 1.5114e-02 | 1.9950e+00 | 
 | Rotational kinetic energy    | 3.4339e-09 | 9.7407e-03 | 6.9569e-04 | 9.1832e-02 | 
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 66 , 62 and 70
 Minimum and maximum number of cells owned by the processors are 48 and 48
@@ -76,7 +76,7 @@ Transient iteration: 600      Time: 0.6      Time step: 0.001
 | Angular velocity magnitude   | 6.1211e-02 | 1.7212e+01 | 1.5850e+00 | 2.0922e+02 |
 | Translational kinetic energy | 2.1396e-08 | 6.5137e-03 | 1.8957e-04 | 2.5023e-02 |
 | Rotational kinetic energy    | 5.0222e-08 | 3.9711e-03 | 1.4555e-04 | 1.9212e-02 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 66 , 44 and 88
 Minimum and maximum number of cells owned by the processors are 48 and 48

--- a/applications_tests/lethe-particles/load_balancing_solid_object.mpirun=2.output
+++ b/applications_tests/lethe-particles/load_balancing_solid_object.mpirun=2.output
@@ -21,7 +21,7 @@ Transient iteration: 1000     Time: 0.01     Time step: 1e-05
 | Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
 | Translational kinetic energy | 1.3578e-07 | 1.3578e-07  | 1.3578e-07 | 1.3578e-04 | 
 | Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -35,7 +35,7 @@ Transient iteration: 2000     Time: 0.02     Time step: 1e-05
 | Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 |
 | Translational kinetic energy | 5.4366e-07 | 5.4366e-07  | 5.4366e-07 | 5.4366e-04 |
 | Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -49,7 +49,7 @@ Transient iteration: 3000     Time: 0.03     Time step: 1e-05
 | Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 |
 | Translational kinetic energy | 1.2236e-06 | 1.2236e-06  | 1.2236e-06 | 1.2236e-03 |
 | Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -63,7 +63,7 @@ Transient iteration: 4000     Time: 0.04     Time step: 1e-05
 | Angular velocity magnitude   | 0.0000e+00 | 1.7716e+02 | 8.2079e+00 | 8.2079e+03 |
 | Translational kinetic energy | 7.6202e-09 | 2.1757e-06 | 1.7824e-06 | 1.7824e-03 |
 | Rotational kinetic energy    | 0.0000e+00 | 7.9867e-07 | 1.4833e-08 | 1.4833e-05 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -77,7 +77,7 @@ Transient iteration: 5000     Time: 0.05     Time step: 1e-05
 | Angular velocity magnitude   | 0.0000e+00 | 2.2119e+02 | 2.1739e+01 | 2.1739e+04 |
 | Translational kinetic energy | 1.1718e-08 | 3.3999e-06 | 2.5399e-06 | 2.5399e-03 |
 | Rotational kinetic energy    | 0.0000e+00 | 1.2450e-06 | 5.3860e-08 | 5.3860e-05 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -91,7 +91,7 @@ Transient iteration: 6000     Time: 0.06     Time step: 1e-05
 | Angular velocity magnitude   | 0.0000e+00 | 2.2276e+02 | 2.7213e+01 | 2.7213e+04 |
 | Translational kinetic energy | 1.2492e-08 | 4.8962e-06 | 3.6756e-06 | 3.6756e-03 |
 | Rotational kinetic energy    | 0.0000e+00 | 1.2627e-06 | 6.2461e-08 | 6.2461e-05 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -105,7 +105,7 @@ Transient iteration: 7000     Time: 0.07     Time step: 1e-05
 | Angular velocity magnitude   | 0.0000e+00 | 2.6094e+02 | 3.2007e+01 | 3.2007e+04 |
 | Translational kinetic energy | 8.0447e-09 | 6.6646e-06 | 4.9470e-06 | 4.9470e-03 |
 | Rotational kinetic energy    | 0.0000e+00 | 1.7327e-06 | 7.3864e-08 | 7.3864e-05 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -119,7 +119,7 @@ Transient iteration: 8000     Time: 0.08     Time step: 1e-05
 | Angular velocity magnitude   | 0.0000e+00 | 2.7191e+02 | 3.9396e+01 | 3.9396e+04 |
 | Translational kinetic energy | 2.7683e-08 | 8.7051e-06 | 6.1625e-06 | 6.1625e-03 |
 | Rotational kinetic energy    | 0.0000e+00 | 1.8814e-06 | 1.0362e-07 | 1.0362e-04 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -133,7 +133,7 @@ Transient iteration: 9000     Time: 0.09     Time step: 1e-05
 | Angular velocity magnitude   | 0.0000e+00 | 2.9721e+02 | 4.9557e+01 | 4.9557e+04 |
 | Translational kinetic energy | 1.6555e-08 | 1.1018e-05 | 7.2861e-06 | 7.2861e-03 |
 | Rotational kinetic energy    | 0.0000e+00 | 2.2478e-06 | 1.5445e-07 | 1.5445e-04 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -147,7 +147,7 @@ Transient iteration: 10000    Time: 0.1      Time step: 1e-05
 | Angular velocity magnitude   | 4.0468e-04 | 3.4629e+02 | 5.7385e+01 | 5.7385e+04 |
 | Translational kinetic energy | 3.9884e-09 | 1.3460e-05 | 8.2246e-06 | 8.2246e-03 |
 | Rotational kinetic energy    | 4.1673e-18 | 3.0515e-06 | 1.9226e-07 | 1.9226e-04 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -161,7 +161,7 @@ Transient iteration: 11000    Time: 0.11     Time step: 1e-05
 | Angular velocity magnitude   | 8.4763e-04 | 3.5192e+02 | 7.1024e+01 | 7.1024e+04 |
 | Translational kinetic energy | 6.8778e-09 | 1.6195e-05 | 8.7668e-06 | 8.7668e-03 |
 | Rotational kinetic energy    | 1.8283e-17 | 3.1515e-06 | 2.5886e-07 | 2.5886e-04 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -175,7 +175,7 @@ Transient iteration: 12000    Time: 0.12     Time step: 1e-05
 | Angular velocity magnitude   | 8.4763e-04 | 4.2365e+02 | 8.1912e+01 | 8.1912e+04 |
 | Translational kinetic energy | 4.0206e-09 | 1.9370e-05 | 8.8813e-06 | 8.8813e-03 |
 | Rotational kinetic energy    | 1.8283e-17 | 4.5672e-06 | 3.0531e-07 | 3.0531e-04 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -189,7 +189,7 @@ Transient iteration: 13000    Time: 0.13     Time step: 1e-05
 | Angular velocity magnitude   | 8.4763e-04 | 3.2223e+02 | 9.9829e+01 | 9.9829e+04 |
 | Translational kinetic energy | 8.9452e-09 | 2.2668e-05 | 8.1874e-06 | 8.1874e-03 |
 | Rotational kinetic energy    | 1.8283e-17 | 2.6422e-06 | 3.9781e-07 | 3.9781e-04 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -203,7 +203,7 @@ Transient iteration: 14000    Time: 0.14     Time step: 1e-05
 | Angular velocity magnitude   | 8.4763e-04 | 3.5951e+02 | 1.1398e+02 | 1.1398e+05 |
 | Translational kinetic energy | 8.9694e-09 | 2.6287e-05 | 6.8576e-06 | 6.8576e-03 |
 | Rotational kinetic energy    | 1.8283e-17 | 3.2889e-06 | 4.6029e-07 | 4.6029e-04 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -217,7 +217,7 @@ Transient iteration: 15000    Time: 0.15     Time step: 1e-05
 | Angular velocity magnitude   | 8.4763e-04 | 4.2135e+02 | 1.2827e+02 | 1.2827e+05 |
 | Translational kinetic energy | 9.8772e-09 | 2.7673e-05 | 4.9259e-06 | 4.9259e-03 |
 | Rotational kinetic energy    | 1.8283e-17 | 4.5177e-06 | 5.4627e-07 | 5.4627e-04 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -231,7 +231,7 @@ Transient iteration: 16000    Time: 0.16     Time step: 1e-05
 | Angular velocity magnitude   | 3.3921e+00 | 4.3063e+02 | 1.2615e+02 | 1.2615e+05 |
 | Translational kinetic energy | 5.6156e-09 | 2.4969e-05 | 3.3351e-06 | 3.3351e-03 |
 | Rotational kinetic energy    | 2.9279e-10 | 4.7190e-06 | 5.1423e-07 | 5.1423e-04 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -245,7 +245,7 @@ Transient iteration: 17000    Time: 0.17     Time step: 1e-05
 | Angular velocity magnitude   | 7.4243e+00 | 4.3063e+02 | 1.1420e+02 | 1.1420e+05 |
 | Translational kinetic energy | 2.8790e-09 | 1.3642e-05 | 2.7475e-06 | 2.7475e-03 |
 | Rotational kinetic energy    | 1.4026e-09 | 4.7190e-06 | 4.2920e-07 | 4.2920e-04 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -259,7 +259,7 @@ Transient iteration: 18000    Time: 0.18     Time step: 1e-05
 | Angular velocity magnitude   | 5.7289e+00 | 3.9051e+02 | 1.1159e+02 | 1.1159e+05 |
 | Translational kinetic energy | 4.3574e-10 | 1.3867e-05 | 2.5056e-06 | 2.5056e-03 |
 | Rotational kinetic energy    | 8.3516e-10 | 3.8805e-06 | 4.1433e-07 | 4.1433e-04 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -273,7 +273,7 @@ Transient iteration: 19000    Time: 0.19     Time step: 1e-05
 | Angular velocity magnitude   | 7.4877e+00 | 3.9051e+02 | 1.1026e+02 | 1.1026e+05 |
 | Translational kinetic energy | 2.8637e-09 | 1.1144e-05 | 2.3542e-06 | 2.3542e-03 |
 | Rotational kinetic energy    | 1.4267e-09 | 3.8805e-06 | 4.1115e-07 | 4.1115e-04 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028
@@ -287,7 +287,7 @@ Transient iteration: 20000    Time: 0.2      Time step: 1e-05
 | Angular velocity magnitude   | 5.5257e+00 | 3.1518e+02 | 1.0881e+02 | 1.0881e+05 |
 | Translational kinetic energy | 1.6480e-09 | 1.1357e-05 | 2.2235e-06 | 2.2235e-03 |
 | Rotational kinetic energy    | 7.7698e-10 | 2.5279e-06 | 4.0152e-07 | 4.0152e-04 |
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 2040 and 4028

--- a/applications_tests/lethe-particles/packing_in_ball_dynamic_load_balance.mpirun=2.output
+++ b/applications_tests/lethe-particles/packing_in_ball_dynamic_load_balance.mpirun=2.output
@@ -11,11 +11,11 @@ This feature should only be activated in geometries with concave boundaries. (Fo
 **********************************************************************
 20 particles of type 0 were inserted, 0 particles of type 0 remaining
 **********************************************************************
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished 
 Average, minimum and maximum number of particles on the processors are 10 , 0 and 20
 Minimum and maximum number of cells owned by the processors are 2940 and 3024
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished
 Average, minimum and maximum number of particles on the processors are 10 , 0 and 20
 Minimum and maximum number of cells owned by the processors are 2940 and 3024

--- a/applications_tests/lethe-particles/periodic_boundary_load_balancing.mpirun=2.output
+++ b/applications_tests/lethe-particles/periodic_boundary_load_balancing.mpirun=2.output
@@ -21,7 +21,7 @@ Transient iteration: 10000    Time: 0.15     Time step: 1.5e-05
 | Angular velocity magnitude   | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
 | Translational kinetic energy | 6.2114e-06 | 6.2114e-06  | 6.2114e-06 | 6.2114e-05 | 
 | Rotational kinetic energy    | 0.0000e+00 | 2.2251e-308 | 0.0000e+00 | 0.0000e+00 | 
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished 
 Average, minimum and maximum number of particles on the processors are 5 , 2 and 8
 Minimum and maximum number of cells owned by the processors are 64 and 64

--- a/applications_tests/lethe-particles/resize_containers.mpirun=2.out
+++ b/applications_tests/lethe-particles/resize_containers.mpirun=2.out
@@ -11,11 +11,11 @@ This feature is useful in geometries with concave boundaries.
 ***********************************************************************
 485 particles of type 0 were inserted, 0 particles of type 0 remaining
 ***********************************************************************
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished 
 Average, minimum and maximum number of particles on the processors are 242.5 , 202 and 283
 Minimum and maximum number of cells owned by the processors are 1127 and 1841
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished 
 Average, minimum and maximum number of particles on the processors are 242.5 , 230 and 255
 Minimum and maximum number of cells owned by the processors are 1463 and 1526

--- a/applications_tests/lethe-particles/restart_cell_weight_function.with_dealii.geq.9.7.mpirun=2.output
+++ b/applications_tests/lethe-particles/restart_cell_weight_function.with_dealii.geq.9.7.mpirun=2.output
@@ -8,7 +8,7 @@ Reading triangulation
 Finished reading triangulation
 Warning: expansion of particle-wall contact list is disabled. 
 This feature is useful in geometries with concave boundaries. 
--->Repartitionning triangulation
+-->Repartitioning triangulation
 Load balance finished 
 Average, minimum and maximum number of particles on the processors are 500 , 0 and 1000
 Minimum and maximum number of cells owned by the processors are 5325 and 16875

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -426,7 +426,7 @@ DEMSolver<dim, PropertiesIndex>::load_balance()
   // load
   particle_handler.prepare_for_coarsening_and_refinement();
 
-  pcout << "-->Repartitionning triangulation" << std::endl;
+  pcout << "-->Repartitioning triangulation" << std::endl;
   triangulation.repartition();
 
   // Unpack the particle handler after the mesh has been repartitioned

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -757,7 +757,7 @@ CFDDEMSolver<dim>::load_balance()
   // Prepare particle handle for serialization
   this->particle_handler.prepare_for_coarsening_and_refinement();
 
-  this->pcout << "-->Repartitionning triangulation" << std::endl;
+  this->pcout << "-->Repartitioning triangulation" << std::endl;
 
   const auto parallel_triangulation =
     dynamic_cast<parallel::distributed::Triangulation<dim> *>(


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

A typo was found in the code regarding the work "Repartitioning" which was written with two 'n"


Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge