### PR TITLE
Add function to identify a refinement step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
+- MINOR Addressing issue #1685, this PR adds a function `is_refinement_step()` to avoid repeating lines to obtain the `refinement_step` variable within the fluid dynamics solvers. [#1987](https://github.com/chaos-polymtl/lethe/pull/1987)
+
 - MINOR There were two functions, `get_step_number()` and `get_iteration_number()`, that returned the same `iteration_number` value. This PR deprecates `get_step_number()` and replaces it by get_iteration_number() everywhere in the code. [#1988](https://github.com/chaos-polymtl/lethe/pull/1988)
 
 ## [Master] - 2026/05/08

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -427,6 +427,8 @@ public:
 
   /**
    * @brief Check if the current step is a refinement step
+   *
+   * @param[in] MeshAdaptation Parameters that control dynamic mesh adaptation
    */
   bool
   is_refinement_step(const Parameters::MeshAdaptation &mesh_adaptation);

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -425,6 +425,11 @@ public:
     return time_step;
   }
 
+  /**
+   * @brief Check if the current step is a refinement step
+   */
+  bool
+  is_refinement_step(const Parameters::MeshAdaptation &mesh_adaptation);
 
   /**
    * @brief Print the current progress status of the simulation

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -74,6 +74,20 @@ SimulationControl::is_output_iteration()
     }
 }
 
+bool
+SimulationControl::is_refinement_step(
+  const Parameters::MeshAdaptation &mesh_adaptation)
+{
+  bool is_refinement_step;
+
+  if (mesh_adaptation.refinement_at_frequency)
+    is_refinement_step = get_iteration_number() % mesh_adaptation.frequency == 0;
+  else
+    is_refinement_step = get_iteration_number() == 0;
+
+  return is_refinement_step;
+}
+
 void
 SimulationControl::update_assembly_method()
 {

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -81,7 +81,8 @@ SimulationControl::is_refinement_step(
   bool is_refinement_step;
 
   if (mesh_adaptation.refinement_at_frequency)
-    is_refinement_step = get_iteration_number() % mesh_adaptation.frequency == 0;
+    is_refinement_step =
+      get_iteration_number() % mesh_adaptation.frequency == 0;
   else
     is_refinement_step = get_iteration_number() == 0;
 

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -821,18 +821,11 @@ template <int dim>
 void
 FluidDynamicsSharp<dim>::mesh_adapt_ib(const bool initial_refinement)
 {
-  bool refinement_step;
-  if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
-    refinement_step = this->simulation_control->get_iteration_number() %
-                        this->simulation_parameters.mesh_adaptation.frequency ==
-                      0;
-  else
-    refinement_step = this->simulation_control->get_iteration_number() == 0;
-
   // If this is not the initial refinement cycle nor a usual refinement step,
   // we refine the cells around immersed solids only if they have moved since
   // the last time step.
-  if (!initial_refinement && !refinement_step)
+  if (!initial_refinement && !this->simulation_control->is_refinement_step(
+                               this->simulation_parameters.mesh_adaptation))
     {
       bool stationary_particles = true;
       for (unsigned int p = 0; p < particles.size(); ++p)

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -205,19 +205,13 @@ FluidDynamicsMatrixBased<dim>::update_mortar_configuration()
 
   TimerOutput::Scope t(this->computing_timer, "Update mortar configuration");
 
-  bool refinement_step;
-  if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
-    refinement_step = this->simulation_control->get_iteration_number() %
-                        this->simulation_parameters.mesh_adaptation.frequency ==
-                      0;
-  else
-    refinement_step = this->simulation_control->get_iteration_number() == 0;
-
   // We need to update the mortar operator/evaluator, as well as the sparsity
   // pattern, at every iteration. Since this is already done within
   // setup_dofs(), which is called in refine_mesh(), here we make sure that,
   // when there is no mesh refinement, the mortar information is still updated
-  if (this->simulation_control->is_at_start() || !refinement_step ||
+  if (this->simulation_control->is_at_start() ||
+      !this->simulation_control->is_refinement_step(
+        this->simulation_parameters.mesh_adaptation) ||
       this->simulation_parameters.mesh_adaptation.type ==
         Parameters::MeshAdaptation::Type::none)
     {

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -3039,19 +3039,13 @@ FluidDynamicsMatrixFree<dim>::update_mortar_configuration()
 
   TimerOutput::Scope t(this->computing_timer, "Update mortar configuration");
 
-  bool refinement_step;
-  if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
-    refinement_step = this->simulation_control->get_iteration_number() %
-                        this->simulation_parameters.mesh_adaptation.frequency ==
-                      0;
-  else
-    refinement_step = this->simulation_control->get_iteration_number() == 0;
-
   // We need to update the mortar operator/evaluator, as well as the sparsity
   // pattern, at every iteration. Since this is already done within
   // setup_dofs(), which is called in refine_mesh(), here we make sure that,
   // when there is no mesh refinement, the mortar information is still updated
-  if (this->simulation_control->is_at_start() || !refinement_step ||
+  if (this->simulation_control->is_at_start() ||
+      !this->simulation_control->is_refinement_step(
+        this->simulation_parameters.mesh_adaptation) ||
       this->simulation_parameters.mesh_adaptation.type ==
         Parameters::MeshAdaptation::Type::none)
     {

--- a/source/solvers/fluid_dynamics_nitsche.cc
+++ b/source/solvers/fluid_dynamics_nitsche.cc
@@ -861,14 +861,8 @@ template <int dim, int spacedim>
 void
 FluidDynamicsNitsche<dim, spacedim>::refine_mesh()
 {
-  bool refinement_step;
-  if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
-    refinement_step = this->simulation_control->get_iteration_number() %
-                        this->simulation_parameters.mesh_adaptation.frequency ==
-                      0;
-  else
-    refinement_step = this->simulation_control->get_iteration_number() == 0;
-  if (refinement_step)
+  if (this->simulation_control->is_refinement_step(
+        this->simulation_parameters.mesh_adaptation))
     {
       // If no adaptation is to be carried out, get out of the function
       if (this->simulation_parameters.mesh_adaptation.type ==

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -784,14 +784,8 @@ template <int dim, typename VectorType, typename DofsType>
 void
 NavierStokesBase<dim, VectorType, DofsType>::refine_mesh()
 {
-  bool refinement_step;
-  if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
-    refinement_step = this->simulation_control->get_iteration_number() %
-                        this->simulation_parameters.mesh_adaptation.frequency ==
-                      0;
-  else
-    refinement_step = this->simulation_control->get_iteration_number() == 0;
-  if (refinement_step)
+  if (this->simulation_control->is_refinement_step(
+        this->simulation_parameters.mesh_adaptation))
     {
       if (this->simulation_parameters.mesh_adaptation.type ==
           Parameters::MeshAdaptation::Type::adaptive)


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

Addressing issue #1685, this PR adds a function `is_refinement_step()` to avoid repeating lines to obtain the `refinement_step` variable within the fluid dynamics solvers.

### Testing

<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

No changes in tests.

### Documentation

<!-- Does this refactor modify or have new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge