### PR TITLE
Mortar: add AssertThrow for time-dependent BCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
+- MINOR When using the mortar feature in transient simulations, the boundary conditions need to be updated at every iteration since the mapping rotation is time-dependent, which wasn't done previously. This PR adds an Assert to ensure that time-dependent boundary conditions have been set. [#1980](https://github.com/chaos-polymtl/lethe/pull/1980)
+
 - MAJOR This PR adds a missing factor in the uniform and Gaussian laser models to account for the reduce heat flux when there is an angle of incidence between the laser and the CLS interface. The factor corresponds to the scalar product between the normal of the interface and the laser direction unit vector. [#1977](https://github.com/chaos-polymtl/lethe/pull/1977)
 
 ## [Master] - 2026/04/30

--- a/applications_tests/lethe-fluid-matrix-free/mortar_tgv_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mortar_tgv_gcmg.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 # Checks the transient stabilized ALE mortar implementation in the matrix-free solver.
 
@@ -112,6 +112,7 @@ end
 
 subsection boundary conditions
   set number                = 4
+  set time dependent        = true
   set fix pressure constant = true
   subsection bc 0
     set type               = periodic

--- a/applications_tests/lethe-fluid/mortar_taylorcouette_transient.prm
+++ b/applications_tests/lethe-fluid/mortar_taylorcouette_transient.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 # Checks the transient matrix-based mortar implementation for a Taylor-Couette example.
 # Also tests the option to fix pressure constant in a node.
@@ -89,6 +89,7 @@ end
 
 subsection boundary conditions
   set number                = 4
+  set time dependent        = true
   set fix pressure constant = true
   subsection bc 0
     set id   = 0

--- a/applications_tests/lethe-fluid/mortar_tgv.prm
+++ b/applications_tests/lethe-fluid/mortar_tgv.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 # Checks the transient stabilized ALE mortar implementation.
 
@@ -112,7 +112,8 @@ end
 #---------------------------------------------------
 
 subsection boundary conditions
-  set number = 4
+  set number         = 4
+  set time dependent = true
   subsection bc 0
     set type               = periodic
     set id                 = 0

--- a/applications_tests/lethe-fluid/mortar_tgv_restart.prm
+++ b/applications_tests/lethe-fluid/mortar_tgv_restart.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 # Checks the storage of checkpoint and restart files when outputting boundaries within the mortar feature.
 
@@ -121,7 +121,8 @@ end
 #---------------------------------------------------
 
 subsection boundary conditions
-  set number = 4
+  set number         = 4
+  set time dependent = true
   subsection bc 0
     set type               = periodic
     set id                 = 0

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2175,6 +2175,15 @@ NavierStokesBase<dim, VectorType, DofsType>::rotate_rotor_mapping(
   if (!this->simulation_parameters.mortar_parameters.enable)
     return;
 
+  // Check if time-dependent BCs have been set; BCs have to be updated at each
+  // iteration because of the rotation of the rotor domain. This check is done
+  // only once at the beginning of the simulation
+  if (is_first && !this->simulation_control->is_steady())
+    AssertThrow(
+      this->simulation_parameters.boundary_conditions.time_dependent,
+      ExcMessage(
+        "The mortar feature requires a time-dependent setup of the boundary conditions so that they are coherent with the mapping rotation. You can do that by adding 'set time dependent = true' on the Boundary Conditions subsection."));
+
   if ((simulation_parameters.mortar_parameters.verbosity ==
          Parameters::Verbosity::verbose ||
        simulation_parameters.mortar_parameters.verbosity ==


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

When using the mortar feature in transient simulations, the boundary conditions need to be updated at every iteration since the mapping rotation is time-dependent, which wasn't done previously.

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->

This PR adds an Assert to ensure that time-dependent boundary conditions have been set.

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

Transient mortar tests have been updated to have `set time dependent = true`. No changes appear, but additional tests showed that the BCs time-update is essential to maintain a coherent solution when the rotation speed increases.

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge