### PR TITLE
Remove all clang warning + fix folder creation on Apple Clang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the Lethe project will be documented in this file.
 The changelog for the previous releases of Lethe are located in the release_notes folder.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2026/05/02
+
+### Fixed
+
+- MINOR Fixed several Clang warnings encountered when compiling Lethe with Apple Clang. The unused-parameter warning in `LetheGridTools::find_cells_around_edge` is silenced with `[[maybe_unused]]` (the parameter is used when compiled with OpenCascade). The unused-private-field warnings in `SubSimulationControlDEM` are resolved by reading the constructor's stored members (via `this->`) instead of the shadowing parameters. The obsolete `#if __GNUC__ > 7` guards around `std::filesystem` usage in `create_output_folder`, `delete_output_folder`, and `delete_vtu_and_pvd_files` are removed; they prevented these functions from working on Apple Clang (which defines `__GNUC__ == 4`) and are no longer needed since Lethe requires C++20. The implicit `double`-to-`int` narrowing in `TimeHarmonicMaxwell::should_solve_auxiliary_physics` is made explicit with `static_cast<int>`. [#1981](https://github.com/chaos-polymtl/lethe/pull/1981)
+
 ## [Master] - 2026/05/01
 
 ### Fixed

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -683,10 +683,10 @@ LetheGridTools::find_cells_around_edge(
   const DoFHandler<dim> &dof_handler,
   std::map<unsigned int,
            std::set<typename DoFHandler<dim>::active_cell_iterator>>
-                                                       &vertices_cell_map,
-  const typename DoFHandler<dim>::active_cell_iterator &cell,
-  Point<dim>                                           &point_1,
-  Point<dim>                                           &point_2)
+    &vertices_cell_map,
+  [[maybe_unused]] const typename DoFHandler<dim>::active_cell_iterator &cell,
+  Point<dim> &point_1,
+  Point<dim> &point_2)
 {
   std::set<typename DoFHandler<dim>::active_cell_iterator> cells_pierced_set;
   DoFHandler<1, dim>       local_edge_dof_handler;

--- a/source/core/sub_simulation_control.cc
+++ b/source/core/sub_simulation_control.cc
@@ -18,47 +18,47 @@ SubSimulationControlDEM::SubSimulationControlDEM(
       fraction_of_rayleigh_characteristic_time)
   , iteration_number(0)
 {
-  Assert(time_interval > 0,
+  Assert(this->time_interval > 0,
          ExcMessage("The time interval must be strictly positive"));
 
 
-  if (iteration_logic == DEMSubIterationLogic::fixed_number_of_iterations)
+  if (this->iteration_logic == DEMSubIterationLogic::fixed_number_of_iterations)
     {
       Assert(
-        coupling_frequency > 0,
+        this->coupling_frequency > 0,
         ExcMessage(
           "The coupling frequency must be positive. A value of zero or a negative value was encountered. The simulation will stop."));
 
       // A fixed number of iterations is requested, the time step is fixed
       // using the coupling frequency and the time interval.
-      time_step                  = time_interval / coupling_frequency;
-      total_number_of_iterations = coupling_frequency;
+      time_step = this->time_interval / this->coupling_frequency;
+      total_number_of_iterations = this->coupling_frequency;
     }
   else //(iteration_logic ==
        // DEMSubIterationLogic::fixed_fraction_of_rayleigh_time_step)
     {
-      Assert(rayleigh_characteristic_time > 0,
+      Assert(this->rayleigh_characteristic_time > 0,
              ExcMessage(
                "The Rayleigh characteristic time must be strictly positive"));
       Assert(
-        fraction_of_rayleigh_characteristic_time > 0,
+        this->fraction_of_rayleigh_characteristic_time > 0,
         ExcMessage(
           "The fraction of the Rayleigh characteristic time must be strictly positive"));
 
       // A fixed fraction of the Rayleigh time step is used. The number of
       // iterations will be manually calculated
-      time_step =
-        fraction_of_rayleigh_characteristic_time * rayleigh_characteristic_time;
+      time_step = this->fraction_of_rayleigh_characteristic_time *
+                  this->rayleigh_characteristic_time;
 
       // We calculate the total number of iterations with the proposed time step
       // We then take the ceiling of it to have a integer number of time steps
       total_number_of_iterations =
-        static_cast<unsigned int>(std::ceil(time_interval / time_step));
+        static_cast<unsigned int>(std::ceil(this->time_interval / time_step));
 
       // Since the total number of iterations needs to be an integer, the actual
       // value of the time step may have changed as a result of the previous
       // calculations. We then recalculate the time step.
-      time_step = time_interval / double(total_number_of_iterations);
+      time_step = this->time_interval / double(total_number_of_iterations);
 
       Assert(
         total_number_of_iterations > 0,

--- a/source/core/utilities.cc
+++ b/source/core/utilities.cc
@@ -8,11 +8,8 @@
 
 #include <boost/algorithm/string/replace.hpp>
 
+#include <filesystem>
 #include <type_traits>
-
-#if __GNUC__ > 7
-#  include <filesystem>
-#endif
 
 template <typename T>
 TableHandler
@@ -367,20 +364,13 @@ fill_string_vectors_from_file(
 void
 create_output_folder(const std::string &dirname)
 {
-#if __GNUC__ > 7
   std::filesystem::create_directory(dirname);
-#else
-  // mkdir(dirname.c_str(), 0755);
-#endif
 }
 
-// TODO find a solution for other compilers
 void
 delete_output_folder(const std::string &dirname)
 {
-#if __GNUC__ > 7
   std::filesystem::remove_all(dirname);
-#endif
 }
 
 template TableHandler
@@ -869,7 +859,6 @@ print_comment_to_output_file(const ConditionalOStream &pcout,
 void
 delete_vtu_and_pvd_files(const std::string &output_path)
 {
-#if __GNUC__ > 7
   for (auto const &filename : std::filesystem::directory_iterator{output_path})
     {
       if (filename.path().extension() == ".vtu" ||
@@ -877,10 +866,4 @@ delete_vtu_and_pvd_files(const std::string &output_path)
           filename.path().extension() == ".pvtu")
         std::filesystem::remove(filename.path());
     }
-#else
-  AssertThrow(
-    false,
-    ExcMessage(
-      "Deleting old vtu files is not possible with the current compiler version."));
-#endif
 }

--- a/source/solvers/time_harmonic_maxwell.cc
+++ b/source/solvers/time_harmonic_maxwell.cc
@@ -1730,11 +1730,11 @@ TimeHarmonicMaxwell<dim>::should_solve_auxiliary_physics()
               // coupling parameter. If they are different, it means we have
               // passed a multiple of the time coupling parameter and we should
               // solve the electromagnetics.
-              int difference_in_time_steps =
+              const int difference_in_time_steps = static_cast<int>(
                 std::floor(this->simulation_control->get_current_time() /
                            thm_parameters.coupling_time) -
                 std::floor(this->simulation_control->get_previous_time() /
-                           thm_parameters.coupling_time);
+                           thm_parameters.coupling_time));
               if (difference_in_time_steps == 1)
                 return true;
               else if (difference_in_time_steps > 1)


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

Fixed several Clang warnings encountered when compiling Lethe with Apple Clang. The unused-parameter warning in `LetheGridTools::find_cells_around_edge` is silenced with `[[maybe_unused]]` (the parameter is used when compiled with OpenCascade). 
The unused-private-field warnings in `SubSimulationControlDEM` are resolved by reading the constructor's stored members (via `this->`) instead of the shadowing parameters. 
The obsolete `#if __GNUC__ > 7` guards around `std::filesystem` usage in `create_output_folder`, `delete_output_folder`, and `delete_vtu_and_pvd_files` are removed; they prevented these functions from working on Apple Clang (which defines `__GNUC__ == 4`) and are no longer needed since Lethe requires C++20.  This enable Mac to create or remove folders when running Lethe instead of manually creating them. I might be the only mac user, but I use it a lot on my Mac so it's more convenient.

The implicit `double`-to-`int` narrowing in `TimeHarmonicMaxwell::should_solve_auxiliary_physics` is made explicit with `static_cast<int>`.

### Testing

No tests results are affected.

### Documentation

<!-- Does this refactor modify or have new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge