### PR TITLE
Cleanup periodic parameter names with and "_"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Lethe project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+### [Master] - 2025-09-29
+
+### Changed
+
+- MINOR We are targetting to uniformize the parameter names. As such, parameter declaration which are made of multiple words will not be separated by an "_" anymore. This is already the case for 95% of the parameters in the code. The remaining "_" will only be kept to indicate an underscore as per LaTeX syntax. This PR refactors the periodic_id and the periodic_direction parameter to follow this syntax. To keep the code stable in the short term, an alias was declared for this parameter which uses the previous syntax. [#1698](https://github.com/chaos-polymtl/lethe/pull/1698)
+
 ### [Master] - 2025-09-26
 
 ### Added

--- a/applications_tests/lethe-fluid-block/apparent_viscosity_carreau_gd.prm
+++ b/applications_tests/lethe-fluid-block/apparent_viscosity_carreau_gd.prm
@@ -94,7 +94,7 @@ subsection boundary conditions
   subsection bc 2
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
 end

--- a/applications_tests/lethe-fluid-block/poiseuille3d_gd.prm
+++ b/applications_tests/lethe-fluid-block/poiseuille3d_gd.prm
@@ -68,7 +68,7 @@ subsection boundary conditions
   subsection bc 1
     set type               = periodic
     set id                 = 1
-    set periodic_id        = 2
+    set periodic id        = 2
     set periodic_direction = 0
   end
 end

--- a/applications_tests/lethe-fluid-block/poiseuille_gd.prm
+++ b/applications_tests/lethe-fluid-block/poiseuille_gd.prm
@@ -103,7 +103,7 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1

--- a/applications_tests/lethe-fluid-block/taylor-green-vortex_gd_bdf1.prm
+++ b/applications_tests/lethe-fluid-block/taylor-green-vortex_gd_bdf1.prm
@@ -111,13 +111,13 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid-block/taylor-green-vortex_gd_bdf2.prm
+++ b/applications_tests/lethe-fluid-block/taylor-green-vortex_gd_bdf2.prm
@@ -111,13 +111,13 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/generators/tgv_restart_bdf1_generator.prm
+++ b/applications_tests/lethe-fluid-matrix-free/generators/tgv_restart_bdf1_generator.prm
@@ -121,13 +121,13 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/generators/turbulent_taylor_couette_generator.prm
+++ b/applications_tests/lethe-fluid-matrix-free/generators/turbulent_taylor_couette_generator.prm
@@ -107,7 +107,7 @@ subsection boundary conditions
   subsection bc 2
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 2
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/poiseuille3d_flow_control.prm
+++ b/applications_tests/lethe-fluid-matrix-free/poiseuille3d_flow_control.prm
@@ -51,7 +51,7 @@ subsection boundary conditions
   subsection bc 1
     set type               = periodic
     set id                 = 1
-    set periodic_id        = 2
+    set periodic id        = 2
     set periodic_direction = 0
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/taylor_couette_3d_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/taylor_couette_3d_gcmg.prm
@@ -110,7 +110,7 @@ subsection boundary conditions
   subsection bc 2
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 2
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/taylor_couette_3d_lsmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/taylor_couette_3d_lsmg.prm
@@ -110,7 +110,7 @@ subsection boundary conditions
   subsection bc 2
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 2
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu.prm
@@ -109,13 +109,13 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu_gls.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu_gls.prm
@@ -109,13 +109,13 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/tgv_restart_bdf1.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_restart_bdf1.prm
@@ -121,13 +121,13 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid-matrix-free/turbulent_taylor_couette_restart.prm
+++ b/applications_tests/lethe-fluid-matrix-free/turbulent_taylor_couette_restart.prm
@@ -117,7 +117,7 @@ subsection boundary conditions
   subsection bc 2
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 2
   end
 end

--- a/applications_tests/lethe-fluid-particles/adaptive_sparse_contacts.prm
+++ b/applications_tests/lethe-fluid-particles/adaptive_sparse_contacts.prm
@@ -107,7 +107,7 @@ subsection boundary conditions
   subsection bc 0
     set id                 = 2
     set type               = periodic
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
   subsection bc 1

--- a/applications_tests/lethe-fluid-particles/periodic_particles_qcm.prm
+++ b/applications_tests/lethe-fluid-particles/periodic_particles_qcm.prm
@@ -109,7 +109,7 @@ subsection boundary conditions
   subsection bc 4
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
 end

--- a/applications_tests/lethe-fluid-sharp/almost_blocked_channels.prm
+++ b/applications_tests/lethe-fluid-sharp/almost_blocked_channels.prm
@@ -81,7 +81,7 @@ subsection boundary conditions
   subsection bc 4
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
 end

--- a/applications_tests/lethe-fluid/cahn_hilliard_periodic_boundaries.prm
+++ b/applications_tests/lethe-fluid/cahn_hilliard_periodic_boundaries.prm
@@ -120,13 +120,13 @@ subsection boundary conditions cahn hilliard
   subsection bc 0
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set id                 = 2
     set type               = periodic
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid/dg_vof_advection_tanh.prm
+++ b/applications_tests/lethe-fluid/dg_vof_advection_tanh.prm
@@ -64,7 +64,7 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
@@ -82,7 +82,7 @@ subsection boundary conditions VOF
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1

--- a/applications_tests/lethe-fluid/generators/poiseuille_restart_generator.prm
+++ b/applications_tests/lethe-fluid/generators/poiseuille_restart_generator.prm
@@ -81,7 +81,7 @@ subsection boundary conditions
   subsection bc 1
     set type               = periodic
     set id                 = 1
-    set periodic_id        = 2
+    set periodic id        = 2
     set periodic_direction = 0
   end
 end

--- a/applications_tests/lethe-fluid/gls_vof_periodic_boundary_condition.prm
+++ b/applications_tests/lethe-fluid/gls_vof_periodic_boundary_condition.prm
@@ -109,13 +109,13 @@ subsection boundary conditions
   subsection bc 0
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set id                 = 2
     set type               = periodic
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end
@@ -125,13 +125,13 @@ subsection boundary conditions VOF
   subsection bc 0
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set id                 = 2
     set type               = periodic
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid/heat_transfer_periodic_boundaries.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_periodic_boundaries.prm
@@ -68,13 +68,13 @@ subsection boundary conditions heat transfer
   subsection bc 0
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set id                 = 2
     set type               = periodic
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid/mortar_tgv.prm
+++ b/applications_tests/lethe-fluid/mortar_tgv.prm
@@ -115,13 +115,13 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
   subsection bc 2

--- a/applications_tests/lethe-fluid/partial_slip.prm
+++ b/applications_tests/lethe-fluid/partial_slip.prm
@@ -82,7 +82,7 @@ subsection boundary conditions
   subsection bc 2
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
 end

--- a/applications_tests/lethe-fluid/phase_change_darcy.prm
+++ b/applications_tests/lethe-fluid/phase_change_darcy.prm
@@ -130,7 +130,7 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 2

--- a/applications_tests/lethe-fluid/phase_change_viscosity.prm
+++ b/applications_tests/lethe-fluid/phase_change_viscosity.prm
@@ -121,7 +121,7 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 2

--- a/applications_tests/lethe-fluid/poiseuille3d-flow-control_gls_bdf1.prm
+++ b/applications_tests/lethe-fluid/poiseuille3d-flow-control_gls_bdf1.prm
@@ -59,7 +59,7 @@ subsection boundary conditions
   subsection bc 1
     set type               = periodic
     set id                 = 1
-    set periodic_id        = 2
+    set periodic id        = 2
     set periodic_direction = 0
   end
 end

--- a/applications_tests/lethe-fluid/poiseuille3d_balanced_grid.prm
+++ b/applications_tests/lethe-fluid/poiseuille3d_balanced_grid.prm
@@ -68,7 +68,7 @@ subsection boundary conditions
   subsection bc 1
     set type               = periodic
     set id                 = 1
-    set periodic_id        = 2
+    set periodic id        = 2
     set periodic_direction = 0
   end
 end

--- a/applications_tests/lethe-fluid/poiseuille3d_gls.prm
+++ b/applications_tests/lethe-fluid/poiseuille3d_gls.prm
@@ -68,7 +68,7 @@ subsection boundary conditions
   subsection bc 1
     set type               = periodic
     set id                 = 1
-    set periodic_id        = 2
+    set periodic id        = 2
     set periodic_direction = 0
   end
 end

--- a/applications_tests/lethe-fluid/poiseuille_gls.prm
+++ b/applications_tests/lethe-fluid/poiseuille_gls.prm
@@ -102,7 +102,7 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1

--- a/applications_tests/lethe-fluid/poiseuille_restart.prm
+++ b/applications_tests/lethe-fluid/poiseuille_restart.prm
@@ -82,7 +82,7 @@ subsection boundary conditions
   subsection bc 1
     set type               = periodic
     set id                 = 1
-    set periodic_id        = 2
+    set periodic id        = 2
     set periodic_direction = 0
   end
 end

--- a/applications_tests/lethe-fluid/taylor-green-vortex-restart-bdf1-adaptive.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex-restart-bdf1-adaptive.prm
@@ -108,13 +108,13 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid/taylor-green-vortex-restart-bdf1-adaptive/generator.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex-restart-bdf1-adaptive/generator.prm
@@ -108,13 +108,13 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid/taylor-green-vortex-restart_gls_bdf1.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex-restart_gls_bdf1.prm
@@ -123,13 +123,13 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid/taylor-green-vortex_gls_bdf1.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex_gls_bdf1.prm
@@ -109,13 +109,13 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid/taylor-green-vortex_gls_bdf2.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex_gls_bdf2.prm
@@ -111,13 +111,13 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid/taylor-green-vortex_gls_sdirk22.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex_gls_sdirk22.prm
@@ -111,13 +111,13 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid/taylor-green-vortex_gls_sdirk33.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex_gls_sdirk33.prm
@@ -111,13 +111,13 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid/tracer_periodic_boundaries.prm
+++ b/applications_tests/lethe-fluid/tracer_periodic_boundaries.prm
@@ -70,13 +70,13 @@ subsection boundary conditions tracer
   subsection bc 0
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set id                 = 2
     set type               = periodic
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
 end

--- a/applications_tests/lethe-fluid/vof-velocity-extrapolation.prm
+++ b/applications_tests/lethe-fluid/vof-velocity-extrapolation.prm
@@ -99,7 +99,7 @@ subsection boundary conditions
   subsection bc 0
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
@@ -117,7 +117,7 @@ subsection boundary conditions VOF
   subsection bc 0
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1

--- a/applications_tests/lethe-fluid/vof_phase_change_darcy.prm
+++ b/applications_tests/lethe-fluid/vof_phase_change_darcy.prm
@@ -162,7 +162,7 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 2

--- a/doc/source/examples/incompressible-flow/3d-flow-over-periodic-hills/3d-flow-over-periodic-hills.rst
+++ b/doc/source/examples/incompressible-flow/3d-flow-over-periodic-hills/3d-flow-over-periodic-hills.rst
@@ -123,7 +123,7 @@ In this section, we specify the boundary conditions taking into account the IDs 
       subsection bc 0
         set type               = periodic
         set id                 = 0
-        set periodic_id        = 1
+        set periodic id        = 1
         set periodic_direction = 0
       end
       subsection bc 1
@@ -137,7 +137,7 @@ In this section, we specify the boundary conditions taking into account the IDs 
       subsection bc 3
         set type               = periodic
         set id                 = 4
-        set periodic_id        = 5
+        set periodic id        = 5
         set periodic_direction = 2
       end
     end

--- a/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
+++ b/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
@@ -87,19 +87,19 @@ The ``boundary conditions`` subsection establishes the constraints on different 
     subsection bc 0
       set type               = periodic
       set id                 = 0
-      set periodic_id        = 1
+      set periodic id        = 1
       set periodic_direction = 0
     end
     subsection bc 1
       set type               = periodic
       set id                 = 2
-      set periodic_id        = 3
+      set periodic id        = 3
       set periodic_direction = 1
     end
     subsection bc 2
       set type               = periodic
       set id                 = 4
-      set periodic_id        = 5
+      set periodic id        = 5
       set periodic_direction = 2
     end
   end

--- a/doc/source/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/3d-turbulent-flow-around-cylinder.rst
+++ b/doc/source/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/3d-turbulent-flow-around-cylinder.rst
@@ -124,7 +124,7 @@ The ``boundary conditions`` subsection establishes the boundary conditions:
     end
     subsection bc 5
       set type               = periodic
-      set periodic_id        = 6
+      set periodic id        = 6
       set periodic_direction = 2
     end
   end

--- a/doc/source/examples/incompressible-flow/3d-turbulent-taylor-couette/3d-turbulent-taylor-couette.rst
+++ b/doc/source/examples/incompressible-flow/3d-turbulent-taylor-couette/3d-turbulent-taylor-couette.rst
@@ -146,7 +146,7 @@ The ``boundary conditions`` subsection establishes the constraints on different 
     subsection bc 2            
       set type               = periodic
       set id                 = 2
-      set periodic_id        = 3
+      set periodic id        = 3
       set periodic_direction = 2
     end
   end

--- a/doc/source/examples/multiphysics/rayleigh-plateau-instability/rayleigh-plateau-instability.rst
+++ b/doc/source/examples/multiphysics/rayleigh-plateau-instability/rayleigh-plateau-instability.rst
@@ -202,7 +202,7 @@ In the ``boundary conditions`` subsection, the inlet velocity perturbation is sp
       subsection bc 1
         set id                 = 2
         set type               = periodic
-        set periodic_id        = 3
+        set periodic id        = 3
         set periodic_direction = 1
       end
       subsection bc 2
@@ -231,7 +231,7 @@ Lasty, in the ``boundary conditions VOF`` subsection we ensure that ``fluid 1`` 
       subsection bc 1
         set id                 = 2
         set type               = periodic
-        set periodic_id        = 3
+        set periodic id        = 3
         set periodic_direction = 1
       end
       subsection bc 2

--- a/doc/source/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability.rst
+++ b/doc/source/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability.rst
@@ -199,7 +199,7 @@ The boundary conditions applied on the left and right boundaries are ``periodic`
     subsection bc 0
       set id                 = 0
       set type               = periodic
-      set periodic_id        = 1
+      set periodic id        = 1
       set periodic_direction = 0
     end
     subsection bc 1
@@ -222,7 +222,7 @@ For VOF, we specify the periodic boundary conditions on the sides and no-flux bo
     subsection bc 0
       set id   = 0
       set type = periodic
-      set periodic_id = 1
+      set periodic id = 1
       set periodic_direction = 0
     end
     subsection bc 1

--- a/doc/source/examples/unresolved-cfd-dem/dense-pneumatic-conveying/dense-pneumatic-conveying.rst
+++ b/doc/source/examples/unresolved-cfd-dem/dense-pneumatic-conveying/dense-pneumatic-conveying.rst
@@ -476,7 +476,7 @@ The boundary condition at the wall of the pipe is a weak function where the Diri
       subsection bc 1
         set id                 = 1
         set type               = periodic
-        set periodic_id        = 2
+        set periodic id        = 2
         set periodic_direction = 0
       end
     end

--- a/doc/source/parameters/cfd/boundary_conditions_cfd.rst
+++ b/doc/source/parameters/cfd/boundary_conditions_cfd.rst
@@ -50,7 +50,7 @@ where :math:`\beta` is a constant  and :math:`(\mathbf{u}\cdot \mathbf{n})_{-}` 
         set z = 0
       end
 
-      set periodic_id        = 1
+      set periodic id        = 1
       set periodic_direction = 0
       set beta               = 1
     end
@@ -82,7 +82,7 @@ where :math:`\beta` is a constant  and :math:`(\mathbf{u}\cdot \mathbf{n})_{-}` 
 
     * The ``center of rotation`` subsection is only necessary when calculating the torque applied on a boundary. See  See :doc:`force_and_torque` for more information.
 
-    * ``periodic id`` and ``periodic_direction`` specify the id and direction of the matching periodic boundary condition. For example, if boundary id 0 (located at xmin) is matched with boundary id 1 (located at xmax), we would set ``id = 0``, ``periodic_id = 1`` and ``periodic_direction = 0``.
+    * ``periodic id`` and ``periodic_direction`` specify the id and direction of the matching periodic boundary condition. For example, if boundary id 0 (located at xmin) is matched with boundary id 1 (located at xmax), we would set ``id = 0``, ``periodic id = 1`` and ``periodic_direction = 0``.
 
     * ``beta`` is a penalization parameter used for both the ``outlet``, ``partial slip``, and ``function weak`` boundary conditions. For the outlet boundary conditions ``beta`` should be close to unity, whereas ``beta`` of 10 or a 100 can be appropriate for the ``function weak`` boundary condition. For the ``partial slip`` condition, use high values of ``beta`` (`i.e.` > 50).
 

--- a/doc/source/parameters/cfd/boundary_conditions_multiphysics.rst
+++ b/doc/source/parameters/cfd/boundary_conditions_multiphysics.rst
@@ -21,7 +21,7 @@ The default parameters for ``temperature`` and ``convection-radiation-flux`` are
     subsection bc 0
       set id                 = 0
       set type               = periodic
-      set periodic_id        = 1
+      set periodic id        = 1
       set periodic_direction = 0
     end
     subsection bc 1
@@ -68,7 +68,7 @@ The default parameters for ``temperature`` and ``convection-radiation-flux`` are
 * ``type``: type of boundary condition being imposed. At the moment, choices are:
     * ``noflux`` (default) so that there is no heat transfer boundary condition,
     * ``temperature`` (Dirichlet BC), to impose a given temperature ``value`` at the boundary,
-    * ``periodic`` to impose periodicity between boundaries. ``periodic id`` and ``periodic_direction`` specify the id and direction of the matching periodic boundary condition. For example, if boundary id 0 (located at xmin) is matched with boundary id 1 (located at xmax), we would set ``id = 0``, ``periodic_id = 1`` and ``periodic_direction = 0``;
+    * ``periodic`` to impose periodicity between boundaries. ``periodic id`` and ``periodic_direction`` specify the id and direction of the matching periodic boundary condition. For example, if boundary id 0 (located at xmin) is matched with boundary id 1 (located at xmax), we would set ``id = 0``, ``periodic id = 1`` and ``periodic_direction = 0``;
     * ``convection-radiation-flux`` (Robin BC) for cooling/heating, depending on the environment temperature at the boundary ``Tinf``, with a given heat transfer coefficient ``h`` and ``emissivity`` of the boundary :math:`\mathbf{\epsilon}` following Newton's law of cooling (and heating) and Stefan-Boltzmann law of radiation. It is also possible to impose a given heat flux (:math:`q_0`) by using the parameter ``heat_flux``. This BC can be represented by:
 
     .. math::
@@ -98,7 +98,7 @@ For tracer boundary conditions, the defaults parameters are:
     subsection bc 0
       set id                 = 0
       set type               = periodic
-      set periodic_id        = 1
+      set periodic id        = 1
       set periodic_direction = 0
     end
     subsection bc 1
@@ -118,7 +118,7 @@ For tracer boundary conditions, the defaults parameters are:
 
 * ``type``: This is the type of boundary condition being imposed:
     * ``dirichlet`` to impose specific values;
-    * ``periodic`` to impose periodicity between boundaries. ``periodic id`` and ``periodic_direction`` specify the id and direction of the matching periodic boundary condition. For example, if boundary id 0 (located at xmin) is matched with boundary id 1 (located at xmax), we would set ``id = 0``, ``periodic_id = 1`` and ``periodic_direction = 0``.
+    * ``periodic`` to impose periodicity between boundaries. ``periodic id`` and ``periodic_direction`` specify the id and direction of the matching periodic boundary condition. For example, if boundary id 0 (located at xmin) is matched with boundary id 1 (located at xmax), we would set ``id = 0``, ``periodic id = 1`` and ``periodic_direction = 0``.
 
 VOF
 ^^^
@@ -133,7 +133,7 @@ For VOF boundary conditions (multiphase flow), the possible ``types`` are ``none
     subsection bc 0
       set id                 = 0
       set type               = periodic
-      set periodic_id        = 1
+      set periodic id        = 1
       set periodic_direction = 0
     end
     subsection bc 1
@@ -166,7 +166,7 @@ For VOF boundary conditions (multiphase flow), the possible ``types`` are ``none
 * ``type``: This is the type of boundary condition being imposed. At the moment, choices are:
     * ``none`` for which nothing happens;
     * ``dirichlet`` for inlet and outlet boundary conditions, to specify which fluid should be at the selected boundary;
-    * ``periodic`` to impose periodicity between boundaries. ``periodic id`` and ``periodic_direction`` specify the id and direction of the matching periodic boundary condition. For example, if boundary id 0 (located at xmin) is matched with boundary id 1 (located at xmax), we would set ``id = 0``, ``periodic_id = 1`` and ``periodic_direction = 0``.
+    * ``periodic`` to impose periodicity between boundaries. ``periodic id`` and ``periodic_direction`` specify the id and direction of the matching periodic boundary condition. For example, if boundary id 0 (located at xmin) is matched with boundary id 1 (located at xmax), we would set ``id = 0``, ``periodic id = 1`` and ``periodic_direction = 0``.
 
     
 Cahn-Hilliard
@@ -182,7 +182,7 @@ For Cahn-Hilliard boundary conditions, the available ``types`` are ``none`` (def
     subsection bc 0
       set id                 = 0
       set type               = periodic
-      set periodic_id        = 1
+      set periodic id        = 1
       set periodic_direction = 0
     end
     subsection bc 1
@@ -220,4 +220,4 @@ For Cahn-Hilliard boundary conditions, the available ``types`` are ``none`` (def
     * ``dirichlet``: Imposes a given phase order parameter function on the boundary. This function can depend on position (:math:`x,y,z`) and on time (:math:`t`).
     * ``angle_of_contact``: Imposes a given angle of contact ``angle value`` between the two phases at the boundary. It refers to the inner angle of contact, in degrees (°).
     * ``free_angle``: Leaves the angle as a free variable to be solved.
-    * ``periodic``: Imposes periodicity between boundaries. ``periodic id`` and ``periodic_direction`` specify the id and direction of the matching periodic boundary condition. For example, if boundary id 0 (located at xmin) is matched with boundary id 1 (located at xmax), we would set ``id = 0``, ``periodic_id = 1`` and ``periodic_direction = 0``.
+    * ``periodic``: Imposes periodicity between boundaries. ``periodic id`` and ``periodic_direction`` specify the id and direction of the matching periodic boundary condition. For example, if boundary id 0 (located at xmin) is matched with boundary id 1 (located at xmax), we would set ``id = 0``, ``periodic id = 1`` and ``periodic_direction = 0``.

--- a/examples/incompressible-flow/3d-periodic-hills/periodic-hills.prm
+++ b/examples/incompressible-flow/3d-periodic-hills/periodic-hills.prm
@@ -89,7 +89,7 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
@@ -103,7 +103,7 @@ subsection boundary conditions
   subsection bc 3
     set type               = periodic
     set id                 = 4
-    set periodic_id        = 5
+    set periodic id        = 5
     set periodic_direction = 2
   end
 end

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-based.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-based.prm
@@ -97,19 +97,19 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
   subsection bc 2
     set type               = periodic
     set id                 = 4
-    set periodic_id        = 5
+    set periodic id        = 5
     set periodic_direction = 2
   end
 end

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free-validation.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free-validation.prm
@@ -102,19 +102,19 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
   subsection bc 2
     set type               = periodic
     set id                 = 4
-    set periodic_id        = 5
+    set periodic id        = 5
     set periodic_direction = 2
   end
 end

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
@@ -100,19 +100,19 @@ subsection boundary conditions
   subsection bc 0
     set type               = periodic
     set id                 = 0
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
   subsection bc 2
     set type               = periodic
     set id                 = 4
-    set periodic_id        = 5
+    set periodic id        = 5
     set periodic_direction = 2
   end
 end

--- a/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/turbulent-cylinder.prm
+++ b/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/turbulent-cylinder.prm
@@ -158,7 +158,7 @@ subsection boundary conditions
   end
   subsection bc 5
     set type               = periodic
-    set periodic_id        = 6
+    set periodic id        = 6
     set periodic_direction = 2
   end
 end

--- a/examples/incompressible-flow/3d-turbulent-taylor-couette/tc-matrix-free.prm
+++ b/examples/incompressible-flow/3d-turbulent-taylor-couette/tc-matrix-free.prm
@@ -120,7 +120,7 @@ subsection boundary conditions
   subsection bc 2
     set type               = periodic
     set id                 = 2
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 2
   end
 end

--- a/examples/multiphysics/capillary-wave/capillary-wave-TSM-0_95.prm
+++ b/examples/multiphysics/capillary-wave/capillary-wave-TSM-0_95.prm
@@ -122,7 +122,7 @@ subsection boundary conditions
   subsection bc 0
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1

--- a/examples/multiphysics/rayleigh-plateau-instability/rayleigh-plateau-J1-We020-Oh0_10_delta0_20/rayleigh-plateau-J1-We020-Oh0_10_delta0_20.prm
+++ b/examples/multiphysics/rayleigh-plateau-instability/rayleigh-plateau-J1-We020-Oh0_10_delta0_20/rayleigh-plateau-J1-We020-Oh0_10_delta0_20.prm
@@ -134,7 +134,7 @@ subsection boundary conditions
   subsection bc 1
     set id                 = 2
     set type               = periodic
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
   subsection bc 2
@@ -160,7 +160,7 @@ subsection boundary conditions VOF
   subsection bc 1
     set id                 = 2
     set type               = periodic
-    set periodic_id        = 3
+    set periodic id        = 3
     set periodic_direction = 1
   end
   subsection bc 2

--- a/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability.prm
+++ b/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability.prm
@@ -144,7 +144,7 @@ subsection boundary conditions
   subsection bc 0
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1
@@ -162,7 +162,7 @@ subsection boundary conditions VOF
   subsection bc 0
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0002/sloshing-in-rectangular-tank_Re0002.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0002/sloshing-in-rectangular-tank_Re0002.prm
@@ -124,7 +124,7 @@ subsection boundary conditions
   subsection bc 0
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0020/sloshing-in-rectangular-tank_Re0020.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0020/sloshing-in-rectangular-tank_Re0020.prm
@@ -124,7 +124,7 @@ subsection boundary conditions
   subsection bc 0
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0200/sloshing-in-rectangular-tank_Re0200.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0200/sloshing-in-rectangular-tank_Re0200.prm
@@ -124,7 +124,7 @@ subsection boundary conditions
   subsection bc 0
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_2000/sloshing-in-rectangular-tank_Re2000.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_2000/sloshing-in-rectangular-tank_Re2000.prm
@@ -124,7 +124,7 @@ subsection boundary conditions
   subsection bc 0
     set id                 = 0
     set type               = periodic
-    set periodic_id        = 1
+    set periodic id        = 1
     set periodic_direction = 0
   end
   subsection bc 1

--- a/examples/unresolved-cfd-dem/dense-pneumatic-conveying/pneumatic-conveying.prm
+++ b/examples/unresolved-cfd-dem/dense-pneumatic-conveying/pneumatic-conveying.prm
@@ -112,7 +112,7 @@ subsection boundary conditions
   subsection bc 1
     set id                 = 1
     set type               = periodic
-    set periodic_id        = 2
+    set periodic id        = 2
     set periodic_direction = 0
   end
 end

--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -245,10 +245,14 @@ namespace BoundaryConditions
       Patterns::Integer(),
       "Mesh id for periodic face matching. Default entry is -1 to ensure that the periodic id is set by the user");
 
+    prm.declare_alias("periodic id", "periodic_id", true);
+
     prm.declare_entry("periodic direction",
                       "0",
                       Patterns::Integer(),
                       "Direction for periodic boundary condition");
+
+    prm.declare_alias("periodic direction", "periodic_direction", true);
 
 
     // Create a dummy NSBoundaryFunctions object to declare the appropriate
@@ -607,10 +611,14 @@ namespace BoundaryConditions
       Patterns::Integer(),
       "Mesh id for periodic face matching. Default entry is -1 to ensure that the periodic id is set by the user");
 
+    prm.declare_alias("periodic id", "periodic_id", true);
+
     prm.declare_entry("periodic direction",
                       "0",
                       Patterns::Integer(),
                       "Direction for periodic boundary condition");
+
+    prm.declare_alias("periodic direction", "periodic_direction", true);
   }
 
   /**
@@ -838,10 +846,15 @@ namespace BoundaryConditions
       Patterns::Integer(),
       "Mesh id for periodic face matching. Default entry is -1 to ensure that the periodic id is set by the user");
 
+    prm.declare_alias("periodic id", "periodic_id", true);
+
+
     prm.declare_entry("periodic direction",
                       "0",
                       Patterns::Integer(),
                       "Direction for periodic boundary condition");
+
+    prm.declare_alias("periodic direction", "periodic_direction", true);
   }
 
   /**
@@ -1042,10 +1055,14 @@ namespace BoundaryConditions
       Patterns::Integer(),
       "Mesh id for periodic face matching. Default entry is -1 to ensure that the periodic id is set by the user");
 
+    prm.declare_alias("periodic id", "periodic_id", true);
+
     prm.declare_entry("periodic direction",
                       "0",
                       Patterns::Integer(),
                       "Direction for periodic boundary condition");
+
+    prm.declare_alias("periodic direction", "periodic_direction", true);
   }
 
   /**
@@ -1253,10 +1270,14 @@ namespace BoundaryConditions
       Patterns::Integer(),
       "Mesh id for periodic face matching. Default entry is -1 to ensure that the periodic id is set by the user");
 
+    prm.declare_alias("periodic id", "periodic_id", true);
+
     prm.declare_entry("periodic direction",
                       "0",
                       Patterns::Integer(),
                       "Direction for periodic boundary condition");
+
+    prm.declare_alias("periodic direction", "periodic_direction", true);
   }
 
   /**

--- a/include/core/boundary_conditions.h
+++ b/include/core/boundary_conditions.h
@@ -240,12 +240,12 @@ namespace BoundaryConditions
       "Mesh id for boundary conditions. Default entry is -1 to ensure that the id is set by the user");
 
     prm.declare_entry(
-      "periodic_id",
+      "periodic id",
       "-1",
       Patterns::Integer(),
       "Mesh id for periodic face matching. Default entry is -1 to ensure that the periodic id is set by the user");
 
-    prm.declare_entry("periodic_direction",
+    prm.declare_entry("periodic direction",
                       "0",
                       Patterns::Integer(),
                       "Direction for periodic boundary condition");
@@ -369,7 +369,7 @@ namespace BoundaryConditions
     if (op == "periodic")
       {
         types::boundary_id periodic_boundary_id =
-          prm.get_integer("periodic_id");
+          prm.get_integer("periodic id");
 
         this->type[boundary_id] = BoundaryType::periodic;
 
@@ -380,7 +380,7 @@ namespace BoundaryConditions
         // We store the periodic id and direction
         this->periodic_neighbor_id[boundary_id] = periodic_boundary_id;
         this->periodic_direction[boundary_id] =
-          prm.get_integer("periodic_direction");
+          prm.get_integer("periodic direction");
 
         // Allocate the navier_stokes_functions object for the periodic neighbor
         // condition to ensure that they have a defined function and a center of
@@ -602,12 +602,12 @@ namespace BoundaryConditions
 
     // Periodic boundary condition parameters for HT physics
     prm.declare_entry(
-      "periodic_id",
+      "periodic id",
       "-1",
       Patterns::Integer(),
       "Mesh id for periodic face matching. Default entry is -1 to ensure that the periodic id is set by the user");
 
-    prm.declare_entry("periodic_direction",
+    prm.declare_entry("periodic direction",
                       "0",
                       Patterns::Integer(),
                       "Direction for periodic boundary condition");
@@ -696,7 +696,7 @@ namespace BoundaryConditions
     else if (op == "periodic")
       {
         types::boundary_id periodic_boundary_id =
-          prm.get_integer("periodic_id");
+          prm.get_integer("periodic id");
 
         this->type[boundary_id] = BoundaryType::periodic;
 
@@ -707,7 +707,7 @@ namespace BoundaryConditions
         // We store the periodic id and direction
         this->periodic_neighbor_id[boundary_id] = periodic_boundary_id;
         this->periodic_direction[boundary_id] =
-          prm.get_integer("periodic_direction");
+          prm.get_integer("periodic direction");
       }
     else
       {
@@ -833,12 +833,12 @@ namespace BoundaryConditions
 
     // Periodic boundary condition parameters for Tracer physics
     prm.declare_entry(
-      "periodic_id",
+      "periodic id",
       "-1",
       Patterns::Integer(),
       "Mesh id for periodic face matching. Default entry is -1 to ensure that the periodic id is set by the user");
 
-    prm.declare_entry("periodic_direction",
+    prm.declare_entry("periodic direction",
                       "0",
                       Patterns::Integer(),
                       "Direction for periodic boundary condition");
@@ -922,7 +922,7 @@ namespace BoundaryConditions
     else if (op == "periodic")
       {
         types::boundary_id periodic_boundary_id =
-          prm.get_integer("periodic_id");
+          prm.get_integer("periodic id");
 
         this->type[boundary_id] = BoundaryType::periodic;
 
@@ -933,7 +933,7 @@ namespace BoundaryConditions
         // We store the periodic id and direction
         this->periodic_neighbor_id[boundary_id] = periodic_boundary_id;
         this->periodic_direction[boundary_id] =
-          prm.get_integer("periodic_direction");
+          prm.get_integer("periodic direction");
       }
     else
       {
@@ -1037,12 +1037,12 @@ namespace BoundaryConditions
 
     // Periodic boundary condition parameters for Cahn-Hilliards physics
     prm.declare_entry(
-      "periodic_id",
+      "periodic id",
       "-1",
       Patterns::Integer(),
       "Mesh id for periodic face matching. Default entry is -1 to ensure that the periodic id is set by the user");
 
-    prm.declare_entry("periodic_direction",
+    prm.declare_entry("periodic direction",
                       "0",
                       Patterns::Integer(),
                       "Direction for periodic boundary condition");
@@ -1142,7 +1142,7 @@ namespace BoundaryConditions
     else if (op == "periodic")
       {
         types::boundary_id periodic_boundary_id =
-          prm.get_integer("periodic_id");
+          prm.get_integer("periodic id");
 
         this->type[boundary_id] = BoundaryType::periodic;
 
@@ -1153,7 +1153,7 @@ namespace BoundaryConditions
         // We store the periodic id and direction
         this->periodic_neighbor_id[boundary_id] = periodic_boundary_id;
         this->periodic_direction[boundary_id] =
-          prm.get_integer("periodic_direction");
+          prm.get_integer("periodic direction");
       }
     else
       {
@@ -1248,12 +1248,12 @@ namespace BoundaryConditions
 
     // Periodic boundary condition parameters for VOF physics
     prm.declare_entry(
-      "periodic_id",
+      "periodic id",
       "-1",
       Patterns::Integer(),
       "Mesh id for periodic face matching. Default entry is -1 to ensure that the periodic id is set by the user");
 
-    prm.declare_entry("periodic_direction",
+    prm.declare_entry("periodic direction",
                       "0",
                       Patterns::Integer(),
                       "Direction for periodic boundary condition");
@@ -1334,7 +1334,7 @@ namespace BoundaryConditions
     if (auto const option = prm.get("type"); option == "periodic")
       {
         types::boundary_id periodic_boundary_id =
-          prm.get_integer("periodic_id");
+          prm.get_integer("periodic id");
 
         this->type[boundary_id] = BoundaryType::periodic;
 
@@ -1345,7 +1345,7 @@ namespace BoundaryConditions
         // We store the periodic id and direction
         this->periodic_neighbor_id[boundary_id] = periodic_boundary_id;
         this->periodic_direction[boundary_id] =
-          prm.get_integer("periodic_direction");
+          prm.get_integer("periodic direction");
       }
   }
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

We have some parameters in lethe which use "_" in their declaration instead of spaces. We do this for very few parameters and it is done in an arbitrary and illogical way (mostly me creating these parameters like 5 years ago). This PR refactors this by removing some of the "_" in the parameters, namely the periodic ones. I have declared an alias for the time being to not break people's prm file, but this will be deprecated anyway.

### Testing

No test should change.

### Documentation

Documentation has been refactored to reflect the change.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Copyright headers are present and up to date
- [ ] Lethe documentation is up to date
- [ ] The branch is rebased onto master
- [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [ ] If parameters are modified, the tests and the documentation of examples are up to date
- [ ] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [ ] No other PR is open related to this refactoring
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If any future works is planned, an issue is opened
- [ ] The PR description is cleaned and ready for merge