### PR TITLE
Unify get_step_number and get_iteration_number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the Lethe project will be documented in this file.
 The changelog for the previous releases of Lethe are located in the release_notes folder.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Master] - 2026/05/09
+
+### Changed
+
+- MINOR There were two functions, `get_step_number()` and `get_iteration_number()`, that returned the same `iteration_number` value. This PR deprecates `get_step_number()` and replaces it by get_iteration_number() everywhere in the code. [#1988](https://github.com/chaos-polymtl/lethe/pull/1988)
+
 ## [Master] - 2026/05/08
 
 ### Changed

--- a/include/core/simulation_control.h
+++ b/include/core/simulation_control.h
@@ -730,17 +730,6 @@ public:
   }
 
   /**
-   * @brief Get step number (alias for get_iteration_number)
-   *
-   * @return Current iteration/step number
-   */
-  unsigned int
-  get_step_number() const
-  {
-    return iteration_number;
-  }
-
-  /**
    * @brief Get number of mesh subdivisions for output
    *
    * @return Number of mesh subdivisions to be used when outputting the results

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/lethe_grid_tools.h>
@@ -532,7 +532,7 @@ SerialSolid<dim, spacedim>::write_output_results(
                Utilities::int_to_string(id, 2);
       }
   }();
-  const unsigned int iter        = simulation_control->get_step_number();
+  const unsigned int iter        = simulation_control->get_iteration_number();
   const double       time        = simulation_control->get_current_time();
   const unsigned int group_files = simulation_control->get_group_files();
 

--- a/source/core/simulation_control.cc
+++ b/source/core/simulation_control.cc
@@ -70,7 +70,7 @@ SimulationControl::is_output_iteration()
   else
     {
       // Check if the current step number matches the output frequency
-      return (get_step_number() % output_iteration_frequency == 0);
+      return (get_iteration_number() % output_iteration_frequency == 0);
     }
 }
 
@@ -184,7 +184,7 @@ SimulationControl::get_number_of_stages(
 bool
 SimulationControl::is_verbose_iteration()
 {
-  return (get_step_number() % log_frequency == 0);
+  return (get_iteration_number() % log_frequency == 0);
 }
 
 void
@@ -407,7 +407,7 @@ SimulationControlTransient::is_output_iteration()
           // Check if the current step number matches the following condition:
           // (The step number matches the output frequency OR is the last
           // time step) AND the current time is within the output time interval
-          return ((get_step_number() % output_iteration_frequency == 0 ||
+          return ((get_iteration_number() % output_iteration_frequency == 0 ||
                    is_at_end()) &&
                   get_current_time() >= output_time_interval[0] &&
                   get_current_time() <= output_time_interval[1]);

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -428,7 +428,7 @@ inline void
 DEMSolver<dim, PropertiesIndex>::check_contact_search_iteration_dynamic()
 {
   const bool parallel_update =
-    (simulation_control->get_step_number() %
+    (simulation_control->get_iteration_number() %
      parameters.model_parameters.contact_detection_frequency) == 0;
   find_particle_contact_detection_step<dim, PropertiesIndex>(
     particle_handler,
@@ -443,7 +443,7 @@ template <int dim, typename PropertiesIndex>
 inline void
 DEMSolver<dim, PropertiesIndex>::check_contact_search_iteration_constant()
 {
-  if ((simulation_control->get_step_number() %
+  if ((simulation_control->get_iteration_number() %
        parameters.model_parameters.contact_detection_frequency) == 0)
     action_manager->contact_detection_step();
 }
@@ -457,9 +457,9 @@ DEMSolver<dim, PropertiesIndex>::insert_particles()
   if (parameters.insertion_info.insertion_frequency == 0)
     return;
 
-  if ((simulation_control->get_step_number() %
+  if ((simulation_control->get_iteration_number() %
        parameters.insertion_info.insertion_frequency) == 1 ||
-      simulation_control->get_step_number() == 1)
+      simulation_control->get_iteration_number() == 1)
     {
       insertion_object->insert(particle_handler, triangulation, parameters);
 
@@ -633,7 +633,7 @@ DEMSolver<dim, PropertiesIndex>::write_output_results()
   const std::string folder = parameters.simulation_control.output_folder;
   const std::string particles_solution_name =
     parameters.simulation_control.output_name;
-  const unsigned int iter        = simulation_control->get_step_number();
+  const unsigned int iter        = simulation_control->get_iteration_number();
   const double       time        = simulation_control->get_current_time();
   const unsigned int group_files = parameters.simulation_control.group_files;
 
@@ -698,15 +698,16 @@ DEMSolver<dim, PropertiesIndex>::post_process_results()
   if (parameters.post_processing.lagrangian_post_processing_enabled &&
       simulation_control->is_output_iteration())
     {
-      write_post_processing_results<dim>(triangulation,
-                                         grid_pvdhandler,
-                                         background_dh,
-                                         particle_handler,
-                                         parameters,
-                                         simulation_control->get_current_time(),
-                                         simulation_control->get_step_number(),
-                                         mpi_communicator,
-                                         sparse_contacts_object);
+      write_post_processing_results<dim>(
+        triangulation,
+        grid_pvdhandler,
+        background_dh,
+        particle_handler,
+        parameters,
+        simulation_control->get_current_time(),
+        simulation_control->get_iteration_number(),
+        mpi_communicator,
+        sparse_contacts_object);
     }
 }
 
@@ -723,7 +724,7 @@ DEMSolver<dim, PropertiesIndex>::report_statistics()
     std::min(number_of_list_built_since_last_log, contact_list.min);
   contact_list.total += number_of_list_built_since_last_log;
   contact_list.average = contact_list.total /
-                         (simulation_control->get_step_number()) *
+                         (simulation_control->get_iteration_number()) *
                          simulation_control->get_log_frequency();
 
   // Calculate statistics on the particles
@@ -1032,7 +1033,7 @@ DEMSolver<dim, PropertiesIndex>::solve()
 
       if (!disable_position_integration)
         {
-          if (simulation_control->get_step_number() == 0)
+          if (simulation_control->get_iteration_number() == 0)
             {
               integrator_object->integrate_half_step_location(
                 particle_handler,
@@ -1074,7 +1075,7 @@ DEMSolver<dim, PropertiesIndex>::solve()
       if (parameters.forces_torques.calculate_force_torque)
         {
           if ((this_mpi_process == 0) &&
-              (simulation_control->get_step_number() %
+              (simulation_control->get_iteration_number() %
                  parameters.forces_torques.output_frequency ==
                0) &&
               (parameters.forces_torques.force_torque_verbosity ==
@@ -1082,9 +1083,9 @@ DEMSolver<dim, PropertiesIndex>::solve()
             {
               write_forces_torques_output_locally(
                 forces_boundary_information[simulation_control
-                                              ->get_step_number()],
+                                              ->get_iteration_number()],
                 torques_boundary_information[simulation_control
-                                               ->get_step_number()]);
+                                               ->get_iteration_number()]);
             }
         }
 
@@ -1093,7 +1094,7 @@ DEMSolver<dim, PropertiesIndex>::solve()
 
       // Write checkpoint if needed
       if (checkpoint_controller.is_checkpoint_time_step(
-            simulation_control->get_step_number()))
+            simulation_control->get_iteration_number()))
         {
           write_checkpoint(computing_timer,
                            parameters,

--- a/source/dem/load_balancing.cc
+++ b/source/dem/load_balancing.cc
@@ -18,7 +18,7 @@ template <int dim, typename PropertiesIndex>
 inline void
 LagrangianLoadBalancing<dim, PropertiesIndex>::check_load_balance_once() const
 {
-  if (simulation_control->get_step_number() == load_balance_step)
+  if (simulation_control->get_iteration_number() == load_balance_step)
     DEMActionManager::get_action_manager()->load_balance_step();
 }
 
@@ -27,7 +27,8 @@ inline void
 LagrangianLoadBalancing<dim, PropertiesIndex>::check_load_balance_frequent()
   const
 {
-  if ((simulation_control->get_step_number() % load_balance_frequency) == 0)
+  if ((simulation_control->get_iteration_number() % load_balance_frequency) ==
+      0)
     DEMActionManager::get_action_manager()->load_balance_step();
 }
 
@@ -35,7 +36,7 @@ template <int dim, typename PropertiesIndex>
 inline void
 LagrangianLoadBalancing<dim, PropertiesIndex>::check_load_balance_dynamic()
 {
-  if (simulation_control->get_step_number() % dynamic_check_frequency == 0)
+  if (simulation_control->get_iteration_number() % dynamic_check_frequency == 0)
     {
       unsigned int maximum_particle_number_on_proc =
         Utilities::MPI::max(particle_handler->n_locally_owned_particles(),
@@ -59,7 +60,7 @@ inline void
 LagrangianLoadBalancing<dim, PropertiesIndex>::
   check_load_balance_with_sparse_contacts()
 {
-  if (simulation_control->get_step_number() % dynamic_check_frequency == 0)
+  if (simulation_control->get_iteration_number() % dynamic_check_frequency == 0)
     {
       // Process to accumulate the load of each process regards the number
       // of cells and particles with their selected weight and with a factor

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -928,9 +928,9 @@ CFDDEMSolver<dim>::insert_particles()
   const auto parallel_triangulation =
     dynamic_cast<parallel::distributed::Triangulation<dim> *>(
       &*this->triangulation);
-  if ((this->simulation_control->get_step_number() %
+  if ((this->simulation_control->get_iteration_number() %
        dem_parameters.insertion_info.insertion_frequency) == 1 ||
-      this->simulation_control->get_step_number() == 1)
+      this->simulation_control->get_iteration_number() == 1)
     {
       insertion_object->insert(this->particle_handler,
                                *parallel_triangulation,
@@ -986,7 +986,7 @@ CFDDEMSolver<dim>::write_dem_output_results()
   const std::string folder = dem_parameters.simulation_control.output_folder;
   const std::string particles_solution_name =
     dem_parameters.simulation_control.output_name + "_particles";
-  const unsigned int iter = this->simulation_control->get_step_number();
+  const unsigned int iter = this->simulation_control->get_iteration_number();
   const double       time = this->simulation_control->get_current_time();
   const unsigned int group_files =
     dem_parameters.simulation_control.group_files;
@@ -1019,7 +1019,7 @@ CFDDEMSolver<dim>::report_particle_statistics()
     std::min(number_of_list_built_since_last_log, contact_list.min);
   contact_list.total   = double(contact_search_total_number);
   contact_list.average = contact_list.total /
-                         (this->simulation_control->get_step_number()) *
+                         (this->simulation_control->get_iteration_number()) *
                          this->simulation_control->get_log_frequency();
 
   // Calculate statistics on the particles
@@ -1094,7 +1094,7 @@ CFDDEMSolver<dim>::report_particle_statistics()
         this->particle_handler,
         dem_parameters,
         this->simulation_control->get_current_time(),
-        this->simulation_control->get_step_number(),
+        this->simulation_control->get_iteration_number(),
         this->mpi_communicator,
         sparse_contacts_object);
     }
@@ -1226,7 +1226,7 @@ CFDDEMSolver<dim>::postprocess_cfd_dem()
         }
 
       // Output pressure drop to a text file from processor 0
-      if ((this->simulation_control->get_step_number() %
+      if ((this->simulation_control->get_iteration_number() %
              this->simulation_parameters.post_processing.output_frequency ==
            0) &&
           this->this_mpi_process == 0)
@@ -1269,7 +1269,7 @@ CFDDEMSolver<dim>::dynamic_flow_control()
       this->flow_control.calculate_beta(
         average_velocity,
         this->simulation_control->get_time_step(),
-        this->simulation_control->get_step_number());
+        this->simulation_control->get_iteration_number());
 
       Tensor<1, 3> beta_particle;
       if (this->simulation_parameters.flow_control.enable_beta_particle)
@@ -1295,7 +1295,7 @@ CFDDEMSolver<dim>::dynamic_flow_control()
       // Showing results
       if (this->simulation_parameters.flow_control.verbosity ==
             Parameters::Verbosity::verbose &&
-          this->simulation_control->get_step_number() > 0 &&
+          this->simulation_control->get_iteration_number() > 0 &&
           this->this_mpi_process == 0)
         {
           announce_string(this->pcout, "Flow control summary");
@@ -1396,7 +1396,7 @@ CFDDEMSolver<dim>::dem_iterator()
   // In the first step, we have to obtain location of particles at half-step
   // time
   // TODO do all DEM time step at first CFD time step are half step?
-  if (this->simulation_control->get_step_number() == 0)
+  if (this->simulation_control->get_iteration_number() == 0)
     {
       integrator_object->integrate_half_step_location(
         this->particle_handler, g, dem_time_step, torque, force, MOI);

--- a/source/fem-dem/cfd_dem_coupling_matrix_free.cc
+++ b/source/fem-dem/cfd_dem_coupling_matrix_free.cc
@@ -975,9 +975,9 @@ CFDDEMMatrixFree<dim>::insert_particles()
   const auto parallel_triangulation =
     dynamic_cast<parallel::distributed::Triangulation<dim> *>(
       &*this->triangulation);
-  if ((this->simulation_control->get_step_number() %
+  if ((this->simulation_control->get_iteration_number() %
        dem_parameters.insertion_info.insertion_frequency) == 1 ||
-      this->simulation_control->get_step_number() == 1)
+      this->simulation_control->get_iteration_number() == 1)
     {
       insertion_object->insert(this->particle_handler,
                                *parallel_triangulation,
@@ -1034,7 +1034,7 @@ CFDDEMMatrixFree<dim>::write_dem_output_results()
   const std::string folder = dem_parameters.simulation_control.output_folder;
   const std::string particles_solution_name =
     dem_parameters.simulation_control.output_name + "_particles";
-  const unsigned int iter = this->simulation_control->get_step_number();
+  const unsigned int iter = this->simulation_control->get_iteration_number();
   const double       time = this->simulation_control->get_current_time();
   const unsigned int group_files =
     dem_parameters.simulation_control.group_files;
@@ -1070,7 +1070,7 @@ CFDDEMMatrixFree<dim>::report_particle_statistics()
     std::min(number_of_list_built_since_last_log, contact_list.min);
   contact_list.total   = double(contact_search_total_number);
   contact_list.average = contact_list.total /
-                         (this->simulation_control->get_step_number()) *
+                         (this->simulation_control->get_iteration_number()) *
                          this->simulation_control->get_log_frequency();
 
   // Calculate statistics on the particles
@@ -1145,7 +1145,7 @@ CFDDEMMatrixFree<dim>::report_particle_statistics()
         this->particle_handler,
         dem_parameters,
         this->simulation_control->get_current_time(),
-        this->simulation_control->get_step_number(),
+        this->simulation_control->get_iteration_number(),
         this->mpi_communicator,
         sparse_contacts_object);
     }
@@ -1207,7 +1207,7 @@ CFDDEMMatrixFree<dim>::postprocess_cfd_dem()
         }
 
       // Output pressure drop to a text file from processor 0
-      if ((this->simulation_control->get_step_number() %
+      if ((this->simulation_control->get_iteration_number() %
              this->simulation_parameters.post_processing.output_frequency ==
            0) &&
           this->this_mpi_process == 0)
@@ -1251,7 +1251,7 @@ CFDDEMMatrixFree<dim>::dynamic_flow_control()
       this->flow_control.calculate_beta(
         average_velocity,
         this->simulation_control->get_time_step(),
-        this->simulation_control->get_step_number());
+        this->simulation_control->get_iteration_number());
 
       Tensor<1, 3> beta_particle;
       if (this->simulation_parameters.flow_control.enable_beta_particle)
@@ -1277,7 +1277,7 @@ CFDDEMMatrixFree<dim>::dynamic_flow_control()
       // Showing results
       if (this->simulation_parameters.flow_control.verbosity ==
             Parameters::Verbosity::verbose &&
-          this->simulation_control->get_step_number() > 0 &&
+          this->simulation_control->get_iteration_number() > 0 &&
           this->this_mpi_process == 0)
         {
           announce_string(this->pcout, "Flow control summary");
@@ -1373,7 +1373,7 @@ CFDDEMMatrixFree<dim>::dem_iterator()
   // In the first step, we have to obtain location of particles at half-step
   // time
   // TODO do all DEM time step at first CFD time step are half step?
-  if (this->simulation_control->get_step_number() == 0)
+  if (this->simulation_control->get_iteration_number() == 0)
     {
       integrator_object->integrate_half_step_location(this->particle_handler,
                                                       g,

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -3333,7 +3333,8 @@ FluidDynamicsSharp<dim>::handle_dem_particle_output_and_postprocessing()
         this->simulation_parameters.simulation_control.output_folder;
       const std::string particles_solution_name =
         this->simulation_parameters.particlesParameters->ib_particles_pvd_file;
-      const unsigned int iter = this->simulation_control->get_step_number();
+      const unsigned int iter =
+        this->simulation_control->get_iteration_number();
       const double       time = this->simulation_control->get_current_time();
       const unsigned int group_files =
         this->simulation_parameters.simulation_control.group_files;
@@ -5186,8 +5187,8 @@ FluidDynamicsSharp<dim>::solve()
                                                    *this->dof_handler,
                                                    *this->face_quadrature,
                                                    *this->mapping);
-          if (this->simulation_control->get_step_number() == 0 ||
-              this->simulation_control->get_step_number() %
+          if (this->simulation_control->get_iteration_number() == 0 ||
+              this->simulation_control->get_iteration_number() %
                   this->simulation_parameters.particlesParameters
                     ->contact_search_frequency ==
                 0)

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -823,11 +823,11 @@ FluidDynamicsSharp<dim>::mesh_adapt_ib(const bool initial_refinement)
 {
   bool refinement_step;
   if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
-    refinement_step = this->simulation_control->get_step_number() %
+    refinement_step = this->simulation_control->get_iteration_number() %
                         this->simulation_parameters.mesh_adaptation.frequency ==
                       0;
   else
-    refinement_step = this->simulation_control->get_step_number() == 0;
+    refinement_step = this->simulation_control->get_iteration_number() == 0;
 
   // If this is not the initial refinement cycle nor a usual refinement step,
   // we refine the cells around immersed solids only if they have moved since

--- a/source/solvers/cahn_hilliard.cc
+++ b/source/solvers/cahn_hilliard.cc
@@ -706,7 +706,7 @@ CahnHilliard<dim>::postprocess(bool first_iteration)
   if (simulation_parameters.post_processing.calculate_phase_statistics)
     {
       calculate_phase_statistics();
-      if (simulation_control->get_step_number() %
+      if (simulation_control->get_iteration_number() %
             this->simulation_parameters.post_processing.output_frequency ==
           0)
         this->write_phase_statistics();
@@ -716,7 +716,7 @@ CahnHilliard<dim>::postprocess(bool first_iteration)
     {
       calculate_phase_energy();
       // Output phase energies to a text file from processor 0
-      if (simulation_control->get_step_number() %
+      if (simulation_control->get_iteration_number() %
             this->simulation_parameters.post_processing.output_frequency ==
           0)
         {
@@ -851,7 +851,7 @@ CahnHilliard<dim>::postprocess(bool first_iteration)
                                              position_and_velocity.second[2]);
 
 
-          if (this->simulation_control->get_step_number() %
+          if (this->simulation_control->get_iteration_number() %
                 this->simulation_parameters.post_processing.output_frequency ==
               0)
             {

--- a/source/solvers/cls.cc
+++ b/source/solvers/cls.cc
@@ -786,11 +786,11 @@ ConservativeLevelSet<dim>::gather_output_hook()
   if (simulation_parameters.multiphysics.cls_parameters.reinitialization_method
         .geometric_interface_reinitialization.enable)
     {
-      if ((simulation_control->get_step_number() %
+      if ((simulation_control->get_iteration_number() %
              simulation_parameters.multiphysics.cls_parameters
                .reinitialization_method.frequency !=
            0) ||
-          (simulation_control->get_step_number() == 0))
+          (simulation_control->get_iteration_number() == 0))
         {
           TimerOutput::Scope t(this->computing_timer, "Signed distance output");
 
@@ -809,7 +809,7 @@ ConservativeLevelSet<dim>::gather_output_hook()
           this->simulation_parameters.simulation_control.output_name,
         this->simulation_parameters.simulation_control.output_folder,
         simulation_control->get_current_time(),
-        simulation_control->get_step_number());
+        simulation_control->get_iteration_number());
     }
   return solution_output_structs;
 }
@@ -1607,7 +1607,7 @@ ConservativeLevelSet<dim>::postprocess(bool first_iteration)
           this->table_monitoring_cls.add_value("sharpening_threshold",
                                                this->sharpening_threshold);
 
-          if (this->simulation_control->get_step_number() %
+          if (this->simulation_control->get_iteration_number() %
                 this->simulation_parameters.post_processing.output_frequency ==
               0)
             {
@@ -1790,7 +1790,7 @@ ConservativeLevelSet<dim>::postprocess(bool first_iteration)
             }
 
 
-          if (this->simulation_control->get_step_number() %
+          if (this->simulation_control->get_iteration_number() %
                 this->simulation_parameters.post_processing.output_frequency ==
               0)
             {
@@ -1849,7 +1849,7 @@ ConservativeLevelSet<dim>::modify_solution()
     if (cls_parameters.reinitialization_method.sharpening.enable)
       {
         // Interface sharpening is done at a constant frequency
-        if (this->simulation_control->get_step_number() %
+        if (this->simulation_control->get_iteration_number() %
               this->simulation_parameters.multiphysics.cls_parameters
                 .reinitialization_method.frequency ==
             0)
@@ -1862,7 +1862,7 @@ ConservativeLevelSet<dim>::modify_solution()
   // Apply PDE-based interface reinitialization
   if (simulation_parameters.multiphysics.cls_parameters.reinitialization_method
         .pde_based_interface_reinitialization.enable &&
-      (simulation_control->get_step_number() %
+      (simulation_control->get_iteration_number() %
          simulation_parameters.multiphysics.cls_parameters
            .reinitialization_method.frequency ==
        0))
@@ -1871,7 +1871,7 @@ ConservativeLevelSet<dim>::modify_solution()
   // Apply geometric interface reinitialization
   if (simulation_parameters.multiphysics.cls_parameters.reinitialization_method
         .geometric_interface_reinitialization.enable &&
-      (simulation_control->get_step_number() %
+      (simulation_control->get_iteration_number() %
          simulation_parameters.multiphysics.cls_parameters
            .reinitialization_method.frequency ==
        0))
@@ -1901,7 +1901,8 @@ ConservativeLevelSet<dim>::handle_interface_sharpening()
         .reinitialization_method.verbosity != Parameters::Verbosity::quiet)
     {
       this->pcout << "Sharpening interface at step "
-                  << this->simulation_control->get_step_number() << std::endl;
+                  << this->simulation_control->get_iteration_number()
+                  << std::endl;
     }
   if (this->simulation_parameters.multiphysics.cls_parameters
         .reinitialization_method.sharpening.type ==

--- a/source/solvers/fluid_dynamics_matrix_based.cc
+++ b/source/solvers/fluid_dynamics_matrix_based.cc
@@ -207,11 +207,11 @@ FluidDynamicsMatrixBased<dim>::update_mortar_configuration()
 
   bool refinement_step;
   if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
-    refinement_step = this->simulation_control->get_step_number() %
+    refinement_step = this->simulation_control->get_iteration_number() %
                         this->simulation_parameters.mesh_adaptation.frequency ==
                       0;
   else
-    refinement_step = this->simulation_control->get_step_number() == 0;
+    refinement_step = this->simulation_control->get_iteration_number() == 0;
 
   // We need to update the mortar operator/evaluator, as well as the sparsity
   // pattern, at every iteration. Since this is already done within

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -3041,11 +3041,11 @@ FluidDynamicsMatrixFree<dim>::update_mortar_configuration()
 
   bool refinement_step;
   if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
-    refinement_step = this->simulation_control->get_step_number() %
+    refinement_step = this->simulation_control->get_iteration_number() %
                         this->simulation_parameters.mesh_adaptation.frequency ==
                       0;
   else
-    refinement_step = this->simulation_control->get_step_number() == 0;
+    refinement_step = this->simulation_control->get_iteration_number() == 0;
 
   // We need to update the mortar operator/evaluator, as well as the sparsity
   // pattern, at every iteration. Since this is already done within

--- a/source/solvers/fluid_dynamics_nitsche.cc
+++ b/source/solvers/fluid_dynamics_nitsche.cc
@@ -795,8 +795,8 @@ FluidDynamicsNitsche<dim, spacedim>::output_solid_particles(
   const std::string solution_name =
     this->simulation_control->get_output_name() + "_solid_particles_" +
     Utilities::int_to_string(i_solid, 2);
-  const unsigned int iter        = this->simulation_control->get_step_number();
-  const double       time        = this->simulation_control->get_current_time();
+  const unsigned int iter = this->simulation_control->get_iteration_number();
+  const double       time = this->simulation_control->get_current_time();
   const unsigned int group_files = this->simulation_control->get_group_files();
 
   write_vtu_and_pvd<0, spacedim>(pvdhandler_solid_particles[i_solid],
@@ -843,8 +843,8 @@ FluidDynamicsNitsche<dim, spacedim>::output_solid_triangulation(
   const std::string solution_name =
     this->simulation_control->get_output_name() + "_solid_triangulation_" +
     Utilities::int_to_string(i_solid, 2);
-  const unsigned int iter        = this->simulation_control->get_step_number();
-  const double       time        = this->simulation_control->get_current_time();
+  const unsigned int iter = this->simulation_control->get_iteration_number();
+  const double       time = this->simulation_control->get_current_time();
   const unsigned int group_files = this->simulation_control->get_group_files();
 
   write_vtu_and_pvd<dim>(pvdhandler_solid_triangulation[i_solid],

--- a/source/solvers/fluid_dynamics_nitsche.cc
+++ b/source/solvers/fluid_dynamics_nitsche.cc
@@ -863,11 +863,11 @@ FluidDynamicsNitsche<dim, spacedim>::refine_mesh()
 {
   bool refinement_step;
   if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
-    refinement_step = this->simulation_control->get_step_number() %
+    refinement_step = this->simulation_control->get_iteration_number() %
                         this->simulation_parameters.mesh_adaptation.frequency ==
                       0;
   else
-    refinement_step = this->simulation_control->get_step_number() == 0;
+    refinement_step = this->simulation_control->get_iteration_number() == 0;
   if (refinement_step)
     {
       // If no adaptation is to be carried out, get out of the function

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -1137,7 +1137,7 @@ HeatTransfer<dim>::postprocess(bool first_iteration)
                                              true);
         }
 
-      if (simulation_control->get_step_number() %
+      if (simulation_control->get_iteration_number() %
             this->simulation_parameters.post_processing.output_frequency ==
           0)
         this->write_temperature_statistics(domain_name);
@@ -1174,7 +1174,7 @@ HeatTransfer<dim>::postprocess(bool first_iteration)
       if (this->simulation_parameters.nitsche->number_solids > 0)
         postprocess_heat_flux_on_nitsche_ib();
 
-      if (simulation_control->get_step_number() %
+      if (simulation_control->get_iteration_number() %
             this->simulation_parameters.post_processing.output_frequency ==
           0)
         this->write_heat_flux(domain_name);
@@ -1188,7 +1188,7 @@ HeatTransfer<dim>::postprocess(bool first_iteration)
         MeltVolumeRequiresPhaseChange());
       postprocess_algebraic_melt_volume();
 
-      if (simulation_control->get_step_number() %
+      if (simulation_control->get_iteration_number() %
             this->simulation_parameters.post_processing.output_frequency ==
           0)
         this->write_algebraic_melt_volume();
@@ -1198,7 +1198,7 @@ HeatTransfer<dim>::postprocess(bool first_iteration)
   if (simulation_parameters.post_processing.calculate_geometric_melt_volume)
     {
       postprocess_geometric_melt_volume_and_surface();
-      if (simulation_control->get_step_number() %
+      if (simulation_control->get_iteration_number() %
             this->simulation_parameters.post_processing.output_frequency ==
           0)
         this->write_geometric_melt_volume();

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -228,14 +228,15 @@ NavierStokesBase<dim, VectorType, DofsType>::dynamic_flow_control()
         *this->face_quadrature,
         *this->get_mapping());
 
-      this->flow_control.calculate_beta(average_velocity,
-                                        simulation_control->get_time_step(),
-                                        simulation_control->get_step_number());
+      this->flow_control.calculate_beta(
+        average_velocity,
+        simulation_control->get_time_step(),
+        simulation_control->get_iteration_number());
 
       // Showing results
       if (simulation_parameters.flow_control.verbosity ==
             Parameters::Verbosity::verbose &&
-          simulation_control->get_step_number() > 0 &&
+          simulation_control->get_iteration_number() > 0 &&
           this->this_mpi_process == 0)
         {
           announce_string(this->pcout, "Flow control summary");
@@ -571,8 +572,8 @@ NavierStokesBase<dim, VectorType, DofsType>::finish_time_step()
       this->simulation_control->set_CFL(CFL);
     }
   if (this->simulation_parameters.restart_parameters.checkpoint &&
-      simulation_control->get_step_number() != 0 &&
-      (simulation_control->get_step_number() %
+      simulation_control->get_iteration_number() != 0 &&
+      (simulation_control->get_iteration_number() %
            this->simulation_parameters.restart_parameters.frequency ==
          0 ||
        simulation_control->is_at_end()))
@@ -1434,7 +1435,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
         }
 
       // Output Enstrophy to a text file from processor 0
-      if (simulation_control->get_step_number() %
+      if (simulation_control->get_iteration_number() %
               this->simulation_parameters.post_processing.output_frequency ==
             0 &&
           this->this_mpi_process == 0)
@@ -1473,7 +1474,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
         }
 
       // Output pressure power to a text file from processor 0
-      if (simulation_control->get_step_number() %
+      if (simulation_control->get_iteration_number() %
               this->simulation_parameters.post_processing.output_frequency ==
             0 &&
           this->this_mpi_process == 0)
@@ -1517,7 +1518,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
         }
 
       // Output pressure power to a text file from processor 0
-      if (simulation_control->get_step_number() %
+      if (simulation_control->get_iteration_number() %
               this->simulation_parameters.post_processing.output_frequency ==
             0 &&
           this->this_mpi_process == 0)
@@ -1566,7 +1567,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
         }
 
       // Output Kinetic Energy to a text file from processor 0
-      if ((simulation_control->get_step_number() %
+      if ((simulation_control->get_iteration_number() %
              this->simulation_parameters.post_processing.output_frequency ==
            0) &&
           this->this_mpi_process == 0)
@@ -1607,7 +1608,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
         }
 
       // Output apparent viscosity to a text file from processor 0
-      if (simulation_control->get_step_number() %
+      if (simulation_control->get_iteration_number() %
               this->simulation_parameters.post_processing.output_frequency ==
             0 &&
           this->this_mpi_process == 0)
@@ -1659,7 +1660,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
         }
 
       // Output pressure drop to a text file from processor 0
-      if ((simulation_control->get_step_number() %
+      if ((simulation_control->get_iteration_number() %
              this->simulation_parameters.post_processing.output_frequency ==
            0) &&
           this->this_mpi_process == 0)
@@ -1716,7 +1717,7 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
         }
 
       // Output flow rate to a text file from processor 0
-      if ((simulation_control->get_step_number() %
+      if ((simulation_control->get_iteration_number() %
              this->simulation_parameters.post_processing.output_frequency ==
            0) &&
           this->this_mpi_process == 0)
@@ -1740,12 +1741,12 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
       // Calculate forces on the boundary conditions
       if (this->simulation_parameters.forces_parameters.calculate_force)
         {
-          if (simulation_control->get_step_number() %
+          if (simulation_control->get_iteration_number() %
                 this->simulation_parameters.forces_parameters
                   .calculation_frequency ==
               0)
             this->postprocessing_forces(present_solution);
-          if (simulation_control->get_step_number() %
+          if (simulation_control->get_iteration_number() %
                 this->simulation_parameters.forces_parameters
                   .output_frequency ==
               0)
@@ -1755,12 +1756,12 @@ NavierStokesBase<dim, VectorType, DofsType>::postprocess_fd(bool firstIter)
       // Calculate torques on the boundary conditions
       if (this->simulation_parameters.forces_parameters.calculate_torque)
         {
-          if (simulation_control->get_step_number() %
+          if (simulation_control->get_iteration_number() %
                 this->simulation_parameters.forces_parameters
                   .calculation_frequency ==
               0)
             this->postprocessing_torques(present_solution);
-          if (simulation_control->get_step_number() %
+          if (simulation_control->get_iteration_number() %
                 this->simulation_parameters.forces_parameters
                   .output_frequency ==
               0)
@@ -2935,7 +2936,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
 
   const std::string  folder        = simulation_control->get_output_path();
   const std::string  solution_name = simulation_control->get_output_name();
-  const unsigned int iter          = simulation_control->get_step_number();
+  const unsigned int iter          = simulation_control->get_iteration_number();
   const double       time          = simulation_control->get_current_time();
   const unsigned int subdivision = simulation_control->get_number_subdivision();
   const unsigned int group_files = simulation_control->get_group_files();
@@ -3063,7 +3064,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
                          this->mpi_communicator);
 
   if (simulation_control->get_output_boundaries() &&
-      (simulation_control->get_step_number() == 0 ||
+      (simulation_control->get_iteration_number() == 0 ||
        simulation_parameters.mortar_parameters.enable))
     {
       DataOutFaces<dim> data_out_faces;

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -786,11 +786,11 @@ NavierStokesBase<dim, VectorType, DofsType>::refine_mesh()
 {
   bool refinement_step;
   if (this->simulation_parameters.mesh_adaptation.refinement_at_frequency)
-    refinement_step = this->simulation_control->get_step_number() %
+    refinement_step = this->simulation_control->get_iteration_number() %
                         this->simulation_parameters.mesh_adaptation.frequency ==
                       0;
   else
-    refinement_step = this->simulation_control->get_step_number() == 0;
+    refinement_step = this->simulation_control->get_iteration_number() == 0;
   if (refinement_step)
     {
       if (this->simulation_parameters.mesh_adaptation.type ==

--- a/source/solvers/time_harmonic_maxwell.cc
+++ b/source/solvers/time_harmonic_maxwell.cc
@@ -1699,7 +1699,7 @@ TimeHarmonicMaxwell<dim>::should_solve_auxiliary_physics()
   // Always solve at the first step of the simulation (simulation start as 0 but
   // it is then incremented before solving the physics for the first time, so
   // the first time this function is called, the step number is 1).
-  if (this->simulation_control->get_step_number() == 1)
+  if (this->simulation_control->get_iteration_number() == 1)
     {
       return true;
     }
@@ -1714,7 +1714,7 @@ TimeHarmonicMaxwell<dim>::should_solve_auxiliary_physics()
           case Parameters::TimeHarmonicMaxwellCouplingStrategy::iteration:
             // Solve only if we are at a multiple of the specified iteration
             // frequency. We subtract 1 since the step number starts at 1.
-            if ((this->simulation_control->get_step_number() - 1) %
+            if ((this->simulation_control->get_iteration_number() - 1) %
                   thm_parameters.coupling_iteration ==
                 0)
               return true;

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -782,7 +782,7 @@ Tracer<dim>::postprocess(bool first_iteration)
   if (simulation_parameters.post_processing.calculate_tracer_statistics)
     {
       calculate_tracer_statistics();
-      if (simulation_control->get_step_number() %
+      if (simulation_control->get_iteration_number() %
             this->simulation_parameters.post_processing.output_frequency ==
           0)
         this->write_tracer_statistics();
@@ -1064,7 +1064,7 @@ Tracer<dim>::write_tracer_flow_rates(
     }
 
   auto mpi_communicator = triangulation->get_mpi_communicator();
-  if ((simulation_control->get_step_number() %
+  if ((simulation_control->get_iteration_number() %
          this->simulation_parameters.post_processing.output_frequency ==
        0) &&
       Utilities::MPI::this_mpi_process(mpi_communicator) == 0)

--- a/tests/core/simulation_control_01.cc
+++ b/tests/core/simulation_control_01.cc
@@ -46,8 +46,8 @@ test()
           << std::endl;
   deallog << "time                : " << simulationControl.get_current_time()
           << std::endl;
-  deallog << "iter                : " << simulationControl.get_step_number()
-          << std::endl;
+  deallog << "iter                : "
+          << simulationControl.get_iteration_number() << std::endl;
   deallog << "OK" << std::endl;
 }
 

--- a/tests/core/simulation_control_02.cc
+++ b/tests/core/simulation_control_02.cc
@@ -37,12 +37,12 @@ test()
 
   SimulationControlSteady simulation_control(simulationControlParameters);
 
-  deallog << "Iteration : " << simulation_control.get_step_number()
+  deallog << "Iteration : " << simulation_control.get_iteration_number()
           << std::endl;
 
   while (simulation_control.integrate())
     {
-      deallog << "Iteration : " << simulation_control.get_step_number()
+      deallog << "Iteration : " << simulation_control.get_iteration_number()
               << "    Time : " << simulation_control.get_current_time()
               << std::endl;
       if (simulation_control.is_at_start())

--- a/tests/core/simulation_control_03.cc
+++ b/tests/core/simulation_control_03.cc
@@ -40,13 +40,13 @@ test()
     deallog << "*************************************************" << std::endl;
     deallog << "Constant time stepping - constant output" << std::endl;
     deallog << "*************************************************" << std::endl;
-    deallog << "Iteration : " << simulation_control.get_step_number()
+    deallog << "Iteration : " << simulation_control.get_iteration_number()
             << "    Time : " << simulation_control.get_current_time()
             << std::endl;
 
     while (simulation_control.integrate())
       {
-        deallog << "Iteration : " << simulation_control.get_step_number()
+        deallog << "Iteration : " << simulation_control.get_iteration_number()
                 << "    Time : " << simulation_control.get_current_time()
                 << std::endl;
 
@@ -73,13 +73,13 @@ test()
     deallog << "*************************************************" << std::endl;
     deallog << "Constant time stepping - specific time output" << std::endl;
     deallog << "*************************************************" << std::endl;
-    deallog << "Iteration : " << simulation_control.get_step_number()
+    deallog << "Iteration : " << simulation_control.get_iteration_number()
             << "    Time : " << simulation_control.get_current_time()
             << std::endl;
 
     while (simulation_control.integrate())
       {
-        deallog << "Iteration : " << simulation_control.get_step_number()
+        deallog << "Iteration : " << simulation_control.get_iteration_number()
                 << "    Time : " << simulation_control.get_current_time()
                 << std::endl;
 
@@ -105,13 +105,13 @@ test()
     deallog << "*************************************************" << std::endl;
     deallog << "Constant time stepping - specific time interval" << std::endl;
     deallog << "*************************************************" << std::endl;
-    deallog << "Iteration : " << simulation_control.get_step_number()
+    deallog << "Iteration : " << simulation_control.get_iteration_number()
             << "    Time : " << simulation_control.get_current_time()
             << std::endl;
 
     while (simulation_control.integrate())
       {
-        deallog << "Iteration : " << simulation_control.get_step_number()
+        deallog << "Iteration : " << simulation_control.get_iteration_number()
                 << "    Time : " << simulation_control.get_current_time()
                 << std::endl;
 
@@ -138,13 +138,13 @@ test()
     deallog << "*************************************************" << std::endl;
     deallog << "Constant time stepping - output time frequency" << std::endl;
     deallog << "*************************************************" << std::endl;
-    deallog << "Iteration : " << simulation_control.get_step_number()
+    deallog << "Iteration : " << simulation_control.get_iteration_number()
             << "    Time : " << simulation_control.get_current_time()
             << std::endl;
 
     while (simulation_control.integrate())
       {
-        deallog << "Iteration : " << simulation_control.get_step_number()
+        deallog << "Iteration : " << simulation_control.get_iteration_number()
                 << "    Time : " << simulation_control.get_current_time()
                 << std::endl;
 
@@ -177,14 +177,14 @@ test()
     deallog << "*************************************************" << std::endl;
     deallog << "Adaptative time stepping - constant output" << std::endl;
     deallog << "*************************************************" << std::endl;
-    deallog << "Iteration : " << simulation_control.get_step_number()
+    deallog << "Iteration : " << simulation_control.get_iteration_number()
             << "    Time : " << simulation_control.get_current_time()
             << "    Time step : " << simulation_control.get_time_step()
             << std::endl;
 
     while (simulation_control.integrate())
       {
-        deallog << "Iteration : " << simulation_control.get_step_number()
+        deallog << "Iteration : " << simulation_control.get_iteration_number()
                 << "    Time : " << simulation_control.get_current_time()
                 << "    Time step : " << simulation_control.get_time_step()
                 << std::endl;
@@ -219,14 +219,14 @@ test()
     deallog << "*************************************************" << std::endl;
     deallog << "Adaptative time stepping - specific time output" << std::endl;
     deallog << "*************************************************" << std::endl;
-    deallog << "Iteration : " << simulation_control.get_step_number()
+    deallog << "Iteration : " << simulation_control.get_iteration_number()
             << "    Time : " << simulation_control.get_current_time()
             << "    Time step : " << simulation_control.get_time_step()
             << std::endl;
 
     while (simulation_control.integrate())
       {
-        deallog << "Iteration : " << simulation_control.get_step_number()
+        deallog << "Iteration : " << simulation_control.get_iteration_number()
                 << "    Time : " << simulation_control.get_current_time()
                 << "    Time step : " << simulation_control.get_time_step()
                 << std::endl;
@@ -262,14 +262,14 @@ test()
     deallog << "*************************************************" << std::endl;
     deallog << "Adaptative time stepping - interval time output" << std::endl;
     deallog << "*************************************************" << std::endl;
-    deallog << "Iteration : " << simulation_control.get_step_number()
+    deallog << "Iteration : " << simulation_control.get_iteration_number()
             << "    Time : " << simulation_control.get_current_time()
             << "    Time step : " << simulation_control.get_time_step()
             << std::endl;
 
     while (simulation_control.integrate())
       {
-        deallog << "Iteration : " << simulation_control.get_step_number()
+        deallog << "Iteration : " << simulation_control.get_iteration_number()
                 << "    Time : " << simulation_control.get_current_time()
                 << "    Time step : " << simulation_control.get_time_step()
                 << std::endl;
@@ -306,14 +306,14 @@ test()
     deallog << "*************************************************" << std::endl;
     deallog << "Adaptative time stepping - output time frequency" << std::endl;
     deallog << "*************************************************" << std::endl;
-    deallog << "Iteration : " << simulation_control.get_step_number()
+    deallog << "Iteration : " << simulation_control.get_iteration_number()
             << "    Time : " << simulation_control.get_current_time()
             << "    Time step : " << simulation_control.get_time_step()
             << std::endl;
 
     while (simulation_control.integrate())
       {
-        deallog << "Iteration : " << simulation_control.get_step_number()
+        deallog << "Iteration : " << simulation_control.get_iteration_number()
                 << "    Time : " << simulation_control.get_current_time()
                 << "    Time step : " << simulation_control.get_time_step()
                 << std::endl;

--- a/tests/core/simulation_control_04.cc
+++ b/tests/core/simulation_control_04.cc
@@ -42,13 +42,13 @@ test()
     deallog << "*************************************************" << std::endl;
     deallog << "Constant time stepping - constant output" << std::endl;
     deallog << "*************************************************" << std::endl;
-    deallog << "Iteration : " << simulation_control.get_step_number()
+    deallog << "Iteration : " << simulation_control.get_iteration_number()
             << "    Time : " << simulation_control.get_current_time()
             << std::endl;
 
     while (simulation_control.integrate())
       {
-        deallog << "Iteration : " << simulation_control.get_step_number()
+        deallog << "Iteration : " << simulation_control.get_iteration_number()
                 << "    Time : " << simulation_control.get_current_time()
                 << std::endl;
       }

--- a/tests/core/simulation_control_05.cc
+++ b/tests/core/simulation_control_05.cc
@@ -44,7 +44,7 @@ test()
     deallog << "*************************************************" << std::endl;
     deallog << "Constant time stepping - constant output" << std::endl;
     deallog << "*************************************************" << std::endl;
-    deallog << "Iteration : " << simulation_control.get_step_number()
+    deallog << "Iteration : " << simulation_control.get_iteration_number()
             << "    Time : " << simulation_control.get_current_time()
             << std::endl;
 
@@ -69,7 +69,7 @@ test()
         else
           method = "the assembly method is not initialized";
 
-        deallog << "Iteration : " << simulation_control.get_step_number()
+        deallog << "Iteration : " << simulation_control.get_iteration_number()
                 << "    Time : " << simulation_control.get_current_time()
                 << " Assembly method : " << method << std::endl;
       }
@@ -85,7 +85,7 @@ test()
     deallog << "*************************************************" << std::endl;
     deallog << "Constant time stepping - constant output" << std::endl;
     deallog << "*************************************************" << std::endl;
-    deallog << "Iteration : " << simulation_control.get_step_number()
+    deallog << "Iteration : " << simulation_control.get_iteration_number()
             << "    Time : " << simulation_control.get_current_time()
             << std::endl;
 
@@ -110,7 +110,7 @@ test()
         else
           method = "the assembly method is not initialized";
 
-        deallog << "Iteration : " << simulation_control.get_step_number()
+        deallog << "Iteration : " << simulation_control.get_iteration_number()
                 << "    Time : " << simulation_control.get_current_time()
                 << " Assembly method : " << method << std::endl;
       }
@@ -128,7 +128,7 @@ test()
     deallog << "*************************************************" << std::endl;
     deallog << "Constant time stepping - constant output" << std::endl;
     deallog << "*************************************************" << std::endl;
-    deallog << "Iteration : " << simulation_control.get_step_number()
+    deallog << "Iteration : " << simulation_control.get_iteration_number()
             << "    Time : " << simulation_control.get_current_time()
             << std::endl;
 
@@ -153,7 +153,7 @@ test()
         else
           method = "the assembly method is not initialized";
 
-        deallog << "Iteration : " << simulation_control.get_step_number()
+        deallog << "Iteration : " << simulation_control.get_iteration_number()
                 << "    Time : " << simulation_control.get_current_time()
                 << " Assembly method : " << method << std::endl;
       }
@@ -169,7 +169,7 @@ test()
     deallog << "*************************************************" << std::endl;
     deallog << "Constant time stepping - constant output" << std::endl;
     deallog << "*************************************************" << std::endl;
-    deallog << "Iteration : " << simulation_control.get_step_number()
+    deallog << "Iteration : " << simulation_control.get_iteration_number()
             << "    Time : " << simulation_control.get_current_time()
             << std::endl;
 
@@ -194,7 +194,7 @@ test()
         else
           method = "the assembly method is not initialized";
 
-        deallog << "Iteration : " << simulation_control.get_step_number()
+        deallog << "Iteration : " << simulation_control.get_iteration_number()
                 << "    Time : " << simulation_control.get_current_time()
                 << " Assembly method : " << method << std::endl;
       }

--- a/tests/solvers/auxiliary_physics_coupling_strategy_01.cc
+++ b/tests/solvers/auxiliary_physics_coupling_strategy_01.cc
@@ -87,7 +87,7 @@ test()
     for (int i = 0; i < 5; ++i)
       {
         simulation_control->integrate();
-        deallog << "Step " << simulation_control->get_step_number() << ": "
+        deallog << "Step " << simulation_control->get_iteration_number() << ": "
                 << (electromagnetics_auxiliary_physics
                         .should_solve_auxiliary_physics() ?
                       "true" :
@@ -122,7 +122,7 @@ test()
     for (int i = 0; i < 7; ++i)
       {
         simulation_control->integrate();
-        deallog << "Step " << simulation_control->get_step_number() << ": "
+        deallog << "Step " << simulation_control->get_iteration_number() << ": "
                 << (electromagnetics_auxiliary_physics
                         .should_solve_auxiliary_physics() ?
                       "true" :
@@ -157,7 +157,7 @@ test()
     for (int i = 0; i < 10; ++i)
       {
         simulation_control->integrate();
-        deallog << "Step " << simulation_control->get_step_number()
+        deallog << "Step " << simulation_control->get_iteration_number()
                 << " (t=" << simulation_control->get_current_time() << "): "
                 << (electromagnetics_auxiliary_physics
                         .should_solve_auxiliary_physics() ?


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

There were two functions, `get_step_number()` and `get_iteration_number()`, that returned the same `iteration_number` value. This PR deprecates `get_step_number()` and replaces it by `get_iteration_number()` everywhere in the code.

### Testing

<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

No changes in tests.

### Documentation

<!-- Does this refactor modify or have new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge