### PR TITLE
Added AssertThrow in the read_checkpoint function in the DEM

### DIFF
--- a/include/dem/read_checkpoint.h
+++ b/include/dem/read_checkpoint.h
@@ -43,4 +43,20 @@ read_checkpoint(
   std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solid_surfaces,
   CheckpointControl &checkpoint_controller);
 
+/**
+ * @brief Asserts that a file exists. If the file does not exist, an exception is
+ * @param[in] f Object associated with the file to check. The file
+ * should be opened before passing it to this function.
+ * @param[in] filename Name of the file that is not found.
+ *
+ */
+inline void
+assert_restart_file_exists(std::ifstream &f, const std::string &filename)
+{
+  AssertThrow(f.is_open(),
+              ExcMessage(
+                std::string("You are trying to restart a previous computation, "
+                            "but the restart file <") +
+                filename + "> does not appear to exist!"));
+}
 #endif

--- a/include/dem/read_checkpoint.h
+++ b/include/dem/read_checkpoint.h
@@ -43,20 +43,4 @@ read_checkpoint(
   std::vector<std::shared_ptr<SerialSolid<dim - 1, dim>>> &solid_surfaces,
   CheckpointControl &checkpoint_controller);
 
-/**
- * @brief Asserts that a file exists. If the file does not exist, an exception is
- * @param[in] f Object associated with the file to check. The file
- * should be opened before passing it to this function.
- * @param[in] filename Name of the file that is not found.
- *
- */
-inline void
-assert_restart_file_exists(std::ifstream &f, const std::string &filename)
-{
-  AssertThrow(f.is_open(),
-              ExcMessage(
-                std::string("You are trying to restart a previous computation, "
-                            "but the restart file <") +
-                filename + "> does not appear to exist!"));
-}
 #endif

--- a/source/dem/read_checkpoint.cc
+++ b/source/dem/read_checkpoint.cc
@@ -37,6 +37,14 @@ read_checkpoint(
     prefix + ".checkpoint_controller";
   std::ifstream iss_checkpoint_controller_obj(
     checkpoint_controller_object_filename);
+
+  AssertThrow(false,
+                ExcMessage(
+                  std::string(
+                    "You are trying to restart a previous computation, "
+                    "but the restart file <") +
+                  checkpoint_controller_object_filename + "> does not appear to exist!"));
+
   boost::archive::text_iarchive ia_checkpoint_controller_obj(
     iss_checkpoint_controller_obj, boost::archive::no_header);
   checkpoint_controller.deserialize(ia_checkpoint_controller_obj);
@@ -57,7 +65,12 @@ read_checkpoint(
   // Gather particle serialization information
   std::string   particle_filename = prefix + ".particles";
   std::ifstream input(particle_filename.c_str());
-  AssertThrow(input, ExcFileNotOpen(particle_filename));
+  AssertThrow(false,
+                ExcMessage(
+                  std::string(
+                    "You are trying to restart a previous computation, "
+                    "but the restart file <") +
+                  particle_filename + "> does not appear to exist!"));
 
   std::string buffer;
   std::getline(input, buffer);

--- a/source/dem/read_checkpoint.cc
+++ b/source/dem/read_checkpoint.cc
@@ -38,8 +38,8 @@ read_checkpoint(
   std::ifstream iss_checkpoint_controller_obj(
     checkpoint_controller_object_filename);
 
-  assert_restart_file_exists(iss_checkpoint_controller_obj,
-                             checkpoint_controller_object_filename);
+  AssertThrow(iss_checkpoint_controller_obj,
+              ExcFileNotOpen(checkpoint_controller_object_filename));
 
   boost::archive::text_iarchive ia_checkpoint_controller_obj(
     iss_checkpoint_controller_obj, boost::archive::no_header);
@@ -62,7 +62,7 @@ read_checkpoint(
   std::string   particle_filename = prefix + ".particles";
   std::ifstream input(particle_filename.c_str());
 
-  assert_restart_file_exists(input, particle_filename);
+  AssertThrow(input, ExcFileNotOpen(particle_filename));
 
   std::string buffer;
   std::getline(input, buffer);
@@ -74,7 +74,7 @@ read_checkpoint(
   const std::string filename = prefix + ".triangulation";
   std::ifstream     in(filename.c_str());
 
-  assert_restart_file_exists(in, filename);
+  AssertThrow(in, ExcFileNotOpen(filename));
 
   try
     {

--- a/source/dem/read_checkpoint.cc
+++ b/source/dem/read_checkpoint.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/checkpoint_control.h>
+#include <core/utilities.h>
 
 #include <dem/dem_action_manager.h>
 #include <dem/read_checkpoint.h>
@@ -38,12 +39,8 @@ read_checkpoint(
   std::ifstream iss_checkpoint_controller_obj(
     checkpoint_controller_object_filename);
 
-  AssertThrow(false,
-              ExcMessage(
-                std::string("You are trying to restart a previous computation, "
-                            "but the restart file <") +
-                checkpoint_controller_object_filename +
-                "> does not appear to exist!"));
+  assert_restart_file_exists(iss_checkpoint_controller_obj,
+                             checkpoint_controller_object_filename);
 
   boost::archive::text_iarchive ia_checkpoint_controller_obj(
     iss_checkpoint_controller_obj, boost::archive::no_header);
@@ -65,11 +62,8 @@ read_checkpoint(
   // Gather particle serialization information
   std::string   particle_filename = prefix + ".particles";
   std::ifstream input(particle_filename.c_str());
-  AssertThrow(false,
-              ExcMessage(
-                std::string("You are trying to restart a previous computation, "
-                            "but the restart file <") +
-                particle_filename + "> does not appear to exist!"));
+
+  assert_restart_file_exists(input, particle_filename);
 
   std::string buffer;
   std::getline(input, buffer);
@@ -80,13 +74,8 @@ read_checkpoint(
 
   const std::string filename = prefix + ".triangulation";
   std::ifstream     in(filename.c_str());
-  if (!in)
-    AssertThrow(false,
-                ExcMessage(
-                  std::string(
-                    "You are trying to restart a previous computation, "
-                    "but the restart file <") +
-                  filename + "> does not appear to exist!"));
+
+  assert_restart_file_exists(in, filename);
 
   try
     {

--- a/source/dem/read_checkpoint.cc
+++ b/source/dem/read_checkpoint.cc
@@ -39,11 +39,11 @@ read_checkpoint(
     checkpoint_controller_object_filename);
 
   AssertThrow(false,
-                ExcMessage(
-                  std::string(
-                    "You are trying to restart a previous computation, "
-                    "but the restart file <") +
-                  checkpoint_controller_object_filename + "> does not appear to exist!"));
+              ExcMessage(
+                std::string("You are trying to restart a previous computation, "
+                            "but the restart file <") +
+                checkpoint_controller_object_filename +
+                "> does not appear to exist!"));
 
   boost::archive::text_iarchive ia_checkpoint_controller_obj(
     iss_checkpoint_controller_obj, boost::archive::no_header);
@@ -66,11 +66,10 @@ read_checkpoint(
   std::string   particle_filename = prefix + ".particles";
   std::ifstream input(particle_filename.c_str());
   AssertThrow(false,
-                ExcMessage(
-                  std::string(
-                    "You are trying to restart a previous computation, "
-                    "but the restart file <") +
-                  particle_filename + "> does not appear to exist!"));
+              ExcMessage(
+                std::string("You are trying to restart a previous computation, "
+                            "but the restart file <") +
+                particle_filename + "> does not appear to exist!"));
 
   std::string buffer;
   std::getline(input, buffer);

--- a/source/dem/read_checkpoint.cc
+++ b/source/dem/read_checkpoint.cc
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/checkpoint_control.h>
-#include <core/utilities.h>
 
 #include <dem/dem_action_manager.h>
 #include <dem/read_checkpoint.h>


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description
If the checkpoint controller does not exist while reading a restart at the beginning of a simulation, no error message was being written and the simulation was crashing. This was annoying when you are copy-pasting a .prm file that already exist, change some parametesr manually and then start your new simulation while forgetting that the `restart` parameter is still at `true`. (Aka, me losing 10 minutes this morning wondering why my prm was not working) 

Now, with the new `AssertThrow`, the user is informed that the checkpoint_controller is not found, thus he know that we are trying to restart a simulation. If he doesn't want to restart, he knows right away what to do. On the other hand, if he wants to restart, well he knows there is a problem. 

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [X] Lethe documentation is up to date
- [X] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [X] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [X] If the fix is temporary, an issue is opened
- [X] The PR description is cleaned and ready for merge