### PR TITLE
Rename GridMotion class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
-- MINOR Addressing issue #1878, this PR renames the GridMotion class in `grid_motion.h` so that it differs from the one in `parameters_lagrangian.h` and hence avoids ambiguity at compilation time.
+- MINOR Addressing issue #1878, this PR renames the `GridMotion` class in `grid_motion.h` so that it differs from the one in `parameters_lagrangian.h` and hence avoids ambiguity at compilation time. [#1985](https://github.com/chaos-polymtl/lethe/pull/1985)
 
 ## [Master] - 2026/05/05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the Lethe project will be documented in this file.
 The changelog for the previous releases of Lethe are located in the release_notes folder.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2026/05/08
+
+### Changed
+
+- MINOR Addressing issue #1878, this PR renames the GridMotion class in `grid_motion.h` so that it differs from the one in `parameters_lagrangian.h` and hence avoids ambiguity at compilation time.
+
 ## [Master] - 2026/05/05
 
 ### Fixed

--- a/include/dem/dem.h
+++ b/include/dem/dem.h
@@ -332,7 +332,7 @@ private:
   /**
    * @brief The grid motion object.
    */
-  std::shared_ptr<::GridMotion<dim>> grid_motion_object;
+  std::shared_ptr<::GridMotionBase<dim>> grid_motion_object;
 
   /**
    * @brief The particle-particle contact force object.

--- a/include/dem/grid_motion.h
+++ b/include/dem/grid_motion.h
@@ -24,9 +24,9 @@ using namespace dealii;
  */
 
 template <int dim, int spacedim = dim>
-class GridMotion
+class GridMotionBase
 {
-  using FuncPtrType = void (GridMotion<dim, spacedim>::*)(
+  using FuncPtrType = void (GridMotionBase<dim, spacedim>::*)(
     Triangulation<dim, spacedim> &triangulation);
   FuncPtrType grid_motion;
 
@@ -39,7 +39,7 @@ public:
    * @param grid_motion_parameters DEM parameters defined using the parameter handler
    * @param dem_time_step DEM time step
    */
-  GridMotion(
+  GridMotionBase(
     const Parameters::Lagrangian::GridMotion<spacedim> &grid_motion_parameters,
     const double                                        dem_time_step);
 

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -111,7 +111,7 @@ DEMSolver<dim, PropertiesIndex>::setup_parameters()
                                size_distribution_object_container);
 
   // Set the grid motion type
-  grid_motion_object = std::make_shared<::GridMotion<dim, dim>>(
+  grid_motion_object = std::make_shared<::GridMotionBase<dim, dim>>(
     parameters.grid_motion, simulation_control->get_time_step());
 
   // Set up the solid objects

--- a/source/dem/grid_motion.cc
+++ b/source/dem/grid_motion.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <dem/dem_action_manager.h>
@@ -9,7 +9,7 @@
 using namespace dealii;
 
 template <int dim, int spacedim>
-GridMotion<dim, spacedim>::GridMotion(
+GridMotionBase<dim, spacedim>::GridMotionBase(
   const Parameters::Lagrangian::GridMotion<spacedim> &grid_motion_parameters,
   const double                                        dem_time_step)
 {
@@ -19,7 +19,7 @@ GridMotion<dim, spacedim>::GridMotion(
     {
       case Parameters::Lagrangian::GridMotion<spacedim>::MotionType::none:
         {
-          grid_motion = &GridMotion<dim, spacedim>::no_motion;
+          grid_motion = &GridMotionBase<dim, spacedim>::no_motion;
           break;
         }
       case Parameters::Lagrangian::GridMotion<spacedim>::MotionType::rotational:
@@ -27,7 +27,7 @@ GridMotion<dim, spacedim>::GridMotion(
           // Communicate to the action manager that there is a grid motion
           action_manager->set_grid_motion_enabled();
 
-          grid_motion = &GridMotion<dim, spacedim>::move_grid_rotational;
+          grid_motion = &GridMotionBase<dim, spacedim>::move_grid_rotational;
           rotation_angle =
             grid_motion_parameters.grid_rotational_speed * dem_time_step;
           rotation_axis = grid_motion_parameters.grid_rotational_axis;
@@ -40,7 +40,7 @@ GridMotion<dim, spacedim>::GridMotion(
           // grid motion
           action_manager->set_grid_motion_enabled();
 
-          grid_motion = &GridMotion<dim, spacedim>::move_grid_translational;
+          grid_motion = &GridMotionBase<dim, spacedim>::move_grid_translational;
           shift_vector =
             grid_motion_parameters.grid_translational_velocity * dem_time_step;
           break;
@@ -52,7 +52,7 @@ GridMotion<dim, spacedim>::GridMotion(
 
 template <>
 void
-GridMotion<1, 2>::move_grid_rotational(Triangulation<1, 2> &)
+GridMotionBase<1, 2>::move_grid_rotational(Triangulation<1, 2> &)
 {
   throw ExcImpossibleInDim(1);
   // TODO We need to add this function to GridTools for dim=1
@@ -61,14 +61,14 @@ GridMotion<1, 2>::move_grid_rotational(Triangulation<1, 2> &)
 
 template <>
 void
-GridMotion<2, 2>::move_grid_rotational(Triangulation<2, 2> &triangulation)
+GridMotionBase<2, 2>::move_grid_rotational(Triangulation<2, 2> &triangulation)
 {
   GridTools::rotate(rotation_angle, triangulation);
 }
 
 template <>
 void
-GridMotion<2, 3>::move_grid_rotational(Triangulation<2, 3> &triangulation)
+GridMotionBase<2, 3>::move_grid_rotational(Triangulation<2, 3> &triangulation)
 {
   Tensor<1, 3> axis({0, 0, 0});
   axis[rotation_axis] = 1;
@@ -77,7 +77,7 @@ GridMotion<2, 3>::move_grid_rotational(Triangulation<2, 3> &triangulation)
 
 template <>
 void
-GridMotion<3, 3>::move_grid_rotational(Triangulation<3, 3> &triangulation)
+GridMotionBase<3, 3>::move_grid_rotational(Triangulation<3, 3> &triangulation)
 {
   Tensor<1, 3> axis({0, 0, 0});
   axis[rotation_axis] = 1;
@@ -86,7 +86,7 @@ GridMotion<3, 3>::move_grid_rotational(Triangulation<3, 3> &triangulation)
 
 template <int dim, int spacedim>
 void
-GridMotion<dim, spacedim>::move_grid_translational(
+GridMotionBase<dim, spacedim>::move_grid_translational(
   Triangulation<dim, spacedim> &triangulation)
 {
   GridTools::shift(shift_vector, triangulation);
@@ -94,7 +94,7 @@ GridMotion<dim, spacedim>::move_grid_translational(
 
 template <int dim, int spacedim>
 void
-GridMotion<dim, spacedim>::
+GridMotionBase<dim, spacedim>::
   update_boundary_points_and_normal_vectors_in_contact_list(
     typename DEM::dem_data_structures<spacedim>::particle_wall_in_contact
       &particle_wall_pairs_in_contact,
@@ -137,7 +137,7 @@ GridMotion<dim, spacedim>::
     }
 }
 
-template class GridMotion<1, 2>;
-template class GridMotion<2, 2>;
-template class GridMotion<2, 3>;
-template class GridMotion<3, 3>;
+template class GridMotionBase<1, 2>;
+template class GridMotionBase<2, 2>;
+template class GridMotionBase<2, 3>;
+template class GridMotionBase<3, 3>;


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

Addressing issue #1878, this PR renames the `GridMotion` class in `grid_motion.h` so that it differs from the one in `parameters_lagrangian.h` and hence avoids ambiguity at compilation time.

### Testing

<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

No changes in tests.

### Documentation

<!-- Does this refactor modify or have new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge