### PR TITLE
Solid in mf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the Lethe project will be documented in this file.
 The changelog for the previous releases of Lethe are located in the release_notes folder.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2026/05/11
+
+### Fixed
+
+- MAJOR Fixed the usage of matrix free solver with solid material id in the domain for both the GCMG and LSMG multigrid preconditioners. This has been tested with the `grid_uniform_channel_with_meshed_cylinder` and required the mesh to have an additional option to disable the transfinite manifold has it does not work for multi-grid which have also been added to this PR. Finally, a test for the mesh `grid_uniform_channel_with_meshed_cylinder` has also been created to keep track of its changes in the future. [#1984](https://github.com/chaos-polymtl/lethe/pull/1984)
 
 ## [Sample] - YYYY/MM/DD
 

--- a/include/core/grid_uniform_channel_with_meshed_cylinder.h
+++ b/include/core/grid_uniform_channel_with_meshed_cylinder.h
@@ -171,6 +171,9 @@ private:
   /// Number of layers in the z direction, 3D only. Minimum is 2, which
   /// corresponds to a single layer of cells in the z direction.
   unsigned int n_slices;
+  /// Whether to use transfinite interpolation for the transition region between
+  /// the cylinder and the channel.
+  bool use_transfinite_region;
   /// Whether to assign distinct boundary IDs to the channel boundaries
   /// following the subdivided_hyper_rectangle convention.
   bool colorize;

--- a/include/solvers/fluid_dynamics_matrix_free_operators.h
+++ b/include/solvers/fluid_dynamics_matrix_free_operators.h
@@ -263,6 +263,15 @@ public:
   compute_element_size();
 
   /**
+   * @brief Compute a per-cell-batch mask that suppresses contributions from
+   * solid cells (material_id > 0). Each lane of @p solid_cell_mask is set to
+   * 1.0 for fluid cells and 0.0 for solid cells, mirroring the matrix-based
+   * behavior where solid cells are skipped during assembly.
+   */
+  void
+  compute_solid_cell_mask();
+
+  /**
    * @brief Precompute forcing term.
    */
   void
@@ -624,6 +633,24 @@ protected:
    *
    */
   AlignedVector<VectorizedArray<number>> element_size;
+
+  /**
+   * @brief Per-cell-batch mask used to suppress contributions from solid
+   * cells (material_id > 0) inside the cell integrals. Each lane is 1.0 for
+   * fluid cells and 0.0 for solid cells. Mirrors the matrix-based behavior
+   * where solid cells are skipped during assembly. Only filled when
+   * @p has_solids is true.
+   *
+   */
+  AlignedVector<VectorizedArray<number>> solid_cell_mask;
+
+  /**
+   * @brief Flag indicating whether the simulation contains any solid region
+   * (material_id > 0). When false, the solid-cell masking is skipped
+   * entirely so the no-solid case has zero overhead in the inner loop.
+   *
+   */
+  bool has_solids = false;
 
   /**
    * @brief Finite element degree for the operator.

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -547,13 +547,24 @@ protected:
    * domain is assumed to have a @p material_id=0 and the rest of the domains
    * have a @p material_id>0.
    *
+   * @param[in] dof_handler DoFHandler for which the solid region is
+   * established. In the majority of cases this is the DoFHandler that is a
+   * member of this class, but if a multigrid preconditioner, constraints must
+   * be built at every level. In this case, this DoFHandler can be the
+   * DoFHandler at any of the multigrid level.
+   *
    * @param[in] non_zero_constraints If this parameter is true, it indicates
    * that non-zero constraints are being constrained for the solid domain. If
    * this is set to false, homogeneous constraints are constrained in the solid
    * domain.
+   *
+   * @param[in] constraints Set of constraints on which the solid domain
+   * constraint is applied.
    */
   void
-  establish_solid_domain(const bool non_zero_constraints);
+  establish_solid_domain(const DoFHandler<dim>     &dof_handler,
+                         const bool                 non_zero_constraints,
+                         AffineConstraints<double> &constraints);
 
   /**
    * @brief Checks and identifies if the cell is located in the constraining
@@ -681,13 +692,13 @@ protected:
    *
    * @param[in] local_dof_indices Vector of a cell's local DOF indices.
    *
-   * @param[out] zero_constraints Homogeneous constraints holding object.
+   * @param[out] constraints Homogeneous constraints holding object.
    */
   inline void
   constrain_solid_cell_velocity_dofs(
     const bool                                 &non_zero_constraints,
     const std::vector<types::global_dof_index> &local_dof_indices,
-    AffineConstraints<double>                  &zero_constraints)
+    AffineConstraints<double>                  &constraints)
   {
     for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
       {
@@ -699,12 +710,11 @@ protected:
             // they are locally owned or not.
             if (non_zero_constraints)
               {
-                this->nonzero_constraints.add_line(local_dof_indices[i]);
-                this->nonzero_constraints.set_inhomogeneity(
-                  local_dof_indices[i], 0);
+                constraints.add_line(local_dof_indices[i]);
+                constraints.set_inhomogeneity(local_dof_indices[i], 0);
               }
             else
-              zero_constraints.add_line(local_dof_indices[i]);
+              constraints.add_line(local_dof_indices[i]);
           }
       }
   }

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -21,6 +21,7 @@
 #include <solvers/postprocessing_velocities.h>
 #include <solvers/postprocessors.h>
 #include <solvers/simulation_parameters.h>
+#include <solvers/solid_constraints.h>
 
 // Dealii Includes
 #include <deal.II/base/conditional_ostream.h>
@@ -562,9 +563,9 @@ protected:
    * constraint is applied.
    */
   void
-  establish_solid_domain(const DoFHandler<dim>     &dof_handler,
-                         const bool                 non_zero_constraints,
-                         AffineConstraints<double> &constraints);
+  make_solid_domain(const DoFHandler<dim>     &dof_handler,
+                    const bool                 non_zero_constraints,
+                    AffineConstraints<double> &constraints);
 
   /**
    * @brief Checks and identifies if the cell is located in the constraining
@@ -681,181 +682,6 @@ protected:
     const std::vector<types::global_dof_index> &local_dof_indices,
     const std::vector<double>                  &local_temperature_values,
     StasisConstraintWithTemperature            &stasis_constraint_struct);
-
-  /**
-   * @brief Constrain velocity DOFs of a solid cell.
-   *
-   * @param[in] non_zero_constraints If this parameter is true, it indicates
-   * that non-zero constraints are applied in the solid domain. If
-   * this is set to false, homogeneous constraints are applied in the solid
-   * domain.
-   *
-   * @param[in] local_dof_indices Vector of a cell's local DOF indices.
-   *
-   * @param[out] constraints Homogeneous constraints holding object.
-   */
-  inline void
-  constrain_solid_cell_velocity_dofs(
-    const bool                                 &non_zero_constraints,
-    const std::vector<types::global_dof_index> &local_dof_indices,
-    AffineConstraints<double>                  &constraints)
-  {
-    for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
-      {
-        const unsigned int component =
-          this->fe->system_to_component_index(i).first;
-        if (component < dim) // velocity DOFs
-          {
-            // We apply a constraint to all DOFs in the solid region, whether
-            // they are locally owned or not.
-            if (non_zero_constraints)
-              {
-                constraints.add_line(local_dof_indices[i]);
-                constraints.set_inhomogeneity(local_dof_indices[i], 0);
-              }
-            else
-              constraints.add_line(local_dof_indices[i]);
-          }
-      }
-  }
-
-  /**
-   * @brief Flag DOFs in solid cells.
-   *
-   * @param[in] local_dof_indices Vector of a cell's local DOF indices.
-   *
-   * @param[out] dofs_are_in_solid Container of global DOF indices located in
-   * solid cells.
-   */
-  inline void
-  flag_dofs_in_solid(
-    const std::vector<types::global_dof_index>  &local_dof_indices,
-    std::unordered_set<types::global_dof_index> &dofs_are_in_solid)
-  {
-    for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
-      {
-        const unsigned int component =
-          this->fe->system_to_component_index(i).first;
-        if (component == dim)
-          {
-            dofs_are_in_solid.insert(local_dof_indices[i]);
-          }
-      }
-  }
-
-  /**
-   * @brief Flag DOFs connected to fluid cells.
-   *
-   * @param[in] local_dof_indices Vector of a cell's local DOF indices.
-   *
-   * @param[out] dofs_are_connected_to_fluid Container of global DOF indices
-   * connected to at least one fluid cell.
-   */
-  inline void
-  flag_dofs_connected_to_fluid(
-    const std::vector<types::global_dof_index>  &local_dof_indices,
-    std::unordered_set<types::global_dof_index> &dofs_are_connected_to_fluid)
-  {
-    for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
-      {
-        const unsigned int component =
-          this->fe->system_to_component_index(i).first;
-        if (component == dim)
-          {
-            dofs_are_connected_to_fluid.insert(local_dof_indices[i]);
-          }
-      }
-  }
-
-  /**
-   * @brief Check if the cell is connected to a fluid cell.
-   *
-   * @param[in] dofs_are_connected_to_fluid Container of global DOF indices
-   * connected to at least one fluid cell.
-   *
-   * @param[in] local_dof_indices Vector of a cell's local DOF indices.
-   *
-   * @return Boolean indicating if the cell is connected to a fluid (true) or
-   * not (false).
-   */
-  inline bool
-  check_cell_is_connected_to_fluid(
-    const std::unordered_set<types::global_dof_index>
-                                               &dofs_are_connected_to_fluid,
-    const std::vector<types::global_dof_index> &local_dof_indices)
-  {
-    for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
-      {
-        auto search = dofs_are_connected_to_fluid.find(local_dof_indices[i]);
-        if (search != dofs_are_connected_to_fluid.end())
-          return true;
-      }
-    return false;
-  }
-
-  /**
-   * @brief Constrain pressure DOFs if cells are not connected to fluid and DOFs
-   * are locally owned.
-   *
-   * @param[in] non_zero_constraints If this parameter is true, it indicates
-   * that non-zero constraints are applied in the solid domain. If
-   * this is set to false, homogeneous constraints are applied in the solid
-   * domain.
-   *
-   * @param[in] local_dof_indices Vector of a cell's local DOF indices.
-   *
-   * @param[out] zero_constraints Homogeneous constraints holding object.
-   */
-  inline void
-  constrain_pressure(
-    const bool                                 &non_zero_constraints,
-    const std::vector<types::global_dof_index> &local_dof_indices,
-    AffineConstraints<double>                  &zero_constraints)
-  {
-    for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
-      {
-        const unsigned int component =
-          this->fe->system_to_component_index(i).first;
-
-        // Only pressure DOFs have an additional Dirichlet condition
-        if (component == dim) // pressure DOFs
-          {
-            // We only apply the constraint on the locally owned pressure DOFs
-            // since we have no way of verifying if the locally relevant DOFs
-            // are connected to a fluid cell.
-            bool dof_is_locally_owned = false;
-
-            // For the GLS-family of solvers, we only have a single index set
-            if constexpr (std::is_same_v<DofsType, IndexSet>)
-              {
-                dof_is_locally_owned =
-                  this->locally_owned_dofs.is_element(local_dof_indices[i]);
-              }
-
-            // For the GD-family of solvers, we have two index sets. One for
-            // velocities and one for pressure.
-            if constexpr (std::is_same_v<DofsType, std::vector<IndexSet>>)
-              {
-                dof_is_locally_owned =
-                  this->locally_owned_dofs[1].is_element(local_dof_indices[i]);
-              }
-
-            if (dof_is_locally_owned)
-              {
-                if (non_zero_constraints)
-                  {
-                    this->nonzero_constraints.add_line(local_dof_indices[i]);
-                    this->nonzero_constraints.set_inhomogeneity(
-                      local_dof_indices[i], 0);
-                  }
-                else
-                  {
-                    zero_constraints.add_line(local_dof_indices[i]);
-                  }
-              }
-          }
-      }
-  }
 
   /**
    * @brief Constrain a fluid's subdomains according to the temperature field to null

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -560,7 +560,8 @@ protected:
    * domain.
    *
    * @param[in] constraints Set of constraints on which the solid domain
-   * constraint is applied.
+   * constraint is applied. These constraints can be either zero or non-zero
+   * constraints, which is decided by the non_zero_constraints flag.
    */
   void
   make_solid_domain(const DoFHandler<dim>     &dof_handler,

--- a/include/solvers/solid_constraints.h
+++ b/include/solvers/solid_constraints.h
@@ -1,0 +1,325 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The Lethe Authors
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+
+#ifndef lethe_solid_constraints_h
+#define lethe_solid_constraints_h
+
+#include <deal.II/base/types.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_system.h>
+
+#include <deal.II/lac/affine_constraints.h>
+
+#include <unordered_set>
+#include <vector>
+
+using namespace dealii;
+/**
+ * @brief Constrain velocity DOFs of a solid cell.
+ *
+ * @param [in] fe Finite element used to extract the different components.
+ * Inherently, we assume that this fe has dim+1 component and corresponds
+ * to a Navier-Stokes problem.
+ *
+ * @param[in] non_zero_constraints If this parameter is true, it indicates
+ * that non-zero constraints are applied in the solid domain. If
+ * this is set to false, homogeneous constraints are applied in the solid
+ * domain.
+ *
+ * @param[in] local_dof_indices Vector of a cell's local DOF indices.
+ *
+ * @param[out] constraints Homogeneous constraints holding object.
+ */
+template <int dim>
+inline void
+constrain_solid_cell_velocity_dofs(
+  const FiniteElement<dim>                   &fe,
+  const bool                                 &non_zero_constraints,
+  const std::vector<types::global_dof_index> &local_dof_indices,
+  AffineConstraints<double>                  &constraints)
+{
+  /// TODO: Add defensive assertions
+
+  for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
+    {
+      const unsigned int component = fe.system_to_component_index(i).first;
+      if (component < dim) // velocity DOFs
+        {
+          // We apply a constraint to all DOFs in the solid region, whether
+          // they are locally owned or not.
+          if (non_zero_constraints)
+            {
+              constraints.add_line(local_dof_indices[i]);
+              constraints.set_inhomogeneity(local_dof_indices[i], 0);
+            }
+          else
+            constraints.add_line(local_dof_indices[i]);
+        }
+    }
+}
+
+/**
+ * @brief Flag DOFs connected to fluid cells.
+ *
+ * @param [in] fe Finite element used to extract the different components.
+ * Inherently, we assume that this fe has dim+1 component and corresponds
+ * to a Navier-Stokes problem.
+ *
+ * @param[in] local_dof_indices Vector of a cell's local DOF indices.
+ *
+ * @param[out] dofs_are_connected_to_fluid Container of global DOF indices
+ * connected to at least one fluid cell.
+ */
+template <int dim>
+inline void
+flag_dofs_connected_to_fluid(
+  const FiniteElement<dim>                    &fe,
+  const std::vector<types::global_dof_index>  &local_dof_indices,
+  std::unordered_set<types::global_dof_index> &dofs_are_connected_to_fluid)
+{
+  /// TODO: Add defensive assertions
+
+  for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
+    {
+      const unsigned int component = fe.system_to_component_index(i).first;
+      if (component == dim)
+        {
+          dofs_are_connected_to_fluid.insert(local_dof_indices[i]);
+        }
+    }
+}
+
+
+/**
+ * @brief Flag DOFs in solid cells.
+ *
+ * @param [in] fe Finite element used to extract the different components.
+ * Inherently, we assume that this fe has dim+1 component and corresponds
+ * to a Navier-Stokes problem.
+ *
+ * @param[in] local_dof_indices Vector of a cell's local DOF indices.
+ *
+ * @param[out] dofs_are_in_solid Container of global DOF indices located in
+ * solid cells.
+ */
+template <int dim>
+inline void
+flag_dofs_in_solid(
+  const FiniteElement<dim>                    &fe,
+  const std::vector<types::global_dof_index>  &local_dof_indices,
+  std::unordered_set<types::global_dof_index> &dofs_are_in_solid)
+{
+  /// TODO: Add defensive assertions
+  for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
+    {
+      const unsigned int component = fe.system_to_component_index(i).first;
+      if (component == dim)
+        {
+          dofs_are_in_solid.insert(local_dof_indices[i]);
+        }
+    }
+}
+
+/**
+ * @brief Check if the cell is connected to a fluid cell.
+ *
+ * @param[in] dofs_are_connected_to_fluid Container of global DOF indices
+ * connected to at least one fluid cell.
+ *
+ * @param[in] local_dof_indices Vector of a cell's local DOF indices.
+ *
+ * @return Boolean indicating if the cell is connected to a fluid (true) or
+ * not (false).
+ */
+inline bool
+check_cell_is_connected_to_fluid(
+  const std::unordered_set<types::global_dof_index>
+                                             &dofs_are_connected_to_fluid,
+  const std::vector<types::global_dof_index> &local_dof_indices)
+{
+  for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
+    {
+      auto search = dofs_are_connected_to_fluid.find(local_dof_indices[i]);
+      if (search != dofs_are_connected_to_fluid.end())
+        return true;
+    }
+  return false;
+}
+
+
+/**
+ * @brief Constrain pressure DOFs if cells are not connected to fluid and DOFs
+ * are locally owned.
+ *
+ * @param[in] non_zero_constraints If this parameter is true, it indicates
+ * that non-zero constraints are applied in the solid domain. If
+ * this is set to false, homogeneous constraints are applied in the solid
+ * domain.
+ *
+ * @param[in] local_dof_indices Vector of a cell's local DOF indices.
+ *
+ * @param[out] constraints Homogeneous constraints holding object.
+ */
+template <int dim, typename DofsType>
+inline void
+constrain_pressure(
+  const FiniteElement<dim>                   &fe,
+  const bool                                 &non_zero_constraints,
+  const DofsType                             &locally_owned_dofs,
+  const std::vector<types::global_dof_index> &local_dof_indices,
+  AffineConstraints<double>                  &constraints)
+{
+  /// TODO: Add defensive assertions
+
+  for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
+    {
+      const unsigned int component = fe.system_to_component_index(i).first;
+
+      // Only pressure DOFs have an additional Dirichlet condition
+      if (component == dim) // pressure DOFs
+        {
+          // We only apply the constraint on the locally owned pressure DOFs
+          // since we have no way of verifying if the locally relevant DOFs
+          // are connected to a fluid cell.
+          bool dof_is_locally_owned = false;
+
+          // For the GLS-family of solvers, we only have a single index set
+          if constexpr (std::is_same_v<DofsType, IndexSet>)
+            {
+              dof_is_locally_owned =
+                locally_owned_dofs.is_element(local_dof_indices[i]);
+            }
+
+          // For the GD-family of solvers, we have two index sets. One for
+          // velocities and one for pressure.
+          if constexpr (std::is_same_v<DofsType, std::vector<IndexSet>>)
+            {
+              dof_is_locally_owned =
+                locally_owned_dofs[1].is_element(local_dof_indices[i]);
+            }
+
+          if (dof_is_locally_owned)
+            {
+              if (non_zero_constraints)
+                {
+                  constraints.add_line(local_dof_indices[i]);
+                  constraints.set_inhomogeneity(local_dof_indices[i], 0);
+                }
+              else
+                {
+                  constraints.add_line(local_dof_indices[i]);
+                }
+            }
+        }
+    }
+}
+
+/**
+ * @brief Turn regions of the mesh where the @p material_id>0 into a solid
+ * block by injecting velocity and pressure DOFs into the zero constraints.
+ *
+ * It is achieved by imposing \f$\mathbf{u}=0\f$ within the cells which have a
+ * @p material_id>0. In addition, solid cells which are not connected to the
+ * fluid by any means also get a pressure Dirichlet boundary condition which
+ * fixes the pressure to 0. It ensures that the linear system is well-posed.
+ * Right now, this routine only supports the usage of 1 solid domain, but
+ * eventually it could be extended to more than one. By default, the fluid
+ * domain is assumed to have a @p material_id=0 and the rest of the domains
+ * have a @p material_id>0.
+ *
+ * @param[in] dof_handler DoFHandler for which the solid region is
+ * established. In the majority of cases this is the DoFHandler that is a
+ * member of this class, but if a multigrid preconditioner, constraints must
+ * be built at every level. In this case, this DoFHandler can be the
+ * DoFHandler at any of the multigrid level.
+ *
+ * @param[in] non_zero_constraints If this parameter is true, it indicates
+ * that non-zero constraints are being constrained for the solid domain. If
+ * this is set to false, homogeneous constraints are constrained in the solid
+ * domain.
+ *
+ * @param[in] constraints Set of constraints on which the solid domain
+ * constraint is applied.
+ */
+template <int dim, typename DofsType>
+void
+establish_solid_domain(const DoFHandler<dim>     &dof_handler,
+                       const DofsType            &locally_owned_dofs,
+                       const bool                 non_zero_constraints,
+                       AffineConstraints<double> &constraints)
+{
+  const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+  // We will need to identify which pressure degrees of freedom are connected to
+  // fluid region. For these, we won't establish a zero pressure constraint.
+  std::unordered_set<types::global_dof_index> dofs_are_connected_to_fluid;
+
+  // Loop through all cells to identify which cells are solid. This first step
+  // is used to 1) constraint the velocity degree of freedom to be zero in the
+  // solid region and 2) to identify which pressure degrees of freedom are
+  // connected to fluid cells
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->is_locally_owned() || cell->is_ghost())
+        {
+          cell->get_dof_indices(local_dof_indices);
+          // If the material_id is higher than 0, the region is a solid region.
+          // Constrain the velocity DOFs to be zero.
+          if (cell->material_id() > 0)
+            {
+              constrain_solid_cell_velocity_dofs(dof_handler.get_fe(),
+                                                 non_zero_constraints,
+                                                 local_dof_indices,
+                                                 constraints);
+            }
+          else
+            {
+              // Cell is a fluid cell and as such all the pressure DOFs of that
+              // cell are connected to the fluid. This will be used later on to
+              // identify which pressure cells to constrain.
+              flag_dofs_connected_to_fluid(dof_handler.get_fe(),
+                                           local_dof_indices,
+                                           dofs_are_connected_to_fluid);
+            }
+        }
+    }
+
+  // All pressure DOFs that are not connected to a fluid cell are constrained
+  // to ensure that the system matrix has adequate conditioning.
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->is_locally_owned() || cell->is_ghost())
+        {
+          cell->get_dof_indices(local_dof_indices);
+          // If the material_id is > 0, the region is a solid region
+          if (cell->material_id() > 0)
+            {
+              // First check if the cell is connected to a fluid cell by
+              // checking if one of the DOF of the cell is connected to a fluid
+              // cell.
+              bool connected_to_fluid =
+                check_cell_is_connected_to_fluid(dofs_are_connected_to_fluid,
+                                                 local_dof_indices);
+
+              // All the pressure DOFs with the cell are not connected to the
+              // fluid. Consequently, we fix a constraint on these pressure
+              // DOFs.
+              if (!connected_to_fluid)
+                {
+                  constrain_pressure(dof_handler.get_fe(),
+                                     non_zero_constraints,
+                                     locally_owned_dofs,
+                                     local_dof_indices,
+                                     constraints);
+                }
+            }
+        }
+    }
+}
+
+
+
+#endif

--- a/include/solvers/solid_constraints.h
+++ b/include/solvers/solid_constraints.h
@@ -12,10 +12,8 @@
 
 #include <deal.II/lac/affine_constraints.h>
 
-#include <unordered_set>
 #include <vector>
 
-using namespace dealii;
 /**
  * @brief Constrain velocity DOFs of a solid cell.
  *
@@ -33,188 +31,12 @@ using namespace dealii;
  * @param[out] constraints Homogeneous constraints holding object.
  */
 template <int dim>
-inline void
+void
 constrain_solid_cell_velocity_dofs(
-  const FiniteElement<dim>                   &fe,
-  const bool                                 &non_zero_constraints,
-  const std::vector<types::global_dof_index> &local_dof_indices,
-  AffineConstraints<double>                  &constraints)
-{
-  /// TODO: Add defensive assertions
-
-  for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
-    {
-      const unsigned int component = fe.system_to_component_index(i).first;
-      if (component < dim) // velocity DOFs
-        {
-          // We apply a constraint to all DOFs in the solid region, whether
-          // they are locally owned or not.
-          if (non_zero_constraints)
-            {
-              constraints.add_line(local_dof_indices[i]);
-              constraints.set_inhomogeneity(local_dof_indices[i], 0);
-            }
-          else
-            constraints.add_line(local_dof_indices[i]);
-        }
-    }
-}
-
-/**
- * @brief Flag DOFs connected to fluid cells.
- *
- * @param [in] fe Finite element used to extract the different components.
- * Inherently, we assume that this fe has dim+1 component and corresponds
- * to a Navier-Stokes problem.
- *
- * @param[in] local_dof_indices Vector of a cell's local DOF indices.
- *
- * @param[out] dofs_are_connected_to_fluid Container of global DOF indices
- * connected to at least one fluid cell.
- */
-template <int dim>
-inline void
-flag_dofs_connected_to_fluid(
-  const FiniteElement<dim>                    &fe,
-  const std::vector<types::global_dof_index>  &local_dof_indices,
-  std::unordered_set<types::global_dof_index> &dofs_are_connected_to_fluid)
-{
-  /// TODO: Add defensive assertions
-
-  for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
-    {
-      const unsigned int component = fe.system_to_component_index(i).first;
-      if (component == dim)
-        {
-          dofs_are_connected_to_fluid.insert(local_dof_indices[i]);
-        }
-    }
-}
-
-
-/**
- * @brief Flag DOFs in solid cells.
- *
- * @param [in] fe Finite element used to extract the different components.
- * Inherently, we assume that this fe has dim+1 component and corresponds
- * to a Navier-Stokes problem.
- *
- * @param[in] local_dof_indices Vector of a cell's local DOF indices.
- *
- * @param[out] dofs_are_in_solid Container of global DOF indices located in
- * solid cells.
- */
-template <int dim>
-inline void
-flag_dofs_in_solid(
-  const FiniteElement<dim>                    &fe,
-  const std::vector<types::global_dof_index>  &local_dof_indices,
-  std::unordered_set<types::global_dof_index> &dofs_are_in_solid)
-{
-  /// TODO: Add defensive assertions
-  for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
-    {
-      const unsigned int component = fe.system_to_component_index(i).first;
-      if (component == dim)
-        {
-          dofs_are_in_solid.insert(local_dof_indices[i]);
-        }
-    }
-}
-
-/**
- * @brief Check if the cell is connected to a fluid cell.
- *
- * @param[in] dofs_are_connected_to_fluid Container of global DOF indices
- * connected to at least one fluid cell.
- *
- * @param[in] local_dof_indices Vector of a cell's local DOF indices.
- *
- * @return Boolean indicating if the cell is connected to a fluid (true) or
- * not (false).
- */
-inline bool
-check_cell_is_connected_to_fluid(
-  const std::unordered_set<types::global_dof_index>
-                                             &dofs_are_connected_to_fluid,
-  const std::vector<types::global_dof_index> &local_dof_indices)
-{
-  for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
-    {
-      auto search = dofs_are_connected_to_fluid.find(local_dof_indices[i]);
-      if (search != dofs_are_connected_to_fluid.end())
-        return true;
-    }
-  return false;
-}
-
-
-/**
- * @brief Constrain pressure DOFs if cells are not connected to fluid and DOFs
- * are locally owned.
- *
- * @param[in] non_zero_constraints If this parameter is true, it indicates
- * that non-zero constraints are applied in the solid domain. If
- * this is set to false, homogeneous constraints are applied in the solid
- * domain.
- *
- * @param[in] local_dof_indices Vector of a cell's local DOF indices.
- *
- * @param[out] constraints Homogeneous constraints holding object.
- */
-template <int dim, typename DofsType>
-inline void
-constrain_pressure(
-  const FiniteElement<dim>                   &fe,
-  const bool                                 &non_zero_constraints,
-  const DofsType                             &locally_owned_dofs,
-  const std::vector<types::global_dof_index> &local_dof_indices,
-  AffineConstraints<double>                  &constraints)
-{
-  /// TODO: Add defensive assertions
-
-  for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
-    {
-      const unsigned int component = fe.system_to_component_index(i).first;
-
-      // Only pressure DOFs have an additional Dirichlet condition
-      if (component == dim) // pressure DOFs
-        {
-          // We only apply the constraint on the locally owned pressure DOFs
-          // since we have no way of verifying if the locally relevant DOFs
-          // are connected to a fluid cell.
-          bool dof_is_locally_owned = false;
-
-          // For the GLS-family of solvers, we only have a single index set
-          if constexpr (std::is_same_v<DofsType, IndexSet>)
-            {
-              dof_is_locally_owned =
-                locally_owned_dofs.is_element(local_dof_indices[i]);
-            }
-
-          // For the GD-family of solvers, we have two index sets. One for
-          // velocities and one for pressure.
-          if constexpr (std::is_same_v<DofsType, std::vector<IndexSet>>)
-            {
-              dof_is_locally_owned =
-                locally_owned_dofs[1].is_element(local_dof_indices[i]);
-            }
-
-          if (dof_is_locally_owned)
-            {
-              if (non_zero_constraints)
-                {
-                  constraints.add_line(local_dof_indices[i]);
-                  constraints.set_inhomogeneity(local_dof_indices[i], 0);
-                }
-              else
-                {
-                  constraints.add_line(local_dof_indices[i]);
-                }
-            }
-        }
-    }
-}
+  const dealii::FiniteElement<dim>                   &fe,
+  const bool                                         &non_zero_constraints,
+  const std::vector<dealii::types::global_dof_index> &local_dof_indices,
+  dealii::AffineConstraints<double>                  &constraints);
 
 /**
  * @brief Turn regions of the mesh where the @p material_id>0 into a solid
@@ -245,81 +67,9 @@ constrain_pressure(
  */
 template <int dim, typename DofsType>
 void
-establish_solid_domain(const DoFHandler<dim>     &dof_handler,
-                       const DofsType            &locally_owned_dofs,
-                       const bool                 non_zero_constraints,
-                       AffineConstraints<double> &constraints)
-{
-  const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
-  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
-
-  // We will need to identify which pressure degrees of freedom are connected to
-  // fluid region. For these, we won't establish a zero pressure constraint.
-  std::unordered_set<types::global_dof_index> dofs_are_connected_to_fluid;
-
-  // Loop through all cells to identify which cells are solid. This first step
-  // is used to 1) constraint the velocity degree of freedom to be zero in the
-  // solid region and 2) to identify which pressure degrees of freedom are
-  // connected to fluid cells
-  for (const auto &cell : dof_handler.active_cell_iterators())
-    {
-      if (cell->is_locally_owned() || cell->is_ghost())
-        {
-          cell->get_dof_indices(local_dof_indices);
-          // If the material_id is higher than 0, the region is a solid region.
-          // Constrain the velocity DOFs to be zero.
-          if (cell->material_id() > 0)
-            {
-              constrain_solid_cell_velocity_dofs(dof_handler.get_fe(),
-                                                 non_zero_constraints,
-                                                 local_dof_indices,
-                                                 constraints);
-            }
-          else
-            {
-              // Cell is a fluid cell and as such all the pressure DOFs of that
-              // cell are connected to the fluid. This will be used later on to
-              // identify which pressure cells to constrain.
-              flag_dofs_connected_to_fluid(dof_handler.get_fe(),
-                                           local_dof_indices,
-                                           dofs_are_connected_to_fluid);
-            }
-        }
-    }
-
-  // All pressure DOFs that are not connected to a fluid cell are constrained
-  // to ensure that the system matrix has adequate conditioning.
-  for (const auto &cell : dof_handler.active_cell_iterators())
-    {
-      if (cell->is_locally_owned() || cell->is_ghost())
-        {
-          cell->get_dof_indices(local_dof_indices);
-          // If the material_id is > 0, the region is a solid region
-          if (cell->material_id() > 0)
-            {
-              // First check if the cell is connected to a fluid cell by
-              // checking if one of the DOF of the cell is connected to a fluid
-              // cell.
-              bool connected_to_fluid =
-                check_cell_is_connected_to_fluid(dofs_are_connected_to_fluid,
-                                                 local_dof_indices);
-
-              // All the pressure DOFs with the cell are not connected to the
-              // fluid. Consequently, we fix a constraint on these pressure
-              // DOFs.
-              if (!connected_to_fluid)
-                {
-                  constrain_pressure(dof_handler.get_fe(),
-                                     non_zero_constraints,
-                                     locally_owned_dofs,
-                                     local_dof_indices,
-                                     constraints);
-                }
-            }
-        }
-    }
-}
-
-
+establish_solid_domain(const dealii::DoFHandler<dim>     &dof_handler,
+                       const DofsType                    &locally_owned_dofs,
+                       const bool                         non_zero_constraints,
+                       dealii::AffineConstraints<double> &constraints);
 
 #endif

--- a/include/solvers/solid_constraints.h
+++ b/include/solvers/solid_constraints.h
@@ -63,7 +63,7 @@ constrain_solid_cell_velocity_dofs(
  * disconnected from the fluid.
  *
  * @param[in] non_zero_constraints If this parameter is true, it indicates
- * that the constraints used for the solid domainare the non-zero constraints.
+ * that the constraints used for the solid domain are the non-zero constraints.
  * If this is set to false, the constraints being used are zero constraints.
  *
  * @param[in] constraints Set of constraints on which the solid domain

--- a/include/solvers/solid_constraints.h
+++ b/include/solvers/solid_constraints.h
@@ -72,4 +72,44 @@ establish_solid_domain(const dealii::DoFHandler<dim>     &dof_handler,
                        const bool                         non_zero_constraints,
                        dealii::AffineConstraints<double> &constraints);
 
+/**
+ * @brief Multigrid-level variant of establish_solid_domain for the local
+ * smoothing multigrid (LSMG) preconditioner.
+ *
+ * Unlike the active-cell version above, this overload walks the cells of a
+ * specific multigrid level using @p mg_cell_iterators_on_level and uses
+ * @p get_mg_dof_indices, so the DOF indices it adds to the constraint object
+ * match the multigrid-level IndexSet with which @p constraints was reinit'd
+ * (i.e. @p locally_owned_mg_dofs(level) and the corresponding locally
+ * relevant level DoFs). Using the active-cell version on an LSMG level
+ * constraint object triggers the @p local_lines.is_element(line_n) assertion
+ * inside @p AffineConstraints::add_line because active and MG DoF numberings
+ * are unrelated.
+ *
+ * The @p material_id is inherited from active cells by their parents on
+ * coarser levels, so the solid/fluid classification is well defined on MG
+ * levels.
+ *
+ * @param[in] dof_handler DoFHandler distributed with @p distribute_mg_dofs.
+ *
+ * @param[in] level Multigrid level on which constraints are built.
+ *
+ * @param[in] locally_owned_mg_dofs The locally owned MG DoFs on @p level
+ * (i.e. @p dof_handler.locally_owned_mg_dofs(level)). Used to filter pressure
+ * DoFs that should receive a Dirichlet constraint when their cell is fully
+ * disconnected from the fluid.
+ *
+ * @param[in] non_zero_constraints If true, set inhomogeneous (zero-valued)
+ * constraints; otherwise add homogeneous constraints.
+ *
+ * @param[in,out] constraints Level constraint object to populate.
+ */
+template <int dim>
+void
+establish_solid_domain_lsmg(const dealii::DoFHandler<dim> &dof_handler,
+                            const unsigned int             level,
+                            const dealii::IndexSet &locally_owned_mg_dofs,
+                            const bool              non_zero_constraints,
+                            dealii::AffineConstraints<double> &constraints);
+
 #endif

--- a/include/solvers/solid_constraints.h
+++ b/include/solvers/solid_constraints.h
@@ -21,12 +21,11 @@
  * Inherently, we assume that this fe has dim+1 component and corresponds
  * to a Navier-Stokes problem.
  *
- * @param[in] non_zero_constraints If this parameter is true, it indicates
- * that non-zero constraints are applied in the solid domain. If
- * this is set to false, homogeneous constraints are applied in the solid
- * domain.
- *
  * @param[in] local_dof_indices Vector of a cell's local DOF indices.
+ *
+ * @param[in] non_zero_constraints If this parameter is true, it indicates
+ * that the constraints used are non-zero constraints. If
+ * this is set to false, the constraints are zero constraints.
  *
  * @param[out] constraints Homogeneous constraints holding object.
  */
@@ -34,13 +33,13 @@ template <int dim>
 void
 constrain_solid_cell_velocity_dofs(
   const dealii::FiniteElement<dim>                   &fe,
-  const bool                                         &non_zero_constraints,
   const std::vector<dealii::types::global_dof_index> &local_dof_indices,
+  const bool                                         &non_zero_constraints,
   dealii::AffineConstraints<double>                  &constraints);
 
 /**
  * @brief Turn regions of the mesh where the @p material_id>0 into a solid
- * block by injecting velocity and pressure DOFs into the zero constraints.
+ * block by injecting velocity and pressure DOFs into the constraints.
  *
  * It is achieved by imposing \f$\mathbf{u}=0\f$ within the cells which have a
  * @p material_id>0. In addition, solid cells which are not connected to the
@@ -57,10 +56,15 @@ constrain_solid_cell_velocity_dofs(
  * be built at every level. In this case, this DoFHandler can be the
  * DoFHandler at any of the multigrid level.
  *
+ *
+ * @param[in] locally_owned_dofs The locally owned DoFs for the dof_handler.
+ * Used to filter pressure DoFs that should receive a
+ * Dirichlet constraint when their cell is fully
+ * disconnected from the fluid.
+ *
  * @param[in] non_zero_constraints If this parameter is true, it indicates
- * that non-zero constraints are being constrained for the solid domain. If
- * this is set to false, homogeneous constraints are constrained in the solid
- * domain.
+ * that the constraints used for the solid domainare the non-zero constraints.
+ * If this is set to false, the constraints being used are zero constraints.
  *
  * @param[in] constraints Set of constraints on which the solid domain
  * constraint is applied.

--- a/source/core/grid_uniform_channel_with_meshed_cylinder.cc
+++ b/source/core/grid_uniform_channel_with_meshed_cylinder.cc
@@ -35,7 +35,7 @@ GridUniformChannelWithMeshedCylinder<dim, spacedim>::
       AssertThrow(
         false,
         ExcMessage(
-          "Mandatory uniform channel with meshed cylinder parameters are (bottom left point : top right point : center of the cylinder : inner radius : outer radius). The points should be given as x,y and the radii should be given as a single number. The optional parameters are (pad bottom : pad top : pad left : pad right : height : n_slices : colorize). The padding parameters should be given as a single integer, the height should be given as a single double, the n_slices should be given as a single integer and the colorize parameter should be given as true/false."));
+          "Mandatory uniform channel with meshed cylinder parameters are (bottom left point : top right point : center of the cylinder : inner radius : outer radius). The points should be given as x,y and the radii should be given as a single number. The optional parameters are (pad bottom : pad top : pad left : pad right : height : n_slices : use_transfinite_region : colorize). The padding parameters should be given as a single integer, the height should be given as a single double, the n_slices should be given as a single integer, use_transfinite_region should be given as true/false, and the colorize parameter should be given as true/false."));
     }
   // Parse bottom_left point
   try
@@ -135,8 +135,10 @@ GridUniformChannelWithMeshedCylinder<dim, spacedim>::
     (arguments.size() > 9) ? Utilities::string_to_double(arguments[9]) : 1.0;
   this->n_slices =
     (arguments.size() > 10) ? Utilities::string_to_int(arguments[10]) : 2.;
-  this->colorize =
+  this->use_transfinite_region =
     (arguments.size() > 11 && arguments[11] == "true") ? true : false;
+  this->colorize =
+    (arguments.size() > 12 && arguments[12] == "true") ? true : false;
 }
 
 
@@ -155,6 +157,8 @@ GridUniformChannelWithMeshedCylinder<dim, spacedim>::generate_2d_channel_mesh(
   const unsigned int pad_right,
   const bool         colorize)
 {
+  const types::material_id fluid_material_id = 0;
+  const types::material_id solid_material_id = 1;
   const types::manifold_id tfi_manifold_id   = 0;
   const types::manifold_id polar_manifold_id = 1;
 
@@ -290,16 +294,20 @@ GridUniformChannelWithMeshedCylinder<dim, spacedim>::generate_2d_channel_mesh(
 
 
   // Assign material and manifold IDs:
-  //  - id 0 (TFI) on all cells and faces (default)
+  //  - id 0 (TFI) on all cells inside the transition region and on all faces
+  //  not on the inner cylinder boundary
   //  - id 1 (polar/cylindrical) on inner-cylinder boundary faces
   triangulation.reset_all_manifolds();
   triangulation.set_all_manifold_ids(tfi_manifold_id);
 
   for (const auto &cell : triangulation.active_cell_iterators())
     {
+      // The inner cylinder is marked with the polar manifold ID for the
+      // material and all faces that have all vertices on the inner circle are
+      // marked with the polar manifold ID for the manifold.
       if (cell->center().distance(center) < inner_radius)
         {
-          cell->set_material_id(polar_manifold_id);
+          cell->set_material_id(solid_material_id);
           for (const auto &face : cell->face_iterators())
             {
               bool all_vertices_on_circle = true;
@@ -317,9 +325,21 @@ GridUniformChannelWithMeshedCylinder<dim, spacedim>::generate_2d_channel_mesh(
                 face->set_all_manifold_ids(polar_manifold_id);
             }
         }
+      // If outside of the transition region, we can mark cells as flat manifold
+      // and fluid material.
+      else if (std::abs(cell->center()[0] - center[0]) >
+                 outer_radius + 1e-10 * outer_radius ||
+               std::abs(cell->center()[1] - center[1]) >
+                 outer_radius + 1e-10 * outer_radius)
+        {
+          cell->set_all_manifold_ids(numbers::flat_manifold_id);
+          cell->set_material_id(fluid_material_id);
+        }
+      // Every other cells stay with TFI manifold and gets the fluid material
+      // ID.
       else
         {
-          cell->set_material_id(tfi_manifold_id);
+          cell->set_material_id(fluid_material_id);
         }
     }
 
@@ -369,12 +389,19 @@ GridUniformChannelWithMeshedCylinder<2, 2>::make_grid(
                            colorize);
 
   // Attach manifold objects for proper refinement behavior
+  FlatManifold<2, 2> flat_manifold;
+  triangulation.set_manifold(numbers::flat_manifold_id, flat_manifold);
+
   PolarManifold<2, 2> polar_manifold(center);
   triangulation.set_manifold(1, polar_manifold);
 
-  TransfiniteInterpolationManifold<2> tfi_manifold;
-  tfi_manifold.initialize(triangulation);
-  triangulation.set_manifold(0, tfi_manifold);
+  triangulation.set_manifold(0, FlatManifold<2, 2>());
+  if (use_transfinite_region)
+    {
+      TransfiniteInterpolationManifold<2> tfi_manifold;
+      tfi_manifold.initialize(triangulation);
+      triangulation.set_manifold(0, tfi_manifold);
+    }
 }
 
 
@@ -404,13 +431,20 @@ GridUniformChannelWithMeshedCylinder<3, 3>::make_grid(
 
   // Attach 3D manifold objects. The manifold IDs (0 for TFI, 1 for
   // cylindrical) were inherited from the 2D mesh during extrusion.
+  FlatManifold<3, 3> flat_manifold;
+  triangulation.set_manifold(numbers::flat_manifold_id, flat_manifold);
+
   const Tensor<1, 3>           direction{{0.0, 0.0, 1.0}};
   const CylindricalManifold<3> cylindrical_manifold(direction, center);
   triangulation.set_manifold(1, cylindrical_manifold);
 
-  TransfiniteInterpolationManifold<3> tfi_manifold;
-  tfi_manifold.initialize(triangulation);
-  triangulation.set_manifold(0, tfi_manifold);
+  triangulation.set_manifold(0, FlatManifold<3, 3>());
+  if (use_transfinite_region)
+    {
+      TransfiniteInterpolationManifold<3> tfi_manifold;
+      tfi_manifold.initialize(triangulation);
+      triangulation.set_manifold(0, tfi_manifold);
+    }
 
   // Set the boundary ids for the extruded top and bottom faces.
   if (colorize)

--- a/source/core/grid_uniform_channel_with_meshed_cylinder.cc
+++ b/source/core/grid_uniform_channel_with_meshed_cylinder.cc
@@ -298,9 +298,8 @@ GridUniformChannelWithMeshedCylinder<dim, spacedim>::generate_2d_channel_mesh(
   //  not on the inner cylinder boundary
   //  - id 1 (polar/cylindrical) on inner-cylinder boundary faces
   triangulation.reset_all_manifolds();
-  const types::manifold_id fluid_manifold_id =
-    use_transfinite_region ? tfi_manifold_id : numbers::flat_manifold_id;
-  triangulation.set_all_manifold_ids(fluid_manifold_id);
+  triangulation.set_all_manifold_ids(
+    use_transfinite_region ? tfi_manifold_id : numbers::flat_manifold_id);
 
   for (const auto &cell : triangulation.active_cell_iterators())
     {
@@ -363,6 +362,19 @@ GridUniformChannelWithMeshedCylinder<dim, spacedim>::generate_2d_channel_mesh(
             face->set_boundary_id(3);
         }
     }
+
+  // Attach manifold objects for proper refinement behavior
+  PolarManifold<2, 2> polar_manifold(center);
+  triangulation.set_manifold(1, polar_manifold);
+
+  // If transfinite interpolation is enabled for the transition region, attach a
+  // TFI, else deal.II will use a default flat manifold.
+  if (use_transfinite_region)
+    {
+      TransfiniteInterpolationManifold<2> tfi_manifold;
+      tfi_manifold.initialize(triangulation);
+      triangulation.set_manifold(0, tfi_manifold);
+    }
 }
 
 
@@ -383,20 +395,6 @@ GridUniformChannelWithMeshedCylinder<2, 2>::make_grid(
                            pad_left,
                            pad_right,
                            colorize);
-
-  // Attach manifold objects for proper refinement behavior
-  FlatManifold<2, 2> flat_manifold;
-  triangulation.set_manifold(numbers::flat_manifold_id, flat_manifold);
-
-  PolarManifold<2, 2> polar_manifold(center);
-  triangulation.set_manifold(1, polar_manifold);
-
-  if (use_transfinite_region)
-    {
-      TransfiniteInterpolationManifold<2> tfi_manifold;
-      tfi_manifold.initialize(triangulation);
-      triangulation.set_manifold(0, tfi_manifold);
-    }
 }
 
 
@@ -426,9 +424,6 @@ GridUniformChannelWithMeshedCylinder<3, 3>::make_grid(
 
   // Attach 3D manifold objects. The manifold IDs (0 for TFI, 1 for
   // cylindrical) were inherited from the 2D mesh during extrusion.
-  FlatManifold<3, 3> flat_manifold;
-  triangulation.set_manifold(numbers::flat_manifold_id, flat_manifold);
-
   const Tensor<1, 3>           direction{{0.0, 0.0, 1.0}};
   const CylindricalManifold<3> cylindrical_manifold(direction, center);
   triangulation.set_manifold(1, cylindrical_manifold);

--- a/source/core/grid_uniform_channel_with_meshed_cylinder.cc
+++ b/source/core/grid_uniform_channel_with_meshed_cylinder.cc
@@ -298,14 +298,19 @@ GridUniformChannelWithMeshedCylinder<dim, spacedim>::generate_2d_channel_mesh(
   //  not on the inner cylinder boundary
   //  - id 1 (polar/cylindrical) on inner-cylinder boundary faces
   triangulation.reset_all_manifolds();
-  triangulation.set_all_manifold_ids(tfi_manifold_id);
+  const types::manifold_id fluid_manifold_id =
+    use_transfinite_region ? tfi_manifold_id : numbers::flat_manifold_id;
+  triangulation.set_all_manifold_ids(fluid_manifold_id);
 
   for (const auto &cell : triangulation.active_cell_iterators())
     {
+      // If cell center is within the inner_radius, it's in the cylinder.
+      bool cell_in_cylinder = cell->center().distance(center) < inner_radius;
+
       // The inner cylinder is marked with the polar manifold ID for the
       // material and all faces that have all vertices on the inner circle are
       // marked with the polar manifold ID for the manifold.
-      if (cell->center().distance(center) < inner_radius)
+      if (cell_in_cylinder)
         {
           cell->set_material_id(solid_material_id);
           for (const auto &face : cell->face_iterators())
@@ -325,19 +330,10 @@ GridUniformChannelWithMeshedCylinder<dim, spacedim>::generate_2d_channel_mesh(
                 face->set_all_manifold_ids(polar_manifold_id);
             }
         }
-      // If outside of the transition region, we can mark cells as flat manifold
-      // and fluid material.
-      else if (std::abs(cell->center()[0] - center[0]) >
-                 outer_radius + 1e-10 * outer_radius ||
-               std::abs(cell->center()[1] - center[1]) >
-                 outer_radius + 1e-10 * outer_radius)
-        {
-          cell->set_all_manifold_ids(numbers::flat_manifold_id);
-          cell->set_material_id(fluid_material_id);
-        }
-      // Every other cells stay with TFI manifold and gets the fluid material
-      // ID.
-      else
+
+      // Every other cells stay with the flat manifold and gets the fluid
+      // material ID.
+      if (!cell_in_cylinder)
         {
           cell->set_material_id(fluid_material_id);
         }
@@ -395,7 +391,6 @@ GridUniformChannelWithMeshedCylinder<2, 2>::make_grid(
   PolarManifold<2, 2> polar_manifold(center);
   triangulation.set_manifold(1, polar_manifold);
 
-  triangulation.set_manifold(0, FlatManifold<2, 2>());
   if (use_transfinite_region)
     {
       TransfiniteInterpolationManifold<2> tfi_manifold;
@@ -438,7 +433,6 @@ GridUniformChannelWithMeshedCylinder<3, 3>::make_grid(
   const CylindricalManifold<3> cylindrical_manifold(direction, center);
   triangulation.set_manifold(1, cylindrical_manifold);
 
-  triangulation.set_manifold(0, FlatManifold<3, 3>());
   if (use_transfinite_region)
     {
       TransfiniteInterpolationManifold<3> tfi_manifold;

--- a/source/core/grid_uniform_channel_with_meshed_square_prism.cc
+++ b/source/core/grid_uniform_channel_with_meshed_square_prism.cc
@@ -576,7 +576,7 @@ GridUniformChannelWithMeshedSquarePrism<2, 2>::make_grid(
                            colorize);
 
   // Attach manifold for id 0 required by deal.II
-  FlatManifold<2,2> FlatManifold;
+  FlatManifold<2, 2> FlatManifold;
   triangulation.set_manifold(0, FlatManifold);
 }
 
@@ -603,7 +603,7 @@ GridUniformChannelWithMeshedSquarePrism<3, 3>::make_grid(
 
   // Attach manifold id 0 on the 2D mesh before extrusion.
   // extrude_triangulation queries get_manifold() on the input 2D triangulation.
-  FlatManifold<2,2> FlatManifold_2d;
+  FlatManifold<2, 2> FlatManifold_2d;
   tria_2D.set_manifold(0, FlatManifold_2d);
 
   // Extrude the 2D cross-section along the z-axis. Manifold  and material IDs
@@ -612,7 +612,7 @@ GridUniformChannelWithMeshedSquarePrism<3, 3>::make_grid(
     tria_2D, n_slices, height, triangulation, true);
 
   // Attach manifold for id 0 required by deal.II
-  FlatManifold<3,3> FlatManifold;
+  FlatManifold<3, 3> FlatManifold;
   triangulation.set_manifold(0, FlatManifold);
 
   // Set the boundary ids for the extruded top and bottom faces.

--- a/source/core/grid_uniform_channel_with_meshed_square_prism.cc
+++ b/source/core/grid_uniform_channel_with_meshed_square_prism.cc
@@ -576,9 +576,8 @@ GridUniformChannelWithMeshedSquarePrism<2, 2>::make_grid(
                            colorize);
 
   // Attach manifold for id 0 required by deal.II
-  TransfiniteInterpolationManifold<2> tfi_manifold;
-  tfi_manifold.initialize(triangulation);
-  triangulation.set_manifold(0, tfi_manifold);
+  FlatManifold<2,2> FlatManifold;
+  triangulation.set_manifold(0, FlatManifold);
 }
 
 
@@ -604,9 +603,8 @@ GridUniformChannelWithMeshedSquarePrism<3, 3>::make_grid(
 
   // Attach manifold id 0 on the 2D mesh before extrusion.
   // extrude_triangulation queries get_manifold() on the input 2D triangulation.
-  TransfiniteInterpolationManifold<2> tfi_manifold_2d;
-  tfi_manifold_2d.initialize(tria_2D);
-  tria_2D.set_manifold(0, tfi_manifold_2d);
+  FlatManifold<2,2> FlatManifold_2d;
+  tria_2D.set_manifold(0, FlatManifold_2d);
 
   // Extrude the 2D cross-section along the z-axis. Manifold  and material IDs
   // from the 2D mesh are copied to the lateral faces of the 3D mesh.
@@ -614,9 +612,8 @@ GridUniformChannelWithMeshedSquarePrism<3, 3>::make_grid(
     tria_2D, n_slices, height, triangulation, true);
 
   // Attach manifold for id 0 required by deal.II
-  TransfiniteInterpolationManifold<3> tfi_manifold;
-  tfi_manifold.initialize(triangulation);
-  triangulation.set_manifold(0, tfi_manifold);
+  FlatManifold<3,3> FlatManifold;
+  triangulation.set_manifold(0, FlatManifold);
 
   // Set the boundary ids for the extruded top and bottom faces.
   if (colorize)

--- a/source/fem-dem/fluid_dynamics_vans_matrix_free_operators.cc
+++ b/source/fem-dem/fluid_dynamics_vans_matrix_free_operators.cc
@@ -318,8 +318,7 @@ VANSOperator<dim, number>::do_cell_integral_local(
   VectorizedArray<number> cell_mask(1.0);
   if (this->has_solids)
     {
-      Assert(cell < this->solid_cell_mask.size(),
-             ExcDimensionMismatch(cell, this->solid_cell_mask.size()));
+      AssertIndexRange(cell, this->solid_cell_mask.size());
       cell_mask = this->solid_cell_mask[cell];
     }
 

--- a/source/fem-dem/fluid_dynamics_vans_matrix_free_operators.cc
+++ b/source/fem-dem/fluid_dynamics_vans_matrix_free_operators.cc
@@ -314,6 +314,15 @@ VANSOperator<dim, number>::do_cell_integral_local(
 
   const unsigned int cell = integrator.get_current_cell_index();
 
+  // Solid-cell mask (1.0 for fluid lanes, 0.0 for solid lanes).
+  VectorizedArray<number> cell_mask(1.0);
+  if (this->has_solids)
+    {
+      Assert(cell < this->solid_cell_mask.size(),
+             ExcDimensionMismatch(cell, this->solid_cell_mask.size()));
+      cell_mask = this->solid_cell_mask[cell];
+    }
+
   // To identify whether the problem is transient or steady
   bool transient =
     (time_stepping_is_bdf(this->simulation_control->get_assembly_method())) ?
@@ -534,6 +543,14 @@ VANSOperator<dim, number>::do_cell_integral_local(
             }
         }
 
+      if (this->has_solids)
+        {
+          gradient_result = gradient_result * cell_mask;
+          value_result    = value_result * cell_mask;
+          if (this->enable_hessians_jacobian)
+            hessian_result = hessian_result * cell_mask;
+        }
+
       integrator.submit_gradient(gradient_result, q);
       integrator.submit_value(value_result, q);
 
@@ -585,6 +602,15 @@ VANSOperator<dim, number>::local_evaluate_residual(
       else
         integrator.evaluate(EvaluationFlags::values |
                             EvaluationFlags::gradients);
+
+      // Solid-cell mask (1.0 for fluid lanes, 0.0 for solid lanes).
+      VectorizedArray<number> cell_mask(1.0);
+      if (this->has_solids)
+        {
+          Assert(cell < this->solid_cell_mask.size(),
+                 ExcDimensionMismatch(cell, this->solid_cell_mask.size()));
+          cell_mask = this->solid_cell_mask[cell];
+        }
 
       // To identify whether the problem is transient or steady
       bool transient = (time_stepping_is_bdf(
@@ -775,6 +801,14 @@ VANSOperator<dim, number>::local_evaluate_residual(
                                              ((*bdf_coefs)[0] * value[i] +
                                               previous_time_derivatives[i]);
                 }
+            }
+
+          if (this->has_solids)
+            {
+              gradient_result = gradient_result * cell_mask;
+              value_result    = value_result * cell_mask;
+              if (this->enable_hessians_residual)
+                hessian_result = hessian_result * cell_mask;
             }
 
           integrator.submit_gradient(gradient_result, q);

--- a/source/solvers/CMakeLists.txt
+++ b/source/solvers/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(lethe-solvers
   postprocessing_scalar.cc
   signed_distance_transformation.cc
   simulation_parameters.cc
+  solid_constraints.cc
   source_terms.cc
   stabilization.cc
   time_harmonic_maxwell.cc
@@ -92,6 +93,7 @@ add_library(lethe-solvers
   ../../include/solvers/postprocessors.h
   ../../include/solvers/signed_distance_transformation.h
   ../../include/solvers/simulation_parameters.h
+  ../../include/solvers/solid_constraints.h
   ../../include/solvers/source_terms.h
   ../../include/solvers/stabilization.h
   ../../include/solvers/time_harmonic_maxwell.h

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -1654,6 +1654,12 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
 
           // If there are solid regions. Also establish them as part of the
           // multigrid
+          if (simulation_parameters.physical_properties_manager
+                .get_number_of_solids() > 0)
+            establish_solid_domain(level_dof_handler,
+                                   level_dof_handler.locally_owned_dofs(),
+                                   false,
+                                   level_constraint);
 
           // constraints
           level_constraint.close();

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -1653,6 +1653,8 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
             }
 
           // If there are solid regions. Also establish them as part of the
+          // multigrid
+
           // constraints
           level_constraint.close();
 

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -1652,6 +1652,8 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
                 level_constraint.add_line(min_index);
             }
 
+          // If there are solid regions. Also establish them as part of the
+          // constraints
           level_constraint.close();
 
           this->mg_setup_timer.leave_subsection("Set boundary conditions");

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -1154,6 +1154,29 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
                 levels[level].first, temp_constraints);
             }
 
+          // If there are solid regions, establish them as part of the
+          // multigrid by registering them as user constraints on
+          // mg_constrained_dofs (same pattern as the pressure-pin and slip
+          // BC handling above). This is required for LSMG: the smoother and
+          // transfer read Dirichlet info from mg_constrained_dofs, not from
+          // level_constraints. The subsequent merge_constraints call (with
+          // add_user_constraints = true) will then propagate them into
+          // level_constraints[level] for the operator.
+          if (simulation_parameters.physical_properties_manager
+                .get_number_of_solids() > 0)
+            {
+              AffineConstraints<double> solid_constraints;
+              solid_constraints.reinit(owned_dofs, relevant_dofs);
+              establish_solid_domain_lsmg(level_dof_handler,
+                                          levels[level].first,
+                                          owned_dofs,
+                                          false,
+                                          solid_constraints);
+              solid_constraints.close();
+              this->mg_constrained_dofs[p_level].add_user_constraints(
+                levels[level].first, solid_constraints);
+            }
+
           this->mg_constrained_dofs[p_level].merge_constraints(
             level_constraints[level],
             levels[level].first,

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -1639,8 +1639,7 @@ NavierStokesStabilizedOperator<dim, number>::do_cell_integral_local(
   VectorizedArray<number> cell_mask(1.0);
   if (this->has_solids)
     {
-      Assert(cell < this->solid_cell_mask.size(),
-             ExcDimensionMismatch(cell, this->solid_cell_mask.size()));
+      AssertIndexRange(cell, this->solid_cell_mask.size());
       cell_mask = this->solid_cell_mask[cell];
     }
 

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -1919,8 +1919,7 @@ NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
       VectorizedArray<number> cell_mask(1.0);
       if (this->has_solids)
         {
-          Assert(cell < this->solid_cell_mask.size(),
-                 ExcDimensionMismatch(cell, this->solid_cell_mask.size()));
+          AssertIndexRange(cell, this->solid_cell_mask.size());
           cell_mask = this->solid_cell_mask[cell];
         }
 
@@ -2182,8 +2181,7 @@ NavierStokesNonNewtonianStabilizedOperator<dim, number>::do_cell_integral_local(
   VectorizedArray<number> cell_mask(1.0);
   if (this->has_solids)
     {
-      Assert(cell < this->solid_cell_mask.size(),
-             ExcDimensionMismatch(cell, this->solid_cell_mask.size()));
+      AssertIndexRange(cell, this->solid_cell_mask.size());
       cell_mask = this->solid_cell_mask[cell];
     }
 
@@ -2455,8 +2453,7 @@ NavierStokesNonNewtonianStabilizedOperator<dim, number>::
       VectorizedArray<number> cell_mask(1.0);
       if (this->has_solids)
         {
-          Assert(cell < this->solid_cell_mask.size(),
-                 ExcDimensionMismatch(cell, this->solid_cell_mask.size()));
+          AssertIndexRange(cell, this->solid_cell_mask.size());
           cell_mask = this->solid_cell_mask[cell];
         }
 

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -193,6 +193,13 @@ NavierStokesOperatorBase<dim, number>::reinit(
 
   this->compute_element_size();
 
+  this->has_solids = (this->properties_manager &&
+                      this->properties_manager->get_number_of_solids() > 0);
+  if (this->has_solids)
+    this->compute_solid_cell_mask();
+  else
+    this->solid_cell_mask.clear();
+
   this->compute_forcing_term();
 
   bool_dof_mask = create_bool_dof_mask(dof_handler.get_fe(), quadrature);
@@ -296,6 +303,34 @@ NavierStokesOperatorBase<dim, number>::initialize_time_stepping_data() const
       // Otherwise, this is not a transient simulation
       data.is_transient = false;
       return data;
+    }
+}
+
+template <int dim, typename number>
+void
+NavierStokesOperatorBase<dim, number>::compute_solid_cell_mask()
+{
+  const unsigned int n_cells =
+    matrix_free.n_cell_batches() + matrix_free.n_ghost_cell_batches();
+  solid_cell_mask.resize(n_cells);
+
+  for (unsigned int cell = 0; cell < n_cells; ++cell)
+    {
+      // Inactive lanes never contribute to dst, but we set them to 0.0 for
+      // safety in case future code reads the mask before submission.
+      VectorizedArray<number> mask(0.0);
+
+      for (unsigned int lane = 0;
+           lane < matrix_free.n_active_entries_per_cell_batch(cell);
+           ++lane)
+        {
+          mask[lane] =
+            (matrix_free.get_cell_iterator(cell, lane)->material_id() == 0) ?
+              1.0 :
+              0.0;
+        }
+
+      solid_cell_mask[cell] = mask;
     }
 }
 
@@ -1598,6 +1633,17 @@ NavierStokesStabilizedOperator<dim, number>::do_cell_integral_local(
 
   const unsigned int cell = integrator.get_current_cell_index();
 
+  // Solid-cell mask (1.0 for fluid lanes, 0.0 for solid lanes). Suppresses
+  // contributions from solid cells, mirroring the matrix-based behavior
+  // where solid cells are skipped during assembly.
+  VectorizedArray<number> cell_mask(1.0);
+  if (this->has_solids)
+    {
+      Assert(cell < this->solid_cell_mask.size(),
+             ExcDimensionMismatch(cell, this->solid_cell_mask.size()));
+      cell_mask = this->solid_cell_mask[cell];
+    }
+
   // Time stepping data information structure.
   // We create a small helper structure that contains everything related to
   // the time-stepping process and carries out all the flag checking.
@@ -1808,6 +1854,14 @@ NavierStokesStabilizedOperator<dim, number>::do_cell_integral_local(
             }
         }
 
+      if (this->has_solids)
+        {
+          gradient_result = gradient_result * cell_mask;
+          value_result    = value_result * cell_mask;
+          if (this->enable_hessians_jacobian)
+            hessian_result = hessian_result * cell_mask;
+        }
+
       integrator.submit_gradient(gradient_result, q);
       integrator.submit_value(value_result, q);
 
@@ -1861,6 +1915,19 @@ NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
       else
         integrator.evaluate(EvaluationFlags::values |
                             EvaluationFlags::gradients);
+
+      // Solid-cell mask (1.0 for fluid lanes, 0.0 for solid lanes).
+      VectorizedArray<number> cell_mask(1.0);
+      if (this->has_solids)
+        {
+          Assert(cell < this->solid_cell_mask.size(),
+                 ExcDimensionMismatch(cell, this->solid_cell_mask.size()));
+          cell_mask = this->solid_cell_mask[cell];
+        }
+
+      // To identify whether mortar feature is enabled (use local variable for
+      // efficiency)
+      const bool enable_mortar = this->enable_mortar;
 
       // Time stepping data information structure.
       // We create a small helper structure that contains everything related to
@@ -2050,6 +2117,14 @@ NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
                 }
             }
 
+          if (this->has_solids)
+            {
+              gradient_result = gradient_result * cell_mask;
+              value_result    = value_result * cell_mask;
+              if (this->enable_hessians_residual)
+                hessian_result = hessian_result * cell_mask;
+            }
+
           integrator.submit_gradient(gradient_result, q);
           integrator.submit_value(value_result, q);
           if (this->enable_hessians_residual)
@@ -2107,6 +2182,15 @@ NavierStokesNonNewtonianStabilizedOperator<dim, number>::do_cell_integral_local(
     integrator.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
   const unsigned int cell = integrator.get_current_cell_index();
+
+  // Solid-cell mask (1.0 for fluid lanes, 0.0 for solid lanes).
+  VectorizedArray<number> cell_mask(1.0);
+  if (this->has_solids)
+    {
+      Assert(cell < this->solid_cell_mask.size(),
+             ExcDimensionMismatch(cell, this->solid_cell_mask.size()));
+      cell_mask = this->solid_cell_mask[cell];
+    }
 
   // Time stepping data information structure.
   // We create a small helper structure that contains everything related to
@@ -2314,6 +2398,14 @@ NavierStokesNonNewtonianStabilizedOperator<dim, number>::do_cell_integral_local(
             }
         }
 
+      if (this->has_solids)
+        {
+          gradient_result = gradient_result * cell_mask;
+          value_result    = value_result * cell_mask;
+          if (this->enable_hessians_jacobian)
+            hessian_result = hessian_result * cell_mask;
+        }
+
       integrator.submit_gradient(gradient_result, q);
       integrator.submit_value(value_result, q);
 
@@ -2363,6 +2455,15 @@ NavierStokesNonNewtonianStabilizedOperator<dim, number>::
       else
         integrator.evaluate(EvaluationFlags::values |
                             EvaluationFlags::gradients);
+
+      // Solid-cell mask (1.0 for fluid lanes, 0.0 for solid lanes).
+      VectorizedArray<number> cell_mask(1.0);
+      if (this->has_solids)
+        {
+          Assert(cell < this->solid_cell_mask.size(),
+                 ExcDimensionMismatch(cell, this->solid_cell_mask.size()));
+          cell_mask = this->solid_cell_mask[cell];
+        }
 
       // Time stepping data information structure.
       // We create a small helper structure that contains everything related to
@@ -2520,6 +2621,14 @@ NavierStokesNonNewtonianStabilizedOperator<dim, number>::
                       ((*bdf_coefficients)[0] * value[i] +
                        previous_time_derivatives[i]);
                 }
+            }
+
+          if (this->has_solids)
+            {
+              gradient_result = gradient_result * cell_mask;
+              value_result    = value_result * cell_mask;
+              if (this->enable_hessians_residual)
+                hessian_result = hessian_result * cell_mask;
             }
 
           integrator.submit_gradient(gradient_result, q);

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -1925,10 +1925,6 @@ NavierStokesStabilizedOperator<dim, number>::local_evaluate_residual(
           cell_mask = this->solid_cell_mask[cell];
         }
 
-      // To identify whether mortar feature is enabled (use local variable for
-      // efficiency)
-      const bool enable_mortar = this->enable_mortar;
-
       // Time stepping data information structure.
       // We create a small helper structure that contains everything related to
       // the time-stepping process and carries out all the flag checking.

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -15,6 +15,7 @@
 #include <solvers/postprocessing_cfd.h>
 #include <solvers/postprocessing_velocities.h>
 #include <solvers/postprocessors.h>
+#include <solvers/solid_constraints.h>
 
 #include <deal.II/distributed/fully_distributed_tria.h>
 #include <deal.II/distributed/grid_refinement.h>
@@ -2000,9 +2001,7 @@ NavierStokesBase<dim, VectorType, DofsType>::define_non_zero_constraints()
         }
     }
 
-  this->establish_solid_domain(*this->dof_handler,
-                               true,
-                               this->nonzero_constraints);
+  this->make_solid_domain(*this->dof_handler, true, this->nonzero_constraints);
 
   nonzero_constraints.close();
 }
@@ -2109,11 +2108,10 @@ NavierStokesBase<dim, VectorType, DofsType>::define_zero_constraints()
         {
           /*Default boundary condition*/
         }
+      /// TODO ADD ASSERTION for the default case here.
     }
 
-  this->establish_solid_domain(*this->dof_handler,
-                               false,
-                               this->zero_constraints);
+  this->make_solid_domain(*this->dof_handler, false, this->zero_constraints);
 
   this->zero_constraints.close();
 }
@@ -2433,7 +2431,7 @@ NavierStokesBase<dim, VectorType, DofsType>::set_solution_from_checkpoint(
 
 template <int dim, typename VectorType, typename DofsType>
 void
-NavierStokesBase<dim, VectorType, DofsType>::establish_solid_domain(
+NavierStokesBase<dim, VectorType, DofsType>::make_solid_domain(
   const DoFHandler<dim>     &dof_handler,
   const bool                 non_zero_constraints,
   AffineConstraints<double> &constraints)
@@ -2444,70 +2442,11 @@ NavierStokesBase<dim, VectorType, DofsType>::establish_solid_domain(
         .get_number_of_solids() == 0)
     return;
 
-  const unsigned int                   dofs_per_cell = this->fe->dofs_per_cell;
-  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
-
-  // We will need to identify which pressure degrees of freedom are connected to
-  // fluid region. For these, we won't establish a zero pressure constraint.
-  std::unordered_set<types::global_dof_index> dofs_are_connected_to_fluid;
-
-  // Loop through all cells to identify which cells are solid. This first step
-  // is used to 1) constraint the velocity degree of freedom to be zero in the
-  // solid region and 2) to identify which pressure degrees of freedom are
-  // connected to fluid cells
-  for (const auto &cell : dof_handler.active_cell_iterators())
-    {
-      if (cell->is_locally_owned() || cell->is_ghost())
-        {
-          cell->get_dof_indices(local_dof_indices);
-          // If the material_id is higher than 0, the region is a solid region.
-          // Constrain the velocity DOFs to be zero.
-          if (cell->material_id() > 0)
-            {
-              constrain_solid_cell_velocity_dofs(non_zero_constraints,
-                                                 local_dof_indices,
-                                                 constraints);
-            }
-          else
-            {
-              // Cell is a fluid cell and as such all the pressure DOFs of that
-              // cell are connected to the fluid. This will be used later on to
-              // identify which pressure cells to constrain.
-              flag_dofs_connected_to_fluid(local_dof_indices,
-                                           dofs_are_connected_to_fluid);
-            }
-        }
-    }
-
-  // All pressure DOFs that are not connected to a fluid cell are constrained
-  // to ensure that the system matrix has adequate conditioning.
-  for (const auto &cell : dof_handler.active_cell_iterators())
-    {
-      if (cell->is_locally_owned() || cell->is_ghost())
-        {
-          cell->get_dof_indices(local_dof_indices);
-          // If the material_id is > 0, the region is a solid region
-          if (cell->material_id() > 0)
-            {
-              // First check if the cell is connected to a fluid cell by
-              // checking if one of the DOF of the cell is connected to a fluid
-              // cell.
-              bool connected_to_fluid =
-                check_cell_is_connected_to_fluid(dofs_are_connected_to_fluid,
-                                                 local_dof_indices);
-
-              // All the pressure DOFs with the cell are not connected to the
-              // fluid. Consequently, we fix a constraint on these pressure
-              // DOFs.
-              if (!connected_to_fluid)
-                {
-                  constrain_pressure(non_zero_constraints,
-                                     local_dof_indices,
-                                     constraints);
-                }
-            }
-        }
-    }
+  // Otherwise we call the generic function to set the solid domain.
+  establish_solid_domain(dof_handler,
+                         locally_owned_dofs,
+                         non_zero_constraints,
+                         constraints);
 }
 
 template <int dim, typename VectorType, typename DofsType>
@@ -2669,7 +2608,8 @@ NavierStokesBase<dim, VectorType, DofsType>::
           temperature > stasis_constraint_struct.max_solid_temperature)
         return;
     }
-  constrain_solid_cell_velocity_dofs(false,
+  constrain_solid_cell_velocity_dofs(*this->fe,
+                                     false,
                                      local_dof_indices,
                                      this->dynamic_zero_constraints);
 }

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2000,7 +2000,9 @@ NavierStokesBase<dim, VectorType, DofsType>::define_non_zero_constraints()
         }
     }
 
-  this->establish_solid_domain(true);
+  this->establish_solid_domain(*this->dof_handler,
+                               true,
+                               this->nonzero_constraints);
 
   nonzero_constraints.close();
 }
@@ -2109,7 +2111,9 @@ NavierStokesBase<dim, VectorType, DofsType>::define_zero_constraints()
         }
     }
 
-  this->establish_solid_domain(false);
+  this->establish_solid_domain(*this->dof_handler,
+                               false,
+                               this->zero_constraints);
 
   this->zero_constraints.close();
 }
@@ -2430,7 +2434,9 @@ NavierStokesBase<dim, VectorType, DofsType>::set_solution_from_checkpoint(
 template <int dim, typename VectorType, typename DofsType>
 void
 NavierStokesBase<dim, VectorType, DofsType>::establish_solid_domain(
-  const bool non_zero_constraints)
+  const DoFHandler<dim>     &dof_handler,
+  const bool                 non_zero_constraints,
+  AffineConstraints<double> &constraints)
 {
   // If there are no solid regions, there is no work to be done and we can
   // return.
@@ -2449,7 +2455,7 @@ NavierStokesBase<dim, VectorType, DofsType>::establish_solid_domain(
   // is used to 1) constraint the velocity degree of freedom to be zero in the
   // solid region and 2) to identify which pressure degrees of freedom are
   // connected to fluid cells
-  for (const auto &cell : dof_handler->active_cell_iterators())
+  for (const auto &cell : dof_handler.active_cell_iterators())
     {
       if (cell->is_locally_owned() || cell->is_ghost())
         {
@@ -2460,7 +2466,7 @@ NavierStokesBase<dim, VectorType, DofsType>::establish_solid_domain(
             {
               constrain_solid_cell_velocity_dofs(non_zero_constraints,
                                                  local_dof_indices,
-                                                 this->zero_constraints);
+                                                 constraints);
             }
           else
             {
@@ -2475,7 +2481,7 @@ NavierStokesBase<dim, VectorType, DofsType>::establish_solid_domain(
 
   // All pressure DOFs that are not connected to a fluid cell are constrained
   // to ensure that the system matrix has adequate conditioning.
-  for (const auto &cell : dof_handler->active_cell_iterators())
+  for (const auto &cell : dof_handler.active_cell_iterators())
     {
       if (cell->is_locally_owned() || cell->is_ghost())
         {
@@ -2497,7 +2503,7 @@ NavierStokesBase<dim, VectorType, DofsType>::establish_solid_domain(
                 {
                   constrain_pressure(non_zero_constraints,
                                      local_dof_indices,
-                                     this->zero_constraints);
+                                     constraints);
                 }
             }
         }

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2609,8 +2609,8 @@ NavierStokesBase<dim, VectorType, DofsType>::
         return;
     }
   constrain_solid_cell_velocity_dofs(*this->fe,
-                                     false,
                                      local_dof_indices,
+                                     false,
                                      this->dynamic_zero_constraints);
 }
 

--- a/source/solvers/solid_constraints.cc
+++ b/source/solvers/solid_constraints.cc
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The Lethe Authors
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+
+#include <solvers/solid_constraints.h>

--- a/source/solvers/solid_constraints.cc
+++ b/source/solvers/solid_constraints.cc
@@ -2,3 +2,247 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <solvers/solid_constraints.h>
+
+#include <deal.II/base/index_set.h>
+
+#include <type_traits>
+#include <unordered_set>
+
+using namespace dealii;
+
+namespace
+{
+  /**
+   * @brief Flag DOFs connected to fluid cells.
+   */
+  template <int dim>
+  void
+  flag_dofs_connected_to_fluid(
+    const FiniteElement<dim>                    &fe,
+    const std::vector<types::global_dof_index>  &local_dof_indices,
+    std::unordered_set<types::global_dof_index> &dofs_are_connected_to_fluid)
+  {
+    for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
+      {
+        const unsigned int component = fe.system_to_component_index(i).first;
+        if (component == dim)
+          {
+            dofs_are_connected_to_fluid.insert(local_dof_indices[i]);
+          }
+      }
+  }
+
+  /**
+   * @brief Check if the cell is connected to a fluid cell.
+   */
+  bool
+  check_cell_is_connected_to_fluid(
+    const std::unordered_set<types::global_dof_index>
+                                               &dofs_are_connected_to_fluid,
+    const std::vector<types::global_dof_index> &local_dof_indices)
+  {
+    for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
+      {
+        auto search = dofs_are_connected_to_fluid.find(local_dof_indices[i]);
+        if (search != dofs_are_connected_to_fluid.end())
+          return true;
+      }
+    return false;
+  }
+
+  /**
+   * @brief Constrain pressure DOFs if cells are not connected to fluid and
+   * DOFs are locally owned.
+   */
+  template <int dim, typename DofsType>
+  void
+  constrain_pressure(
+    const FiniteElement<dim>                   &fe,
+    const bool                                 &non_zero_constraints,
+    const DofsType                             &locally_owned_dofs,
+    const std::vector<types::global_dof_index> &local_dof_indices,
+    AffineConstraints<double>                  &constraints)
+  {
+    for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
+      {
+        const unsigned int component = fe.system_to_component_index(i).first;
+
+        // Only pressure DOFs have an additional Dirichlet condition
+        if (component == dim) // pressure DOFs
+          {
+            // We only apply the constraint on the locally owned pressure DOFs
+            // since we have no way of verifying if the locally relevant DOFs
+            // are connected to a fluid cell.
+            bool dof_is_locally_owned = false;
+
+            // For the GLS-family of solvers, we only have a single index set
+            if constexpr (std::is_same_v<DofsType, IndexSet>)
+              {
+                dof_is_locally_owned =
+                  locally_owned_dofs.is_element(local_dof_indices[i]);
+              }
+
+            // For the GD-family of solvers, we have two index sets. One for
+            // velocities and one for pressure.
+            if constexpr (std::is_same_v<DofsType, std::vector<IndexSet>>)
+              {
+                dof_is_locally_owned =
+                  locally_owned_dofs[1].is_element(local_dof_indices[i]);
+              }
+
+            if (dof_is_locally_owned)
+              {
+                if (non_zero_constraints)
+                  {
+                    constraints.add_line(local_dof_indices[i]);
+                    constraints.set_inhomogeneity(local_dof_indices[i], 0);
+                  }
+                else
+                  {
+                    constraints.add_line(local_dof_indices[i]);
+                  }
+              }
+          }
+      }
+  }
+} // namespace
+
+template <int dim>
+void
+constrain_solid_cell_velocity_dofs(
+  const FiniteElement<dim>                   &fe,
+  const bool                                 &non_zero_constraints,
+  const std::vector<types::global_dof_index> &local_dof_indices,
+  AffineConstraints<double>                  &constraints)
+{
+  for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
+    {
+      const unsigned int component = fe.system_to_component_index(i).first;
+      if (component < dim) // velocity DOFs
+        {
+          // We apply a constraint to all DOFs in the solid region, whether
+          // they are locally owned or not.
+          if (non_zero_constraints)
+            {
+              constraints.add_line(local_dof_indices[i]);
+              constraints.set_inhomogeneity(local_dof_indices[i], 0);
+            }
+          else
+            constraints.add_line(local_dof_indices[i]);
+        }
+    }
+}
+
+template <int dim, typename DofsType>
+void
+establish_solid_domain(const DoFHandler<dim>     &dof_handler,
+                       const DofsType            &locally_owned_dofs,
+                       const bool                 non_zero_constraints,
+                       AffineConstraints<double> &constraints)
+{
+  const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+  // We will need to identify which pressure degrees of freedom are connected to
+  // fluid region. For these, we won't establish a zero pressure constraint.
+  std::unordered_set<types::global_dof_index> dofs_are_connected_to_fluid;
+
+  // Loop through all cells to identify which cells are solid. This first step
+  // is used to 1) constraint the velocity degree of freedom to be zero in the
+  // solid region and 2) to identify which pressure degrees of freedom are
+  // connected to fluid cells
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->is_locally_owned() || cell->is_ghost())
+        {
+          cell->get_dof_indices(local_dof_indices);
+          // If the material_id is higher than 0, the region is a solid region.
+          // Constrain the velocity DOFs to be zero.
+          if (cell->material_id() > 0)
+            {
+              constrain_solid_cell_velocity_dofs(dof_handler.get_fe(),
+                                                 non_zero_constraints,
+                                                 local_dof_indices,
+                                                 constraints);
+            }
+          else
+            {
+              // Cell is a fluid cell and as such all the pressure DOFs of that
+              // cell are connected to the fluid. This will be used later on to
+              // identify which pressure cells to constrain.
+              flag_dofs_connected_to_fluid(dof_handler.get_fe(),
+                                           local_dof_indices,
+                                           dofs_are_connected_to_fluid);
+            }
+        }
+    }
+
+  // All pressure DOFs that are not connected to a fluid cell are constrained
+  // to ensure that the system matrix has adequate conditioning.
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->is_locally_owned() || cell->is_ghost())
+        {
+          cell->get_dof_indices(local_dof_indices);
+          // If the material_id is > 0, the region is a solid region
+          if (cell->material_id() > 0)
+            {
+              // First check if the cell is connected to a fluid cell by
+              // checking if one of the DOF of the cell is connected to a fluid
+              // cell.
+              bool connected_to_fluid =
+                check_cell_is_connected_to_fluid(dofs_are_connected_to_fluid,
+                                                 local_dof_indices);
+
+              // All the pressure DOFs with the cell are not connected to the
+              // fluid. Consequently, we fix a constraint on these pressure
+              // DOFs.
+              if (!connected_to_fluid)
+                {
+                  constrain_pressure(dof_handler.get_fe(),
+                                     non_zero_constraints,
+                                     locally_owned_dofs,
+                                     local_dof_indices,
+                                     constraints);
+                }
+            }
+        }
+    }
+}
+
+// Explicit template instantiations
+template void
+constrain_solid_cell_velocity_dofs<2>(
+  const FiniteElement<2>                     &fe,
+  const bool                                 &non_zero_constraints,
+  const std::vector<types::global_dof_index> &local_dof_indices,
+  AffineConstraints<double>                  &constraints);
+template void
+constrain_solid_cell_velocity_dofs<3>(
+  const FiniteElement<3>                     &fe,
+  const bool                                 &non_zero_constraints,
+  const std::vector<types::global_dof_index> &local_dof_indices,
+  AffineConstraints<double>                  &constraints);
+
+template void
+establish_solid_domain<2, IndexSet>(const DoFHandler<2>       &dof_handler,
+                                    const IndexSet            &locally_owned_dofs,
+                                    const bool                 non_zero_constraints,
+                                    AffineConstraints<double> &constraints);
+template void
+establish_solid_domain<3, IndexSet>(const DoFHandler<3>       &dof_handler,
+                                    const IndexSet            &locally_owned_dofs,
+                                    const bool                 non_zero_constraints,
+                                    AffineConstraints<double> &constraints);
+template void
+establish_solid_domain<2, std::vector<IndexSet>>(
+  const DoFHandler<2>          &dof_handler,
+  const std::vector<IndexSet>  &locally_owned_dofs,
+  const bool                    non_zero_constraints,
+  AffineConstraints<double>    &constraints);
+template void
+establish_solid_domain<3, std::vector<IndexSet>>(
+  const DoFHandler<3>          &dof_handler,
+  const std::vector<IndexSet>  &locally_owned_dofs,
+  const bool                    non_zero_constraints,
+  AffineConstraints<double>    &constraints);

--- a/source/solvers/solid_constraints.cc
+++ b/source/solvers/solid_constraints.cc
@@ -3,6 +3,7 @@
 
 #include <solvers/solid_constraints.h>
 
+#include <deal.II/base/exceptions.h>
 #include <deal.II/base/index_set.h>
 
 #include <type_traits>
@@ -22,6 +23,14 @@ namespace
     const std::vector<types::global_dof_index>  &local_dof_indices,
     std::unordered_set<types::global_dof_index> &dofs_are_connected_to_fluid)
   {
+    Assert(fe.n_components() == dim + 1,
+           ExcMessage("The finite element passed to "
+                      "flag_dofs_connected_to_fluid must have dim+1 "
+                      "components (velocity + pressure). This routine is "
+                      "intended for fluid dynamics problems only."));
+    Assert(local_dof_indices.size() == fe.dofs_per_cell,
+           ExcDimensionMismatch(local_dof_indices.size(), fe.dofs_per_cell));
+
     for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
       {
         const unsigned int component = fe.system_to_component_index(i).first;
@@ -63,6 +72,26 @@ namespace
     const std::vector<types::global_dof_index> &local_dof_indices,
     AffineConstraints<double>                  &constraints)
   {
+    Assert(fe.n_components() == dim + 1,
+           ExcMessage("The finite element passed to constrain_pressure must "
+                      "have dim+1 components (velocity + pressure). This "
+                      "routine is intended for fluid dynamics problems only."));
+    Assert(local_dof_indices.size() == fe.dofs_per_cell,
+           ExcDimensionMismatch(local_dof_indices.size(), fe.dofs_per_cell));
+    static_assert(std::is_same_v<DofsType, IndexSet> ||
+                    std::is_same_v<DofsType, std::vector<IndexSet>>,
+                  "constrain_pressure only supports IndexSet (GLS family) or "
+                  "std::vector<IndexSet> (GD family) for the locally owned "
+                  "DOFs container.");
+    if constexpr (std::is_same_v<DofsType, std::vector<IndexSet>>)
+      {
+        Assert(locally_owned_dofs.size() == 2,
+               ExcMessage("For block (GD-family) solvers, the locally owned "
+                          "DOFs container must contain exactly two index "
+                          "sets: velocities (block 0) and pressure "
+                          "(block 1)."));
+      }
+
     for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
       {
         const unsigned int component = fe.system_to_component_index(i).first;
@@ -115,6 +144,14 @@ constrain_solid_cell_velocity_dofs(
   const std::vector<types::global_dof_index> &local_dof_indices,
   AffineConstraints<double>                  &constraints)
 {
+  Assert(fe.n_components() == dim + 1,
+         ExcMessage("The finite element passed to "
+                    "constrain_solid_cell_velocity_dofs must have dim+1 "
+                    "components (velocity + pressure). This routine is "
+                    "intended for fluid dynamics problems only."));
+  Assert(local_dof_indices.size() == fe.dofs_per_cell,
+         ExcDimensionMismatch(local_dof_indices.size(), fe.dofs_per_cell));
+
   for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
     {
       const unsigned int component = fe.system_to_component_index(i).first;
@@ -140,6 +177,12 @@ establish_solid_domain(const DoFHandler<dim>     &dof_handler,
                        const bool                 non_zero_constraints,
                        AffineConstraints<double> &constraints)
 {
+  Assert(dof_handler.get_fe().n_components() == dim + 1,
+         ExcMessage("The DoFHandler passed to establish_solid_domain must "
+                    "use a finite element with dim+1 components (velocity + "
+                    "pressure). This routine is intended for fluid dynamics "
+                    "problems only."));
+
   const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
@@ -225,24 +268,24 @@ constrain_solid_cell_velocity_dofs<3>(
   AffineConstraints<double>                  &constraints);
 
 template void
-establish_solid_domain<2, IndexSet>(const DoFHandler<2>       &dof_handler,
-                                    const IndexSet            &locally_owned_dofs,
-                                    const bool                 non_zero_constraints,
+establish_solid_domain<2, IndexSet>(const DoFHandler<2> &dof_handler,
+                                    const IndexSet      &locally_owned_dofs,
+                                    const bool           non_zero_constraints,
                                     AffineConstraints<double> &constraints);
 template void
-establish_solid_domain<3, IndexSet>(const DoFHandler<3>       &dof_handler,
-                                    const IndexSet            &locally_owned_dofs,
-                                    const bool                 non_zero_constraints,
+establish_solid_domain<3, IndexSet>(const DoFHandler<3> &dof_handler,
+                                    const IndexSet      &locally_owned_dofs,
+                                    const bool           non_zero_constraints,
                                     AffineConstraints<double> &constraints);
 template void
 establish_solid_domain<2, std::vector<IndexSet>>(
-  const DoFHandler<2>          &dof_handler,
-  const std::vector<IndexSet>  &locally_owned_dofs,
-  const bool                    non_zero_constraints,
-  AffineConstraints<double>    &constraints);
+  const DoFHandler<2>         &dof_handler,
+  const std::vector<IndexSet> &locally_owned_dofs,
+  const bool                   non_zero_constraints,
+  AffineConstraints<double>   &constraints);
 template void
 establish_solid_domain<3, std::vector<IndexSet>>(
-  const DoFHandler<3>          &dof_handler,
-  const std::vector<IndexSet>  &locally_owned_dofs,
-  const bool                    non_zero_constraints,
-  AffineConstraints<double>    &constraints);
+  const DoFHandler<3>         &dof_handler,
+  const std::vector<IndexSet> &locally_owned_dofs,
+  const bool                   non_zero_constraints,
+  AffineConstraints<double>   &constraints);

--- a/source/solvers/solid_constraints.cc
+++ b/source/solvers/solid_constraints.cc
@@ -140,8 +140,8 @@ template <int dim>
 void
 constrain_solid_cell_velocity_dofs(
   const FiniteElement<dim>                   &fe,
-  const bool                                 &non_zero_constraints,
   const std::vector<types::global_dof_index> &local_dof_indices,
+  const bool                                 &non_zero_constraints,
   AffineConstraints<double>                  &constraints)
 {
   Assert(fe.n_components() == dim + 1,
@@ -204,8 +204,8 @@ establish_solid_domain(const DoFHandler<dim>     &dof_handler,
           if (cell->material_id() > 0)
             {
               constrain_solid_cell_velocity_dofs(dof_handler.get_fe(),
-                                                 non_zero_constraints,
                                                  local_dof_indices,
+                                                 non_zero_constraints,
                                                  constraints);
             }
           else
@@ -286,8 +286,8 @@ establish_solid_domain_lsmg(const DoFHandler<dim>     &dof_handler,
       if (cell->material_id() > 0)
         {
           constrain_solid_cell_velocity_dofs(dof_handler.get_fe(),
-                                             non_zero_constraints,
                                              local_dof_indices,
+                                             non_zero_constraints,
                                              constraints);
         }
       else
@@ -329,14 +329,14 @@ establish_solid_domain_lsmg(const DoFHandler<dim>     &dof_handler,
 template void
 constrain_solid_cell_velocity_dofs<2>(
   const FiniteElement<2>                     &fe,
-  const bool                                 &non_zero_constraints,
   const std::vector<types::global_dof_index> &local_dof_indices,
+  const bool                                 &non_zero_constraints,
   AffineConstraints<double>                  &constraints);
 template void
 constrain_solid_cell_velocity_dofs<3>(
   const FiniteElement<3>                     &fe,
-  const bool                                 &non_zero_constraints,
   const std::vector<types::global_dof_index> &local_dof_indices,
+  const bool                                 &non_zero_constraints,
   AffineConstraints<double>                  &constraints);
 
 template void

--- a/source/solvers/solid_constraints.cc
+++ b/source/solvers/solid_constraints.cc
@@ -50,9 +50,9 @@ namespace
                                                &dofs_are_connected_to_fluid,
     const std::vector<types::global_dof_index> &local_dof_indices)
   {
-    for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
+    for (const auto &dof_index : local_dof_indices)
       {
-        auto search = dofs_are_connected_to_fluid.find(local_dof_indices[i]);
+        auto search = dofs_are_connected_to_fluid.find(dof_index);
         if (search != dofs_are_connected_to_fluid.end())
           return true;
       }

--- a/source/solvers/solid_constraints.cc
+++ b/source/solvers/solid_constraints.cc
@@ -33,7 +33,7 @@ namespace
 
     for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
       {
-        const unsigned int component = fe.system_to_component_index(i).first;
+        const int component = fe.system_to_component_index(i).first;
         if (component == dim)
           {
             dofs_are_connected_to_fluid.insert(local_dof_indices[i]);
@@ -94,7 +94,7 @@ namespace
 
     for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
       {
-        const unsigned int component = fe.system_to_component_index(i).first;
+        const int component = fe.system_to_component_index(i).first;
 
         // Only pressure DOFs have an additional Dirichlet condition
         if (component == dim) // pressure DOFs
@@ -154,7 +154,7 @@ constrain_solid_cell_velocity_dofs(
 
   for (unsigned int i = 0; i < local_dof_indices.size(); ++i)
     {
-      const unsigned int component = fe.system_to_component_index(i).first;
+      const int component = fe.system_to_component_index(i).first;
       if (component < dim) // velocity DOFs
         {
           // We apply a constraint to all DOFs in the solid region, whether

--- a/source/solvers/solid_constraints.cc
+++ b/source/solvers/solid_constraints.cc
@@ -253,6 +253,78 @@ establish_solid_domain(const DoFHandler<dim>     &dof_handler,
     }
 }
 
+template <int dim>
+void
+establish_solid_domain_lsmg(const DoFHandler<dim>     &dof_handler,
+                            const unsigned int         level,
+                            const IndexSet            &locally_owned_mg_dofs,
+                            const bool                 non_zero_constraints,
+                            AffineConstraints<double> &constraints)
+{
+  Assert(dof_handler.get_fe().n_components() == dim + 1,
+         ExcMessage("The DoFHandler passed to establish_solid_domain_lsmg "
+                    "must use a finite element with dim+1 components "
+                    "(velocity + pressure). This routine is intended for "
+                    "fluid dynamics problems only."));
+
+  const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+  // Pressure DOFs (in MG numbering on this level) that touch a fluid cell.
+  std::unordered_set<types::global_dof_index> dofs_are_connected_to_fluid;
+
+  // First pass: classify cells on this level. We must include both
+  // owned-on-level and ghost-on-level cells so that the connectivity
+  // information for pressure DOFs at the fluid/solid interface is complete.
+  for (const auto &cell : dof_handler.mg_cell_iterators_on_level(level))
+    {
+      if (cell->level_subdomain_id() == numbers::artificial_subdomain_id)
+        continue;
+
+      cell->get_mg_dof_indices(local_dof_indices);
+
+      if (cell->material_id() > 0)
+        {
+          constrain_solid_cell_velocity_dofs(dof_handler.get_fe(),
+                                             non_zero_constraints,
+                                             local_dof_indices,
+                                             constraints);
+        }
+      else
+        {
+          flag_dofs_connected_to_fluid(dof_handler.get_fe(),
+                                       local_dof_indices,
+                                       dofs_are_connected_to_fluid);
+        }
+    }
+
+  // Second pass: for solid cells fully disconnected from the fluid, pin the
+  // pressure to keep the system well posed.
+  for (const auto &cell : dof_handler.mg_cell_iterators_on_level(level))
+    {
+      if (cell->level_subdomain_id() == numbers::artificial_subdomain_id)
+        continue;
+
+      if (cell->material_id() > 0)
+        {
+          cell->get_mg_dof_indices(local_dof_indices);
+
+          const bool connected_to_fluid =
+            check_cell_is_connected_to_fluid(dofs_are_connected_to_fluid,
+                                             local_dof_indices);
+
+          if (!connected_to_fluid)
+            {
+              constrain_pressure(dof_handler.get_fe(),
+                                 non_zero_constraints,
+                                 locally_owned_mg_dofs,
+                                 local_dof_indices,
+                                 constraints);
+            }
+        }
+    }
+}
+
 // Explicit template instantiations
 template void
 constrain_solid_cell_velocity_dofs<2>(
@@ -283,6 +355,19 @@ establish_solid_domain<2, std::vector<IndexSet>>(
   const std::vector<IndexSet> &locally_owned_dofs,
   const bool                   non_zero_constraints,
   AffineConstraints<double>   &constraints);
+template void
+establish_solid_domain_lsmg<2>(const DoFHandler<2>       &dof_handler,
+                               const unsigned int         level,
+                               const IndexSet            &locally_owned_mg_dofs,
+                               const bool                 non_zero_constraints,
+                               AffineConstraints<double> &constraints);
+template void
+establish_solid_domain_lsmg<3>(const DoFHandler<3>       &dof_handler,
+                               const unsigned int         level,
+                               const IndexSet            &locally_owned_mg_dofs,
+                               const bool                 non_zero_constraints,
+                               AffineConstraints<double> &constraints);
+
 template void
 establish_solid_domain<3, std::vector<IndexSet>>(
   const DoFHandler<3>         &dof_handler,

--- a/tests/core/grid_uniform_channel_with_meshed_cylinder.cc
+++ b/tests/core/grid_uniform_channel_with_meshed_cylinder.cc
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The Lethe Authors
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+
+// Deal.II
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
+
+// Lethe
+#include <core/grid_uniform_channel_with_meshed_cylinder.h>
+
+// Tests (with common definitions)
+#include <../tests/tests.h>
+
+#include <fstream>
+#include <map>
+
+template <int dim>
+void
+run_test(const std::string &case_name,
+         const std::string &grid_arguments,
+         const unsigned int global_refinement = 0)
+{
+  deallog << "==================================================" << std::endl;
+  deallog << "Case: " << case_name << std::endl;
+  deallog << "Grid arguments: \"" << grid_arguments << "\"" << std::endl;
+
+  Triangulation<dim, dim>                        triangulation;
+  GridUniformChannelWithMeshedCylinder<dim, dim> grid(grid_arguments);
+  grid.make_grid(triangulation);
+
+  if (global_refinement > 0)
+    triangulation.refine_global(global_refinement);
+
+  deallog << "Number of active cells : " << triangulation.n_active_cells()
+          << std::endl;
+  deallog << "Number of vertices     : " << triangulation.n_vertices()
+          << std::endl;
+  deallog << "Mesh volume            : " << GridTools::volume(triangulation)
+          << std::endl;
+
+  // Count the number of faces per boundary id.
+  std::map<types::boundary_id, unsigned int> boundary_face_count;
+  for (const auto &cell : triangulation.active_cell_iterators())
+    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      if (cell->face(f)->at_boundary())
+        boundary_face_count[cell->face(f)->boundary_id()]++;
+
+  for (const auto &[id, count] : boundary_face_count)
+    deallog << "Boundary id " << static_cast<int>(id)
+            << " face count : " << count << std::endl;
+
+  // Write one VTK file per case for visual checks.
+  GridOut           go;
+  const std::string vtk_filename =
+    "grid_uniform_channel_with_meshed_cylinder_" + case_name + ".vtk";
+  std::ofstream vtk_out(vtk_filename);
+  go.write_vtk(triangulation, vtk_out);
+}
+
+
+int
+main()
+{
+  try
+    {
+      initlog();
+      run_test<2>("2D half-unit outer radius, no padding",
+                  "0,0:1,1:0.5,0.5:0.2:0.5");
+
+      run_test<2>("2D 2x1 channel, padded", "0,0:2,1:1,0.5:0.1:0.2:1:1:1:1");
+
+      run_test<2>("2D 2x1 channel, padded, refined once",
+                  "0,0:2,1:1,0.5:0.1:0.2:1:1:1:1",
+                  1);
+
+      run_test<3>("3D 2x1x1 channel, padded, boundary ids, and no TFI region",
+                  "0,0:2,1:1,0.5:0.1:0.2:1:1:1:1:1.0:2:false:true");
+
+      run_test<3>("3D 2x1x1 channel, padded, boundary ids, and TFI region",
+                  "0,0:2,1:1,0.5:0.1:0.2:1:1:1:1:1.0:2:true:true",
+                  1);
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+
+  return 0;
+}

--- a/tests/core/grid_uniform_channel_with_meshed_cylinder.cc
+++ b/tests/core/grid_uniform_channel_with_meshed_cylinder.cc
@@ -75,7 +75,8 @@ main()
                   1);
 
       run_test<3>("3D 2x1x1 channel, padded, boundary ids, and no TFI region",
-                  "0,0:2,1:1,0.5:0.1:0.2:1:1:1:1:1.0:2:false:true");
+                  "0,0:2,1:1,0.5:0.1:0.2:1:1:1:1:1.0:2:false:true",
+                  1);
 
       run_test<3>("3D 2x1x1 channel, padded, boundary ids, and TFI region",
                   "0,0:2,1:1,0.5:0.1:0.2:1:1:1:1:1.0:2:true:true",

--- a/tests/core/grid_uniform_channel_with_meshed_cylinder.output
+++ b/tests/core/grid_uniform_channel_with_meshed_cylinder.output
@@ -23,15 +23,15 @@ DEAL::Boundary id 0 face count : 32
 DEAL::==================================================
 DEAL::Case: 3D 2x1x1 channel, padded, boundary ids, and no TFI region
 DEAL::Grid arguments: "0,0:2,1:1,0.5:0.1:0.2:1:1:1:1:1.0:2:false:true"
-DEAL::Number of active cells : 32
-DEAL::Number of vertices     : 82
+DEAL::Number of active cells : 256
+DEAL::Number of vertices     : 435
 DEAL::Mesh volume            : 2.00000
-DEAL::Boundary id 0 face count : 4
-DEAL::Boundary id 1 face count : 4
-DEAL::Boundary id 2 face count : 4
-DEAL::Boundary id 3 face count : 4
-DEAL::Boundary id 4 face count : 32
-DEAL::Boundary id 5 face count : 32
+DEAL::Boundary id 0 face count : 16
+DEAL::Boundary id 1 face count : 16
+DEAL::Boundary id 2 face count : 16
+DEAL::Boundary id 3 face count : 16
+DEAL::Boundary id 4 face count : 128
+DEAL::Boundary id 5 face count : 128
 DEAL::==================================================
 DEAL::Case: 3D 2x1x1 channel, padded, boundary ids, and TFI region
 DEAL::Grid arguments: "0,0:2,1:1,0.5:0.1:0.2:1:1:1:1:1.0:2:true:true"

--- a/tests/core/grid_uniform_channel_with_meshed_cylinder.output
+++ b/tests/core/grid_uniform_channel_with_meshed_cylinder.output
@@ -1,0 +1,46 @@
+
+DEAL::==================================================
+DEAL::Case: 2D half-unit outer radius, no padding
+DEAL::Grid arguments: "0,0:1,1:0.5,0.5:0.2:0.5"
+DEAL::Number of active cells : 20
+DEAL::Number of vertices     : 25
+DEAL::Mesh volume            : 1.00000
+DEAL::Boundary id 0 face count : 8
+DEAL::==================================================
+DEAL::Case: 2D 2x1 channel, padded
+DEAL::Grid arguments: "0,0:2,1:1,0.5:0.1:0.2:1:1:1:1"
+DEAL::Number of active cells : 32
+DEAL::Number of vertices     : 41
+DEAL::Mesh volume            : 2.00000
+DEAL::Boundary id 0 face count : 16
+DEAL::==================================================
+DEAL::Case: 2D 2x1 channel, padded, refined once
+DEAL::Grid arguments: "0,0:2,1:1,0.5:0.1:0.2:1:1:1:1"
+DEAL::Number of active cells : 128
+DEAL::Number of vertices     : 145
+DEAL::Mesh volume            : 2.00000
+DEAL::Boundary id 0 face count : 32
+DEAL::==================================================
+DEAL::Case: 3D 2x1x1 channel, padded, boundary ids, and no TFI region
+DEAL::Grid arguments: "0,0:2,1:1,0.5:0.1:0.2:1:1:1:1:1.0:2:false:true"
+DEAL::Number of active cells : 32
+DEAL::Number of vertices     : 82
+DEAL::Mesh volume            : 2.00000
+DEAL::Boundary id 0 face count : 4
+DEAL::Boundary id 1 face count : 4
+DEAL::Boundary id 2 face count : 4
+DEAL::Boundary id 3 face count : 4
+DEAL::Boundary id 4 face count : 32
+DEAL::Boundary id 5 face count : 32
+DEAL::==================================================
+DEAL::Case: 3D 2x1x1 channel, padded, boundary ids, and TFI region
+DEAL::Grid arguments: "0,0:2,1:1,0.5:0.1:0.2:1:1:1:1:1.0:2:true:true"
+DEAL::Number of active cells : 256
+DEAL::Number of vertices     : 435
+DEAL::Mesh volume            : 2.00000
+DEAL::Boundary id 0 face count : 16
+DEAL::Boundary id 1 face count : 16
+DEAL::Boundary id 2 face count : 16
+DEAL::Boundary id 3 face count : 16
+DEAL::Boundary id 4 face count : 128
+DEAL::Boundary id 5 face count : 128


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

When using the matrix free solver with solid in the domain, the GMG preconditioner was not taking into the solid domain in the coarser level. It follows that the solver could not converge.

Additionally, the transfinite manifold is not supported for GMG, so it is now possible to disable it when necessary in the `grid_uniform_channel_with_meshed_cylinder` and `grid_uniform_channel_with_meshed_square_prism`. A test for the grid with the cylinder has also been added to the test suit of Lethe since it was missing.

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

### Solution

Bruno refactored the solid constraints so it can now apply the constraints on all levels of multi-grid preconditioner. The helper function is now on its own in `solid_constraints` instead of of being own by  NavierStokesBase. This way the matrix-free operator can call the function to update the different multi-grid level constraints. 

### Testing

This bug fix has been tested using the concentric heat exchanger example adapted from the examples of Lethe to run in matrix free. A custom PRM using the `grid_uniform_channel_with_meshed_cylinder` mesh and the matrix free solver has also been use to validate the solver. 

The changes in the custom Lethe mesh also now has a test to keep track of it.

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

### Documentation

No new documentation required.
<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge