### PR TITLE
Skip unnecessary Sharp fluid GMRES solves below tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
+- MINOR This PR skips unnecessary Newton linear solves when the assembled Sharp fluid residual is already below the nonlinear tolerance, and adds a dedicated 2D application test for that solver path. [#1961](https://github.com/chaos-polymtl/lethe/pull/1961)
+
+## [Master] - 2026/03/31
+
+### Changed
+
 - MAJOR Following PRs [#1937](https://github.com/chaos-polymtl/lethe/pull/1937), [#1938](https://github.com/chaos-polymtl/lethe/pull/1938), [#1944](https://github.com/chaos-polymtl/lethe/pull/1944) and [#1950](https://github.com/chaos-polymtl/lethe/pull/1950) this PR renames all occurrences of "interface regularization", "algebraic interface reinitialization", and "phase fraction" with "interface reinitialization", "pde-based interface reinitialization", and "phase indicator" in the code.[#1954](https://github.com/chaos-polymtl/lethe/pull/1954).
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the Lethe project will be documented in this file.
 The changelog for the previous releases of Lethe are located in the release_notes folder.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2026/04/15
+
+### Changed
+
+- MINOR This PR skips unnecessary Newton linear solves when the assembled Sharp fluid residual is already below the nonlinear tolerance, and adds a dedicated 2D application test for that solver path. [#1962](https://github.com/chaos-polymtl/lethe/pull/1962)
+
 ## [Master] - 2026/04/10
 
 ### Fixed
@@ -24,12 +30,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - MINOR Sharp-IB now mirrors DEM-style particle output and post-processing more closely: IB particle PVD output follows the fluid output cadence, including step 0, and DEM force-chain and lagrangian post-processing can now be rebuilt from Sharp-IB particles. Application tests and documentation were added for the new output paths. [#1958](https://github.com/chaos-polymtl/lethe/pull/1958)
-
-## [Master] - 2026/03/31
-
-### Changed
-
-- MINOR This PR skips unnecessary Newton linear solves when the assembled Sharp fluid residual is already below the nonlinear tolerance, and adds a dedicated 2D application test for that solver path. [#1962](https://github.com/chaos-polymtl/lethe/pull/1962)
 
 ## [Master] - 2026/03/31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
-- MINOR This PR skips unnecessary Newton linear solves when the assembled Sharp fluid residual is already below the nonlinear tolerance, and adds a dedicated 2D application test for that solver path. [#1961](https://github.com/chaos-polymtl/lethe/pull/1961)
+- MINOR This PR skips unnecessary Newton linear solves when the assembled Sharp fluid residual is already below the nonlinear tolerance, and adds a dedicated 2D application test for that solver path. [#1962](https://github.com/chaos-polymtl/lethe/pull/1962)
 
 ## [Master] - 2026/03/31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the Lethe project will be documented in this file.
 The changelog for the previous releases of Lethe are located in the release_notes folder.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2026/06/28
+
+### Changed
+
+- MINOR Sharp IB now skips unnecessary Newton linear solves when the freshly assembled fluid residual is already below the nonlinear tolerance, and adds a dedicated 2D application test for that solver path.
+
 ## [Master] - 2026/06/01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
-- MINOR Sharp IB now skips unnecessary Newton linear solves when the freshly assembled fluid residual is already below the nonlinear tolerance, and adds a dedicated 2D application test for that solver path.
+- MINOR Sharp IB now skips unnecessary Newton linear solves when the freshly assembled fluid residual is already below the nonlinear tolerance, and adds a dedicated 2D application test for that solver path. [#1962](https://github.com/chaos-polymtl/lethe/pull/1962)
 
 ## [Master] - 2026/06/01
 

--- a/applications_tests/lethe-fluid-sharp/moving_stokes_2d_gmres_skip.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes_2d_gmres_skip.prm
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+
+# Listing of Parameters
+#----------------------
+
+set dimension = 2
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
+
+subsection simulation control
+  set method            = bdf1 # Time-stepping method
+  set time step         = 1    # Time step
+  set number mesh adapt = 2    # If steady, nb mesh adaptation
+  set time end          = 1    # End time of simulation
+  set output frequency  = 0    # Frequency of simulation output
+end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
+
+subsection physical properties
+  subsection fluid 0
+    set kinematic viscosity = 1
+    set density             = 1
+  end
+end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
+subsection mesh
+  set type               = dealii
+  set grid type          = subdivided_hyper_rectangle
+  set grid arguments     = 2,1: -2,-1 : 2 , 1  : true
+  set initial refinement = 3
+end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
+
+subsection FEM
+  set velocity order = 1
+  set pressure order = 1
+end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
+
+subsection boundary conditions
+  set number         = 4
+  set time dependent = true
+  subsection bc 0
+    set id   = 0
+    set type = function
+    subsection u
+      set Function expression = (-y^2*(0.375*(y^2 + (x - cos(t))^2)^(3/2) + 0.03125*sqrt(y^2 + (x - cos(t))^2) - (y^2 + (x - cos(t))^2)^2) + (x - cos(t))^2*(-0.75*(y^2 + (x - cos(t))^2)^(3/2) + 0.0625*sqrt(y^2 + (x - cos(t))^2) + (y^2 + (x - cos(t))^2)^2) - (y^2 + (x - cos(t))^2)^3)*sin(t)/(y^2 + (x - cos(t))^2)^3
+    end
+    subsection v
+      set Function expression = y*(x - cos(t))*(-0.375*y^2 - 0.375*(x - cos(t))^2 + 0.09375)*sin(t)/(y^2 + (x - cos(t))^2)^(5/2)
+    end
+    subsection w
+      set Function expression = 0
+    end
+  end
+  subsection bc 1
+    set id   = 3
+    set type = function
+    subsection u
+      set Function expression = (-y^2*(0.375*(y^2 + (x - cos(t))^2)^(3/2) + 0.03125*sqrt(y^2 + (x - cos(t))^2) - (y^2 + (x - cos(t))^2)^2) + (x - cos(t))^2*(-0.75*(y^2 + (x - cos(t))^2)^(3/2) + 0.0625*sqrt(y^2 + (x - cos(t))^2) + (y^2 + (x - cos(t))^2)^2) - (y^2 + (x - cos(t))^2)^3)*sin(t)/(y^2 + (x - cos(t))^2)^3
+    end
+    subsection v
+      set Function expression = y*(x - cos(t))*(-0.375*y^2 - 0.375*(x - cos(t))^2 + 0.09375)*sin(t)/(y^2 + (x - cos(t))^2)^(5/2)
+    end
+    subsection w
+      set Function expression = 0
+    end
+  end
+  subsection bc 2
+    set id   = 2
+    set type = function
+    subsection u
+      set Function expression = (-y^2*(0.375*(y^2 + (x - cos(t))^2)^(3/2) + 0.03125*sqrt(y^2 + (x - cos(t))^2) - (y^2 + (x - cos(t))^2)^2) + (x - cos(t))^2*(-0.75*(y^2 + (x - cos(t))^2)^(3/2) + 0.0625*sqrt(y^2 + (x - cos(t))^2) + (y^2 + (x - cos(t))^2)^2) - (y^2 + (x - cos(t))^2)^3)*sin(t)/(y^2 + (x - cos(t))^2)^3
+    end
+    subsection v
+      set Function expression = y*(x - cos(t))*(-0.375*y^2 - 0.375*(x - cos(t))^2 + 0.09375)*sin(t)/(y^2 + (x - cos(t))^2)^(5/2)
+    end
+    subsection w
+      set Function expression = 0
+    end
+  end
+  subsection bc 3
+    set id   = 1
+    set type = function weak
+    set beta = 10000
+
+    subsection u
+      set Function expression = (-y^2*(0.375*(y^2 + (x - cos(t))^2)^(3/2) + 0.03125*sqrt(y^2 + (x - cos(t))^2) - (y^2 + (x - cos(t))^2)^2) + (x - cos(t))^2*(-0.75*(y^2 + (x - cos(t))^2)^(3/2) + 0.0625*sqrt(y^2 + (x - cos(t))^2) + (y^2 + (x - cos(t))^2)^2) - (y^2 + (x - cos(t))^2)^3)*sin(t)/(y^2 + (x - cos(t))^2)^3
+    end
+    subsection v
+      set Function expression = y*(x - cos(t))*(-0.375*y^2 - 0.375*(x - cos(t))^2 + 0.09375)*sin(t)/(y^2 + (x - cos(t))^2)^(5/2)
+    end
+    subsection w
+      set Function expression = 0
+    end
+    subsection p
+      set Function expression = -0.75*(x - cos(t))*sin(t)/(y^2 + (x - cos(t))^2)^(3/2)
+    end
+  end
+end
+
+#---------------------------------------------------
+# Analytical Solution
+#---------------------------------------------------
+
+subsection analytical solution
+  set enable    = true
+  set verbosity = quiet
+  subsection uvwp
+    # A= -(eta_ * eta_) / (1. - eta_ * eta_);
+    # B= ri_ * ri_ / (1. - eta_ * eta_);
+
+    set Function constants  = ri=0.5
+    set Function expression = if(sqrt((x - cos(t))*(x - cos(t))+y*y)>ri,(-y^2*(0.375*(y^2 + (x - cos(t))^2)^(3/2) + 0.03125*sqrt(y^2 + (x - cos(t))^2) - (y^2 + (x - cos(t))^2)^2) + (x - cos(t))^2*(-0.75*(y^2 + (x - cos(t))^2)^(3/2) + 0.0625*sqrt(y^2 + (x - cos(t))^2) + (y^2 + (x - cos(t))^2)^2) - (y^2 + (x - cos(t))^2)^3)*sin(t)/(y^2 + (x - cos(t))^2)^3,-sin(t)) ; if(sqrt((x - cos(t))*(x - cos(t))+y*y)>ri,y*(x - cos(t))*(-0.375*y^2 - 0.375*(x - cos(t))^2 + 0.09375)*sin(t)/(y^2 + (x - cos(t))^2)^(5/2),0) ; if(sqrt((x - cos(t))*(x - cos(t))+y*y)>ri,-0.75*(x - cos(t))*sin(t)/(y^2 + (x - cos(t))^2)^(3/2),0)
+  end
+end
+
+#---------------------------------------------------
+# Source term
+#---------------------------------------------------
+
+subsection source term
+  subsection fluid dynamics
+    set Function expression = -2*y^2*(x - cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)^2/(y^2 + (x - cos(t))^2)^2 + y^2*(0.375*(x - cos(t))*sin(t)/(y^2 + (x - cos(t))^2)^(3/2) + 0.09375*(x - cos(t))*sin(t)/(y^2 + (x - cos(t))^2)^(5/2))*sin(t)/(y^2 + (x - cos(t))^2) + y^2*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*cos(t)/(y^2 + (x - cos(t))^2) + y*((x - cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) - (x - cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2))*(-2*y^3*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2)^2 + y^2*(0.375*y/(y^2 + (x - cos(t))^2)^(3/2) + 0.09375*y/(y^2 + (x - cos(t))^2)^(5/2))*sin(t)/(y^2 + (x - cos(t))^2) - 2*y*(x - cos(t))^2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2)^2 + 2*y*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))^2*(0.75*y/(y^2 + (x - cos(t))^2)^(3/2) - 0.1875*y/(y^2 + (x - cos(t))^2)^(5/2))*sin(t)/(y^2 + (x - cos(t))^2))/sqrt(y^2) - 0.75*(-3*x + 3*cos(t))*(x - cos(t))*sin(t)/(y^2 + (x - cos(t))^2)^(5/2) - 2*(x - cos(t))^3*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)^2/(y^2 + (x - cos(t))^2)^2 + (x - cos(t))^2*(0.75*(x - cos(t))*sin(t)/(y^2 + (x - cos(t))^2)^(3/2) - 0.1875*(x - cos(t))*sin(t)/(y^2 + (x - cos(t))^2)^(5/2))*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))^2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*cos(t)/(y^2 + (x - cos(t))^2) + 2*(x - cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)^2/(y^2 + (x - cos(t))^2) + (y^2*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))^2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2) - sin(t))*(y^2*(-2*x + 2*cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2)^2 + y^2*(-0.03125*(-3*x + 3*cos(t))/(y^2 + (x - cos(t))^2)^(5/2) - 0.375*(-x + cos(t))/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2) + (-2*x + 2*cos(t))*(x - cos(t))^2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2)^2 + (x - cos(t))^2*(0.0625*(-3*x + 3*cos(t))/(y^2 + (x - cos(t))^2)^(5/2) - 0.75*(-x + cos(t))/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2) + (2*x - 2*cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2)) + (y^2*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))^2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2) - sin(t))*(y^2*(-2*x + 2*cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2)^2 + y^2*(-0.03125*(-3*x + 3*cos(t))/(y^2 + (x - cos(t))^2)^(5/2) - 0.375*(-x + cos(t))/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2) + y*(-2*y*(x - cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2)^2 + 2*y*(x - cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2)^2 - (x - cos(t))*(0.375*y/(y^2 + (x - cos(t))^2)^(3/2) + 0.09375*y/(y^2 + (x - cos(t))^2)^(5/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))*(0.75*y/(y^2 + (x - cos(t))^2)^(3/2) - 0.1875*y/(y^2 + (x - cos(t))^2)^(5/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y*(y^2 + (x - cos(t))^2)) - (x - cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y*(y^2 + (x - cos(t))^2)))/sqrt(y^2) + (-2*x + 2*cos(t))*(x - cos(t))^2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2)^2 + (x - cos(t))^2*(0.0625*(-3*x + 3*cos(t))/(y^2 + (x - cos(t))^2)^(5/2) - 0.75*(-x + cos(t))/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2) + (2*x - 2*cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2)) - (-4*y^4*(0.375 + 0.09375/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(7/2) - 8*y^4*(-1 + 0.375/sqrt(y^2 + (x - cos(t))^2) + 0.03125/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^3 + 4*y^2*(0.375 + 0.09375/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(5/2) - 4*y^2*(0.75 - 0.1875/(y^2 + (x - cos(t))^2))*(x - cos(t))^2/(y^2 + (x - cos(t))^2)^(7/2) + 8*y^2*(x - cos(t))^2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^3 + 10*y^2*(-1 + 0.375/sqrt(y^2 + (x - cos(t))^2) + 0.03125/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^2 - y^2*(1.125*y^2/(y^2 + (x - cos(t))^2) + 0.46875*y^2/(y^2 + (x - cos(t))^2)^2 - 0.375 - 0.09375/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(5/2) - 2*(x - cos(t))^2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^2 - (x - cos(t))^2*(2.25*y^2/(y^2 + (x - cos(t))^2) - 0.9375*y^2/(y^2 + (x - cos(t))^2)^2 - 0.75 + 0.1875/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(5/2) - 2*(-1 + 0.375/sqrt(y^2 + (x - cos(t))^2) + 0.03125/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2))*sin(t) - (-4*y^2*(0.375 + 0.09375/(y^2 + (x - cos(t))^2))*(x - cos(t))^2/(y^2 + (x - cos(t))^2)^(7/2) - 8*y^2*(x - cos(t))^2*(-1 + 0.375/sqrt(y^2 + (x - cos(t))^2) + 0.03125/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^3 + 2*y^2*(-1 + 0.375/sqrt(y^2 + (x - cos(t))^2) + 0.03125/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^2 - y^2*(1.125*(x - cos(t))^2/(y^2 + (x - cos(t))^2) + 0.46875*(x - cos(t))^2/(y^2 + (x - cos(t))^2)^2 - 0.375 - 0.09375/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(5/2) - 4*(0.75 - 0.1875/(y^2 + (x - cos(t))^2))*(x - cos(t))^4/(y^2 + (x - cos(t))^2)^(7/2) + 4*(0.75 - 0.1875/(y^2 + (x - cos(t))^2))*(x - cos(t))^2/(y^2 + (x - cos(t))^2)^(5/2) + 8*(x - cos(t))^4*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^3 - 10*(x - cos(t))^2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^2 - (x - cos(t))^2*(2.25*(x - cos(t))^2/(y^2 + (x - cos(t))^2) - 0.9375*(x - cos(t))^2/(y^2 + (x - cos(t))^2)^2 - 0.75 + 0.1875/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(5/2) + 2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2))*sin(t) - cos(t) - 0.75*sin(t)/(y^2 + (x - cos(t))^2)^(3/2);y^2*((x - cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) - (x - cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2))*(-2*y*(x - cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2)^2 + 2*y*(x - cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2)^2 - (x - cos(t))*(0.375*y/(y^2 + (x - cos(t))^2)^(3/2) + 0.09375*y/(y^2 + (x - cos(t))^2)^(5/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))*(0.75*y/(y^2 + (x - cos(t))^2)^(3/2) - 0.1875*y/(y^2 + (x - cos(t))^2)^(5/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y*(y^2 + (x - cos(t))^2)) - (x - cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y*(y^2 + (x - cos(t))^2)))/y^2 - y*(x - cos(t))*(4*y^2*(0.375 + 0.09375/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(7/2) - 4*y^2*(0.75 - 0.1875/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(7/2) + 8*y^2*(-1 + 0.375/sqrt(y^2 + (x - cos(t))^2) + 0.03125/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^3 + 8*y^2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^3 - 2*(0.375 + 0.09375/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(5/2) + 2*(0.75 - 0.1875/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(5/2) - 6*(-1 + 0.375/sqrt(y^2 + (x - cos(t))^2) + 0.03125/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^2 - 6*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^2 + (1.125*y^2/(y^2 + (x - cos(t))^2) + 0.46875*y^2/(y^2 + (x - cos(t))^2)^2 - 0.375 - 0.09375/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(5/2) - (2.25*y^2/(y^2 + (x - cos(t))^2) - 0.9375*y^2/(y^2 + (x - cos(t))^2)^2 - 0.75 + 0.1875/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(5/2))*sin(t) - y*(x - cos(t))*(4*(0.375 + 0.09375/(y^2 + (x - cos(t))^2))*(x - cos(t))^2/(y^2 + (x - cos(t))^2)^(7/2) - 2*(0.375 + 0.09375/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(5/2) - 4*(0.75 - 0.1875/(y^2 + (x - cos(t))^2))*(x - cos(t))^2/(y^2 + (x - cos(t))^2)^(7/2) + 2*(0.75 - 0.1875/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(5/2) + 8*(x - cos(t))^2*(-1 + 0.375/sqrt(y^2 + (x - cos(t))^2) + 0.03125/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^3 + 8*(x - cos(t))^2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^3 - 6*(-1 + 0.375/sqrt(y^2 + (x - cos(t))^2) + 0.03125/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^2 - 6*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))/(y^2 + (x - cos(t))^2)^2 + (1.125*(x - cos(t))^2/(y^2 + (x - cos(t))^2) + 0.46875*(x - cos(t))^2/(y^2 + (x - cos(t))^2)^2 - 0.375 - 0.09375/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(5/2) - (2.25*(x - cos(t))^2/(y^2 + (x - cos(t))^2) - 0.9375*(x - cos(t))^2/(y^2 + (x - cos(t))^2)^2 - 0.75 + 0.1875/(y^2 + (x - cos(t))^2))/(y^2 + (x - cos(t))^2)^(5/2))*sin(t) + 2.25*y*(x - cos(t))*sin(t)/(y^2 + (x - cos(t))^2)^(5/2) + y*((x - cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) - (x - cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2))*(y^2*(-2*x + 2*cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2)^2 + y^2*(-0.03125*(-3*x + 3*cos(t))/(y^2 + (x - cos(t))^2)^(5/2) - 0.375*(-x + cos(t))/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2) + y*(-2*y*(x - cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2)^2 + 2*y*(x - cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2)^2 - (x - cos(t))*(0.375*y/(y^2 + (x - cos(t))^2)^(3/2) + 0.09375*y/(y^2 + (x - cos(t))^2)^(5/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))*(0.75*y/(y^2 + (x - cos(t))^2)^(3/2) - 0.1875*y/(y^2 + (x - cos(t))^2)^(5/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y*(y^2 + (x - cos(t))^2)) - (x - cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y*(y^2 + (x - cos(t))^2)))/sqrt(y^2) + (-2*x + 2*cos(t))*(x - cos(t))^2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2)^2 + (x - cos(t))^2*(0.0625*(-3*x + 3*cos(t))/(y^2 + (x - cos(t))^2)^(5/2) - 0.75*(-x + cos(t))/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2) + (2*x - 2*cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2))/sqrt(y^2) + y*(y^2*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))^2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2) - sin(t))*((-2*x + 2*cos(t))*(x - cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2)^2 - (-2*x + 2*cos(t))*(x - cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2)^2 - (x - cos(t))*(-0.03125*(-3*x + 3*cos(t))/(y^2 + (x - cos(t))^2)^(5/2) - 0.375*(-x + cos(t))/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))*(0.0625*(-3*x + 3*cos(t))/(y^2 + (x - cos(t))^2)^(5/2) - 0.75*(-x + cos(t))/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) + (1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) - (1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2))/sqrt(y^2) + y*(-2*(x - cos(t))^2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)^2/(y^2 + (x - cos(t))^2)^2 + 2*(x - cos(t))^2*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)^2/(y^2 + (x - cos(t))^2)^2 - (x - cos(t))*(0.375*(x - cos(t))*sin(t)/(y^2 + (x - cos(t))^2)^(3/2) + 0.09375*(x - cos(t))*sin(t)/(y^2 + (x - cos(t))^2)^(5/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))*(0.75*(x - cos(t))*sin(t)/(y^2 + (x - cos(t))^2)^(3/2) - 0.1875*(x - cos(t))*sin(t)/(y^2 + (x - cos(t))^2)^(5/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*cos(t)/(y^2 + (x - cos(t))^2) - (x - cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*cos(t)/(y^2 + (x - cos(t))^2) + (1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)^2/(y^2 + (x - cos(t))^2) - (1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)^2/(y^2 + (x - cos(t))^2))/sqrt(y^2);(y^2*(-2*x + 2*cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2)^2 + y^2*(-0.03125*(-3*x + 3*cos(t))/(y^2 + (x - cos(t))^2)^(5/2) - 0.375*(-x + cos(t))/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2) + y*(-2*y*(x - cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2)^2 + 2*y*(x - cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2)^2 - (x - cos(t))*(0.375*y/(y^2 + (x - cos(t))^2)^(3/2) + 0.09375*y/(y^2 + (x - cos(t))^2)^(5/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))*(0.75*y/(y^2 + (x - cos(t))^2)^(3/2) - 0.1875*y/(y^2 + (x - cos(t))^2)^(5/2))*sqrt(y^2)*sin(t)/(y^2 + (x - cos(t))^2) + (x - cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y*(y^2 + (x - cos(t))^2)) - (x - cos(t))*(1 - 0.375/sqrt(y^2 + (x - cos(t))^2) - 0.03125/(y^2 + (x - cos(t))^2)^(3/2))*sqrt(y^2)*sin(t)/(y*(y^2 + (x - cos(t))^2)))/sqrt(y^2) + (-2*x + 2*cos(t))*(x - cos(t))^2*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2)^2 + (x - cos(t))^2*(0.0625*(-3*x + 3*cos(t))/(y^2 + (x - cos(t))^2)^(5/2) - 0.75*(-x + cos(t))/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2) + (2*x - 2*cos(t))*(1 - 0.75/sqrt(y^2 + (x - cos(t))^2) + 0.0625/(y^2 + (x - cos(t))^2)^(3/2))*sin(t)/(y^2 + (x - cos(t))^2))
+  end
+end
+
+#---------------------------------------------------
+# IB particles
+#---------------------------------------------------
+
+subsection particles
+  set number of particles                     = 1
+  set assemble Navier-Stokes inside particles = false
+
+  subsection extrapolation function
+    set stencil order = 6
+    set length ratio  = 2
+  end
+
+  subsection input file
+    set load particles from file = false
+    set particles file           = particles.input
+  end
+
+  subsection local mesh refinement
+    set initial refinement                = 0
+    set refine mesh inside radius factor  = 111
+    set refine mesh outside radius factor = 111
+  end
+  subsection DEM
+    set particle nonlinear tolerance = 1e-6
+  end
+  subsection particle info 0
+    subsection position
+      set Function expression = cos(t);0
+    end
+    subsection velocity
+      set Function expression = -sin(t);0
+    end
+    subsection omega
+      set Function expression = 0;0;0
+    end
+    set pressure location = 0.00001; 0.00001
+    set type              = sphere
+    set shape arguments   = 0.5
+
+    subsection physical properties
+      set density = 2
+    end
+  end
+end
+
+#---------------------------------------------------
+# Mesh Adaptation Control
+#---------------------------------------------------
+
+subsection mesh adaptation
+  # Fraction of coarsened elements
+  set fraction coarsening = 0.00
+
+  # Fraction of refined elements
+  set fraction refinement = 0
+
+  # How the fraction of refinement/coarsening are interepretedChoices are
+  # <number|fraction>.
+  set fraction type = number
+
+  # Frequency of the mesh refinement
+  set frequency = 1
+
+  # Maximum number of elements
+  set max number elements = 100000
+
+  # Type of mesh adaptation. Choices are <none|uniform|adaptive>.
+  set type = none
+
+  # Variable for kelly estimationChoices are <velocity|pressure>.
+  set variable = velocity
+end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
+
+subsection non-linear solver
+  subsection fluid dynamics
+    set tolerance             = 1e-4
+    set max iterations        = 20
+    set verbosity             = quiet
+    set force rhs calculation = true
+  end
+end
+
+#---------------------------------------------------
+# Forces
+#---------------------------------------------------
+
+subsection forces
+  set verbosity = quiet
+end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
+
+subsection linear solver
+  subsection fluid dynamics
+    set method                                    = gmres
+    set max iters                                 = 1000
+    set relative residual                         = 1e-6
+    set minimum residual                          = 1e-9
+    set preconditioner                            = amg
+    set ilu preconditioner fill                   = 2
+    set ilu preconditioner absolute tolerance     = 1e-11
+    set ilu preconditioner relative tolerance     = 1
+    set amg aggregation threshold                 = 1e-20
+    set amg n cycles                              = 1
+    set amg preconditioner ilu absolute tolerance = 1e-20
+    set amg preconditioner ilu fill               = 0
+    set amg preconditioner ilu relative tolerance = 1.00
+    set amg smoother overlap                      = 1
+    set amg smoother sweeps                       = 2
+    set amg w cycles                              = false
+    set verbosity                                 = quiet
+  end
+end

--- a/applications_tests/lethe-fluid-sharp/moving_stokes_2d_gmres_skip.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes_2d_gmres_skip.prm
@@ -45,8 +45,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------
@@ -150,7 +150,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
     set length ratio  = 2
   end
 

--- a/applications_tests/lethe-fluid-sharp/moving_stokes_2d_gmres_skip.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes_2d_gmres_skip.prm
@@ -11,11 +11,10 @@ set dimension = 2
 #---------------------------------------------------
 
 subsection simulation control
-  set method            = bdf1 # Time-stepping method
-  set time step         = 1    # Time step
-  set number mesh adapt = 2    # If steady, nb mesh adaptation
-  set time end          = 1    # End time of simulation
-  set output frequency  = 0    # Frequency of simulation output
+  set method           = bdf1 # Time-stepping method
+  set time step        = 1    # Time step
+  set time end         = 1    # End time of simulation
+  set output frequency = 0    # Frequency of simulation output
 end
 
 #---------------------------------------------------
@@ -151,12 +150,7 @@ subsection particles
 
   subsection extrapolation function
     set stencil degree = 6
-    set length ratio  = 2
-  end
-
-  subsection input file
-    set load particles from file = false
-    set particles file           = particles.input
+    set length ratio   = 2
   end
 
   subsection local mesh refinement
@@ -188,34 +182,6 @@ subsection particles
 end
 
 #---------------------------------------------------
-# Mesh Adaptation Control
-#---------------------------------------------------
-
-subsection mesh adaptation
-  # Fraction of coarsened elements
-  set fraction coarsening = 0.00
-
-  # Fraction of refined elements
-  set fraction refinement = 0
-
-  # How the fraction of refinement/coarsening are interepretedChoices are
-  # <number|fraction>.
-  set fraction type = number
-
-  # Frequency of the mesh refinement
-  set frequency = 1
-
-  # Maximum number of elements
-  set max number elements = 100000
-
-  # Type of mesh adaptation. Choices are <none|uniform|adaptive>.
-  set type = none
-
-  # Variable for kelly estimationChoices are <velocity|pressure>.
-  set variable = velocity
-end
-
-#---------------------------------------------------
 # Non-Linear Solver Control
 #---------------------------------------------------
 
@@ -242,22 +208,14 @@ end
 
 subsection linear solver
   subsection fluid dynamics
-    set method                                    = gmres
-    set max iters                                 = 1000
-    set relative residual                         = 1e-6
-    set minimum residual                          = 1e-9
-    set preconditioner                            = amg
-    set ilu preconditioner fill                   = 2
-    set ilu preconditioner absolute tolerance     = 1e-11
-    set ilu preconditioner relative tolerance     = 1
-    set amg aggregation threshold                 = 1e-20
-    set amg n cycles                              = 1
-    set amg preconditioner ilu absolute tolerance = 1e-20
-    set amg preconditioner ilu fill               = 0
-    set amg preconditioner ilu relative tolerance = 1.00
-    set amg smoother overlap                      = 1
-    set amg smoother sweeps                       = 2
-    set amg w cycles                              = false
-    set verbosity                                 = quiet
+    set method                                = gmres
+    set max iters                             = 1000
+    set relative residual                     = 1e-6
+    set minimum residual                      = 1e-9
+    set preconditioner                        = ilu
+    set ilu preconditioner fill               = 2
+    set ilu preconditioner absolute tolerance = 1e-11
+    set ilu preconditioner relative tolerance = 1
+    set verbosity                             = quiet
   end
 end

--- a/applications_tests/lethe-fluid-sharp/moving_stokes_2d_gmres_skip.run_only
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes_2d_gmres_skip.run_only
@@ -1,0 +1,1 @@
+# This marker tells the Lethe test harness to check successful execution only.

--- a/include/core/inexact_newton_non_linear_solver_strategy.h
+++ b/include/core/inexact_newton_non_linear_solver_strategy.h
@@ -115,8 +115,13 @@ InexactNewtonNonLinearSolverStrategy<VectorType>::solve()
       {
         const double assembled_res =
           solver->get_system_rhs().l2_norm() / rescale_metric;
-        if (assembled_res <= this->params.tolerance)
+        if (solver
+              ->allow_skip_linear_solve_when_residual_is_below_tolerance() &&
+            assembled_res <= this->params.tolerance)
           {
+            // This path is reserved for solvers whose outer nonlinear residual
+            // may remain active even after the assembled linear-system
+            // residual is already below tolerance.
             current_res         = assembled_res;
             auto &newton_update = solver->get_newton_update();
             newton_update       = 0;

--- a/include/core/inexact_newton_non_linear_solver_strategy.h
+++ b/include/core/inexact_newton_non_linear_solver_strategy.h
@@ -96,7 +96,9 @@ InexactNewtonNonLinearSolverStrategy<VectorType>::solve()
           solver->setup_preconditioner();
         }
 
-      if (this->params.force_rhs_calculation || outer_iteration == 0)
+      const bool rhs_was_assembled =
+        this->params.force_rhs_calculation || outer_iteration == 0;
+      if (rhs_was_assembled)
         solver->assemble_system_rhs();
 
       if (outer_iteration == 0)
@@ -115,13 +117,19 @@ InexactNewtonNonLinearSolverStrategy<VectorType>::solve()
       {
         const double assembled_res =
           solver->get_system_rhs().l2_norm() / rescale_metric;
-        if (solver
+        if (rhs_was_assembled &&
+            solver
               ->allow_skip_linear_solve_when_residual_is_below_tolerance() &&
             assembled_res <= this->params.tolerance)
           {
-            // This path is reserved for solvers whose outer nonlinear residual
-            // may remain active even after the assembled linear-system
-            // residual is already below tolerance.
+            // This shortcut is only valid when system_rhs was freshly
+            // assembled on this Newton iteration. Otherwise assembled_res may
+            // still reflect an older evaluation point, and skipping the solve
+            // from that stale residual would be incorrect.
+            //
+            // Solvers that opt into this path are expected to keep
+            // force_rhs_calculation enabled, or otherwise guarantee that the
+            // RHS was explicitly reassembled before reaching this check.
             current_res         = assembled_res;
             auto &newton_update = solver->get_newton_update();
             newton_update       = 0;

--- a/include/core/inexact_newton_non_linear_solver_strategy.h
+++ b/include/core/inexact_newton_non_linear_solver_strategy.h
@@ -117,7 +117,7 @@ InexactNewtonNonLinearSolverStrategy<VectorType>::solve()
           solver->get_system_rhs().l2_norm() / rescale_metric;
         if (assembled_res <= this->params.tolerance)
           {
-            current_res = assembled_res;
+            current_res         = assembled_res;
             auto &newton_update = solver->get_newton_update();
             newton_update       = 0;
 

--- a/include/core/inexact_newton_non_linear_solver_strategy.h
+++ b/include/core/inexact_newton_non_linear_solver_strategy.h
@@ -112,6 +112,23 @@ InexactNewtonNonLinearSolverStrategy<VectorType>::solve()
                         << "  - Residual:  " << current_res << std::endl;
         }
 
+      {
+        const double assembled_res =
+          solver->get_system_rhs().l2_norm() / rescale_metric;
+        if (assembled_res <= this->params.tolerance)
+          {
+            current_res = assembled_res;
+            auto &newton_update = solver->get_newton_update();
+            newton_update       = 0;
+
+            global_res       = solver->get_current_residual() / rescale_metric;
+            present_solution = evaluation_point;
+            last_res         = current_res;
+            ++outer_iteration;
+            continue;
+          }
+      }
+
       solver->solve_linear_system();
       double last_alpha_res = current_res;
 

--- a/include/core/inexact_newton_non_linear_solver_strategy.h
+++ b/include/core/inexact_newton_non_linear_solver_strategy.h
@@ -59,13 +59,13 @@ template <typename VectorType>
 void
 InexactNewtonNonLinearSolverStrategy<VectorType>::solve()
 {
-  double       global_res;
-  double       current_res;
-  double       last_res;
-  unsigned int outer_iteration = 0;
-  last_res                     = 1e6;
-  current_res                  = 1e6;
-  global_res                   = 1e6;
+  double global_res;
+  double current_res;
+  double last_res;
+  this->outer_iteration = 0;
+  last_res              = 1e6;
+  current_res           = 1e6;
+  global_res            = 1e6;
 
   // current_res and global_res are different as one is defined based on the l2
   // norm of the residual vector (current_res) and the other (global_res) is
@@ -86,7 +86,7 @@ InexactNewtonNonLinearSolverStrategy<VectorType>::solve()
     matrix_requires_assembly = true;
 
   while ((global_res > this->params.tolerance) &&
-         outer_iteration < this->params.max_iterations)
+         this->outer_iteration < this->params.max_iterations)
     {
       evaluation_point = present_solution;
 
@@ -96,12 +96,12 @@ InexactNewtonNonLinearSolverStrategy<VectorType>::solve()
           solver->setup_preconditioner();
         }
 
-      const bool rhs_was_assembled =
-        this->params.force_rhs_calculation || outer_iteration == 0;
-      if (rhs_was_assembled)
+      const bool assemble_rhs_this_iteration =
+        this->params.force_rhs_calculation || this->outer_iteration == 0;
+      if (assemble_rhs_this_iteration)
         solver->assemble_system_rhs();
 
-      if (outer_iteration == 0)
+      if (this->outer_iteration == 0)
         {
           auto &system_rhs = solver->get_system_rhs();
           current_res      = system_rhs.l2_norm() / rescale_metric;
@@ -110,37 +110,18 @@ InexactNewtonNonLinearSolverStrategy<VectorType>::solve()
 
       if (this->params.verbosity != Parameters::Verbosity::quiet)
         {
-          solver->pcout << "Newton iteration: " << outer_iteration
+          solver->pcout << "Newton iteration: " << this->outer_iteration
                         << "  - Residual:  " << current_res << std::endl;
         }
 
-      {
-        const double assembled_res =
-          solver->get_system_rhs().l2_norm() / rescale_metric;
-        if (rhs_was_assembled &&
-            solver
-              ->allow_skip_linear_solve_when_residual_is_below_tolerance() &&
-            assembled_res <= this->params.tolerance)
-          {
-            // This shortcut is only valid when system_rhs was freshly
-            // assembled on this Newton iteration. Otherwise assembled_res may
-            // still reflect an older evaluation point, and skipping the solve
-            // from that stale residual would be incorrect.
-            //
-            // Solvers that opt into this path are expected to keep
-            // force_rhs_calculation enabled, or otherwise guarantee that the
-            // RHS was explicitly reassembled before reaching this check.
-            current_res         = assembled_res;
-            auto &newton_update = solver->get_newton_update();
-            newton_update       = 0;
-
-            global_res       = solver->get_current_residual() / rescale_metric;
-            present_solution = evaluation_point;
-            last_res         = current_res;
-            ++outer_iteration;
-            continue;
-          }
-      }
+      if (this->skip_linear_solve_if_fresh_rhs_is_already_converged(
+            assemble_rhs_this_iteration,
+            rescale_metric,
+            current_res,
+            last_res,
+            global_res,
+            this->outer_iteration))
+        continue;
 
       solver->solve_linear_system();
       double last_alpha_res = current_res;
@@ -213,13 +194,13 @@ InexactNewtonNonLinearSolverStrategy<VectorType>::solve()
       global_res       = solver->get_current_residual() / rescale_metric;
       present_solution = evaluation_point;
       last_res         = current_res;
-      ++outer_iteration;
+      ++this->outer_iteration;
     }
 
   // If the non-linear solver has not converged abort simulation if
   // abort_at_convergence_failure=true
   if ((global_res > this->params.tolerance) &&
-      outer_iteration >= this->params.max_iterations &&
+      this->outer_iteration >= this->params.max_iterations &&
       this->params.abort_at_convergence_failure)
     {
       throw(std::runtime_error(

--- a/include/core/inexact_newton_non_linear_solver_strategy.h
+++ b/include/core/inexact_newton_non_linear_solver_strategy.h
@@ -119,8 +119,7 @@ InexactNewtonNonLinearSolverStrategy<VectorType>::solve()
             rescale_metric,
             current_res,
             last_res,
-            global_res,
-            this->outer_iteration))
+            global_res))
         continue;
 
       solver->solve_linear_system();

--- a/include/core/newton_non_linear_solver_strategy.h
+++ b/include/core/newton_non_linear_solver_strategy.h
@@ -102,7 +102,7 @@ NewtonNonLinearSolverStrategy<VectorType>::solve()
           solver->get_system_rhs().l2_norm() / rescale_metric;
         if (assembled_res <= this->params.tolerance)
           {
-            current_res = assembled_res;
+            current_res         = assembled_res;
             auto &newton_update = solver->get_newton_update();
             newton_update       = 0;
 

--- a/include/core/newton_non_linear_solver_strategy.h
+++ b/include/core/newton_non_linear_solver_strategy.h
@@ -97,6 +97,23 @@ NewtonNonLinearSolverStrategy<VectorType>::solve()
                         << "  - Residual:  " << current_res << std::endl;
         }
 
+      {
+        const double assembled_res =
+          solver->get_system_rhs().l2_norm() / rescale_metric;
+        if (assembled_res <= this->params.tolerance)
+          {
+            current_res = assembled_res;
+            auto &newton_update = solver->get_newton_update();
+            newton_update       = 0;
+
+            global_res       = solver->get_current_residual() / rescale_metric;
+            present_solution = evaluation_point;
+            last_res         = current_res;
+            ++this->outer_iteration;
+            continue;
+          }
+      }
+
       solver->solve_linear_system();
       double last_alpha_res = current_res;
 

--- a/include/core/newton_non_linear_solver_strategy.h
+++ b/include/core/newton_non_linear_solver_strategy.h
@@ -100,8 +100,13 @@ NewtonNonLinearSolverStrategy<VectorType>::solve()
       {
         const double assembled_res =
           solver->get_system_rhs().l2_norm() / rescale_metric;
-        if (assembled_res <= this->params.tolerance)
+        if (solver
+              ->allow_skip_linear_solve_when_residual_is_below_tolerance() &&
+            assembled_res <= this->params.tolerance)
           {
+            // This path is reserved for solvers whose outer nonlinear residual
+            // may remain active even after the assembled linear-system
+            // residual is already below tolerance.
             current_res         = assembled_res;
             auto &newton_update = solver->get_newton_update();
             newton_update       = 0;

--- a/include/core/newton_non_linear_solver_strategy.h
+++ b/include/core/newton_non_linear_solver_strategy.h
@@ -81,7 +81,9 @@ NewtonNonLinearSolverStrategy<VectorType>::solve()
       if (!this->params.reuse_preconditioner || this->outer_iteration == 0)
         solver->setup_preconditioner();
 
-      if (this->params.force_rhs_calculation || this->outer_iteration == 0)
+      const bool rhs_was_assembled =
+        this->params.force_rhs_calculation || this->outer_iteration == 0;
+      if (rhs_was_assembled)
         solver->assemble_system_rhs();
 
       if (this->outer_iteration == 0)
@@ -100,13 +102,19 @@ NewtonNonLinearSolverStrategy<VectorType>::solve()
       {
         const double assembled_res =
           solver->get_system_rhs().l2_norm() / rescale_metric;
-        if (solver
+        if (rhs_was_assembled &&
+            solver
               ->allow_skip_linear_solve_when_residual_is_below_tolerance() &&
             assembled_res <= this->params.tolerance)
           {
-            // This path is reserved for solvers whose outer nonlinear residual
-            // may remain active even after the assembled linear-system
-            // residual is already below tolerance.
+            // This shortcut is only valid when system_rhs was freshly
+            // assembled on this Newton iteration. Otherwise assembled_res may
+            // still reflect an older evaluation point, and skipping the solve
+            // from that stale residual would be incorrect.
+            //
+            // Solvers that opt into this path are expected to keep
+            // force_rhs_calculation enabled, or otherwise guarantee that the
+            // RHS was explicitly reassembled before reaching this check.
             current_res         = assembled_res;
             auto &newton_update = solver->get_newton_update();
             newton_update       = 0;

--- a/include/core/newton_non_linear_solver_strategy.h
+++ b/include/core/newton_non_linear_solver_strategy.h
@@ -81,9 +81,9 @@ NewtonNonLinearSolverStrategy<VectorType>::solve()
       if (!this->params.reuse_preconditioner || this->outer_iteration == 0)
         solver->setup_preconditioner();
 
-      const bool rhs_was_assembled =
+      const bool assemble_rhs_this_iteration =
         this->params.force_rhs_calculation || this->outer_iteration == 0;
-      if (rhs_was_assembled)
+      if (assemble_rhs_this_iteration)
         solver->assemble_system_rhs();
 
       if (this->outer_iteration == 0)
@@ -99,33 +99,14 @@ NewtonNonLinearSolverStrategy<VectorType>::solve()
                         << "  - Residual:  " << current_res << std::endl;
         }
 
-      {
-        const double assembled_res =
-          solver->get_system_rhs().l2_norm() / rescale_metric;
-        if (rhs_was_assembled &&
-            solver
-              ->allow_skip_linear_solve_when_residual_is_below_tolerance() &&
-            assembled_res <= this->params.tolerance)
-          {
-            // This shortcut is only valid when system_rhs was freshly
-            // assembled on this Newton iteration. Otherwise assembled_res may
-            // still reflect an older evaluation point, and skipping the solve
-            // from that stale residual would be incorrect.
-            //
-            // Solvers that opt into this path are expected to keep
-            // force_rhs_calculation enabled, or otherwise guarantee that the
-            // RHS was explicitly reassembled before reaching this check.
-            current_res         = assembled_res;
-            auto &newton_update = solver->get_newton_update();
-            newton_update       = 0;
-
-            global_res       = solver->get_current_residual() / rescale_metric;
-            present_solution = evaluation_point;
-            last_res         = current_res;
-            ++this->outer_iteration;
-            continue;
-          }
-      }
+      if (this->skip_linear_solve_if_fresh_rhs_is_already_converged(
+            assemble_rhs_this_iteration,
+            rescale_metric,
+            current_res,
+            last_res,
+            global_res,
+            this->outer_iteration))
+        continue;
 
       solver->solve_linear_system();
       double last_alpha_res = current_res;

--- a/include/core/newton_non_linear_solver_strategy.h
+++ b/include/core/newton_non_linear_solver_strategy.h
@@ -104,8 +104,7 @@ NewtonNonLinearSolverStrategy<VectorType>::solve()
             rescale_metric,
             current_res,
             last_res,
-            global_res,
-            this->outer_iteration))
+            global_res))
         continue;
 
       solver->solve_linear_system();

--- a/include/core/physics_solver.h
+++ b/include/core/physics_solver.h
@@ -144,6 +144,23 @@ public:
   }
 
   /**
+   * @brief Return whether this solver may skip the inner linear solve when the
+   * freshly assembled residual is already below the nonlinear tolerance.
+   *
+   * The default behavior is conservative and keeps the linear solve enabled.
+   * Solvers whose outer nonlinear residual may remain active for reasons other
+   * than the assembled linear-system residual can override this hook.
+   *
+   * @return `true` if the solver allows skipping the linear solve once the
+   * assembled residual is already below the nonlinear tolerance.
+   */
+  virtual bool
+  allow_skip_linear_solve_when_residual_is_below_tolerance() const
+  {
+    return false;
+  }
+
+  /**
    * @brief Return the current newton iteration of this physics solver.
    */
   inline unsigned int

--- a/include/core/physics_solver_strategy.h
+++ b/include/core/physics_solver_strategy.h
@@ -6,6 +6,8 @@
 
 #include <core/parameters.h>
 
+#include <deal.II/base/exceptions.h>
+
 template <typename VectorType>
 class PhysicsSolver;
 
@@ -68,6 +70,42 @@ public:
 
 protected:
   /**
+   * @brief Skip the inner linear solve when the current Newton evaluation
+   * already produced a freshly assembled RHS whose residual is below the
+   * nonlinear tolerance.
+   *
+   * This shortcut is only valid when the RHS was assembled for the current
+   * evaluation point. Otherwise the residual may still correspond to an older
+   * state and skipping the solve would incorrectly reuse stale information.
+   *
+   * Solvers must opt into this behavior explicitly through
+   * allow_skip_linear_solve_when_residual_is_below_tolerance(). Opting in also
+   * requires force_rhs_calculation to be enabled so that every Newton
+   * iteration reaches this helper with a fresh RHS.
+   *
+   * @param[in] rhs_was_assembled_this_iteration Whether the current Newton
+   * iteration assembled the RHS at the current evaluation point.
+   * @param[in] rescale_metric Residual rescaling factor used by the nonlinear
+   * solver strategy.
+   * @param[in,out] current_res Current matrix residual norm.
+   * @param[in,out] last_res Last accepted matrix residual norm.
+   * @param[in,out] global_res Current nonlinear residual reported by the
+   * physics solver.
+   * @param[in,out] outer_iteration Current Newton iteration counter.
+   *
+   * @return true if the linear solve was skipped and the Newton state was
+   * advanced consistently, false otherwise.
+   */
+  bool
+  skip_linear_solve_if_fresh_rhs_is_already_converged(
+    const bool    rhs_was_assembled_this_iteration,
+    const double  rescale_metric,
+    double       &current_res,
+    double       &last_res,
+    double       &global_res,
+    unsigned int &outer_iteration);
+
+  /**
    * @brief Physics solver for which we need a non-linear solver.
    *
    */
@@ -100,5 +138,46 @@ PhysicsSolverStrategy<VectorType>::PhysicsSolverStrategy(
   PhysicsSolver<VectorType> *physics_solver)
   : physics_solver(physics_solver)
 {}
+
+template <typename VectorType>
+bool
+PhysicsSolverStrategy<VectorType>::
+  skip_linear_solve_if_fresh_rhs_is_already_converged(
+    const bool    rhs_was_assembled_this_iteration,
+    const double  rescale_metric,
+    double       &current_res,
+    double       &last_res,
+    double       &global_res,
+    unsigned int &outer_iteration)
+{
+  PhysicsSolver<VectorType> *solver = this->physics_solver;
+
+  if (!solver->allow_skip_linear_solve_when_residual_is_below_tolerance())
+    return false;
+
+  AssertThrow(
+    this->params.force_rhs_calculation,
+    ExcMessage(
+      "Skipping the linear solve based on the assembled RHS residual requires "
+      "'force rhs calculation = true' so the residual is freshly assembled on "
+      "every Newton iteration."));
+
+  if (!rhs_was_assembled_this_iteration)
+    return false;
+
+  const double assembled_res =
+    solver->get_system_rhs().l2_norm() / rescale_metric;
+  if (assembled_res > this->params.tolerance)
+    return false;
+
+  current_res                 = assembled_res;
+  solver->get_newton_update() = 0;
+  global_res                  = solver->get_current_residual() / rescale_metric;
+  solver->get_present_solution() = solver->get_evaluation_point();
+  last_res                       = current_res;
+  ++outer_iteration;
+
+  return true;
+}
 
 #endif

--- a/include/core/physics_solver_strategy.h
+++ b/include/core/physics_solver_strategy.h
@@ -79,10 +79,11 @@ protected:
    * state and skipping the solve would incorrectly reuse stale information.
    *
    * Solvers must opt into this behavior explicitly through
-   * allow_skip_linear_solve_when_residual_is_below_tolerance(). When the
-   * shortcut is actually taken, force_rhs_calculation must also be enabled so
-   * that the converged residual comes from a fresh RHS assembled at the
-   * current Newton evaluation point.
+   * allow_skip_linear_solve_when_residual_is_below_tolerance(). The shortcut
+   * is always safe on Newton iteration 0 because the RHS is assembled
+   * unconditionally there. On later Newton iterations, it requires
+   * force_rhs_calculation so that the converged residual comes from a fresh
+   * RHS assembled at the current Newton evaluation point.
    *
    * @param[in] rhs_was_assembled_this_iteration Whether the current Newton
    * iteration assembled the RHS at the current evaluation point.
@@ -92,19 +93,16 @@ protected:
    * @param[in,out] last_res Last accepted matrix residual norm.
    * @param[in,out] global_res Current nonlinear residual reported by the
    * physics solver.
-   * @param[in,out] outer_iteration Current Newton iteration counter.
-   *
    * @return true if the linear solve was skipped and the Newton state was
    * advanced consistently, false otherwise.
    */
   bool
   skip_linear_solve_if_fresh_rhs_is_already_converged(
-    const bool    rhs_was_assembled_this_iteration,
-    const double  rescale_metric,
-    double       &current_res,
-    double       &last_res,
-    double       &global_res,
-    unsigned int &outer_iteration);
+    const bool   rhs_was_assembled_this_iteration,
+    const double rescale_metric,
+    double      &current_res,
+    double      &last_res,
+    double      &global_res);
 
   /**
    * @brief Physics solver for which we need a non-linear solver.
@@ -144,12 +142,11 @@ template <typename VectorType>
 bool
 PhysicsSolverStrategy<VectorType>::
   skip_linear_solve_if_fresh_rhs_is_already_converged(
-    const bool    rhs_was_assembled_this_iteration,
-    const double  rescale_metric,
-    double       &current_res,
-    double       &last_res,
-    double       &global_res,
-    unsigned int &outer_iteration)
+    const bool   rhs_was_assembled_this_iteration,
+    const double rescale_metric,
+    double      &current_res,
+    double      &last_res,
+    double      &global_res)
 {
   PhysicsSolver<VectorType> *solver = this->physics_solver;
 
@@ -165,18 +162,18 @@ PhysicsSolverStrategy<VectorType>::
     return false;
 
   AssertThrow(
-    this->params.force_rhs_calculation,
+    this->params.force_rhs_calculation || this->outer_iteration == 0,
     ExcMessage(
       "Skipping the linear solve based on the assembled RHS residual requires "
-      "'force rhs calculation = true' so the residual is freshly assembled on "
-      "every Newton iteration."));
+      "either Newton iteration 0, where the RHS is always freshly assembled, "
+      "or 'force rhs calculation = true' on later Newton iterations."));
 
   current_res                 = assembled_res;
   solver->get_newton_update() = 0;
   global_res                  = solver->get_current_residual() / rescale_metric;
   solver->get_present_solution() = solver->get_evaluation_point();
   last_res                       = current_res;
-  ++outer_iteration;
+  ++this->outer_iteration;
 
   return true;
 }

--- a/include/core/physics_solver_strategy.h
+++ b/include/core/physics_solver_strategy.h
@@ -79,9 +79,10 @@ protected:
    * state and skipping the solve would incorrectly reuse stale information.
    *
    * Solvers must opt into this behavior explicitly through
-   * allow_skip_linear_solve_when_residual_is_below_tolerance(). Opting in also
-   * requires force_rhs_calculation to be enabled so that every Newton
-   * iteration reaches this helper with a fresh RHS.
+   * allow_skip_linear_solve_when_residual_is_below_tolerance(). When the
+   * shortcut is actually taken, force_rhs_calculation must also be enabled so
+   * that the converged residual comes from a fresh RHS assembled at the
+   * current Newton evaluation point.
    *
    * @param[in] rhs_was_assembled_this_iteration Whether the current Newton
    * iteration assembled the RHS at the current evaluation point.
@@ -155,13 +156,6 @@ PhysicsSolverStrategy<VectorType>::
   if (!solver->allow_skip_linear_solve_when_residual_is_below_tolerance())
     return false;
 
-  AssertThrow(
-    this->params.force_rhs_calculation,
-    ExcMessage(
-      "Skipping the linear solve based on the assembled RHS residual requires "
-      "'force rhs calculation = true' so the residual is freshly assembled on "
-      "every Newton iteration."));
-
   if (!rhs_was_assembled_this_iteration)
     return false;
 
@@ -169,6 +163,13 @@ PhysicsSolverStrategy<VectorType>::
     solver->get_system_rhs().l2_norm() / rescale_metric;
   if (assembled_res > this->params.tolerance)
     return false;
+
+  AssertThrow(
+    this->params.force_rhs_calculation,
+    ExcMessage(
+      "Skipping the linear solve based on the assembled RHS residual requires "
+      "'force rhs calculation = true' so the residual is freshly assembled on "
+      "every Newton iteration."));
 
   current_res                 = assembled_res;
   solver->get_newton_update() = 0;

--- a/include/fem-dem/fluid_dynamics_sharp.h
+++ b/include/fem-dem/fluid_dynamics_sharp.h
@@ -544,6 +544,25 @@ Return a bool that describes  if a cell contains a specific point
                        ->particle_nonlinear_tolerance;
     return std::max(this->system_rhs.l2_norm(), particle_residual * scaling);
   }
+
+  /**
+   * @brief Sharp may keep the outer nonlinear iteration active because of the
+   * particle-coupling residual even when the assembled fluid residual is
+   * already below tolerance.
+   *
+   * In that situation, the inner fluid linear solve is unnecessary and may be
+   * skipped while the outer coupled iteration continues.
+   *
+   * @return `true` because Sharp allows skipping the inner fluid linear solve
+   * once the assembled fluid residual is already below the nonlinear
+   * tolerance.
+   */
+  bool
+  allow_skip_linear_solve_when_residual_is_below_tolerance() const override
+  {
+    return true;
+  }
+
   /**
    * @brief
    *This function updates the precalculations for every immersed particle

--- a/include/fem-dem/fluid_dynamics_sharp.h
+++ b/include/fem-dem/fluid_dynamics_sharp.h
@@ -61,7 +61,7 @@ public:
   assemble_system_rhs() override
   {
     assemble_rhs();
-    sharp_edge();
+    sharp_edge(true);
   }
 
 
@@ -177,7 +177,7 @@ private:
       }
     this->FluidDynamicsMatrixBased<dim>::assemble_system_matrix();
 
-    sharp_edge();
+    sharp_edge(false);
   }
 
 
@@ -232,9 +232,13 @@ private:
    * Galerkin sharp-interface immersed boundary method and its application to
    * incompressible flow problems,» Computers & Fluids, 2020, in press, ref.
    * CAF-D-20-00773
+   *
+   * @param assemble_rhs_terms If true, overwrite the Sharp-IB RHS entries in
+   * addition to the matrix rows. Matrix assembly paths should pass false so
+   * they do not touch a stale residual vector.
    */
   void
-  sharp_edge();
+  sharp_edge(const bool assemble_rhs_terms);
 
   /**
    * @brief

--- a/include/fem-dem/fluid_dynamics_sharp.h
+++ b/include/fem-dem/fluid_dynamics_sharp.h
@@ -61,7 +61,7 @@ public:
   assemble_system_rhs() override
   {
     assemble_rhs();
-    sharp_edge(true);
+    sharp_edge();
   }
 
 
@@ -177,7 +177,7 @@ private:
       }
     this->FluidDynamicsMatrixBased<dim>::assemble_system_matrix();
 
-    sharp_edge(false);
+    sharp_edge();
   }
 
 
@@ -232,13 +232,9 @@ private:
    * Galerkin sharp-interface immersed boundary method and its application to
    * incompressible flow problems,» Computers & Fluids, 2020, in press, ref.
    * CAF-D-20-00773
-   *
-   * @param assemble_rhs_terms If true, overwrite the Sharp-IB RHS entries in
-   * addition to the matrix rows. Matrix assembly paths should pass false so
-   * they do not touch a stale residual vector.
    */
   void
-  sharp_edge(const bool assemble_rhs_terms);
+  sharp_edge();
 
   /**
    * @brief

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -3375,7 +3375,7 @@ FluidDynamicsSharp<dim>::handle_dem_particle_output_and_postprocessing()
 
 template <int dim>
 void
-FluidDynamicsSharp<dim>::sharp_edge()
+FluidDynamicsSharp<dim>::sharp_edge(const bool assemble_rhs_terms)
 {
   // This function defines an Immersed Boundary based on the sharp edge method
   // on a solid of dim=2 or dim=3
@@ -3394,6 +3394,25 @@ FluidDynamicsSharp<dim>::sharp_edge()
   // Define a map to all DOFs and their support points
   std::map<types::global_dof_index, Point<dim>> support_points =
     DoFTools::map_dofs_to_support_points(*this->mapping, *this->dof_handler);
+
+  // When sharp_edge() is called from RHS assembly, the standard distributed
+  // contributions have already been accumulated in add mode. Flush them before
+  // applying the Sharp-IB row overwrites so every rank sees the same baseline.
+  if (assemble_rhs_terms)
+    this->system_rhs.compress(VectorOperation::add);
+  this->system_matrix.compress(VectorOperation::add);
+
+  auto overwrite_rhs_entry =
+    [this, assemble_rhs_terms](const types::global_dof_index dof_index,
+                               const double                  value) {
+      if (!assemble_rhs_terms)
+        return;
+
+      const double                  current_value = this->system_rhs(dof_index);
+      const types::global_dof_index index         = dof_index;
+      const double                  delta         = value - current_value;
+      this->system_rhs.add(1, &index, &delta);
+    };
 
   // Initalize fe value objects in order to do calculation with it later
   QGauss<dim>        q_formula(this->number_quadrature_points);
@@ -3487,8 +3506,9 @@ FluidDynamicsSharp<dim>::sharp_edge()
               // cell. this is the new reference pressure inside a
               // particle
               this->system_matrix.add(inside_index, inside_index, sum_line);
-              this->system_rhs(inside_index) =
-                0 - this->evaluation_point(inside_index) * sum_line;
+              overwrite_rhs_entry(inside_index,
+                                  -this->evaluation_point(inside_index) *
+                                    sum_line);
             }
         }
     }
@@ -3608,13 +3628,14 @@ FluidDynamicsSharp<dim>::sharp_edge()
                                                       sum_line);
 
                               // Write the RHS
-                              this->system_rhs(local_dof_indices[i]) =
+                              overwrite_rhs_entry(
+                                local_dof_indices[i],
                                 -this->evaluation_point(local_dof_indices[i]) *
-                                  sum_line +
-                                interpolation * sum_line +
-                                this->zero_constraints.get_inhomogeneity(
-                                  local_dof_indices[i]) *
-                                  sum_line;
+                                    sum_line +
+                                  interpolation * sum_line +
+                                  this->zero_constraints.get_inhomogeneity(
+                                    local_dof_indices[i]) *
+                                    sum_line);
                             }
                           if (this->nonzero_constraints.is_constrained(
                                 local_dof_indices[i]))
@@ -3668,13 +3689,14 @@ FluidDynamicsSharp<dim>::sharp_edge()
                                                       sum_line);
 
                               // Write the RHS
-                              this->system_rhs(local_dof_indices[i]) =
+                              overwrite_rhs_entry(
+                                local_dof_indices[i],
                                 -this->evaluation_point(local_dof_indices[i]) *
-                                  sum_line +
-                                interpolation * sum_line +
-                                this->nonzero_constraints.get_inhomogeneity(
-                                  local_dof_indices[i]) *
-                                  sum_line;
+                                    sum_line +
+                                  interpolation * sum_line +
+                                  this->nonzero_constraints.get_inhomogeneity(
+                                    local_dof_indices[i]) *
+                                    sum_line);
                             }
                         }
 
@@ -4001,14 +4023,16 @@ FluidDynamicsSharp<dim>::sharp_edge()
                           const double pressure_scaling_factor =
                             this->simulation_parameters.stabilization
                               .pressure_scaling_factor;
-                          this->system_rhs(global_index_overwrite) =
-                            component_i == dim ? (v_ib * sum_line + rhs_add) /
-                                                   pressure_scaling_factor :
-                                                 v_ib * sum_line + rhs_add;
+                          overwrite_rhs_entry(global_index_overwrite,
+                                              component_i == dim ?
+                                                (v_ib * sum_line + rhs_add) /
+                                                  pressure_scaling_factor :
+                                                v_ib * sum_line + rhs_add);
 
                           if (dof_on_ib)
                             // Dof is on the immersed boundary
-                            this->system_rhs(global_index_overwrite) =
+                            overwrite_rhs_entry(
+                              global_index_overwrite,
                               component_i == dim ?
                                 (v_ib * sum_line - this->evaluation_point(
                                                      global_index_overwrite) *
@@ -4016,13 +4040,14 @@ FluidDynamicsSharp<dim>::sharp_edge()
                                   pressure_scaling_factor :
                                 (v_ib * sum_line - this->evaluation_point(
                                                      global_index_overwrite) *
-                                                     sum_line);
+                                                     sum_line));
 
                           if (skip_stencil && dof_on_ib == false)
                             // Impose the value of the dummy dof. This help
                             // with pressure variation when the IB is
                             // moving.
-                            this->system_rhs(global_index_overwrite) =
+                            overwrite_rhs_entry(
+                              global_index_overwrite,
                               component_i == dim ?
                                 (sum_line * v_ib - this->evaluation_point(
                                                      global_index_overwrite) *
@@ -4030,7 +4055,7 @@ FluidDynamicsSharp<dim>::sharp_edge()
                                   pressure_scaling_factor :
                                 sum_line * v_ib - this->evaluation_point(
                                                     global_index_overwrite) *
-                                                    sum_line;
+                                                    sum_line);
                         }
 
                       if (component_i == dim &&
@@ -4104,8 +4129,8 @@ FluidDynamicsSharp<dim>::sharp_edge()
                                     global_index_overwrite,
                                     global_index_overwrite,
                                     sum_line);
-                                  auto &system_rhs = this->system_rhs;
-                                  system_rhs(global_index_overwrite) = 0;
+                                  overwrite_rhs_entry(global_index_overwrite,
+                                                      0.0);
                                 }
                             }
                         }
@@ -4115,7 +4140,8 @@ FluidDynamicsSharp<dim>::sharp_edge()
         }
     }
 
-  this->system_rhs.compress(VectorOperation::insert);
+  if (assemble_rhs_terms)
+    this->system_rhs.compress(VectorOperation::add);
   this->system_matrix.compress(VectorOperation::add);
 }
 

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -3373,7 +3373,7 @@ FluidDynamicsSharp<dim>::handle_dem_particle_output_and_postprocessing()
 
 template <int dim>
 void
-FluidDynamicsSharp<dim>::sharp_edge()
+FluidDynamicsSharp<dim>::sharp_edge(const bool assemble_rhs_terms)
 {
   // This function defines an Immersed Boundary based on the sharp edge method
   // on a solid of dim=2 or dim=3
@@ -3392,6 +3392,25 @@ FluidDynamicsSharp<dim>::sharp_edge()
   // Define a map to all DOFs and their support points
   std::map<types::global_dof_index, Point<dim>> support_points =
     DoFTools::map_dofs_to_support_points(*this->mapping, *this->dof_handler);
+
+  // When sharp_edge() is called from RHS assembly, the standard distributed
+  // contributions have already been accumulated in add mode. Flush them before
+  // applying the Sharp-IB row overwrites so every rank sees the same baseline.
+  if (assemble_rhs_terms)
+    this->system_rhs.compress(VectorOperation::add);
+  this->system_matrix.compress(VectorOperation::add);
+
+  auto overwrite_rhs_entry =
+    [this, assemble_rhs_terms](const types::global_dof_index dof_index,
+                               const double                  value) {
+      if (!assemble_rhs_terms)
+        return;
+
+      const double                  current_value = this->system_rhs(dof_index);
+      const types::global_dof_index index         = dof_index;
+      const double                  delta         = value - current_value;
+      this->system_rhs.add(1, &index, &delta);
+    };
 
   // Initalize fe value objects in order to do calculation with it later
   QGauss<dim>        q_formula(this->number_quadrature_points);
@@ -3486,8 +3505,9 @@ FluidDynamicsSharp<dim>::sharp_edge()
               // cell. this is the new reference pressure inside a
               // particle
               this->system_matrix.add(inside_index, inside_index, sum_line);
-              this->system_rhs(inside_index) =
-                0 - this->evaluation_point(inside_index) * sum_line;
+              overwrite_rhs_entry(inside_index,
+                                  -this->evaluation_point(inside_index) *
+                                    sum_line);
             }
         }
     }
@@ -3607,13 +3627,14 @@ FluidDynamicsSharp<dim>::sharp_edge()
                                                       sum_line);
 
                               // Write the RHS
-                              this->system_rhs(local_dof_indices[i]) =
+                              overwrite_rhs_entry(
+                                local_dof_indices[i],
                                 -this->evaluation_point(local_dof_indices[i]) *
-                                  sum_line +
-                                interpolation * sum_line +
-                                this->zero_constraints.get_inhomogeneity(
-                                  local_dof_indices[i]) *
-                                  sum_line;
+                                    sum_line +
+                                  interpolation * sum_line +
+                                  this->zero_constraints.get_inhomogeneity(
+                                    local_dof_indices[i]) *
+                                    sum_line);
                             }
                           if (this->nonzero_constraints.is_constrained(
                                 local_dof_indices[i]))
@@ -3667,13 +3688,14 @@ FluidDynamicsSharp<dim>::sharp_edge()
                                                       sum_line);
 
                               // Write the RHS
-                              this->system_rhs(local_dof_indices[i]) =
+                              overwrite_rhs_entry(
+                                local_dof_indices[i],
                                 -this->evaluation_point(local_dof_indices[i]) *
-                                  sum_line +
-                                interpolation * sum_line +
-                                this->nonzero_constraints.get_inhomogeneity(
-                                  local_dof_indices[i]) *
-                                  sum_line;
+                                    sum_line +
+                                  interpolation * sum_line +
+                                  this->nonzero_constraints.get_inhomogeneity(
+                                    local_dof_indices[i]) *
+                                    sum_line);
                             }
                         }
 
@@ -4000,14 +4022,16 @@ FluidDynamicsSharp<dim>::sharp_edge()
                           const double pressure_scaling_factor =
                             this->simulation_parameters.stabilization
                               .pressure_scaling_factor;
-                          this->system_rhs(global_index_overwrite) =
-                            component_i == dim ? (v_ib * sum_line + rhs_add) /
-                                                   pressure_scaling_factor :
-                                                 v_ib * sum_line + rhs_add;
+                          overwrite_rhs_entry(global_index_overwrite,
+                                              component_i == dim ?
+                                                (v_ib * sum_line + rhs_add) /
+                                                  pressure_scaling_factor :
+                                                v_ib * sum_line + rhs_add);
 
                           if (dof_on_ib)
                             // Dof is on the immersed boundary
-                            this->system_rhs(global_index_overwrite) =
+                            overwrite_rhs_entry(
+                              global_index_overwrite,
                               component_i == dim ?
                                 (v_ib * sum_line - this->evaluation_point(
                                                      global_index_overwrite) *
@@ -4015,13 +4039,14 @@ FluidDynamicsSharp<dim>::sharp_edge()
                                   pressure_scaling_factor :
                                 (v_ib * sum_line - this->evaluation_point(
                                                      global_index_overwrite) *
-                                                     sum_line);
+                                                     sum_line));
 
                           if (skip_stencil && dof_on_ib == false)
                             // Impose the value of the dummy dof. This help
                             // with pressure variation when the IB is
                             // moving.
-                            this->system_rhs(global_index_overwrite) =
+                            overwrite_rhs_entry(
+                              global_index_overwrite,
                               component_i == dim ?
                                 (sum_line * v_ib - this->evaluation_point(
                                                      global_index_overwrite) *
@@ -4029,7 +4054,7 @@ FluidDynamicsSharp<dim>::sharp_edge()
                                   pressure_scaling_factor :
                                 sum_line * v_ib - this->evaluation_point(
                                                     global_index_overwrite) *
-                                                    sum_line;
+                                                    sum_line);
                         }
 
                       if (component_i == dim &&
@@ -4103,8 +4128,8 @@ FluidDynamicsSharp<dim>::sharp_edge()
                                     global_index_overwrite,
                                     global_index_overwrite,
                                     sum_line);
-                                  auto &system_rhs = this->system_rhs;
-                                  system_rhs(global_index_overwrite) = 0;
+                                  overwrite_rhs_entry(global_index_overwrite,
+                                                      0.0);
                                 }
                             }
                         }
@@ -4114,7 +4139,8 @@ FluidDynamicsSharp<dim>::sharp_edge()
         }
     }
 
-  this->system_rhs.compress(VectorOperation::insert);
+  if (assemble_rhs_terms)
+    this->system_rhs.compress(VectorOperation::add);
   this->system_matrix.compress(VectorOperation::add);
 }
 

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -3373,7 +3373,7 @@ FluidDynamicsSharp<dim>::handle_dem_particle_output_and_postprocessing()
 
 template <int dim>
 void
-FluidDynamicsSharp<dim>::sharp_edge(const bool assemble_rhs_terms)
+FluidDynamicsSharp<dim>::sharp_edge()
 {
   // This function defines an Immersed Boundary based on the sharp edge method
   // on a solid of dim=2 or dim=3
@@ -3392,25 +3392,6 @@ FluidDynamicsSharp<dim>::sharp_edge(const bool assemble_rhs_terms)
   // Define a map to all DOFs and their support points
   std::map<types::global_dof_index, Point<dim>> support_points =
     DoFTools::map_dofs_to_support_points(*this->mapping, *this->dof_handler);
-
-  // When sharp_edge() is called from RHS assembly, the standard distributed
-  // contributions have already been accumulated in add mode. Flush them before
-  // applying the Sharp-IB row overwrites so every rank sees the same baseline.
-  if (assemble_rhs_terms)
-    this->system_rhs.compress(VectorOperation::add);
-  this->system_matrix.compress(VectorOperation::add);
-
-  auto overwrite_rhs_entry =
-    [this, assemble_rhs_terms](const types::global_dof_index dof_index,
-                               const double                  value) {
-      if (!assemble_rhs_terms)
-        return;
-
-      const double                  current_value = this->system_rhs(dof_index);
-      const types::global_dof_index index         = dof_index;
-      const double                  delta         = value - current_value;
-      this->system_rhs.add(1, &index, &delta);
-    };
 
   // Initalize fe value objects in order to do calculation with it later
   QGauss<dim>        q_formula(this->number_quadrature_points);
@@ -3505,9 +3486,8 @@ FluidDynamicsSharp<dim>::sharp_edge(const bool assemble_rhs_terms)
               // cell. this is the new reference pressure inside a
               // particle
               this->system_matrix.add(inside_index, inside_index, sum_line);
-              overwrite_rhs_entry(inside_index,
-                                  -this->evaluation_point(inside_index) *
-                                    sum_line);
+              this->system_rhs(inside_index) =
+                0 - this->evaluation_point(inside_index) * sum_line;
             }
         }
     }
@@ -3627,14 +3607,13 @@ FluidDynamicsSharp<dim>::sharp_edge(const bool assemble_rhs_terms)
                                                       sum_line);
 
                               // Write the RHS
-                              overwrite_rhs_entry(
-                                local_dof_indices[i],
+                              this->system_rhs(local_dof_indices[i]) =
                                 -this->evaluation_point(local_dof_indices[i]) *
-                                    sum_line +
-                                  interpolation * sum_line +
-                                  this->zero_constraints.get_inhomogeneity(
-                                    local_dof_indices[i]) *
-                                    sum_line);
+                                  sum_line +
+                                interpolation * sum_line +
+                                this->zero_constraints.get_inhomogeneity(
+                                  local_dof_indices[i]) *
+                                  sum_line;
                             }
                           if (this->nonzero_constraints.is_constrained(
                                 local_dof_indices[i]))
@@ -3688,14 +3667,13 @@ FluidDynamicsSharp<dim>::sharp_edge(const bool assemble_rhs_terms)
                                                       sum_line);
 
                               // Write the RHS
-                              overwrite_rhs_entry(
-                                local_dof_indices[i],
+                              this->system_rhs(local_dof_indices[i]) =
                                 -this->evaluation_point(local_dof_indices[i]) *
-                                    sum_line +
-                                  interpolation * sum_line +
-                                  this->nonzero_constraints.get_inhomogeneity(
-                                    local_dof_indices[i]) *
-                                    sum_line);
+                                  sum_line +
+                                interpolation * sum_line +
+                                this->nonzero_constraints.get_inhomogeneity(
+                                  local_dof_indices[i]) *
+                                  sum_line;
                             }
                         }
 
@@ -4022,16 +4000,14 @@ FluidDynamicsSharp<dim>::sharp_edge(const bool assemble_rhs_terms)
                           const double pressure_scaling_factor =
                             this->simulation_parameters.stabilization
                               .pressure_scaling_factor;
-                          overwrite_rhs_entry(global_index_overwrite,
-                                              component_i == dim ?
-                                                (v_ib * sum_line + rhs_add) /
-                                                  pressure_scaling_factor :
-                                                v_ib * sum_line + rhs_add);
+                          this->system_rhs(global_index_overwrite) =
+                            component_i == dim ? (v_ib * sum_line + rhs_add) /
+                                                   pressure_scaling_factor :
+                                                 v_ib * sum_line + rhs_add;
 
                           if (dof_on_ib)
                             // Dof is on the immersed boundary
-                            overwrite_rhs_entry(
-                              global_index_overwrite,
+                            this->system_rhs(global_index_overwrite) =
                               component_i == dim ?
                                 (v_ib * sum_line - this->evaluation_point(
                                                      global_index_overwrite) *
@@ -4039,14 +4015,13 @@ FluidDynamicsSharp<dim>::sharp_edge(const bool assemble_rhs_terms)
                                   pressure_scaling_factor :
                                 (v_ib * sum_line - this->evaluation_point(
                                                      global_index_overwrite) *
-                                                     sum_line));
+                                                     sum_line);
 
                           if (skip_stencil && dof_on_ib == false)
                             // Impose the value of the dummy dof. This help
                             // with pressure variation when the IB is
                             // moving.
-                            overwrite_rhs_entry(
-                              global_index_overwrite,
+                            this->system_rhs(global_index_overwrite) =
                               component_i == dim ?
                                 (sum_line * v_ib - this->evaluation_point(
                                                      global_index_overwrite) *
@@ -4054,7 +4029,7 @@ FluidDynamicsSharp<dim>::sharp_edge(const bool assemble_rhs_terms)
                                   pressure_scaling_factor :
                                 sum_line * v_ib - this->evaluation_point(
                                                     global_index_overwrite) *
-                                                    sum_line);
+                                                    sum_line;
                         }
 
                       if (component_i == dim &&
@@ -4128,8 +4103,8 @@ FluidDynamicsSharp<dim>::sharp_edge(const bool assemble_rhs_terms)
                                     global_index_overwrite,
                                     global_index_overwrite,
                                     sum_line);
-                                  overwrite_rhs_entry(global_index_overwrite,
-                                                      0.0);
+                                  auto &system_rhs = this->system_rhs;
+                                  system_rhs(global_index_overwrite) = 0;
                                 }
                             }
                         }
@@ -4139,8 +4114,7 @@ FluidDynamicsSharp<dim>::sharp_edge(const bool assemble_rhs_terms)
         }
     }
 
-  if (assemble_rhs_terms)
-    this->system_rhs.compress(VectorOperation::add);
+  this->system_rhs.compress(VectorOperation::insert);
   this->system_matrix.compress(VectorOperation::add);
 }
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

This PR improves the robustness of Sharp resolved CFD-DEM when the coupled outer nonlinear iteration remains active because of the particle residual even though the fluid subsystem is already converged to the requested nonlinear tolerance.

The motivation is that, in Sharp, the outer residual is not just the fluid residual. `FluidDynamicsSharp::get_current_residual()` returns the maximum of:

- the assembled fluid RHS norm, and
- a scaled particle-coupling residual

As a result, it is possible for the freshly assembled fluid residual to already be below the nonlinear tolerance while the outer coupled iteration still needs to continue because the particle residual has not yet converged. Previously, the Newton and inexact-Newton strategies still called `solve_linear_system()` in that situation. In the problematic coarse Sharp cases, this launched GMRES on an almost-homogeneous fluid system with a very small RHS and could fail with AztecOO `GMRES Hessenberg ill-conditioned`.

The integration is intentionally minimal, and does not affect solvers besides Sharp (although I propose that it may be worthwhile for the others - I am just not anywhere near qualified to say for sure...):

- `PhysicsSolver` now exposes an explicit internal hook, `allow_skip_linear_solve_when_residual_is_below_tolerance()`, which defaults to `false`
- `FluidDynamicsSharp` overrides that hook and returns `true`
- `NewtonNonLinearSolverStrategy::solve()` now checks the freshly assembled fluid residual immediately before the linear solve, but only for solvers that opt in through that hook
- `InexactNewtonNonLinearSolverStrategy::solve()` applies the same logic
- if the assembled fluid residual is already below the nonlinear tolerance, the code skips the fluid linear solve, zeroes the Newton update, preserves the current fluid state, and continues the outer coupled iteration so that the particle residual can still converge

This PR does not change the Sharp convergence criterion. It only avoids an unnecessary inner fluid linear solve once the fluid subsystem is already within the configured nonlinear tolerance.

### Testing

This PR adds one minimal Sharp application test:

- `applications_tests/lethe-fluid-sharp/moving_stokes_2d_gmres_skip.prm`
- `applications_tests/lethe-fluid-sharp/moving_stokes_2d_gmres_skip.run_only`

This test is based on the existing 2D moving Stokes Sharp case and is designed to trigger the exact case described:

- a relatively loose fluid nonlinear tolerance of `1e-4`
- a tighter Sharp particle tolerance of `1e-6`
- a short 2D run with no output files

There should be no negative impact on existing tests. The branch does not add new required parameters and only changes the behaviour when the assembled fluid residual is already below the nonlinear tolerance.

### Documentation

This PR does not introduce new simulation parameters.

No parameter documentation changes were needed. The user-facing change is instead reflected in the changelog

### Miscellaneous (will be removed when merged)

The below-tolerance linear-solve skip is now explicitly scoped to Sharp rather than applied generically to every Newton-based solver. This keeps the fix aligned with the original motivation:

- in Sharp, the outer nonlinear residual can remain active because of particle coupling even when the assembled fluid residual is already below tolerance
- for other solvers, the default behaviour is unchanged because the new internal hook returns `false`

### Checklist (will be removed when merged)

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge
