### PR TITLE
Fe name degree instead of order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Deprecated
 
-- MINOR The FEM subsection parameters `velocity order`, `pressure order`, `temperature order`, `tracer order`, `cls order` (and its alias `VOF order`), `void fraction order`, `phase cahn hilliard order`, `potential cahn hilliard order`, `electromagnetics trial order`, and `electromagnetics test order` have been renamed to use `degree` instead of `order` (e.g., `velocity degree`, `pressure degree`). The parameter name `degree` is more adequate, since it refers to the degree of the underlying shape functions that are used. The old names are kept as deprecated aliases and will continue to work but will trigger a deprecation warning. All examples, application tests, and documentation have been updated to use the new names. [#1994](https://github.com/chaos-polymtl/lethe/pull/1994)
+- MAJOR The FEM subsection parameters `velocity order`, `pressure order`, `temperature order`, `tracer order`, `cls order` (and its alias `VOF order`), `void fraction order`, `phase cahn hilliard order`, `potential cahn hilliard order`, `electromagnetics trial order`, and `electromagnetics test order` have been renamed to use `degree` instead of `order` (e.g., `velocity degree`, `pressure degree`). The parameter name `degree` is more adequate, since it refers to the degree of the underlying shape functions that are used. The old names are kept as deprecated aliases and will continue to work but will trigger a deprecation warning. All examples, application tests, and documentation have been updated to use the new names. [#1994](https://github.com/chaos-polymtl/lethe/pull/1994)
 
 ## [Master] - 2026/05/18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - MINOR The project version in `CMakeLists.txt` has been updated with the latest released version. [#2001](https://github.com/chaos-polymtl/lethe/pull/2001)
 
+### Deprecated
+
+- MINOR The FEM subsection parameters `velocity order`, `pressure order`, `temperature order`, `tracer order`, `cls order` (and its alias `VOF order`), `void fraction order`, `phase cahn hilliard order`, `potential cahn hilliard order`, `electromagnetics trial order`, and `electromagnetics test order` have been renamed to use `degree` instead of `order` (e.g., `velocity degree`, `pressure degree`). The parameter name `degree` is more adequate, since it refers to the degree of the underlying shape functions that are used. The old names are kept as deprecated aliases and will continue to work but will trigger a deprecation warning. All examples, application tests, and documentation have been updated to use the new names. [#1994](https://github.com/chaos-polymtl/lethe/pull/1994)
+
 ## [Master] - 2026/05/18
 
 ### Fixed

--- a/applications_tests/lethe-fluid-block/apparent_viscosity_carreau_gd.prm
+++ b/applications_tests/lethe-fluid-block/apparent_viscosity_carreau_gd.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-block/apparent_viscosity_carreau_gd.prm
+++ b/applications_tests/lethe-fluid-block/apparent_viscosity_carreau_gd.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
+  set velocity degree = 2
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-block/cylinder_carreau_gd.prm
+++ b/applications_tests/lethe-fluid-block/cylinder_carreau_gd.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-block/cylinder_carreau_gd.prm
+++ b/applications_tests/lethe-fluid-block/cylinder_carreau_gd.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
+  set velocity degree = 2
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-block/mms-conduction_gd.prm
+++ b/applications_tests/lethe-fluid-block/mms-conduction_gd.prm
@@ -23,9 +23,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-block/mms-conduction_gd.prm
+++ b/applications_tests/lethe-fluid-block/mms-conduction_gd.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-block/mms2d-unstructured_gd.prm
+++ b/applications_tests/lethe-fluid-block/mms2d-unstructured_gd.prm
@@ -43,9 +43,9 @@ end
 
 subsection FEM
   # interpolation order velocity
-  set velocity order = 2
+  set velocity degree = 2
   # interpolation order pressure
-  set pressure order = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-block/mms2d-unstructured_gd.prm
+++ b/applications_tests/lethe-fluid-block/mms2d-unstructured_gd.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019, 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-block/mms2d-unstructured_gd.prm
+++ b/applications_tests/lethe-fluid-block/mms2d-unstructured_gd.prm
@@ -42,9 +42,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  # interpolation order velocity
+  # degree of the polynomial for velocity
   set velocity degree = 2
-  # interpolation order pressure
+  # degree of the polynomial for pressure
   set pressure degree = 1
 end
 

--- a/applications_tests/lethe-fluid-block/mms2d_gd.prm
+++ b/applications_tests/lethe-fluid-block/mms2d_gd.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019, 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-block/mms2d_gd.prm
+++ b/applications_tests/lethe-fluid-block/mms2d_gd.prm
@@ -44,9 +44,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  # interpolation order velocity
+  # degree of the polynomial for velocity
   set velocity degree = 2
-  # interpolation order pressure
+  # degree of the polynomial for pressure
   set pressure degree = 1
 end
 

--- a/applications_tests/lethe-fluid-block/mms2d_gd.prm
+++ b/applications_tests/lethe-fluid-block/mms2d_gd.prm
@@ -45,9 +45,9 @@ end
 
 subsection FEM
   # interpolation order velocity
-  set velocity order = 2
+  set velocity degree = 2
   # interpolation order pressure
-  set pressure order = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-block/mms2d_powerlaw_gd.prm
+++ b/applications_tests/lethe-fluid-block/mms2d_powerlaw_gd.prm
@@ -61,9 +61,9 @@ end
 
 subsection FEM
   # interpolation order velocity
-  set velocity order = 2
+  set velocity degree = 2
   # interpolation order pressure
-  set pressure order = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-block/mms2d_powerlaw_gd.prm
+++ b/applications_tests/lethe-fluid-block/mms2d_powerlaw_gd.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-block/mms2d_powerlaw_gd.prm
+++ b/applications_tests/lethe-fluid-block/mms2d_powerlaw_gd.prm
@@ -60,9 +60,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  # interpolation order velocity
+  # degree of the polynomial for velocity
   set velocity degree = 2
-  # interpolation order pressure
+  # degree of the polynomial for pressure
   set pressure degree = 1
 end
 

--- a/applications_tests/lethe-fluid-block/mms3d_gd.prm
+++ b/applications_tests/lethe-fluid-block/mms3d_gd.prm
@@ -63,9 +63,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  # interpolation order velocity
+  # degree of the polynomial for velocity
   set velocity degree = 2
-  # interpolation order pressure
+  # degree of the polynomial for pressure
   set pressure degree = 1
 end
 

--- a/applications_tests/lethe-fluid-block/mms3d_gd.prm
+++ b/applications_tests/lethe-fluid-block/mms3d_gd.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019, 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-block/mms3d_gd.prm
+++ b/applications_tests/lethe-fluid-block/mms3d_gd.prm
@@ -64,9 +64,9 @@ end
 
 subsection FEM
   # interpolation order velocity
-  set velocity order = 2
+  set velocity degree = 2
   # interpolation order pressure
-  set pressure order = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-block/poiseuille3d_gd.prm
+++ b/applications_tests/lethe-fluid-block/poiseuille3d_gd.prm
@@ -32,8 +32,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
+  set velocity degree = 2
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-block/poiseuille3d_gd.prm
+++ b/applications_tests/lethe-fluid-block/poiseuille3d_gd.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019, 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-block/poiseuille_gd.prm
+++ b/applications_tests/lethe-fluid-block/poiseuille_gd.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019, 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-block/poiseuille_gd.prm
+++ b/applications_tests/lethe-fluid-block/poiseuille_gd.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
+  set velocity degree = 2
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-block/taylor-green-vortex_gd_bdf1.prm
+++ b/applications_tests/lethe-fluid-block/taylor-green-vortex_gd_bdf1.prm
@@ -25,8 +25,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
+  set velocity degree = 2
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-block/taylor-green-vortex_gd_bdf1.prm
+++ b/applications_tests/lethe-fluid-block/taylor-green-vortex_gd_bdf1.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019, 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-block/taylor-green-vortex_gd_bdf2.prm
+++ b/applications_tests/lethe-fluid-block/taylor-green-vortex_gd_bdf2.prm
@@ -25,8 +25,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
+  set velocity degree = 2
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-block/taylor-green-vortex_gd_bdf2.prm
+++ b/applications_tests/lethe-fluid-block/taylor-green-vortex_gd_bdf2.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019, 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-block/taylorcouette_gd.prm
+++ b/applications_tests/lethe-fluid-block/taylorcouette_gd.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019, 2021-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-block/taylorcouette_gd.prm
+++ b/applications_tests/lethe-fluid-block/taylorcouette_gd.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
+  set velocity degree = 2
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-block/taylorcouette_gd_dimensions.prm
+++ b/applications_tests/lethe-fluid-block/taylorcouette_gd_dimensions.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-block/taylorcouette_gd_dimensions.prm
+++ b/applications_tests/lethe-fluid-block/taylorcouette_gd_dimensions.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
+  set velocity degree = 2
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/couette_function_weak.prm
+++ b/applications_tests/lethe-fluid-matrix-free/couette_function_weak.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/couette_function_weak.prm
+++ b/applications_tests/lethe-fluid-matrix-free/couette_function_weak.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_gcmg.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_gcmg.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_gcmg_asm.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_gcmg_asm.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_gcmg_asm.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_gcmg_asm.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_lsmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_lsmg.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_lsmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_lsmg.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_lsmg_asm.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_lsmg_asm.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_lsmg_asm.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_kelly_estimator_lsmg_asm.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/cylinder_outlet_bc.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_outlet_bc.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/cylinder_outlet_bc.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_outlet_bc.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/cylinder_transient_avg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_transient_avg.prm
@@ -26,8 +26,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/cylinder_transient_avg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/cylinder_transient_avg.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # This test case runs a transient flow simulation around a cylinder

--- a/applications_tests/lethe-fluid-matrix-free/generators/tgv_restart_bdf1_generator.prm
+++ b/applications_tests/lethe-fluid-matrix-free/generators/tgv_restart_bdf1_generator.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/generators/tgv_restart_bdf1_generator.prm
+++ b/applications_tests/lethe-fluid-matrix-free/generators/tgv_restart_bdf1_generator.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/generators/turbulent_taylor_couette_generator.prm
+++ b/applications_tests/lethe-fluid-matrix-free/generators/turbulent_taylor_couette_generator.prm
@@ -64,8 +64,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/generators/turbulent_taylor_couette_generator.prm
+++ b/applications_tests/lethe-fluid-matrix-free/generators/turbulent_taylor_couette_generator.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/heat_transfer_high_pe_stab_gls.prm
+++ b/applications_tests/lethe-fluid-matrix-free/heat_transfer_high_pe_stab_gls.prm
@@ -23,9 +23,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/heat_transfer_high_pe_stab_gls.prm
+++ b/applications_tests/lethe-fluid-matrix-free/heat_transfer_high_pe_stab_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/mms2d_carreau_fe1.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms2d_carreau_fe1.prm
@@ -52,9 +52,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  # interpolation order velocity
+  # degree of the polynomial for velocity
   set velocity degree = 1
-  # interpolation order pressure
+  # degree of the polynomial for pressure
   set pressure degree = 1
 end
 

--- a/applications_tests/lethe-fluid-matrix-free/mms2d_carreau_fe1.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms2d_carreau_fe1.prm
@@ -53,9 +53,9 @@ end
 
 subsection FEM
   # interpolation order velocity
-  set velocity order = 1
+  set velocity degree = 1
   # interpolation order pressure
-  set pressure order = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mms2d_carreau_fe1.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms2d_carreau_fe1.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/mms2d_carreau_fe2.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms2d_carreau_fe2.prm
@@ -53,9 +53,9 @@ end
 
 subsection FEM
   # interpolation order velocity
-  set velocity order = 2
+  set velocity degree = 2
   # interpolation order pressure
-  set pressure order = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mms2d_carreau_fe2.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms2d_carreau_fe2.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/mms2d_carreau_fe2.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms2d_carreau_fe2.prm
@@ -52,9 +52,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  # interpolation order velocity
+  # degree of the polynomial for velocity
   set velocity degree = 2
-  # interpolation order pressure
+  # degree of the polynomial for pressure
   set pressure degree = 2
 end
 

--- a/applications_tests/lethe-fluid-matrix-free/mms2d_fe1.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms2d_fe1.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/mms2d_fe1.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms2d_fe1.prm
@@ -31,8 +31,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mms2d_fe2.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms2d_fe2.prm
@@ -31,8 +31,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mms2d_fe2.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms2d_fe2.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/mms2d_fe2_weak.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms2d_fe2_weak.prm
@@ -31,8 +31,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mms2d_fe2_weak.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms2d_fe2_weak.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/mms2d_fe3.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms2d_fe3.prm
@@ -31,8 +31,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 3
-  set pressure order = 3
+  set velocity degree = 3
+  set pressure degree = 3
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mms2d_fe3.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms2d_fe3.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/mms3d_fe2_lsmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms3d_fe2_lsmg.prm
@@ -31,8 +31,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mms3d_fe2_lsmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms3d_fe2_lsmg.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/mms3d_fe3_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mms3d_fe3_gcmg.prm
@@ -34,8 +34,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 3
-  set pressure order = 3
+  set velocity degree = 3
+  set pressure degree = 3
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mortar_linear_interface.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mortar_linear_interface.prm
@@ -64,8 +64,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = false
-  set velocity degree                  = 2
-  set pressure degree                  = 2
+  set velocity degree                 = 2
+  set pressure degree                 = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mortar_linear_interface.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mortar_linear_interface.prm
@@ -64,8 +64,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = false
-  set velocity order                  = 2
-  set pressure order                  = 2
+  set velocity degree                  = 2
+  set pressure degree                  = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mortar_linear_interface.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mortar_linear_interface.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Verifies the implementation of the mortar linear interface for a linear velocity

--- a/applications_tests/lethe-fluid-matrix-free/mortar_mms2d_ilu.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mortar_mms2d_ilu.prm
@@ -65,8 +65,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mortar_mms2d_ilu.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mortar_mms2d_ilu.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Checks the steady case matrix-free mortar implementation for an MMS example.

--- a/applications_tests/lethe-fluid-matrix-free/mortar_mms_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mortar_mms_gcmg.prm
@@ -67,8 +67,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mortar_mms_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mortar_mms_gcmg.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Checks the global coarsening multigrid preconditioner for a mortar MMS example.

--- a/applications_tests/lethe-fluid-matrix-free/mortar_mms_p_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mortar_mms_p_gcmg.prm
@@ -64,8 +64,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 3
-  set pressure order = 3
+  set velocity degree = 3
+  set pressure degree = 3
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mortar_taylor_couette_2d_ilu.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mortar_taylor_couette_2d_ilu.prm
@@ -80,8 +80,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mortar_taylor_couette_2d_ilu.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mortar_taylor_couette_2d_ilu.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Checks the steady case matrix-free mortar implementation with ILU preconditioner.

--- a/applications_tests/lethe-fluid-matrix-free/mortar_taylor_couette_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mortar_taylor_couette_gcmg.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Checks the global coarsening multigrid preconditioner for a mortar Taylor-Couette example.

--- a/applications_tests/lethe-fluid-matrix-free/mortar_taylor_couette_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mortar_taylor_couette_gcmg.prm
@@ -74,8 +74,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mortar_tgv_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mortar_tgv_gcmg.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/mortar_tgv_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/mortar_tgv_gcmg.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Checks the transient stabilized ALE mortar implementation in the matrix-free solver.

--- a/applications_tests/lethe-fluid-matrix-free/multiphysics_check_tracer.prm
+++ b/applications_tests/lethe-fluid-matrix-free/multiphysics_check_tracer.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Checks that the tracer can be called within a multiphysics simulation using matrix-free solver.

--- a/applications_tests/lethe-fluid-matrix-free/multiphysics_check_tracer.prm
+++ b/applications_tests/lethe-fluid-matrix-free/multiphysics_check_tracer.prm
@@ -21,9 +21,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/pressure_poiseuille.prm
+++ b/applications_tests/lethe-fluid-matrix-free/pressure_poiseuille.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/taylor_couette_2d_local_ref.prm
+++ b/applications_tests/lethe-fluid-matrix-free/taylor_couette_2d_local_ref.prm
@@ -54,8 +54,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/taylor_couette_2d_local_ref.prm
+++ b/applications_tests/lethe-fluid-matrix-free/taylor_couette_2d_local_ref.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/taylor_couette_3d_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/taylor_couette_3d_gcmg.prm
@@ -69,8 +69,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/taylor_couette_3d_gcmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/taylor_couette_3d_gcmg.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/taylor_couette_3d_lsmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/taylor_couette_3d_lsmg.prm
@@ -69,8 +69,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/taylor_couette_3d_lsmg.prm
+++ b/applications_tests/lethe-fluid-matrix-free/taylor_couette_3d_lsmg.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu_gls.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu_gls.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu_gls.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_fe1_ilu_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/tgv_restart_bdf1.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_restart_bdf1.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/tgv_restart_bdf1.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_restart_bdf1.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-matrix-free/tgv_sdirk33_dt1.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_sdirk33_dt1.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Test that the SDIRK method combined with the matrix-free solver is

--- a/applications_tests/lethe-fluid-matrix-free/tgv_sdirk33_dt1.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_sdirk33_dt1.prm
@@ -33,8 +33,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 3
-  set pressure order = 3
+  set velocity degree = 3
+  set pressure degree = 3
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/tgv_sdirk33_dt2.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_sdirk33_dt2.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Test that the SDIRK method combined with the matrix-free solver is

--- a/applications_tests/lethe-fluid-matrix-free/tgv_sdirk33_dt2.prm
+++ b/applications_tests/lethe-fluid-matrix-free/tgv_sdirk33_dt2.prm
@@ -33,8 +33,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 3
-  set pressure order = 3
+  set velocity degree = 3
+  set pressure degree = 3
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/turbulent_taylor_couette_restart.prm
+++ b/applications_tests/lethe-fluid-matrix-free/turbulent_taylor_couette_restart.prm
@@ -80,8 +80,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-matrix-free/turbulent_taylor_couette_restart.prm
+++ b/applications_tests/lethe-fluid-matrix-free/turbulent_taylor_couette_restart.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-nitsche/generators/two-bar-mixer-start.prm
+++ b/applications_tests/lethe-fluid-nitsche/generators/two-bar-mixer-start.prm
@@ -25,9 +25,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 2
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 2
 end
 
 #--------------------------------------------------

--- a/applications_tests/lethe-fluid-nitsche/generators/two-bar-mixer-start.prm
+++ b/applications_tests/lethe-fluid-nitsche/generators/two-bar-mixer-start.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-nitsche/impeller.prm
+++ b/applications_tests/lethe-fluid-nitsche/impeller.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-nitsche/impeller.prm
+++ b/applications_tests/lethe-fluid-nitsche/impeller.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, 2023 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-nitsche/impeller.prm
+++ b/applications_tests/lethe-fluid-nitsche/impeller.prm
@@ -25,8 +25,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-nitsche/mixer_back_and_forth.prm
+++ b/applications_tests/lethe-fluid-nitsche/mixer_back_and_forth.prm
@@ -25,9 +25,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-nitsche/mixer_back_and_forth.prm
+++ b/applications_tests/lethe-fluid-nitsche/mixer_back_and_forth.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-nitsche/noslip33_simplex.prm
+++ b/applications_tests/lethe-fluid-nitsche/noslip33_simplex.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-nitsche/noslip33_simplex.prm
+++ b/applications_tests/lethe-fluid-nitsche/noslip33_simplex.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-nitsche/noslip_22.prm
+++ b/applications_tests/lethe-fluid-nitsche/noslip_22.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-nitsche/noslip_22.prm
+++ b/applications_tests/lethe-fluid-nitsche/noslip_22.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-nitsche/noslip_33.prm
+++ b/applications_tests/lethe-fluid-nitsche/noslip_33.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-nitsche/noslip_33.prm
+++ b/applications_tests/lethe-fluid-nitsche/noslip_33.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-nitsche/poiseuille_22.prm
+++ b/applications_tests/lethe-fluid-nitsche/poiseuille_22.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
+  set velocity degree = 2
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-nitsche/poiseuille_22.prm
+++ b/applications_tests/lethe-fluid-nitsche/poiseuille_22.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-nitsche/poiseuille_two_solids_22.prm
+++ b/applications_tests/lethe-fluid-nitsche/poiseuille_two_solids_22.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-nitsche/poiseuille_two_solids_22.prm
+++ b/applications_tests/lethe-fluid-nitsche/poiseuille_two_solids_22.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-nitsche/taylor_couette_nitsche_22.prm
+++ b/applications_tests/lethe-fluid-nitsche/taylor_couette_nitsche_22.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-nitsche/taylor_couette_nitsche_22.prm
+++ b/applications_tests/lethe-fluid-nitsche/taylor_couette_nitsche_22.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-nitsche/two-bar-mixer-restart.prm
+++ b/applications_tests/lethe-fluid-nitsche/two-bar-mixer-restart.prm
@@ -25,9 +25,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 2
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-nitsche/two-bar-mixer-restart.prm
+++ b/applications_tests/lethe-fluid-nitsche/two-bar-mixer-restart.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles-matrix-free/explicit-particle-sedimentation-load-balance.prm
+++ b/applications_tests/lethe-fluid-particles-matrix-free/explicit-particle-sedimentation-load-balance.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles-matrix-free/explicit-particle-sedimentation-load-balance.prm
+++ b/applications_tests/lethe-fluid-particles-matrix-free/explicit-particle-sedimentation-load-balance.prm
@@ -33,8 +33,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles-matrix-free/explicit-particle-sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles-matrix-free/explicit-particle-sedimentation.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles-matrix-free/explicit-particle-sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles-matrix-free/explicit-particle-sedimentation.prm
@@ -33,8 +33,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles-matrix-free/implicit-particle-sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles-matrix-free/implicit-particle-sedimentation.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles-matrix-free/implicit-particle-sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles-matrix-free/implicit-particle-sedimentation.prm
@@ -33,8 +33,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles-matrix-free/semi-implicit-particle-sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles-matrix-free/semi-implicit-particle-sedimentation.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles-matrix-free/semi-implicit-particle-sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles-matrix-free/semi-implicit-particle-sedimentation.prm
@@ -32,8 +32,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/dynamic_contact_search.prm
+++ b/applications_tests/lethe-fluid-particles/dynamic_contact_search.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/dynamic_contact_search.prm
+++ b/applications_tests/lethe-fluid-particles/dynamic_contact_search.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/dynamic_particle_insertion.prm
+++ b/applications_tests/lethe-fluid-particles/dynamic_particle_insertion.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/dynamic_particle_insertion.prm
+++ b/applications_tests/lethe-fluid-particles/dynamic_particle_insertion.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/explicit-particle-sedimentation-project.prm
+++ b/applications_tests/lethe-fluid-particles/explicit-particle-sedimentation-project.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/explicit-particle-sedimentation-project.prm
+++ b/applications_tests/lethe-fluid-particles/explicit-particle-sedimentation-project.prm
@@ -36,8 +36,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/explicit-particle-sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/explicit-particle-sedimentation.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/explicit-particle-sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/explicit-particle-sedimentation.prm
@@ -33,8 +33,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/generators/gas_solid_fluidized_bed_generator_step_2_cfd-dem.prm
+++ b/applications_tests/lethe-fluid-particles/generators/gas_solid_fluidized_bed_generator_step_2_cfd-dem.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/generators/gas_solid_fluidized_bed_generator_step_2_cfd-dem.prm
+++ b/applications_tests/lethe-fluid-particles/generators/gas_solid_fluidized_bed_generator_step_2_cfd-dem.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/generators/restart_particle_sedimentation_generator.prm
+++ b/applications_tests/lethe-fluid-particles/generators/restart_particle_sedimentation_generator.prm
@@ -26,8 +26,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/generators/restart_particle_sedimentation_generator.prm
+++ b/applications_tests/lethe-fluid-particles/generators/restart_particle_sedimentation_generator.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/implicit-particle-sedimentation-project.prm
+++ b/applications_tests/lethe-fluid-particles/implicit-particle-sedimentation-project.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/implicit-particle-sedimentation-project.prm
+++ b/applications_tests/lethe-fluid-particles/implicit-particle-sedimentation-project.prm
@@ -31,8 +31,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/implicit-particle-sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/implicit-particle-sedimentation.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/implicit-particle-sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/implicit-particle-sedimentation.prm
@@ -33,8 +33,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/liquid_fluidized_bed.prm
+++ b/applications_tests/lethe-fluid-particles/liquid_fluidized_bed.prm
@@ -38,8 +38,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/liquid_fluidized_bed.prm
+++ b/applications_tests/lethe-fluid-particles/liquid_fluidized_bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/particle_sedimentation.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/particle_sedimentation.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/particle_sedimentation_adaptive_time_step.prm
+++ b/applications_tests/lethe-fluid-particles/particle_sedimentation_adaptive_time_step.prm
@@ -28,8 +28,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/periodic_particles_qcm.prm
+++ b/applications_tests/lethe-fluid-particles/periodic_particles_qcm.prm
@@ -132,8 +132,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/periodic_particles_qcm.prm
+++ b/applications_tests/lethe-fluid-particles/periodic_particles_qcm.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/qcm_gauss_lobatto_particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/qcm_gauss_lobatto_particle_sedimentation.prm
@@ -30,8 +30,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/qcm_gauss_lobatto_particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/qcm_gauss_lobatto_particle_sedimentation.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #  Test description: Test Gauss-Lobatto rule with 3 quadrature points when using QCM void fraction.

--- a/applications_tests/lethe-fluid-particles/qcm_gauss_particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/qcm_gauss_particle_sedimentation.prm
@@ -30,8 +30,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/qcm_gauss_particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/qcm_gauss_particle_sedimentation.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Test description: Test Gauss rule with 3 quadrature points when using QCM void fraction.

--- a/applications_tests/lethe-fluid-particles/restart_gas_solid_fluidized_bed.prm
+++ b/applications_tests/lethe-fluid-particles/restart_gas_solid_fluidized_bed.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/restart_gas_solid_fluidized_bed.prm
+++ b/applications_tests/lethe-fluid-particles/restart_gas_solid_fluidized_bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/restart_particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/restart_particle_sedimentation.prm
@@ -26,8 +26,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/restart_particle_sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/restart_particle_sedimentation.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/semi-implicit-particle-sedimentation-project.prm
+++ b/applications_tests/lethe-fluid-particles/semi-implicit-particle-sedimentation-project.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/semi-implicit-particle-sedimentation-project.prm
+++ b/applications_tests/lethe-fluid-particles/semi-implicit-particle-sedimentation-project.prm
@@ -31,8 +31,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/semi-implicit-particle-sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/semi-implicit-particle-sedimentation.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/semi-implicit-particle-sedimentation.prm
+++ b/applications_tests/lethe-fluid-particles/semi-implicit-particle-sedimentation.prm
@@ -33,8 +33,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-particles/spouted_bed_load_balancing.prm
+++ b/applications_tests/lethe-fluid-particles/spouted_bed_load_balancing.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-particles/spouted_bed_load_balancing.prm
+++ b/applications_tests/lethe-fluid-particles/spouted_bed_load_balancing.prm
@@ -25,8 +25,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/almost_blocked_channels.prm
+++ b/applications_tests/lethe-fluid-sharp/almost_blocked_channels.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/almost_blocked_channels.prm
+++ b/applications_tests/lethe-fluid-sharp/almost_blocked_channels.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/cavatappi_composite_test.prm
+++ b/applications_tests/lethe-fluid-sharp/cavatappi_composite_test.prm
@@ -32,8 +32,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/cavatappi_composite_test.prm
+++ b/applications_tests/lethe-fluid-sharp/cavatappi_composite_test.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/check_point.prm
+++ b/applications_tests/lethe-fluid-sharp/check_point.prm
@@ -43,8 +43,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/check_point.prm
+++ b/applications_tests/lethe-fluid-sharp/check_point.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/couette2d_gls.prm
+++ b/applications_tests/lethe-fluid-sharp/couette2d_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/couette2d_gls.prm
+++ b/applications_tests/lethe-fluid-sharp/couette2d_gls.prm
@@ -43,8 +43,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/couette2d_gls_poisson.prm
+++ b/applications_tests/lethe-fluid-sharp/couette2d_gls_poisson.prm
@@ -43,8 +43,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/couette2d_gls_poisson.prm
+++ b/applications_tests/lethe-fluid-sharp/couette2d_gls_poisson.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/coupled_moving_stokes.prm
+++ b/applications_tests/lethe-fluid-sharp/coupled_moving_stokes.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/coupled_moving_stokes.prm
+++ b/applications_tests/lethe-fluid-sharp/coupled_moving_stokes.prm
@@ -43,8 +43,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/flow_around_cuthollowsphere.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_cuthollowsphere.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/flow_around_cuthollowsphere.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_cuthollowsphere.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/flow_around_ellipsoid_rectangle.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_ellipsoid_rectangle.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/flow_around_ellipsoid_rectangle.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_ellipsoid_rectangle.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/flow_around_multiple_objects.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_multiple_objects.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/flow_around_multiple_objects.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_multiple_objects.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/flow_around_rbf.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_rbf.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/flow_around_rbf.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_rbf.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/flow_around_torus.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_torus.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/flow_around_torus.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_torus.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/generators/check_point_generator.prm
+++ b/applications_tests/lethe-fluid-sharp/generators/check_point_generator.prm
@@ -43,8 +43,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 subsection stabilization

--- a/applications_tests/lethe-fluid-sharp/generators/check_point_generator.prm
+++ b/applications_tests/lethe-fluid-sharp/generators/check_point_generator.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/load_particles_from_file_test.prm
+++ b/applications_tests/lethe-fluid-sharp/load_particles_from_file_test.prm
@@ -43,8 +43,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/load_particles_from_file_test.prm
+++ b/applications_tests/lethe-fluid-sharp/load_particles_from_file_test.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/minimal_crown_refinement.prm
+++ b/applications_tests/lethe-fluid-sharp/minimal_crown_refinement.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/minimal_crown_refinement.prm
+++ b/applications_tests/lethe-fluid-sharp/minimal_crown_refinement.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/mms_tracer_reaction_heterogeneous_gaussian.prm
+++ b/applications_tests/lethe-fluid-sharp/mms_tracer_reaction_heterogeneous_gaussian.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # This MMS tests a 1.3th-order heterogeneous reaction across a disk.

--- a/applications_tests/lethe-fluid-sharp/mms_tracer_reaction_heterogeneous_gaussian.prm
+++ b/applications_tests/lethe-fluid-sharp/mms_tracer_reaction_heterogeneous_gaussian.prm
@@ -32,9 +32,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/mms_tracer_reaction_heterogeneous_tanh.prm
+++ b/applications_tests/lethe-fluid-sharp/mms_tracer_reaction_heterogeneous_tanh.prm
@@ -32,9 +32,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/mms_tracer_reaction_heterogeneous_tanh.prm
+++ b/applications_tests/lethe-fluid-sharp/mms_tracer_reaction_heterogeneous_tanh.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # This MMS tests a 1.5-order heterogeneous reaction across a disk.

--- a/applications_tests/lethe-fluid-sharp/moving_ib_gls.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_ib_gls.prm
@@ -46,8 +46,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/moving_ib_gls.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_ib_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/moving_ib_gls_poisson.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_ib_gls_poisson.prm
@@ -46,8 +46,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/moving_ib_gls_poisson.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_ib_gls_poisson.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/moving_rectangle.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_rectangle.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/moving_rectangle.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_rectangle.prm
@@ -44,8 +44,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/moving_stokes.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes.prm
@@ -50,8 +50,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/moving_stokes.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #-------------------------------------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/moving_stokes_2d.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes_2d.prm
@@ -46,8 +46,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/moving_stokes_2d.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes_2d.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/moving_stokes_2d_output_control.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes_2d_output_control.prm
@@ -52,8 +52,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/moving_stokes_distance_coarsening.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes_distance_coarsening.prm
@@ -51,8 +51,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/moving_stokes_distance_coarsening.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes_distance_coarsening.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #-------------------------------------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/opencascade/static_stokes_step.prm
+++ b/applications_tests/lethe-fluid-sharp/opencascade/static_stokes_step.prm
@@ -43,8 +43,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/opencascade/static_stokes_step.prm
+++ b/applications_tests/lethe-fluid-sharp/opencascade/static_stokes_step.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/opencascade/static_stokes_step.prm
+++ b/applications_tests/lethe-fluid-sharp/opencascade/static_stokes_step.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/pp_contact_test.prm
+++ b/applications_tests/lethe-fluid-sharp/pp_contact_test.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/pp_contact_test.prm
+++ b/applications_tests/lethe-fluid-sharp/pp_contact_test.prm
@@ -42,8 +42,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/pw_contact_test.prm
+++ b/applications_tests/lethe-fluid-sharp/pw_contact_test.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/pw_contact_test.prm
+++ b/applications_tests/lethe-fluid-sharp/pw_contact_test.prm
@@ -43,8 +43,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/pw_lubrication_test.prm
+++ b/applications_tests/lethe-fluid-sharp/pw_lubrication_test.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/pw_lubrication_test.prm
+++ b/applications_tests/lethe-fluid-sharp/pw_lubrication_test.prm
@@ -43,8 +43,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/pw_moving_wall_contact.prm
+++ b/applications_tests/lethe-fluid-sharp/pw_moving_wall_contact.prm
@@ -49,8 +49,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/pw_rolling_test.prm
+++ b/applications_tests/lethe-fluid-sharp/pw_rolling_test.prm
@@ -36,8 +36,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/pw_rolling_test.prm
+++ b/applications_tests/lethe-fluid-sharp/pw_rolling_test.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/pw_rotating_wall_contact.prm
+++ b/applications_tests/lethe-fluid-sharp/pw_rotating_wall_contact.prm
@@ -49,8 +49,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/rbf_sphere_mms_adaptive.prm
+++ b/applications_tests/lethe-fluid-sharp/rbf_sphere_mms_adaptive.prm
@@ -36,8 +36,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/rbf_sphere_mms_adaptive.prm
+++ b/applications_tests/lethe-fluid-sharp/rbf_sphere_mms_adaptive.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/sphere_power_law_ramp.prm
+++ b/applications_tests/lethe-fluid-sharp/sphere_power_law_ramp.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/sphere_power_law_ramp.prm
+++ b/applications_tests/lethe-fluid-sharp/sphere_power_law_ramp.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/spooky_composite_test.prm
+++ b/applications_tests/lethe-fluid-sharp/spooky_composite_test.prm
@@ -32,8 +32,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/spooky_composite_test.prm
+++ b/applications_tests/lethe-fluid-sharp/spooky_composite_test.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/static_stokes.prm
+++ b/applications_tests/lethe-fluid-sharp/static_stokes.prm
@@ -48,8 +48,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/static_stokes.prm
+++ b/applications_tests/lethe-fluid-sharp/static_stokes.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023-2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #-------------------------------------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/steady_couette_sphere.prm
+++ b/applications_tests/lethe-fluid-sharp/steady_couette_sphere.prm
@@ -41,8 +41,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/steady_couette_sphere.prm
+++ b/applications_tests/lethe-fluid-sharp/steady_couette_sphere.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/steady_couette_sphere_poisson.prm
+++ b/applications_tests/lethe-fluid-sharp/steady_couette_sphere_poisson.prm
@@ -41,8 +41,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/steady_couette_sphere_poisson.prm
+++ b/applications_tests/lethe-fluid-sharp/steady_couette_sphere_poisson.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/taylorcouette2d_carreau_gls.prm
+++ b/applications_tests/lethe-fluid-sharp/taylorcouette2d_carreau_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/taylorcouette2d_carreau_gls.prm
+++ b/applications_tests/lethe-fluid-sharp/taylorcouette2d_carreau_gls.prm
@@ -54,8 +54,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/tracer_around_sphere.prm
+++ b/applications_tests/lethe-fluid-sharp/tracer_around_sphere.prm
@@ -21,8 +21,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/tracer_around_sphere.prm
+++ b/applications_tests/lethe-fluid-sharp/tracer_around_sphere.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/tube_shape_test.prm
+++ b/applications_tests/lethe-fluid-sharp/tube_shape_test.prm
@@ -32,8 +32,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/tube_shape_test.prm
+++ b/applications_tests/lethe-fluid-sharp/tube_shape_test.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-sharp/two_non_sphere_contact.prm
+++ b/applications_tests/lethe-fluid-sharp/two_non_sphere_contact.prm
@@ -45,8 +45,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-sharp/two_non_sphere_contact.prm
+++ b/applications_tests/lethe-fluid-sharp/two_non_sphere_contact.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans-matrix-free/case0_vans_A_Q2_gcmg.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/case0_vans_A_Q2_gcmg.prm
@@ -46,8 +46,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/case0_vans_A_Q2_lsmg.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/case0_vans_A_Q2_lsmg.prm
@@ -46,8 +46,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/case1_vans_A_Q2_gcmg.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/case1_vans_A_Q2_gcmg.prm
@@ -46,8 +46,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/case1_vans_A_Q2_lsmg.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/case1_vans_A_Q2_lsmg.prm
@@ -46,8 +46,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/case1_vans_A_gcmg.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/case1_vans_A_gcmg.prm
@@ -46,8 +46,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/case1_vans_A_lsmg.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/case1_vans_A_lsmg.prm
@@ -46,8 +46,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/case2_vans_A_Q2_gcmg.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/case2_vans_A_Q2_gcmg.prm
@@ -68,9 +68,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order      = 2
-  set pressure order      = 2
-  set void fraction order = 2
+  set velocity degree      = 2
+  set pressure degree      = 2
+  set void fraction degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/case2_vans_A_Q2_lsmg.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/case2_vans_A_Q2_lsmg.prm
@@ -68,9 +68,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order      = 2
-  set pressure order      = 2
-  set void fraction order = 2
+  set velocity degree      = 2
+  set pressure degree      = 2
+  set void fraction degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/case2_vans_A_grad_div_gcmg.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/case2_vans_A_grad_div_gcmg.prm
@@ -68,9 +68,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order      = 2
-  set pressure order      = 2
-  set void fraction order = 2
+  set velocity degree      = 2
+  set pressure degree      = 2
+  set void fraction degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/case2_vans_A_grad_div_lsmg.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/case2_vans_A_grad_div_lsmg.prm
@@ -68,9 +68,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order      = 2
-  set pressure order      = 2
-  set void fraction order = 2
+  set velocity degree      = 2
+  set pressure degree      = 2
+  set void fraction degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_no_drag.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_no_drag.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_no_drag.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_no_drag.prm
@@ -21,8 +21,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_explicit.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_explicit.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_explicit.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_explicit.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_implicit_gcmg.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_implicit_gcmg.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_implicit_gcmg.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_implicit_gcmg.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_implicit_lsmg.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_implicit_lsmg.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_implicit_lsmg.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_implicit_lsmg.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_semi-implicit.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_semi-implicit.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_semi-implicit.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_packed_bed_rong_drag_semi-implicit.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_water_packed_bed_difelice_drag_explicit.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_water_packed_bed_difelice_drag_explicit.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Tests the explicit drag force coupling for a packed bed

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_water_packed_bed_difelice_drag_explicit.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_water_packed_bed_difelice_drag_explicit.prm
@@ -29,8 +29,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_water_packed_bed_difelice_drag_implicit.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_water_packed_bed_difelice_drag_implicit.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Tests the implicit drag force coupling for a packed bed

--- a/applications_tests/lethe-fluid-vans-matrix-free/qcm_water_packed_bed_difelice_drag_implicit.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/qcm_water_packed_bed_difelice_drag_implicit.prm
@@ -29,8 +29,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/tanh_vans_A.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/tanh_vans_A.prm
@@ -65,8 +65,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans-matrix-free/tanh_vans_A.prm
+++ b/applications_tests/lethe-fluid-vans-matrix-free/tanh_vans_A.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans/beetstra_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/beetstra_packed_bed.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/beetstra_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/beetstra_packed_bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans/case1_vans_A.prm
+++ b/applications_tests/lethe-fluid-vans/case1_vans_A.prm
@@ -43,8 +43,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/case1_vans_A.prm
+++ b/applications_tests/lethe-fluid-vans/case1_vans_A.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans/case1_vans_B.prm
+++ b/applications_tests/lethe-fluid-vans/case1_vans_B.prm
@@ -43,8 +43,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/case1_vans_B.prm
+++ b/applications_tests/lethe-fluid-vans/case1_vans_B.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans/case1_vans_weak.prm
+++ b/applications_tests/lethe-fluid-vans/case1_vans_weak.prm
@@ -43,8 +43,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/case1_vans_weak.prm
+++ b/applications_tests/lethe-fluid-vans/case1_vans_weak.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans/case3_vans.prm
+++ b/applications_tests/lethe-fluid-vans/case3_vans.prm
@@ -26,8 +26,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/case3_vans.prm
+++ b/applications_tests/lethe-fluid-vans/case3_vans.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans/dallavalle_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/dallavalle_packed_bed.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/dallavalle_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/dallavalle_packed_bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans/difelice_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/difelice_packed_bed.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/difelice_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/difelice_packed_bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans/gidaspow_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/gidaspow_packed_bed.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/gidaspow_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/gidaspow_packed_bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans/kochhill_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/kochhill_packed_bed.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/kochhill_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/kochhill_packed_bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans/pcm_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/pcm_packed_bed.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/pcm_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/pcm_packed_bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans/qcm_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/qcm_packed_bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans/qcm_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/qcm_packed_bed.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/rong_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/rong_packed_bed.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/rong_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/rong_packed_bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid-vans/spm_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/spm_packed_bed.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid-vans/spm_packed_bed.prm
+++ b/applications_tests/lethe-fluid-vans/spm_packed_bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/buoyant_flow_between_parallel_plates.prm
+++ b/applications_tests/lethe-fluid/buoyant_flow_between_parallel_plates.prm
@@ -23,9 +23,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/buoyant_flow_between_parallel_plates.prm
+++ b/applications_tests/lethe-fluid/buoyant_flow_between_parallel_plates.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/cahn_hilliard_navier_stokes_energy_postprocessing.prm
+++ b/applications_tests/lethe-fluid/cahn_hilliard_navier_stokes_energy_postprocessing.prm
@@ -160,10 +160,10 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set phase cahn hilliard order     = 1
-  set potential cahn hilliard order = 1
-  set velocity order                = 1
-  set pressure order                = 1
+  set phase cahn hilliard degree     = 1
+  set potential cahn hilliard degree = 1
+  set velocity degree                = 1
+  set pressure degree                = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/cahn_hilliard_navier_stokes_energy_postprocessing.prm
+++ b/applications_tests/lethe-fluid/cahn_hilliard_navier_stokes_energy_postprocessing.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/cavity_adjoint_gls.prm
+++ b/applications_tests/lethe-fluid/cavity_adjoint_gls.prm
@@ -79,8 +79,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/cls-algebraic-interface-reinitialization-advected-circle-bdf2-frequency-check.prm
+++ b/applications_tests/lethe-fluid/cls-algebraic-interface-reinitialization-advected-circle-bdf2-frequency-check.prm
@@ -125,9 +125,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
-  set cls order      = 1
+  set velocity degree = 2
+  set pressure degree = 1
+  set cls degree      = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/cls-algebraic-interface-reinitialization-advected-circle.prm
+++ b/applications_tests/lethe-fluid/cls-algebraic-interface-reinitialization-advected-circle.prm
@@ -121,9 +121,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
-  set cls order      = 1
+  set velocity degree = 2
+  set pressure degree = 1
+  set cls degree      = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/cls-capillary-time-step-constraint-CTR-10.prm
+++ b/applications_tests/lethe-fluid/cls-capillary-time-step-constraint-CTR-10.prm
@@ -153,9 +153,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
-  set cls order      = 1
+  set velocity degree = 2
+  set pressure degree = 1
+  set cls degree      = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/cls-capillary-time-step-constraint-isothermal-compressible-flow.prm
+++ b/applications_tests/lethe-fluid/cls-capillary-time-step-constraint-isothermal-compressible-flow.prm
@@ -169,9 +169,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
-  set cls order      = 1
+  set velocity degree = 2
+  set pressure degree = 1
+  set cls degree      = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/cls-capillary-time-step-constraint-kelly-refinement-bdf2.prm
+++ b/applications_tests/lethe-fluid/cls-capillary-time-step-constraint-kelly-refinement-bdf2.prm
@@ -172,9 +172,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
-  set cls order      = 1
+  set velocity degree = 2
+  set pressure degree = 1
+  set cls degree      = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/cls-geometric-interface-reinitialization-swirling-flow.prm
+++ b/applications_tests/lethe-fluid/cls-geometric-interface-reinitialization-swirling-flow.prm
@@ -204,8 +204,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/cls_phase_change_darcy.prm
+++ b/applications_tests/lethe-fluid/cls_phase_change_darcy.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/cls_phase_change_darcy.prm
+++ b/applications_tests/lethe-fluid/cls_phase_change_darcy.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/cylinder-rigid-body_gls.prm
+++ b/applications_tests/lethe-fluid/cylinder-rigid-body_gls.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/cylinder-rigid-body_gls.prm
+++ b/applications_tests/lethe-fluid/cylinder-rigid-body_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/cylinder_gls.prm
+++ b/applications_tests/lethe-fluid/cylinder_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019, 2021-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/cylinder_gls.prm
+++ b/applications_tests/lethe-fluid/cylinder_gls.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/cylinder_outlet_bc.prm
+++ b/applications_tests/lethe-fluid/cylinder_outlet_bc.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/cylinder_outlet_bc.prm
+++ b/applications_tests/lethe-fluid/cylinder_outlet_bc.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/dg_cls_advection_tanh.prm
+++ b/applications_tests/lethe-fluid/dg_cls_advection_tanh.prm
@@ -22,9 +22,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set cls order      = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set cls degree      = 1
   set cls uses dg    = true
 end
 

--- a/applications_tests/lethe-fluid/dg_cls_advection_tanh.prm
+++ b/applications_tests/lethe-fluid/dg_cls_advection_tanh.prm
@@ -25,7 +25,7 @@ subsection FEM
   set velocity degree = 1
   set pressure degree = 1
   set cls degree      = 1
-  set cls uses dg    = true
+  set cls uses dg     = true
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/dg_tracer_advection_tanh.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_advection_tanh.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/dg_tracer_advection_tanh.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_advection_tanh.prm
@@ -23,9 +23,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
   set tracer uses dg = true
 end
 

--- a/applications_tests/lethe-fluid/dg_tracer_advection_tanh.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_advection_tanh.prm
@@ -26,7 +26,7 @@ subsection FEM
   set velocity degree = 1
   set pressure degree = 1
   set tracer degree   = 1
-  set tracer uses dg = true
+  set tracer uses dg  = true
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/dg_tracer_advection_tanh_bdf2.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_advection_tanh_bdf2.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/dg_tracer_advection_tanh_bdf2.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_advection_tanh_bdf2.prm
@@ -25,7 +25,7 @@ subsection FEM
   set velocity degree = 1
   set pressure degree = 1
   set tracer degree   = 1
-  set tracer uses dg = true
+  set tracer uses dg  = true
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/dg_tracer_advection_tanh_bdf2.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_advection_tanh_bdf2.prm
@@ -22,9 +22,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
   set tracer uses dg = true
 end
 

--- a/applications_tests/lethe-fluid/dg_tracer_circular_advection.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_circular_advection.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/dg_tracer_circular_advection.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_circular_advection.prm
@@ -21,9 +21,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
   set tracer uses dg = true
 end
 

--- a/applications_tests/lethe-fluid/dg_tracer_circular_advection.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_circular_advection.prm
@@ -24,7 +24,7 @@ subsection FEM
   set velocity degree = 1
   set pressure degree = 1
   set tracer degree   = 1
-  set tracer uses dg = true
+  set tracer uses dg  = true
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/dg_tracer_circular_advection_adapt.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_circular_advection_adapt.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/dg_tracer_circular_advection_adapt.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_circular_advection_adapt.prm
@@ -21,9 +21,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
   set tracer uses dg = true
 end
 

--- a/applications_tests/lethe-fluid/dg_tracer_circular_advection_adapt.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_circular_advection_adapt.prm
@@ -24,7 +24,7 @@ subsection FEM
   set velocity degree = 1
   set pressure degree = 1
   set tracer degree   = 1
-  set tracer uses dg = true
+  set tracer uses dg  = true
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/dg_tracer_diffusion_mms_2d.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_diffusion_mms_2d.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/dg_tracer_diffusion_mms_2d.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_diffusion_mms_2d.prm
@@ -21,9 +21,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
   set tracer uses dg = true
 end
 

--- a/applications_tests/lethe-fluid/dg_tracer_diffusion_mms_2d.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_diffusion_mms_2d.prm
@@ -24,7 +24,7 @@ subsection FEM
   set velocity degree = 1
   set pressure degree = 1
   set tracer degree   = 1
-  set tracer uses dg = true
+  set tracer uses dg  = true
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/dg_tracer_diffusion_residual.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_diffusion_residual.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/dg_tracer_diffusion_residual.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_diffusion_residual.prm
@@ -24,7 +24,7 @@ subsection FEM
   set velocity degree = 1
   set pressure degree = 1
   set tracer degree   = 1
-  set tracer uses dg = false
+  set tracer uses dg  = false
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/dg_tracer_diffusion_residual.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_diffusion_residual.prm
@@ -21,9 +21,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
   set tracer uses dg = false
 end
 

--- a/applications_tests/lethe-fluid/dg_tracer_high_pe.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_high_pe.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/dg_tracer_high_pe.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_high_pe.prm
@@ -21,9 +21,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
   set tracer uses dg = true
 end
 

--- a/applications_tests/lethe-fluid/dg_tracer_high_pe.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_high_pe.prm
@@ -24,7 +24,7 @@ subsection FEM
   set velocity degree = 1
   set pressure degree = 1
   set tracer degree   = 1
-  set tracer uses dg = true
+  set tracer uses dg  = true
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/dg_tracer_pipe.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_pipe.prm
@@ -26,9 +26,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
   set tracer uses dg = true
 end
 

--- a/applications_tests/lethe-fluid/dg_tracer_pipe.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_pipe.prm
@@ -29,7 +29,7 @@ subsection FEM
   set velocity degree = 1
   set pressure degree = 1
   set tracer degree   = 1
-  set tracer uses dg = true
+  set tracer uses dg  = true
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/dg_tracer_pipe.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_pipe.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Tests DG approach to tracer for a flow inside a cylindrical pipe.

--- a/applications_tests/lethe-fluid/dg_tracer_pipe.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_pipe.prm
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Tests DG approach to tracer for a flow inside a cylindrical pipe.
-# In the test, we apply a 2nd order polynomial inlet velocity and tracer concentration,
+# In the test, we apply a 2nd degree polynomial inlet velocity and tracer concentration,
 # which runs until reaching steady-state.
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/dg_tracer_sharp_edge_90_degrees_curve.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_sharp_edge_90_degrees_curve.prm
@@ -25,9 +25,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
   set tracer uses dg = true
 end
 

--- a/applications_tests/lethe-fluid/dg_tracer_sharp_edge_90_degrees_curve.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_sharp_edge_90_degrees_curve.prm
@@ -28,7 +28,7 @@ subsection FEM
   set velocity degree = 1
   set pressure degree = 1
   set tracer degree   = 1
-  set tracer uses dg = true
+  set tracer uses dg  = true
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/dg_tracer_sharp_edge_90_degrees_curve.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_sharp_edge_90_degrees_curve.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Test robustness of the DG tracer when handling hanging nodes.

--- a/applications_tests/lethe-fluid/dg_tracer_sharp_initial_conditions.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_sharp_initial_conditions.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/dg_tracer_sharp_initial_conditions.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_sharp_initial_conditions.prm
@@ -25,7 +25,7 @@ subsection FEM
   set velocity degree = 1
   set pressure degree = 1
   set tracer degree   = 2
-  set tracer uses dg = true
+  set tracer uses dg  = true
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/dg_tracer_sharp_initial_conditions.prm
+++ b/applications_tests/lethe-fluid/dg_tracer_sharp_initial_conditions.prm
@@ -22,9 +22,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 2
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 2
   set tracer uses dg = true
 end
 

--- a/applications_tests/lethe-fluid/evaporation_plane_constant_mass_flux.prm
+++ b/applications_tests/lethe-fluid/evaporation_plane_constant_mass_flux.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/evaporation_plane_constant_mass_flux.prm
+++ b/applications_tests/lethe-fluid/evaporation_plane_constant_mass_flux.prm
@@ -30,9 +30,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/evaporation_plane_temperature_dependent_mass_flux.prm
+++ b/applications_tests/lethe-fluid/evaporation_plane_temperature_dependent_mass_flux.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/evaporation_plane_temperature_dependent_mass_flux.prm
+++ b/applications_tests/lethe-fluid/evaporation_plane_temperature_dependent_mass_flux.prm
@@ -30,7 +30,7 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set temperature order = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/evaporation_static_droplet_constant_mass_flux.prm
+++ b/applications_tests/lethe-fluid/evaporation_static_droplet_constant_mass_flux.prm
@@ -141,9 +141,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set cls order      = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set cls degree      = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/evaporation_static_droplet_constant_mass_flux.prm
+++ b/applications_tests/lethe-fluid/evaporation_static_droplet_constant_mass_flux.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/generators/heat_transfer_average_temperature_modified_initial_time.prm
+++ b/applications_tests/lethe-fluid/generators/heat_transfer_average_temperature_modified_initial_time.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/generators/heat_transfer_average_temperature_modified_initial_time.prm
+++ b/applications_tests/lethe-fluid/generators/heat_transfer_average_temperature_modified_initial_time.prm
@@ -170,8 +170,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/generators/mortar_tgv_restart_generator.prm
+++ b/applications_tests/lethe-fluid/generators/mortar_tgv_restart_generator.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/generators/mortar_tgv_restart_generator.prm
+++ b/applications_tests/lethe-fluid/generators/mortar_tgv_restart_generator.prm
@@ -32,8 +32,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = true
-  set velocity order                  = 1
-  set pressure order                  = 1
+  set velocity degree                  = 1
+  set pressure degree                  = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/generators/mortar_tgv_restart_generator.prm
+++ b/applications_tests/lethe-fluid/generators/mortar_tgv_restart_generator.prm
@@ -32,8 +32,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = true
-  set velocity degree                  = 1
-  set pressure degree                  = 1
+  set velocity degree                 = 1
+  set pressure degree                 = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/generators/poiseuille_restart_generator.prm
+++ b/applications_tests/lethe-fluid/generators/poiseuille_restart_generator.prm
@@ -91,8 +91,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/generators/poiseuille_restart_generator.prm
+++ b/applications_tests/lethe-fluid/generators/poiseuille_restart_generator.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/generators/time_harmonic_maxwell_waveguide_dirichlet_restart_generator.prm
+++ b/applications_tests/lethe-fluid/generators/time_harmonic_maxwell_waveguide_dirichlet_restart_generator.prm
@@ -38,8 +38,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set electromagnetics trial order = 1
-  set electromagnetics test order  = 2
+  set electromagnetics trial degree = 1
+  set electromagnetics test degree  = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/ggls-stab_gls.prm
+++ b/applications_tests/lethe-fluid/ggls-stab_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/ggls-stab_gls.prm
+++ b/applications_tests/lethe-fluid/ggls-stab_gls.prm
@@ -23,9 +23,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_cls_1_isothermal_compressible_fluid.prm
+++ b/applications_tests/lethe-fluid/gls_cls_1_isothermal_compressible_fluid.prm
@@ -122,8 +122,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_cls_1_isothermal_compressible_fluid.prm
+++ b/applications_tests/lethe-fluid/gls_cls_1_isothermal_compressible_fluid.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_1_isothermal_compressible_fluid.prm
+++ b/applications_tests/lethe-fluid/gls_cls_1_isothermal_compressible_fluid.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_2_isothermal_compressible_fluids.prm
+++ b/applications_tests/lethe-fluid/gls_cls_2_isothermal_compressible_fluids.prm
@@ -125,8 +125,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_cls_2_isothermal_compressible_fluids.prm
+++ b/applications_tests/lethe-fluid/gls_cls_2_isothermal_compressible_fluids.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_2_isothermal_compressible_fluids.prm
+++ b/applications_tests/lethe-fluid/gls_cls_2_isothermal_compressible_fluids.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_buoyant_flow_between_parallel_plates.prm
+++ b/applications_tests/lethe-fluid/gls_cls_buoyant_flow_between_parallel_plates.prm
@@ -23,9 +23,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_cls_dirichlet_boundary_condition.prm
+++ b/applications_tests/lethe-fluid/gls_cls_dirichlet_boundary_condition.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_cls_dirichlet_boundary_condition.prm
+++ b/applications_tests/lethe-fluid/gls_cls_dirichlet_boundary_condition.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_dirichlet_boundary_condition.prm
+++ b/applications_tests/lethe-fluid/gls_cls_dirichlet_boundary_condition.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_heat-transfer_hydrostat.prm
+++ b/applications_tests/lethe-fluid/gls_cls_heat-transfer_hydrostat.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_heat-transfer_hydrostat.prm
+++ b/applications_tests/lethe-fluid/gls_cls_heat-transfer_hydrostat.prm
@@ -174,8 +174,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_cls_heat-transfer_hydrostat.prm
+++ b/applications_tests/lethe-fluid/gls_cls_heat-transfer_hydrostat.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_hydrostat.prm
+++ b/applications_tests/lethe-fluid/gls_cls_hydrostat.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_hydrostat.prm
+++ b/applications_tests/lethe-fluid/gls_cls_hydrostat.prm
@@ -136,8 +136,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_cls_hydrostat_initial_refine.prm
+++ b/applications_tests/lethe-fluid/gls_cls_hydrostat_initial_refine.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_hydrostat_initial_refine.prm
+++ b/applications_tests/lethe-fluid/gls_cls_hydrostat_initial_refine.prm
@@ -136,8 +136,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_cls_hydrostat_initial_refine.prm
+++ b/applications_tests/lethe-fluid/gls_cls_hydrostat_initial_refine.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_hydrostat_mesh-adapt.prm
+++ b/applications_tests/lethe-fluid/gls_cls_hydrostat_mesh-adapt.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_hydrostat_mesh-adapt.prm
+++ b/applications_tests/lethe-fluid/gls_cls_hydrostat_mesh-adapt.prm
@@ -136,8 +136,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_cls_periodic_boundary_condition.prm
+++ b/applications_tests/lethe-fluid/gls_cls_periodic_boundary_condition.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_cls_periodic_boundary_condition.prm
+++ b/applications_tests/lethe-fluid/gls_cls_periodic_boundary_condition.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_periodic_boundary_condition.prm
+++ b/applications_tests/lethe-fluid/gls_cls_periodic_boundary_condition.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_static_droplet_surface_tension_force_with_tanh_filter.prm
+++ b/applications_tests/lethe-fluid/gls_cls_static_droplet_surface_tension_force_with_tanh_filter.prm
@@ -153,8 +153,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_cls_static_droplet_surface_tension_force_with_tanh_filter.prm
+++ b/applications_tests/lethe-fluid/gls_cls_static_droplet_surface_tension_force_with_tanh_filter.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_tanh_filter.prm
+++ b/applications_tests/lethe-fluid/gls_cls_tanh_filter.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_cls_tanh_filter.prm
+++ b/applications_tests/lethe-fluid/gls_cls_tanh_filter.prm
@@ -141,8 +141,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_cls_tanh_filter.prm
+++ b/applications_tests/lethe-fluid/gls_cls_tanh_filter.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_static_droplet_surface_tension_force.prm
+++ b/applications_tests/lethe-fluid/gls_static_droplet_surface_tension_force.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_static_droplet_surface_tension_force.prm
+++ b/applications_tests/lethe-fluid/gls_static_droplet_surface_tension_force.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_static_droplet_surface_tension_force.prm
+++ b/applications_tests/lethe-fluid/gls_static_droplet_surface_tension_force.prm
@@ -148,8 +148,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_tracer_advection_tanh.prm
+++ b/applications_tests/lethe-fluid/gls_tracer_advection_tanh.prm
@@ -24,9 +24,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_tracer_advection_tanh.prm
+++ b/applications_tests/lethe-fluid/gls_tracer_advection_tanh.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_tracer_diffusion_mms_2d.prm
+++ b/applications_tests/lethe-fluid/gls_tracer_diffusion_mms_2d.prm
@@ -21,9 +21,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_tracer_diffusion_mms_2d.prm
+++ b/applications_tests/lethe-fluid/gls_tracer_diffusion_mms_2d.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_tracer_high_pe_stab.prm
+++ b/applications_tests/lethe-fluid/gls_tracer_high_pe_stab.prm
@@ -21,9 +21,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_tracer_high_pe_stab.prm
+++ b/applications_tests/lethe-fluid/gls_tracer_high_pe_stab.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/gls_tracer_simplex_diffusion_mms_2d.prm
+++ b/applications_tests/lethe-fluid/gls_tracer_simplex_diffusion_mms_2d.prm
@@ -21,9 +21,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/gls_tracer_simplex_diffusion_mms_2d.prm
+++ b/applications_tests/lethe-fluid/gls_tracer_simplex_diffusion_mms_2d.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/heat_transfer_ale_bar.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_ale_bar.prm
@@ -199,8 +199,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/heat_transfer_ale_bar.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_ale_bar.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/heat_transfer_average_temperature.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_average_temperature.prm
@@ -169,8 +169,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/heat_transfer_average_temperature.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_average_temperature.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Verify if the time-averaged temperature calculation leads to a segfault. The validity of the average temperature is tested in tests/solvers. This is the heat_transfer_conduction in solid test. The subsections post-processing, mesh refinement and restart have been added.

--- a/applications_tests/lethe-fluid/heat_transfer_average_temperature_modified_initial_time.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_average_temperature_modified_initial_time.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Based on the heat_transfer_average_temperature test. Checks if restarting with a different initial time for average temperature and heat flux parameter leads to a segfault. A warning message should appear saying that the checkpointed time-averaged temperature and heat flux have been initialized/reinitialized.

--- a/applications_tests/lethe-fluid/heat_transfer_average_temperature_modified_initial_time.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_average_temperature_modified_initial_time.prm
@@ -177,8 +177,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/heat_transfer_cls_interface_gaussian_laser.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_cls_interface_gaussian_laser.prm
@@ -153,8 +153,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/heat_transfer_cls_interface_gaussian_laser.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_cls_interface_gaussian_laser.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/heat_transfer_cls_interface_gaussian_laser.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_cls_interface_gaussian_laser.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/heat_transfer_cls_melt_volume.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_cls_melt_volume.prm
@@ -38,9 +38,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/heat_transfer_cls_radiation.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_cls_radiation.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/heat_transfer_cls_radiation.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_cls_radiation.prm
@@ -31,9 +31,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/heat_transfer_conduction_in_solid.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_conduction_in_solid.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/heat_transfer_conduction_in_solid.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_conduction_in_solid.prm
@@ -143,8 +143,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/heat_transfer_laser.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_laser.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/heat_transfer_laser.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_laser.prm
@@ -181,8 +181,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/heat_transfer_laser.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_laser.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/heat_transfer_linear_thermal_conductivity.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_linear_thermal_conductivity.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/heat_transfer_linear_thermal_conductivity.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_linear_thermal_conductivity.prm
@@ -22,9 +22,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/heat_transfer_radiation.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_radiation.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/heat_transfer_radiation.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_radiation.prm
@@ -181,8 +181,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/heat_transfer_radiation.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_radiation.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/heat_transfer_stefan.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_stefan.prm
@@ -32,9 +32,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/heat_transfer_stefan.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_stefan.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #-------------------------------------------------------------------------------

--- a/applications_tests/lethe-fluid/heat_transfer_stefan.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_stefan.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #-------------------------------------------------------------------------------

--- a/applications_tests/lethe-fluid/heat_transfer_stefan_bdf2.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_stefan_bdf2.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/heat_transfer_stefan_bdf2.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_stefan_bdf2.prm
@@ -23,9 +23,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/heat_transfer_transient_conduction.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_transient_conduction.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/heat_transfer_transient_conduction.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_transient_conduction.prm
@@ -150,9 +150,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 2
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/heat_transfer_transient_conduction_bdf3.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_transient_conduction_bdf3.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/heat_transfer_transient_conduction_bdf3.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_transient_conduction_bdf3.prm
@@ -150,9 +150,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 2
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/high_pe_stab_gls.prm
+++ b/applications_tests/lethe-fluid/high_pe_stab_gls.prm
@@ -23,9 +23,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/high_pe_stab_gls.prm
+++ b/applications_tests/lethe-fluid/high_pe_stab_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/interface_sharpening_blurred_circle.prm
+++ b/applications_tests/lethe-fluid/interface_sharpening_blurred_circle.prm
@@ -149,8 +149,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/interface_sharpening_blurred_circle_adaptive_mass_conservation.prm
+++ b/applications_tests/lethe-fluid/interface_sharpening_blurred_circle_adaptive_mass_conservation.prm
@@ -154,8 +154,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mms-conduction_gls.prm
+++ b/applications_tests/lethe-fluid/mms-conduction_gls.prm
@@ -21,9 +21,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mms-conduction_gls.prm
+++ b/applications_tests/lethe-fluid/mms-conduction_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/mms-conv-bc_gls.prm
+++ b/applications_tests/lethe-fluid/mms-conv-bc_gls.prm
@@ -21,9 +21,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mms-conv-bc_gls.prm
+++ b/applications_tests/lethe-fluid/mms-conv-bc_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/mms-transient-conduction-restart_gls.prm
+++ b/applications_tests/lethe-fluid/mms-transient-conduction-restart_gls.prm
@@ -24,9 +24,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 2
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mms-transient-conduction-restart_gls.prm
+++ b/applications_tests/lethe-fluid/mms-transient-conduction-restart_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/mms-transient-conduction_gls.prm
+++ b/applications_tests/lethe-fluid/mms-transient-conduction_gls.prm
@@ -24,9 +24,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 2
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mms-transient-conduction_gls.prm
+++ b/applications_tests/lethe-fluid/mms-transient-conduction_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/mms2d_carreau_1st-order_gls.prm
+++ b/applications_tests/lethe-fluid/mms2d_carreau_1st-order_gls.prm
@@ -52,9 +52,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  # interpolation order velocity
+  # degree of the polynomial for velocity
   set velocity degree = 1
-  # interpolation order pressure
+  # degree of the polynomial for pressure
   set pressure degree = 1
 end
 

--- a/applications_tests/lethe-fluid/mms2d_carreau_1st-order_gls.prm
+++ b/applications_tests/lethe-fluid/mms2d_carreau_1st-order_gls.prm
@@ -53,9 +53,9 @@ end
 
 subsection FEM
   # interpolation order velocity
-  set velocity order = 1
+  set velocity degree = 1
   # interpolation order pressure
-  set pressure order = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mms2d_carreau_1st-order_gls.prm
+++ b/applications_tests/lethe-fluid/mms2d_carreau_1st-order_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/mms2d_carreau_2nd-order_gls.prm
+++ b/applications_tests/lethe-fluid/mms2d_carreau_2nd-order_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/mms2d_carreau_2nd-order_gls.prm
+++ b/applications_tests/lethe-fluid/mms2d_carreau_2nd-order_gls.prm
@@ -53,9 +53,9 @@ end
 
 subsection FEM
   # interpolation order velocity
-  set velocity order = 2
+  set velocity degree = 2
   # interpolation order pressure
-  set pressure order = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mms2d_carreau_2nd-order_gls.prm
+++ b/applications_tests/lethe-fluid/mms2d_carreau_2nd-order_gls.prm
@@ -52,9 +52,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  # interpolation order velocity
+  # degree of the polynomial for velocity
   set velocity degree = 2
-  # interpolation order pressure
+  # degree of the polynomial for pressure
   set pressure degree = 1
 end
 

--- a/applications_tests/lethe-fluid/mms2d_full_gls.prm
+++ b/applications_tests/lethe-fluid/mms2d_full_gls.prm
@@ -31,8 +31,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mms2d_full_gls.prm
+++ b/applications_tests/lethe-fluid/mms2d_full_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/mms_adv_diff_diss_gls.prm
+++ b/applications_tests/lethe-fluid/mms_adv_diff_diss_gls.prm
@@ -21,9 +21,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mms_adv_diff_diss_gls.prm
+++ b/applications_tests/lethe-fluid/mms_adv_diff_diss_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous.prm
+++ b/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous.prm
@@ -32,9 +32,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous.prm
+++ b/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # This MMS tests a second order homogeneous reaction using CG tracer elements.

--- a/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous_dg.prm
+++ b/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous_dg.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # This MMS tests a second order homogeneous reaction using DG tracer elements.

--- a/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous_dg.prm
+++ b/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous_dg.prm
@@ -35,7 +35,7 @@ subsection FEM
   set velocity degree = 1
   set pressure degree = 1
   set tracer degree   = 1
-  set tracer uses dg = true
+  set tracer uses dg  = true
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous_dg.prm
+++ b/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous_dg.prm
@@ -32,9 +32,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
   set tracer uses dg = true
 end
 

--- a/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous_dg_volume_rescale.prm
+++ b/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous_dg_volume_rescale.prm
@@ -36,7 +36,7 @@ subsection FEM
   set velocity degree = 1
   set pressure degree = 1
   set tracer degree   = 1
-  set tracer uses dg = true
+  set tracer uses dg  = true
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous_dg_volume_rescale.prm
+++ b/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous_dg_volume_rescale.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # This is a test for the rescale residuals parameter for the tracer.

--- a/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous_dg_volume_rescale.prm
+++ b/applications_tests/lethe-fluid/mms_tracer_reaction_homogeneous_dg_volume_rescale.prm
@@ -33,9 +33,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
   set tracer uses dg = true
 end
 

--- a/applications_tests/lethe-fluid/mortar_asymmetric_height.prm
+++ b/applications_tests/lethe-fluid/mortar_asymmetric_height.prm
@@ -99,8 +99,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = true
-  set velocity order                  = 1
-  set pressure order                  = 1
+  set velocity degree                  = 1
+  set pressure degree                  = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mortar_asymmetric_height.prm
+++ b/applications_tests/lethe-fluid/mortar_asymmetric_height.prm
@@ -99,8 +99,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = true
-  set velocity degree                  = 1
-  set pressure degree                  = 1
+  set velocity degree                 = 1
+  set pressure degree                 = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mortar_linear_interface.prm
+++ b/applications_tests/lethe-fluid/mortar_linear_interface.prm
@@ -64,8 +64,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = false
-  set velocity degree                  = 2
-  set pressure degree                  = 2
+  set velocity degree                 = 2
+  set pressure degree                 = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mortar_linear_interface.prm
+++ b/applications_tests/lethe-fluid/mortar_linear_interface.prm
@@ -64,8 +64,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = false
-  set velocity order                  = 2
-  set pressure order                  = 2
+  set velocity degree                  = 2
+  set pressure degree                  = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mortar_linear_interface.prm
+++ b/applications_tests/lethe-fluid/mortar_linear_interface.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Verifies the implementation of the mortar linear interface for a linear velocity

--- a/applications_tests/lethe-fluid/mortar_mms.prm
+++ b/applications_tests/lethe-fluid/mortar_mms.prm
@@ -69,8 +69,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mortar_mms.prm
+++ b/applications_tests/lethe-fluid/mortar_mms.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Checks the steady matrix-based mortar implementation for an MMS example.

--- a/applications_tests/lethe-fluid/mortar_mms3d.prm
+++ b/applications_tests/lethe-fluid/mortar_mms3d.prm
@@ -99,8 +99,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = true
-  set velocity order                  = 1
-  set pressure order                  = 1
+  set velocity degree                  = 1
+  set pressure degree                  = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mortar_mms3d.prm
+++ b/applications_tests/lethe-fluid/mortar_mms3d.prm
@@ -99,8 +99,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = true
-  set velocity degree                  = 1
-  set pressure degree                  = 1
+  set velocity degree                 = 1
+  set pressure degree                 = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mortar_mms_Q1Q1.prm
+++ b/applications_tests/lethe-fluid/mortar_mms_Q1Q1.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Checks the use of bubble enrichment function for Q1Q1 simulation with the mortar feature.

--- a/applications_tests/lethe-fluid/mortar_mms_Q1Q1.prm
+++ b/applications_tests/lethe-fluid/mortar_mms_Q1Q1.prm
@@ -63,8 +63,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order                  = 1
-  set pressure order                  = 1
+  set velocity degree                  = 1
+  set pressure degree                  = 1
   set enable bubble function velocity = true
 end
 

--- a/applications_tests/lethe-fluid/mortar_mms_Q1Q1.prm
+++ b/applications_tests/lethe-fluid/mortar_mms_Q1Q1.prm
@@ -63,8 +63,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity degree                  = 1
-  set pressure degree                  = 1
+  set velocity degree                 = 1
+  set pressure degree                 = 1
   set enable bubble function velocity = true
 end
 

--- a/applications_tests/lethe-fluid/mortar_mms_gmsh.prm
+++ b/applications_tests/lethe-fluid/mortar_mms_gmsh.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Checks the use of gmsh-type meshes within the mortar implementation.

--- a/applications_tests/lethe-fluid/mortar_mms_gmsh.prm
+++ b/applications_tests/lethe-fluid/mortar_mms_gmsh.prm
@@ -77,8 +77,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mortar_mms_rotated.prm
+++ b/applications_tests/lethe-fluid/mortar_mms_rotated.prm
@@ -67,8 +67,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mortar_mms_rotated.prm
+++ b/applications_tests/lethe-fluid/mortar_mms_rotated.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Checks the steady matrix-based mortar implementation for a rotated MMS example.

--- a/applications_tests/lethe-fluid/mortar_taylorcouette.prm
+++ b/applications_tests/lethe-fluid/mortar_taylorcouette.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Checks the steady matrix-based mortar implementation for a Taylor-Couette example.

--- a/applications_tests/lethe-fluid/mortar_taylorcouette.prm
+++ b/applications_tests/lethe-fluid/mortar_taylorcouette.prm
@@ -78,8 +78,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
+  set velocity degree = 2
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mortar_taylorcouette_transient.prm
+++ b/applications_tests/lethe-fluid/mortar_taylorcouette_transient.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Checks the transient matrix-based mortar implementation for a Taylor-Couette example.

--- a/applications_tests/lethe-fluid/mortar_taylorcouette_transient.prm
+++ b/applications_tests/lethe-fluid/mortar_taylorcouette_transient.prm
@@ -26,8 +26,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
+  set velocity degree = 2
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mortar_tgv.prm
+++ b/applications_tests/lethe-fluid/mortar_tgv.prm
@@ -25,8 +25,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = true
-  set velocity degree                  = 1
-  set pressure degree                  = 1
+  set velocity degree                 = 1
+  set pressure degree                 = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mortar_tgv.prm
+++ b/applications_tests/lethe-fluid/mortar_tgv.prm
@@ -25,8 +25,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = true
-  set velocity order                  = 1
-  set pressure order                  = 1
+  set velocity degree                  = 1
+  set pressure degree                  = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mortar_tgv.prm
+++ b/applications_tests/lethe-fluid/mortar_tgv.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Checks the transient stabilized ALE mortar implementation.

--- a/applications_tests/lethe-fluid/mortar_tgv_restart.prm
+++ b/applications_tests/lethe-fluid/mortar_tgv_restart.prm
@@ -34,8 +34,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = true
-  set velocity degree                  = 1
-  set pressure degree                  = 1
+  set velocity degree                 = 1
+  set pressure degree                 = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/mortar_tgv_restart.prm
+++ b/applications_tests/lethe-fluid/mortar_tgv_restart.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Checks the storage of checkpoint and restart files when outputting boundaries within the mortar feature.

--- a/applications_tests/lethe-fluid/mortar_tgv_restart.prm
+++ b/applications_tests/lethe-fluid/mortar_tgv_restart.prm
@@ -34,8 +34,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = true
-  set velocity order                  = 1
-  set pressure order                  = 1
+  set velocity degree                  = 1
+  set pressure degree                  = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/non-uniform_heat_flux_bc.prm
+++ b/applications_tests/lethe-fluid/non-uniform_heat_flux_bc.prm
@@ -20,9 +20,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 2
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/non-uniform_heat_flux_bc.prm
+++ b/applications_tests/lethe-fluid/non-uniform_heat_flux_bc.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/non-uniform_transient_heat_flux_bc.prm
+++ b/applications_tests/lethe-fluid/non-uniform_transient_heat_flux_bc.prm
@@ -22,9 +22,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 2
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/non-uniform_transient_heat_flux_bc.prm
+++ b/applications_tests/lethe-fluid/non-uniform_transient_heat_flux_bc.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/partial_slip.prm
+++ b/applications_tests/lethe-fluid/partial_slip.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/partial_slip.prm
+++ b/applications_tests/lethe-fluid/partial_slip.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
+  set velocity degree = 2
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/phase_change_darcy.prm
+++ b/applications_tests/lethe-fluid/phase_change_darcy.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/phase_change_darcy.prm
+++ b/applications_tests/lethe-fluid/phase_change_darcy.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/phase_change_viscosity.prm
+++ b/applications_tests/lethe-fluid/phase_change_viscosity.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/phase_change_viscosity.prm
+++ b/applications_tests/lethe-fluid/phase_change_viscosity.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/poiseuille3d_balanced_grid.prm
+++ b/applications_tests/lethe-fluid/poiseuille3d_balanced_grid.prm
@@ -32,8 +32,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/poiseuille3d_balanced_grid.prm
+++ b/applications_tests/lethe-fluid/poiseuille3d_balanced_grid.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/poiseuille3d_gls.prm
+++ b/applications_tests/lethe-fluid/poiseuille3d_gls.prm
@@ -32,8 +32,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/poiseuille3d_gls.prm
+++ b/applications_tests/lethe-fluid/poiseuille3d_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019, 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/poiseuille_gls.prm
+++ b/applications_tests/lethe-fluid/poiseuille_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019, 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/poiseuille_gls.prm
+++ b/applications_tests/lethe-fluid/poiseuille_gls.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/poiseuille_restart.prm
+++ b/applications_tests/lethe-fluid/poiseuille_restart.prm
@@ -92,8 +92,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/poiseuille_restart.prm
+++ b/applications_tests/lethe-fluid/poiseuille_restart.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/poiseuille_restart.prm
+++ b/applications_tests/lethe-fluid/poiseuille_restart.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, 2023 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/pressure_poiseuille.prm
+++ b/applications_tests/lethe-fluid/pressure_poiseuille.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/pressure_poiseuille.prm
+++ b/applications_tests/lethe-fluid/pressure_poiseuille.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019, 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # This test solves a 2D Poiseuille flow driven by pressure boundary conditions

--- a/applications_tests/lethe-fluid/refinement_at_frequency_off.prm
+++ b/applications_tests/lethe-fluid/refinement_at_frequency_off.prm
@@ -75,8 +75,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/refinement_at_frequency_off.prm
+++ b/applications_tests/lethe-fluid/refinement_at_frequency_off.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/refinement_at_frequency_on.prm
+++ b/applications_tests/lethe-fluid/refinement_at_frequency_on.prm
@@ -75,8 +75,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/refinement_at_frequency_on.prm
+++ b/applications_tests/lethe-fluid/refinement_at_frequency_on.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/rigid-body-rotation_gls.prm
+++ b/applications_tests/lethe-fluid/rigid-body-rotation_gls.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/rigid-body-rotation_gls.prm
+++ b/applications_tests/lethe-fluid/rigid-body-rotation_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/taylor-green-vortex-restart-bdf1-adaptive.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex-restart-bdf1-adaptive.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/taylor-green-vortex-restart-bdf1-adaptive.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex-restart-bdf1-adaptive.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/taylor-green-vortex-restart-bdf1-adaptive/generator.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex-restart-bdf1-adaptive/generator.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/taylor-green-vortex-restart-bdf1-adaptive/generator.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex-restart-bdf1-adaptive/generator.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/taylor-green-vortex-restart_gls_bdf1.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex-restart_gls_bdf1.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/taylor-green-vortex-restart_gls_bdf1.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex-restart_gls_bdf1.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/taylor-green-vortex_gls_bdf1.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex_gls_bdf1.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019, 2021, 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/taylor-green-vortex_gls_bdf1.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex_gls_bdf1.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/taylor-green-vortex_gls_bdf2.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex_gls_bdf2.prm
@@ -26,8 +26,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/taylor-green-vortex_gls_bdf2.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex_gls_bdf2.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Testing the results of the 2nd order BDF scheme on the TGV example

--- a/applications_tests/lethe-fluid/taylor-green-vortex_gls_sdirk22.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex_gls_sdirk22.prm
@@ -26,8 +26,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/taylor-green-vortex_gls_sdirk22.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex_gls_sdirk22.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Testing the results of the SDIRK22 (2nd order with 2 stages) scheme on the TGV example

--- a/applications_tests/lethe-fluid/taylor-green-vortex_gls_sdirk33.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex_gls_sdirk33.prm
@@ -26,8 +26,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/taylor-green-vortex_gls_sdirk33.prm
+++ b/applications_tests/lethe-fluid/taylor-green-vortex_gls_sdirk33.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Testing the results of the SDIRK33 (3rd order with 3 stages) scheme on the TGV example

--- a/applications_tests/lethe-fluid/taylorcouette-unstructured_gls.prm
+++ b/applications_tests/lethe-fluid/taylorcouette-unstructured_gls.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/taylorcouette-unstructured_gls.prm
+++ b/applications_tests/lethe-fluid/taylorcouette-unstructured_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019, 2021, 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/taylorcouette_boundary_ref.prm
+++ b/applications_tests/lethe-fluid/taylorcouette_boundary_ref.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/taylorcouette_boundary_ref.prm
+++ b/applications_tests/lethe-fluid/taylorcouette_boundary_ref.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/taylorcouette_gls.prm
+++ b/applications_tests/lethe-fluid/taylorcouette_gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019, 2021-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/taylorcouette_gls.prm
+++ b/applications_tests/lethe-fluid/taylorcouette_gls.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/taylorcouette_gls_scaled.prm
+++ b/applications_tests/lethe-fluid/taylorcouette_gls_scaled.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/taylorcouette_gls_scaled.prm
+++ b/applications_tests/lethe-fluid/taylorcouette_gls_scaled.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/time_dependent_boundaries_ch.prm
+++ b/applications_tests/lethe-fluid/time_dependent_boundaries_ch.prm
@@ -158,10 +158,10 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set phase cahn hilliard order     = 1
-  set potential cahn hilliard order = 1
-  set velocity order                = 1
-  set pressure order                = 1
+  set phase cahn hilliard degree     = 1
+  set potential cahn hilliard degree = 1
+  set velocity degree                = 1
+  set pressure degree                = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/time_dependent_boundaries_ch.prm
+++ b/applications_tests/lethe-fluid/time_dependent_boundaries_ch.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/time_dependent_boundaries_cls.prm
+++ b/applications_tests/lethe-fluid/time_dependent_boundaries_cls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/time_dependent_boundaries_cls.prm
+++ b/applications_tests/lethe-fluid/time_dependent_boundaries_cls.prm
@@ -146,9 +146,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set cls order      = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set cls degree      = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/time_dependent_boundaries_heat_transfer.prm
+++ b/applications_tests/lethe-fluid/time_dependent_boundaries_heat_transfer.prm
@@ -159,9 +159,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/time_dependent_boundaries_heat_transfer.prm
+++ b/applications_tests/lethe-fluid/time_dependent_boundaries_heat_transfer.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/time_dependent_boundaries_tracer.prm
+++ b/applications_tests/lethe-fluid/time_dependent_boundaries_tracer.prm
@@ -140,9 +140,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/time_dependent_boundaries_tracer.prm
+++ b/applications_tests/lethe-fluid/time_dependent_boundaries_tracer.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/applications_tests/lethe-fluid/time_harmonic_maxwell_waveguide_dirichlet_restart.prm
+++ b/applications_tests/lethe-fluid/time_harmonic_maxwell_waveguide_dirichlet_restart.prm
@@ -44,8 +44,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set electromagnetics trial order = 1
-  set electromagnetics test order  = 2
+  set electromagnetics trial degree = 1
+  set electromagnetics test degree  = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/time_harmonic_maxwell_waveguide_robin.prm
+++ b/applications_tests/lethe-fluid/time_harmonic_maxwell_waveguide_robin.prm
@@ -41,8 +41,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set electromagnetics trial order = 1
-  set electromagnetics test order  = 2
+  set electromagnetics trial degree = 1
+  set electromagnetics test degree  = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/time_harmonic_maxwell_waveguide_robin_dissipative.prm
+++ b/applications_tests/lethe-fluid/time_harmonic_maxwell_waveguide_robin_dissipative.prm
@@ -41,8 +41,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set electromagnetics trial order = 1
-  set electromagnetics test order  = 2
+  set electromagnetics trial degree = 1
+  set electromagnetics test degree  = 2
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/tracer_reaction_initial_condition_zero.prm
+++ b/applications_tests/lethe-fluid/tracer_reaction_initial_condition_zero.prm
@@ -32,9 +32,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
 end
 
 #---------------------------------------------------

--- a/applications_tests/lethe-fluid/tracer_reaction_initial_condition_zero.prm
+++ b/applications_tests/lethe-fluid/tracer_reaction_initial_condition_zero.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # This MMS tests a 0.5th-order homogeneous reaction using CG tracer elements starting from the default initial condition (tracer = 0).

--- a/applications_tests/lethe-fluid/uniform_mesh_adapt_limit.prm
+++ b/applications_tests/lethe-fluid/uniform_mesh_adapt_limit.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Tests maximum level of mesh adaptation using uniform method

--- a/applications_tests/lethe-fluid/uniform_mesh_adapt_limit.prm
+++ b/applications_tests/lethe-fluid/uniform_mesh_adapt_limit.prm
@@ -98,8 +98,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/contrib/utilities/automatic_launch/cylinder.prm
+++ b/contrib/utilities/automatic_launch/cylinder.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/contrib/utilities/automatic_launch/cylinder.prm
+++ b/contrib/utilities/automatic_launch/cylinder.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/doc/source/examples/incompressible-flow/2d-backward-facing-step/2d-backward-facing-step.rst
+++ b/doc/source/examples/incompressible-flow/2d-backward-facing-step/2d-backward-facing-step.rst
@@ -137,7 +137,7 @@ For higher Reynolds numbers with adjoint time stepping, ``frequency = 5`` can be
 FEM
 ~~~
 
-In this example, the interpolation order has been set to one for both velocity and pressure.
+In this example, the degree of the polynomial interpolation used for both velocity and pressure is set to one.
 
 .. code-block:: text
 

--- a/doc/source/examples/incompressible-flow/2d-backward-facing-step/2d-backward-facing-step.rst
+++ b/doc/source/examples/incompressible-flow/2d-backward-facing-step/2d-backward-facing-step.rst
@@ -142,8 +142,8 @@ In this example, the interpolation order has been set to one for both velocity a
 .. code-block:: text
 
     subsection FEM
-      set pressure order = 1
-      set velocity order = 1
+      set pressure degree = 1
+      set velocity degree = 1
     end
 
 Boundary Conditions

--- a/doc/source/examples/incompressible-flow/2d-lid-driven-cavity-flow/lid-driven-cavity-flow.rst
+++ b/doc/source/examples/incompressible-flow/2d-lid-driven-cavity-flow/lid-driven-cavity-flow.rst
@@ -135,8 +135,8 @@ We specify the interpolation order for both pressure and velocity using the ``FE
 .. code-block:: text
 
     subsection FEM
-      set velocity order = 1
-      set pressure order = 1
+      set velocity degree = 1
+      set pressure degree = 1
     end
 
 .. warning:: 

--- a/doc/source/examples/incompressible-flow/2d-lid-driven-cavity-flow/lid-driven-cavity-flow.rst
+++ b/doc/source/examples/incompressible-flow/2d-lid-driven-cavity-flow/lid-driven-cavity-flow.rst
@@ -128,7 +128,7 @@ By default, simulations only contain a single fluid which is labeled ``0``.
 FEM Interpolation
 ~~~~~~~~~~~~~~~~~
 
-Lethe supports the use of polynomial interpolation of arbitrary degree. The default solver for this case is ``lethe-fluid`` which uses a stabilized method and supports equal order interpolation.
+Lethe supports the use of polynomial interpolation of arbitrary degree. The default solver for this case is ``lethe-fluid`` which uses a stabilized method and supports the use of equal polynomial degree for both pressure and velocity.
 
 We specify the interpolation polynomial degree for both pressure and velocity using the ``FEM`` subsection:
 

--- a/doc/source/examples/incompressible-flow/2d-lid-driven-cavity-flow/lid-driven-cavity-flow.rst
+++ b/doc/source/examples/incompressible-flow/2d-lid-driven-cavity-flow/lid-driven-cavity-flow.rst
@@ -128,9 +128,9 @@ By default, simulations only contain a single fluid which is labeled ``0``.
 FEM Interpolation
 ~~~~~~~~~~~~~~~~~
 
-Lethe supports the use of arbitrary interpolation order. The default solver for this case is ``lethe-fluid`` which uses a stabilized method and supports equal order interpolation. 
+Lethe supports the use of polynomial interpolation of arbitrary degree. The default solver for this case is ``lethe-fluid`` which uses a stabilized method and supports equal order interpolation.
 
-We specify the interpolation order for both pressure and velocity using the ``FEM`` subsection:
+We specify the interpolation polynomial degree for both pressure and velocity using the ``FEM`` subsection:
 
 .. code-block:: text
 
@@ -138,6 +138,8 @@ We specify the interpolation order for both pressure and velocity using the ``FE
       set velocity degree = 1
       set pressure degree = 1
     end
+
+Since first-degree polynomials are used, the resulting formulation will be second-order accurate for velocity.
 
 .. warning:: 
     An alternative would be to use the ``lethe-fluid-block`` solver for which `LBB <https://en.wikipedia.org/wiki/Ladyzhenskaya%E2%80%93Babu%C5%A1ka%E2%80%93Brezzi_condition>`_ stable elements must be used (e.g. Qn-Q(n-1)). Only the stabilized solver supports the use of equal order elements. 

--- a/doc/source/examples/incompressible-flow/2d-mms/2d-mms.rst
+++ b/doc/source/examples/incompressible-flow/2d-mms/2d-mms.rst
@@ -71,7 +71,10 @@ where :math:`\nu` is the kinematic viscosity.
 Parameter File
 --------------
 
-The simulations are conducted on the domain :math:`\Omega = [-1,1] \times [-1,1]` using two types of meshes: one composed of quadrilateral cells and the other of triangular cells (simplex mesh). The polynomial degree :math:`k_v` of the velocity interpolation was varied from :math:`k_v=1` to :math:`k_v=3` for the quadrilateral mesh, and from :math:`k_v=1` to :math:`k_v=2` for the triangular mesh, as deal.II does not yet support higher-order polynomials for simplex mesh elements. Additionally, for each velocity approximation degree :math:`k_v`, the pressure field polynomial degree :math:`k_p` ranged from :math:`k_p=1`  up to  :math:`k_p = k_v`. Finally, for each combination of velocity and pressure shape functions, six different mesh resolutions were tested on the quadrilateral mesh, while four resolutions were tested on the triangular mesh.
+The simulations are conducted on the domain :math:`\Omega = [-1,1] \times [-1,1]` using two types of meshes: one composed of quadrilateral cells and the other of triangular cells (simplex mesh).
+The polynomial degree :math:`k_v` of the velocity interpolation was varied from :math:`k_v=1` to :math:`k_v=3` for the quadrilateral mesh, and from :math:`k_v=1` to :math:`k_v=2` for the triangular mesh.
+Additionally, for each velocity approximation degree :math:`k_v`, the pressure field polynomial degree :math:`k_p` ranged from :math:`k_p=1`  up to  :math:`k_p = k_v`.
+Finally, for each combination of velocity and pressure shape functions, six different mesh resolutions were tested on the quadrilateral mesh, while four resolutions were tested on the triangular mesh.
 
 Since several parameter files are needed with a common syntax, except for the three parameters varied, a `parameter file template <https://chaos-polymtl.github.io/lethe/documentation/tools/automatic_launch/automatic_launch.html>`_ is employed for automated file launch.
 

--- a/doc/source/examples/incompressible-flow/2d-mms/2d-mms.rst
+++ b/doc/source/examples/incompressible-flow/2d-mms/2d-mms.rst
@@ -141,13 +141,13 @@ For this analysis, the Reynolds number (based on the maximum velocity in the dom
 FEM Interpolation
 ~~~~~~~~~~~~~~~~~
 
-Similarly to the ``initial refinement`` parameter in the case of a simplex mesh, ``velocity order`` and ``pressure order``  are set to the ``{{Poly_deg_u}}`` and ``{{Poly_deg_p}}`` parameter variables, respectively, in Jinja2 format.
+Similarly to the ``initial refinement`` parameter in the case of a simplex mesh, ``velocity degree`` and ``pressure degree``  are set to the ``{{Poly_deg_u}}`` and ``{{Poly_deg_p}}`` parameter variables, respectively, in Jinja2 format.
 
 .. code-block:: text
 
   subsection FEM
-    set velocity order = {{Poly_deg_u}}
-    set pressure order = {{Poly_deg_p}}
+    set velocity degree = {{Poly_deg_u}}
+    set pressure degree = {{Poly_deg_p}}
   end
 
 Non-linear Solver

--- a/doc/source/examples/incompressible-flow/2d-naca0012-low-reynolds/2d-naca0012-low-reynolds.rst
+++ b/doc/source/examples/incompressible-flow/2d-naca0012-low-reynolds/2d-naca0012-low-reynolds.rst
@@ -294,7 +294,8 @@ The fundamental frequency is :math:`f_1=0.72 \ \text{Hz}`, which gives a sheddin
 Possibilities for Extension
 ---------------------------
 
-- **High-order elements**: In order to get more precise results on the forces and the coefficients, Q2-Q2 elements may be used. It can be modified by setting ``set velocity degree = 2`` and ``set pressure degree = 2`` in the ``FEM`` subsection of ``naca.prm`` .
+- **High-order elements**: In order to get more precise results on the forces and the coefficients, Q2-Q2 elements may be used.
+It can be modified by setting ``set velocity degree = 2`` and ``set pressure degree = 2`` in the ``FEM`` subsection of ``naca.prm``.
 
 - **Going 3D**: the mesh can be extruded into the third dimension. Some modifications will be required in the boundary conditions, and getting the correct boundaries id is not trivial. However, with periodic boundary conditions set on the sides of the box, spanwise effects can be taken into account, which should yield much better results.
 

--- a/doc/source/examples/incompressible-flow/2d-naca0012-low-reynolds/2d-naca0012-low-reynolds.rst
+++ b/doc/source/examples/incompressible-flow/2d-naca0012-low-reynolds/2d-naca0012-low-reynolds.rst
@@ -294,8 +294,7 @@ The fundamental frequency is :math:`f_1=0.72 \ \text{Hz}`, which gives a sheddin
 Possibilities for Extension
 ---------------------------
 
-- **High-order elements**: In order to get more precise results on the forces and the coefficients, Q2-Q2 elements may be used.
-It can be modified by setting ``set velocity degree = 2`` and ``set pressure degree = 2`` in the ``FEM`` subsection of ``naca.prm``.
+- **High-order elements**: In order to get more precise results on the forces and the coefficients, Q2-Q2 elements may be used. It can be modified by setting ``set velocity degree = 2`` and ``set pressure degree = 2`` in the ``FEM`` subsection of ``naca.prm``.
 
 - **Going 3D**: the mesh can be extruded into the third dimension. Some modifications will be required in the boundary conditions, and getting the correct boundaries id is not trivial. However, with periodic boundary conditions set on the sides of the box, spanwise effects can be taken into account, which should yield much better results.
 

--- a/doc/source/examples/incompressible-flow/2d-naca0012-low-reynolds/2d-naca0012-low-reynolds.rst
+++ b/doc/source/examples/incompressible-flow/2d-naca0012-low-reynolds/2d-naca0012-low-reynolds.rst
@@ -294,7 +294,7 @@ The fundamental frequency is :math:`f_1=0.72 \ \text{Hz}`, which gives a sheddin
 Possibilities for Extension
 ---------------------------
 
-- **High-order elements**: In order to get more precise results on the forces and the coefficients, Q2-Q2 elements may be used. It can be modified by setting ``set velocity order = 2`` and ``set pressure order = 2`` in the ``FEM`` subsection of ``naca.prm`` .
+- **High-order elements**: In order to get more precise results on the forces and the coefficients, Q2-Q2 elements may be used. It can be modified by setting ``set velocity degree = 2`` and ``set pressure degree = 2`` in the ``FEM`` subsection of ``naca.prm`` .
 
 - **Going 3D**: the mesh can be extruded into the third dimension. Some modifications will be required in the boundary conditions, and getting the correct boundaries id is not trivial. However, with periodic boundary conditions set on the sides of the box, spanwise effects can be taken into account, which should yield much better results.
 

--- a/doc/source/examples/incompressible-flow/2d-paddle-mixer-mortar/2d-paddle-mixer-mortar.rst
+++ b/doc/source/examples/incompressible-flow/2d-paddle-mixer-mortar/2d-paddle-mixer-mortar.rst
@@ -70,8 +70,8 @@ For this example, Q1 elements are used for both velocity and pressure. The bubbl
 
   subsection FEM
     set enable bubble function velocity = true
-    set velocity order                  = 1
-    set pressure order                  = 1
+    set velocity degree                  = 1
+    set pressure degree                  = 1
   end
 
 Mesh

--- a/doc/source/examples/incompressible-flow/2d-sudden-expansion-flow/2d-sudden-expansion-flow.rst
+++ b/doc/source/examples/incompressible-flow/2d-sudden-expansion-flow/2d-sudden-expansion-flow.rst
@@ -152,8 +152,8 @@ A linear interpolation order is chosen for the velocity and pressure fields for 
 .. code-block:: text
 
     subsection FEM
-      set pressure order = 1
-      set velocity order = 1
+      set pressure degree = 1
+      set velocity degree = 1
     end
 
 Boundary Conditions

--- a/doc/source/examples/incompressible-flow/2d-sudden-expansion-flow/2d-sudden-expansion-flow.rst
+++ b/doc/source/examples/incompressible-flow/2d-sudden-expansion-flow/2d-sudden-expansion-flow.rst
@@ -147,7 +147,7 @@ The ``mesh refinement controller`` feature aims to maintain the total number of 
 FEM
 ~~~
 
-A linear interpolation order is chosen for the velocity and pressure fields for both :math:`\textrm{Re}` values:
+A linear interpolation is chosen for the velocity and pressure fields for both :math:`\textrm{Re}` values:
 
 .. code-block:: text
 

--- a/doc/source/examples/incompressible-flow/2d-taylor-couette-flow-nitsche/2d-taylor-couette-flow-nitsche.rst
+++ b/doc/source/examples/incompressible-flow/2d-taylor-couette-flow-nitsche/2d-taylor-couette-flow-nitsche.rst
@@ -158,8 +158,7 @@ FEM Interpolation
 .. note::
 
   In `Example 2 <https://chaos-polymtl.github.io/lethe/documentation/examples/incompressible-flow/2d-taylor-couette-flow/2d-taylor-couette-flow.html>`_ we have used Q2 (quadratic) elements for velocity.
-  In this problem, since we are using immersed boundary conditions, moving to higher degree polynomials would not enhance the order of convergence
-   as the solid boundary is not represented with high accuracy with the Nitsche immersed boundary method.
+  In this problem, since we are using immersed boundary conditions, moving to higher degree polynomials would not enhance the order of convergence as the solid boundary is not represented with high accuracy with the Nitsche immersed boundary method.
 
 .. code-block:: text
 

--- a/doc/source/examples/incompressible-flow/2d-taylor-couette-flow-nitsche/2d-taylor-couette-flow-nitsche.rst
+++ b/doc/source/examples/incompressible-flow/2d-taylor-couette-flow-nitsche/2d-taylor-couette-flow-nitsche.rst
@@ -157,7 +157,9 @@ FEM Interpolation
 
 .. note::
 
-  In `Example 2 <https://chaos-polymtl.github.io/lethe/documentation/examples/incompressible-flow/2d-taylor-couette-flow/2d-taylor-couette-flow.html>`_ we have used second order element for velocity. In this problem, since we are using immersed boundary conditions, moving to higher order polynomials would not enhance the order of convergence as the solid boundary is not represented with high accuracy.
+  In `Example 2 <https://chaos-polymtl.github.io/lethe/documentation/examples/incompressible-flow/2d-taylor-couette-flow/2d-taylor-couette-flow.html>`_ we have used Q2 (quadratic) elements for velocity.
+  In this problem, since we are using immersed boundary conditions, moving to higher degree polynomials would not enhance the order of convergence
+   as the solid boundary is not represented with high accuracy with the Nitsche immersed boundary method.
 
 .. code-block:: text
 

--- a/doc/source/examples/incompressible-flow/2d-taylor-couette-flow-nitsche/2d-taylor-couette-flow-nitsche.rst
+++ b/doc/source/examples/incompressible-flow/2d-taylor-couette-flow-nitsche/2d-taylor-couette-flow-nitsche.rst
@@ -162,8 +162,8 @@ FEM Interpolation
 .. code-block:: text
 
     subsection FEM
-      set velocity order = 1
-      set pressure order = 1
+      set velocity degree = 1
+      set pressure degree = 1
     end
 
 Analytical Solution

--- a/doc/source/examples/incompressible-flow/2d-taylor-couette-flow/2d-taylor-couette-flow.rst
+++ b/doc/source/examples/incompressible-flow/2d-taylor-couette-flow/2d-taylor-couette-flow.rst
@@ -122,7 +122,10 @@ The analytical solution for the Taylor-Couette problem is only valid at low Reyn
 FEM Interpolation
 ~~~~~~~~~~~~~~~~~
 
-Lethe supports the use of arbitrary interpolation order. The :math:`\mathcal{L}^2` norm of the error is :math:`\mathcal{O}\left(h^{n+1} \right)` where :math:`h` is a measure of the element size and :math:`n` is the interpolation order of the velocity. However, since the torque applied on the inner cylinder depends on the deviatoric stress tensor, which depends on the velocity gradient, its error will be :math:`\mathcal{O}(h^n)`. Taking this into account, we use second order polynomials in this example to obtain higher accuracy on the torque. We specify the interpolation order for both pressure and velocity using the ``FEM`` subsection:
+Lethe supports the use of arbitrary interpolation order. The :math:`\mathcal{L}^2` norm of the error is :math:`\mathcal{O}\left(h^{p+1} \right)` where :math:`h` is a measure of the element size and
+ :math:`p` is the degree of the polynomial shape function of the velocity. However, since the torque applied on the inner cylinder depends on the deviatoric stress tensor, which depends on the velocity gradient,
+ its error will be :math:`\mathcal{O}(h^p)`. Taking this into account, we use second degree polynomials to obtain higher accuracy on the torque. We specify the polynomial degree for both
+ pressure and velocity using the ``FEM`` subsection:
 
 .. code-block:: text
 

--- a/doc/source/examples/incompressible-flow/2d-taylor-couette-flow/2d-taylor-couette-flow.rst
+++ b/doc/source/examples/incompressible-flow/2d-taylor-couette-flow/2d-taylor-couette-flow.rst
@@ -122,10 +122,7 @@ The analytical solution for the Taylor-Couette problem is only valid at low Reyn
 FEM Interpolation
 ~~~~~~~~~~~~~~~~~
 
-Lethe supports the use of arbitrary interpolation degree. The :math:`\mathcal{L}^2` norm of the error is :math:`\mathcal{O}\left(h^{p+1} \right)` where :math:`h` is a measure of the element size and
- :math:`p` is the degree of the polynomial shape function of the velocity. However, since the torque applied on the inner cylinder depends on the deviatoric stress tensor, which depends on the velocity gradient,
- its error will be :math:`\mathcal{O}(h^p)`. Taking this into account, we use second degree polynomials to obtain higher accuracy on the torque. We specify the polynomial degree for both
- pressure and velocity using the ``FEM`` subsection:
+Lethe supports the use of arbitrary interpolation degree. The :math:`\mathcal{L}^2` norm of the error is :math:`\mathcal{O}\left(h^{p+1} \right)` where :math:`h` is a measure of the element size and :math:`p` is the degree of the polynomial shape function of the velocity. However, since the torque applied on the inner cylinder depends on the deviatoric stress tensor, which depends on the velocity gradient, its error will be :math:`\mathcal{O}(h^p)`. Taking this into account, we use second degree polynomials to obtain higher accuracy on the torque. We specify the polynomial degree for both pressure and velocity using the ``FEM`` subsection:
 
 .. code-block:: text
 

--- a/doc/source/examples/incompressible-flow/2d-taylor-couette-flow/2d-taylor-couette-flow.rst
+++ b/doc/source/examples/incompressible-flow/2d-taylor-couette-flow/2d-taylor-couette-flow.rst
@@ -127,8 +127,8 @@ Lethe supports the use of arbitrary interpolation order. The :math:`\mathcal{L}^
 .. code-block:: text
 
     subsection FEM
-        set velocity order = 2
-        set pressure order = 1
+        set velocity degree = 2
+        set pressure degree = 1
     end
 
 .. note::

--- a/doc/source/examples/incompressible-flow/2d-taylor-couette-flow/2d-taylor-couette-flow.rst
+++ b/doc/source/examples/incompressible-flow/2d-taylor-couette-flow/2d-taylor-couette-flow.rst
@@ -122,7 +122,7 @@ The analytical solution for the Taylor-Couette problem is only valid at low Reyn
 FEM Interpolation
 ~~~~~~~~~~~~~~~~~
 
-Lethe supports the use of arbitrary interpolation order. The :math:`\mathcal{L}^2` norm of the error is :math:`\mathcal{O}\left(h^{p+1} \right)` where :math:`h` is a measure of the element size and
+Lethe supports the use of arbitrary interpolation degree. The :math:`\mathcal{L}^2` norm of the error is :math:`\mathcal{O}\left(h^{p+1} \right)` where :math:`h` is a measure of the element size and
  :math:`p` is the degree of the polynomial shape function of the velocity. However, since the torque applied on the inner cylinder depends on the deviatoric stress tensor, which depends on the velocity gradient,
  its error will be :math:`\mathcal{O}(h^p)`. Taking this into account, we use second degree polynomials to obtain higher accuracy on the torque. We specify the polynomial degree for both
  pressure and velocity using the ``FEM`` subsection:
@@ -230,7 +230,7 @@ Using Paraview, the steady-state velocity profile can be visualized:
     :align: center
     :height: 10cm
 
-As it can be seen, each cell is curved because a Q2 isoparametric mapping was used. To visualize these high-order cells, we need to subdivide the regular cell to store additional information onto them. A good practice is to use as many subdivisions as the interpolation order of the scheme. Hence, we used ``subdivision = 2`` in the simulation control subsection. Finally, by default, Paraview does not render high-order elements. To enable the rendering of high-order elements, the *Nonlinear Subdivision Level* slider must be increased above one. For more information on this topic, please consult the deal.II wiki page on `rendering high-order elements <https://github.com/dealii/dealii/wiki/Notes-on-visualizing-high-order-output>`_.
+As it can be seen, each cell is curved because a Q2 isoparametric mapping was used. To visualize these high-order cells, we need to subdivide the regular cell to store additional information onto them. A good practice is to use as many subdivisions as the polynomial degree of the scheme. Hence, we used ``subdivision = 2`` in the simulation control subsection. Finally, by default, Paraview does not render high-order elements. To enable the rendering of high-order elements, the *Nonlinear Subdivision Level* slider must be increased above one. For more information on this topic, please consult the deal.II wiki page on `rendering high-order elements <https://github.com/dealii/dealii/wiki/Notes-on-visualizing-high-order-output>`_.
 
 .. note::
   To showcase the curvature of the cells, we have illustrated the results on a mesh coarser that the initial mesh used in this simulation.

--- a/doc/source/examples/incompressible-flow/2d-transient-flow-around-cylinder/2d-transient-flow-around-cylinder.rst
+++ b/doc/source/examples/incompressible-flow/2d-transient-flow-around-cylinder/2d-transient-flow-around-cylinder.rst
@@ -70,8 +70,8 @@ The interpolation orders for the velocity and pressure are set to Q2-Q1 in the `
 .. code-block:: text
 
     subsection FEM
-      set velocity order = 2
-      set pressure order = 1
+      set velocity degree = 2
+      set pressure degree = 1
     end
 
 Mesh

--- a/doc/source/examples/incompressible-flow/2d-transient-flow-around-cylinder/2d-transient-flow-around-cylinder.rst
+++ b/doc/source/examples/incompressible-flow/2d-transient-flow-around-cylinder/2d-transient-flow-around-cylinder.rst
@@ -65,7 +65,7 @@ This example uses a 2nd order backward differentiation (``method = bdf2``) for t
 FEM Interpolation
 ~~~~~~~~~~~~~~~~~
 
-The interpolation orders for the velocity and pressure are set to Q2-Q1 in the ``FEM`` subsection:
+The polynomial degree for the velocity and pressure are set to Q2-Q1 in the ``FEM`` subsection:
 
 .. code-block:: text
 

--- a/doc/source/examples/incompressible-flow/3d-flow-around-sphere/flow-around-sphere.rst
+++ b/doc/source/examples/incompressible-flow/3d-flow-around-sphere/flow-around-sphere.rst
@@ -156,9 +156,9 @@ By default, simulations only contain a single fluid which is labeled ``0``.
 FEM Interpolation
 ~~~~~~~~~~~~~~~~~
 
-The default FEM parameters for this example use first order polynomials. They can be easily changed to Q2-Q1 elements.
+The default FEM parameters for this example use first degree polynomials. They can be easily changed to Q2-Q1 elements.
 
-We specify the interpolation order for both pressure and velocity using the ``FEM`` subsection:
+We specify the polynomial degree for both pressure and velocity using the ``FEM`` subsection:
 
 .. code-block:: text
 

--- a/doc/source/examples/incompressible-flow/3d-flow-around-sphere/flow-around-sphere.rst
+++ b/doc/source/examples/incompressible-flow/3d-flow-around-sphere/flow-around-sphere.rst
@@ -163,8 +163,8 @@ We specify the interpolation order for both pressure and velocity using the ``FE
 .. code-block:: text
 
     subsection FEM
-      set velocity order = 1
-      set pressure order = 1
+      set velocity degree = 1
+      set pressure degree = 1
     end
 
 .. warning:: 

--- a/doc/source/examples/incompressible-flow/3d-flow-over-periodic-hills/3d-flow-over-periodic-hills.rst
+++ b/doc/source/examples/incompressible-flow/3d-flow-over-periodic-hills/3d-flow-over-periodic-hills.rst
@@ -186,8 +186,8 @@ The FEM subsection specifies the order of the elements used for both velocity an
 .. code-block:: text
 
     subsection FEM
-      set velocity order = 1
-      set pressure order = 1
+      set velocity degree = 1
+      set pressure degree = 1
     end
 
 For this example we simply consider Q1-Q1 elements. However, it can also be run using Q2-Q2 elements.

--- a/doc/source/examples/incompressible-flow/3d-flow-over-periodic-hills/3d-flow-over-periodic-hills.rst
+++ b/doc/source/examples/incompressible-flow/3d-flow-over-periodic-hills/3d-flow-over-periodic-hills.rst
@@ -181,7 +181,7 @@ In this example, we enable the calculation of average velocities through the par
 
 FEM
 ~~~
-The FEM subsection specifies the order of the elements used for both velocity and pressure.
+The FEM subsection specifies the polynomial degree used for both pressure and velocity.
 
 .. code-block:: text
 
@@ -190,7 +190,7 @@ The FEM subsection specifies the order of the elements used for both velocity an
       set pressure degree = 1
     end
 
-For this example we simply consider Q1-Q1 elements. However, it can also be run using Q2-Q2 elements.
+For this example we simply consider Q1-Q1 elements. However, it can also be run using Q2-Q2 or Q3-Q3 elements.
 
 Non-linear Solver
 ~~~~~~~~~~~~~~~~~

--- a/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
+++ b/doc/source/examples/incompressible-flow/3d-taylor-green-vortex/3d-taylor-green-vortex.rst
@@ -133,8 +133,8 @@ The results obtained for the Taylor-Green vortex are highly dependent on the num
 .. code-block:: text
 
     subsection FEM
-        set velocity order = 2 #3 for Q3
-        set pressure order = 2 #3 for Q3
+        set velocity degree = 2 #3 for Q3
+        set pressure degree = 2 #3 for Q3
     end
 
 Post-processing

--- a/doc/source/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/3d-turbulent-flow-around-cylinder.rst
+++ b/doc/source/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/3d-turbulent-flow-around-cylinder.rst
@@ -162,8 +162,8 @@ The results obtained for the turbulent flow around a cylinder are highly mesh an
 .. code-block:: text
 
     subsection FEM
-      set velocity order = 1  
-      set pressure order = 1  
+      set velocity degree = 1  
+      set pressure degree = 1  
     end
 
 Forces

--- a/doc/source/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/3d-turbulent-flow-around-cylinder.rst
+++ b/doc/source/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/3d-turbulent-flow-around-cylinder.rst
@@ -157,7 +157,8 @@ The Reynolds number is defined as: :math:`Re = \frac{U_{\infty}D}{\nu}`, where :
 FEM Interpolation
 ~~~~~~~~~~~~~~~~~
 
-The results obtained for the turbulent flow around a cylinder are highly mesh and order dependent. The present example consider both :math:`Q_1Q_1` and :math:`Q_2Q_2` elements. The order of the velocity and pressure interpolation can be set in the ``FEM`` subsection.
+The results obtained for the turbulent flow around a cylinder are highly mesh and order dependent. The present example considers both :math:`Q_1Q_1` and :math:`Q_2Q_2` elements.
+The polynomial degree for the velocity and pressure interpolation can be set in the ``FEM`` subsection.
 
 .. code-block:: text
 

--- a/doc/source/examples/incompressible-flow/3d-turbulent-taylor-couette/3d-turbulent-taylor-couette.rst
+++ b/doc/source/examples/incompressible-flow/3d-turbulent-taylor-couette/3d-turbulent-taylor-couette.rst
@@ -196,8 +196,8 @@ The results obtained for the turbulent Taylor-Couette flow are highly dependent 
 .. code-block:: text
 
     subsection FEM
-      set velocity order = 2  #3 for Q3
-      set pressure order = 2  #3 for Q3
+      set velocity degree = 2  #3 for Q3
+      set pressure degree = 2  #3 for Q3
     end
 
 Forces

--- a/doc/source/examples/incompressible-flow/3d-turbulent-taylor-couette/3d-turbulent-taylor-couette.rst
+++ b/doc/source/examples/incompressible-flow/3d-turbulent-taylor-couette/3d-turbulent-taylor-couette.rst
@@ -191,7 +191,7 @@ The ``type`` is set to ``nodal``. Then we choose the ``uvwp subsection`` which a
 FEM Interpolation
 ~~~~~~~~~~~~~~~~~
 
-The results obtained for the turbulent Taylor-Couette flow are highly dependent on the numerical dissipation that occurs within the CFD scheme. Generally, high-order methods outperform traditional second-order accurate methods for this type of flow. In the present case, we will compare the usage of second (Q2) and third degree (Q3) polynomial.
+The results obtained for the turbulent Taylor-Couette flow are highly dependent on the numerical dissipation that occurs within the CFD scheme. Generally, high-order methods outperform traditional second-order accurate methods for this type of flow. In the present case, we will compare the usage of second (Q2) and third degree (Q3) polynomials.
 
 .. code-block:: text
 

--- a/doc/source/examples/incompressible-flow/3d-turbulent-taylor-couette/3d-turbulent-taylor-couette.rst
+++ b/doc/source/examples/incompressible-flow/3d-turbulent-taylor-couette/3d-turbulent-taylor-couette.rst
@@ -247,7 +247,7 @@ The ``simulation control`` subsection controls the flow of the simulation. To ma
 
 .. tip::
 
-  A good practice is to use as many subdivisions as the interpolation order scheme. 
+  A good practice is to use as many subdivisions as the highest polynomial degree used in the simulation.
 
 Other Subsections
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -296,7 +296,7 @@ The enstrophy plot features a zoomed section of the enstrophy cascade. The follo
 +-------------------------------------------------------------------------------------------------------------------+
 
 
-We note that the enstrophy history does not match either reference scheme. Increasing the order from Q2 to Q3 leads to the following results, which are quite close to the P4 and P5 solutions:
+We note that the enstrophy history does not match either reference scheme. Increasing the polynomial degree from Q2 to Q3 leads to the following results, which are quite close to the P4 and P5 solutions:
 
 +-------------------------------------------------------------------------------------------------------------------+
 |  .. figure:: images/enstrophy_comparison_Q3Q3_153k.png                                                            |
@@ -304,7 +304,7 @@ We note that the enstrophy history does not match either reference scheme. Incre
 |                                                                                                                   |
 +-------------------------------------------------------------------------------------------------------------------+
 
-We then revert the scheme order back to Q2 and refine the mesh by setting the ``initial refinement = 5`` in the mesh subsection resulting in a total of 942,080 cells. This simulation closely matches the references for the first 30 seconds and captures the second peak of enstrophy better than the previous simulations:
+We then revert the degree back to Q2 and refine the mesh by setting the ``initial refinement = 5`` in the mesh subsection resulting in a total of 942,080 cells. This simulation closely matches the references for the first 30 seconds and captures the second peak of enstrophy better than the previous simulations:
 
 +-------------------------------------------------------------------------------------------------------------------+
 |  .. figure:: images/enstrophy_comparison_Q2Q2_942k.png                                                            |

--- a/doc/source/examples/multiphysics/cooling-fin/cooling-fin.rst
+++ b/doc/source/examples/multiphysics/cooling-fin/cooling-fin.rst
@@ -257,7 +257,7 @@ We see that even with a relatively coarse mesh, the heat fluxes calculated by th
 Possibilities for Extension
 ----------------------------
 
-- The heat flux is sensitive to the finite element order used for the temperature field. Try the simulations again with first-order Q1 elements and compare the results.
+- The heat flux is sensitive to the finite element used for the temperature field. Try the simulations again with first-degree (Q1) elements and compare the results.
 
 ------------
 References

--- a/doc/source/examples/multiphysics/cooling-fin/cooling-fin.rst
+++ b/doc/source/examples/multiphysics/cooling-fin/cooling-fin.rst
@@ -184,7 +184,7 @@ In the ``mesh`` subsection, we define a cylinder with the appropriate dimensions
 FEM 
 ~~~~
 
-We use the ``FEM`` subsection to define the order of the finite element method used in the simulation. We set the order to 2 for the temperature field.
+We use the ``FEM`` subsection to define the polynomial degree of the elements used in the simulation. We set the polynomial degree to 2 for the temperature.
 
 .. code-block:: text
 

--- a/doc/source/examples/multiphysics/cooling-fin/cooling-fin.rst
+++ b/doc/source/examples/multiphysics/cooling-fin/cooling-fin.rst
@@ -189,7 +189,7 @@ We use the ``FEM`` subsection to define the order of the finite element method u
 .. code-block:: text
 
   subsection FEM
-    set temperature order = 2
+    set temperature degree = 2
   end
   
 Postprocessing 

--- a/doc/source/examples/multiphysics/warming-up-a-viscous-fluid/warming-up-a-viscous-fluid.rst
+++ b/doc/source/examples/multiphysics/warming-up-a-viscous-fluid/warming-up-a-viscous-fluid.rst
@@ -407,4 +407,4 @@ Possibilities for Extension
 
 * Study the **sensitivity to the time step**, namely to assess how large the ``time step`` can be before stating any difference in the heat transfer solution.
 * Test a **different time integration scheme** and see if there is any difference in the computational cost and/or the precision with regards to the analytical solution.
-* See how the **resolution order** (``velocity degree``, ``pressure degree`` and ``temperature degree``) affects the precision with regards to the analytical solution.
+* See how the **degree of the polynomial interpolation** (``velocity degree``, ``pressure degree`` and ``temperature degree``) affects the precision with regards to the analytical solution.

--- a/doc/source/examples/multiphysics/warming-up-a-viscous-fluid/warming-up-a-viscous-fluid.rst
+++ b/doc/source/examples/multiphysics/warming-up-a-viscous-fluid/warming-up-a-viscous-fluid.rst
@@ -73,9 +73,9 @@ The order of resolution for the ``velocity``, ``pressure`` and ``temperature`` a
 .. code-block:: text
 
     subsection FEM
-      set velocity order    = 1
-      set pressure order    = 1
-      set temperature order = 2
+      set velocity degree    = 1
+      set pressure degree    = 1
+      set temperature degree = 2
     end
 
 Physical Properties
@@ -407,4 +407,4 @@ Possibilities for Extension
 
 * Study the **sensitivity to the time step**, namely to assess how large the ``time step`` can be before stating any difference in the heat transfer solution.
 * Test a **different time integration scheme** and see if there is any difference in the computational cost and/or the precision with regards to the analytical solution.
-* See how the **resolution order** (``velocity order``, ``pressure order`` and ``temperature order``) affects the precision with regards to the analytical solution.
+* See how the **resolution order** (``velocity degree``, ``pressure degree`` and ``temperature degree``) affects the precision with regards to the analytical solution.

--- a/doc/source/examples/multiphysics/warming-up-a-viscous-fluid/warming-up-a-viscous-fluid.rst
+++ b/doc/source/examples/multiphysics/warming-up-a-viscous-fluid/warming-up-a-viscous-fluid.rst
@@ -68,7 +68,7 @@ Time integration is defined by a 2nd order backward differentiation (``bdf2``), 
 FEM
 ~~~~~~~~~~~~~~
 
-The order of resolution for the ``velocity``, ``pressure`` and ``temperature`` are given in the subsection FEM:
+The polynomial degree for the ``velocity``, ``pressure`` and ``temperature`` are given in the subsection FEM:
 
 .. code-block:: text
 
@@ -407,4 +407,4 @@ Possibilities for Extension
 
 * Study the **sensitivity to the time step**, namely to assess how large the ``time step`` can be before stating any difference in the heat transfer solution.
 * Test a **different time integration scheme** and see if there is any difference in the computational cost and/or the precision with regards to the analytical solution.
-* See how the **degree of the polynomial interpolation** (``velocity degree``, ``pressure degree`` and ``temperature degree``) affects the precision with regards to the analytical solution.
+* See how the **degree of the polynomial interpolation** (``velocity degree``, ``pressure degree`` and ``temperature degree``) affects the accuracy with regards to the analytical solution.

--- a/doc/source/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.rst
+++ b/doc/source/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.rst
@@ -83,8 +83,8 @@ FEM
 .. code-block:: text
 
     subsection FEM
-      set velocity order = 1
-      set pressure order = 1
+      set velocity degree = 1
+      set pressure degree = 1
     end
 
 Here we use Q1-Q1 elements. This case is only for demonstration purposes as such we want to propose a simulation that is not too costly to run.

--- a/doc/source/examples/sharp-immersed-boundary/sedimentation-64-particles/sedimentation-64-particles.rst
+++ b/doc/source/examples/sharp-immersed-boundary/sedimentation-64-particles/sedimentation-64-particles.rst
@@ -82,8 +82,8 @@ FEM
 .. code-block:: text
 
     subsection FEM
-      set velocity order = 1
-      set pressure order = 1
+      set velocity degree = 1
+      set pressure degree = 1
     end
 
 Here we use Q1Q1 elements to reduce the computational cost.

--- a/doc/source/parameters/cfd/fem.rst
+++ b/doc/source/parameters/cfd/fem.rst
@@ -2,31 +2,31 @@
 Finite Element Interpolation (FEM)
 ==================================
 
-This subsection specifies the characteristics of the finite element method used in the simulations. The interpolation orders of velocity, pressure and other physics are specified. An additional option is also present to enable the use of high-order mapping throughout the entire mesh. At the moment, all variables are interpolated using Lagrange elements. On quad/hex meshes, `FE_Q <https://www.dealii.org/current/doxygen/deal.II/classFE__Q.html>`_ elements are used whereas on simplex meshes (triangles, tetrahedron), `FE_P <https://www.dealii.org/current/doxygen/deal.II/classFE__SimplexP.html>`_ elements are used.
+This subsection specifies the characteristics of the finite element method used in the simulations. The polynomial degrees for velocity, pressure and other physics are specified. An additional option is also present to enable the use of high-order mapping throughout the entire mesh. At the moment, all variables are interpolated using Lagrange elements. On quad/hex meshes, `FE_Q <https://www.dealii.org/current/doxygen/deal.II/classFE__Q.html>`_ elements are used whereas on simplex meshes (triangles, tetrahedron), `FE_P <https://www.dealii.org/current/doxygen/deal.II/classFE__SimplexP.html>`_ elements are used.
 
 
 .. code-block:: text
 
   subsection FEM
-    # interpolation order pressure
-    set pressure order     = 1
+    # interpolation degree pressure
+    set pressure degree     = 1
 
-    # interpolation order velocity
-    set velocity order     = 1
+    # interpolation degree velocity
+    set velocity degree     = 1
 
-    # interpolation order temperature
-    set temperature order  = 1
+    # interpolation degree temperature
+    set temperature degree  = 1
 
-    # interpolation order tracer
-    set tracer order       = 1
-    set tracer uses dg     = false
+    # interpolation degree tracer
+    set tracer degree       = 1
+    set tracer uses dg      = false
 
-    # interpolation order CLS
-    set CLS order          = 1
+    # interpolation degree CLS
+    set CLS degree          = 1
 
-    # interpolation order cahn hilliard
-    set phase cahn hilliard order     = 1
-    set potential cahn hilliard order = 1
+    # interpolation degree cahn hilliard
+    set phase cahn hilliard degree     = 1
+    set potential cahn hilliard degree = 1
 
     # bubble enrichment function
     set enable bubble function velocity = false
@@ -34,13 +34,13 @@ This subsection specifies the characteristics of the finite element method used 
   end
 
 
-* ``velocity order`` specifies the interpolation order for velocity.
+* ``velocity degree`` specifies the polynomial degree for velocity.
 
-* ``pressure order`` specifies the interpolation order for pressure. For the **lethe-fluid** family of solvers, the interpolation order for pressure can be equal or lower than that of velocity. For the **lethe-fluid-block** family of solvers, the interpolation order for pressure has to be one degree lower than that of velocity.
+* ``pressure degree`` specifies the polynomial degree for pressure. For the **lethe-fluid** family of solvers, the polynomial degree for pressure can be equal or lower than that of velocity. For the **lethe-fluid-block** family of solvers, the polynomial degree for pressure has to be one degree lower than that of velocity.
 
-* ``temperature order`` specifies the interpolation order for temperature for the heat transfer physics.
+* ``temperature degree`` specifies the polynomial degree for temperature for the heat transfer physics.
 
-* ``tracer order`` specifies the interpolation order for the tracer physics.
+* ``tracer degree`` specifies the polynomial degree for the tracer physics.
 
 * ``tracer uses dg`` specifies if the Discontinuous Galerkin (DG) formulation is used instead of the Continuous Galerkin (CG) that is used by default, for the tracer physics. This formulation allows discontinuities between elements and at boundaries, and only penalizes them; this prevents oscillations and enforces local conservation of mass, at the cost of more numerous degrees of freedom.
 
@@ -48,9 +48,9 @@ This subsection specifies the characteristics of the finite element method used 
 
     The DG formulation is sensitive to the CFL value. Use a small time step to  keep the tracer value bounded. From our experience, a CFL of 1 or lower is recommended.
 
-* ``CLS order`` specifies the interpolation for the CLS phase indicator. It is not recommended to use higher order interpolation for the CLS method as this may conflict with the bounding and the sharpening mechanism used therein.
+* ``CLS degree`` specifies the polynomial degree for the CLS phase indicator. It is not recommended to use higher polynomial degrees for the CLS method as this may conflict with the bounding and the sharpening mechanism used therein.
 
-* ``phase cahn hilliard order`` and ``potential cahn hilliard order`` specify the interpolation order for the phase order parameter and the chemical potential in the Cahn-Hilliard equations. The orders chosen should be equal. They are left as two separate parameters for debugging purposes.
+* ``phase cahn hilliard degree`` and ``potential cahn hilliard degree`` specify the polynomial degree for the phase order parameter and the chemical potential in the Cahn-Hilliard equations. The degrees chosen should be equal. They are left as two separate parameters for debugging purposes.
 
 * ``enable bubble function velocity`` and ``enable bubble function pressure`` specifies if the bubble enrichment function is used in the velocity and pressure fields, respectively. This is a polynomial enrichment function centered at the mid-point of the cell and that vanishes at the element boundary. It can be used to improve accuracy and stability in Galerkin FEM, similarly to SUPG stabilization; we refer the reader to the work of  `Franca and Farhat 1995 <https://www.sciencedirect.com/science/article/abs/pii/004578259400721X>`_ and `Brezzi et al 1992 <https://www.sciencedirect.com/science/article/abs/pii/004578259290102P>`_ for more detail.
 

--- a/doc/source/parameters/cfd/simulation_control.rst
+++ b/doc/source/parameters/cfd/simulation_control.rst
@@ -231,7 +231,7 @@ Paraview output file parameters
 * ``subdivision``: sub-division of the mesh cells to enable visualisation of high-order elements with Paraview. 
 
   .. tip::
-	  Generally, we advise to use a subdivision level of :math:`(p)` for interpolation degree of :math:`p`. For example, a Q2-Q1 interpolation could be visualized with ``set subdivision = 2``.
+	  Generally, we advise to use a subdivision level of :math:`p` where :math:`p` is the highest interpolation degree. For example, a Q2-Q1 interpolation could be visualized with ``set subdivision = 2``.
 
 ---------------------------------------
 Explicit coupling constraint parameters

--- a/doc/source/parameters/cfd/simulation_control.rst
+++ b/doc/source/parameters/cfd/simulation_control.rst
@@ -231,7 +231,7 @@ Paraview output file parameters
 * ``subdivision``: sub-division of the mesh cells to enable visualisation of high-order elements with Paraview. 
 
   .. tip::
-	  Generally, we advise to use a subdivision level of :math:`(n)` for interpolation order of :math:`n`. For example, a Q2-Q1 interpolation could be visualized with ``set subdivision = 2``.
+	  Generally, we advise to use a subdivision level of :math:`(p)` for interpolation degree of :math:`p`. For example, a Q2-Q1 interpolation could be visualized with ``set subdivision = 2``.
 
 ---------------------------------------
 Explicit coupling constraint parameters

--- a/examples/incompressible-flow/2d-backward-facing-step/Reynolds100/Reynolds100_steady.prm
+++ b/examples/incompressible-flow/2d-backward-facing-step/Reynolds100/Reynolds100_steady.prm
@@ -53,8 +53,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set pressure order = 1
-  set velocity order = 1
+  set pressure degree = 1
+  set velocity degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-backward-facing-step/Reynolds100/Reynolds100_steady.prm
+++ b/examples/incompressible-flow/2d-backward-facing-step/Reynolds100/Reynolds100_steady.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/2d-backward-facing-step/Reynolds1000/Reynolds1000_steadybdf.prm
+++ b/examples/incompressible-flow/2d-backward-facing-step/Reynolds1000/Reynolds1000_steadybdf.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/2d-backward-facing-step/Reynolds1000/Reynolds1000_steadybdf.prm
+++ b/examples/incompressible-flow/2d-backward-facing-step/Reynolds1000/Reynolds1000_steadybdf.prm
@@ -59,8 +59,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set pressure order = 1
-  set velocity order = 1
+  set pressure degree = 1
+  set velocity degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-flow-around-cylinder/cylinder.prm
+++ b/examples/incompressible-flow/2d-flow-around-cylinder/cylinder.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-flow-around-cylinder/cylinder.prm
+++ b/examples/incompressible-flow/2d-flow-around-cylinder/cylinder.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/2d-lid-driven-cavity/Reynolds_7500/cavity.prm
+++ b/examples/incompressible-flow/2d-lid-driven-cavity/Reynolds_7500/cavity.prm
@@ -75,8 +75,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-lid-driven-cavity/cavity.prm
+++ b/examples/incompressible-flow/2d-lid-driven-cavity/cavity.prm
@@ -70,8 +70,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-lid-driven-cavity/cavity.prm
+++ b/examples/incompressible-flow/2d-lid-driven-cavity/cavity.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/2d-mms/mms_quad/mms_2d_steady.prm
+++ b/examples/incompressible-flow/2d-mms/mms_quad/mms_2d_steady.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/2d-mms/mms_quad/mms_2d_steady.prm
+++ b/examples/incompressible-flow/2d-mms/mms_quad/mms_2d_steady.prm
@@ -85,8 +85,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = {{Poly_deg_u}}
-  set pressure order = {{Poly_deg_p}}
+  set velocity degree = {{Poly_deg_u}}
+  set pressure degree = {{Poly_deg_p}}
 end
 
 # --------------------------------------------------

--- a/examples/incompressible-flow/2d-mms/mms_simplex/mms_2d_steady.prm
+++ b/examples/incompressible-flow/2d-mms/mms_simplex/mms_2d_steady.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/2d-mms/mms_simplex/mms_2d_steady.prm
+++ b/examples/incompressible-flow/2d-mms/mms_simplex/mms_2d_steady.prm
@@ -85,8 +85,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = {{Poly_deg_u}}
-  set pressure order = {{Poly_deg_p}}
+  set velocity degree = {{Poly_deg_u}}
+  set pressure degree = {{Poly_deg_p}}
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-naca0012-low-reynolds/naca.prm
+++ b/examples/incompressible-flow/2d-naca0012-low-reynolds/naca.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/2d-naca0012-low-reynolds/naca.prm
+++ b/examples/incompressible-flow/2d-naca0012-low-reynolds/naca.prm
@@ -26,8 +26,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-paddle-mixer-mortar/paddle_mixer_mortar.prm
+++ b/examples/incompressible-flow/2d-paddle-mixer-mortar/paddle_mixer_mortar.prm
@@ -26,8 +26,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = true
-  set velocity degree                  = 1
-  set pressure degree                  = 1
+  set velocity degree                 = 1
+  set pressure degree                 = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-paddle-mixer-mortar/paddle_mixer_mortar.prm
+++ b/examples/incompressible-flow/2d-paddle-mixer-mortar/paddle_mixer_mortar.prm
@@ -26,8 +26,8 @@ end
 
 subsection FEM
   set enable bubble function velocity = true
-  set velocity order                  = 1
-  set pressure order                  = 1
+  set velocity degree                  = 1
+  set pressure degree                  = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-sudden-expansion-flow/Reynolds610/Reynolds610-jet.prm
+++ b/examples/incompressible-flow/2d-sudden-expansion-flow/Reynolds610/Reynolds610-jet.prm
@@ -62,8 +62,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set pressure order = 1
-  set velocity order = 1
+  set pressure degree = 1
+  set velocity degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-sudden-expansion-flow/Reynolds70/Reynolds70-jet.prm
+++ b/examples/incompressible-flow/2d-sudden-expansion-flow/Reynolds70/Reynolds70-jet.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/2d-sudden-expansion-flow/Reynolds70/Reynolds70-jet.prm
+++ b/examples/incompressible-flow/2d-sudden-expansion-flow/Reynolds70/Reynolds70-jet.prm
@@ -57,8 +57,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set pressure order = 1
-  set velocity order = 1
+  set pressure degree = 1
+  set velocity degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-taylor-couette-nitsche/adaptive-taylor-couette-nitsche.prm
+++ b/examples/incompressible-flow/2d-taylor-couette-nitsche/adaptive-taylor-couette-nitsche.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-taylor-couette-nitsche/adaptive-taylor-couette-nitsche.prm
+++ b/examples/incompressible-flow/2d-taylor-couette-nitsche/adaptive-taylor-couette-nitsche.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/2d-taylor-couette-nitsche/uniform-taylor-couette-nitsche.prm
+++ b/examples/incompressible-flow/2d-taylor-couette-nitsche/uniform-taylor-couette-nitsche.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-taylor-couette-nitsche/uniform-taylor-couette-nitsche.prm
+++ b/examples/incompressible-flow/2d-taylor-couette-nitsche/uniform-taylor-couette-nitsche.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/2d-taylor-couette/taylor-couette.prm
+++ b/examples/incompressible-flow/2d-taylor-couette/taylor-couette.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
+  set velocity degree = 2
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-taylor-couette/taylor-couette.prm
+++ b/examples/incompressible-flow/2d-taylor-couette/taylor-couette.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/2d-transient-flow-around-ahmed-body/ahmed.prm
+++ b/examples/incompressible-flow/2d-transient-flow-around-ahmed-body/ahmed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020, 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/2d-transient-flow-around-ahmed-body/ahmed.prm
+++ b/examples/incompressible-flow/2d-transient-flow-around-ahmed-body/ahmed.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-transient-flow-around-cylinder/cylinder.prm
+++ b/examples/incompressible-flow/2d-transient-flow-around-cylinder/cylinder.prm
@@ -25,8 +25,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
+  set velocity degree = 2
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/2d-transient-flow-around-cylinder/cylinder.prm
+++ b/examples/incompressible-flow/2d-transient-flow-around-cylinder/cylinder.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/3d-flow-around-sphere/sphere-0.1.prm
+++ b/examples/incompressible-flow/3d-flow-around-sphere/sphere-0.1.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/3d-flow-around-sphere/sphere-0.1.prm
+++ b/examples/incompressible-flow/3d-flow-around-sphere/sphere-0.1.prm
@@ -22,8 +22,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/3d-flow-around-sphere/sphere-150.prm
+++ b/examples/incompressible-flow/3d-flow-around-sphere/sphere-150.prm
@@ -26,8 +26,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/3d-flow-around-sphere/sphere-150.prm
+++ b/examples/incompressible-flow/3d-flow-around-sphere/sphere-150.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/3d-flow-around-sphere/sphere-150.prm
+++ b/examples/incompressible-flow/3d-flow-around-sphere/sphere-150.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/3d-flow-around-sphere/sphere-adapt.prm
+++ b/examples/incompressible-flow/3d-flow-around-sphere/sphere-adapt.prm
@@ -26,8 +26,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/3d-flow-around-sphere/sphere-adapt.prm
+++ b/examples/incompressible-flow/3d-flow-around-sphere/sphere-adapt.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/3d-flow-around-sphere/sphere-adapt.prm
+++ b/examples/incompressible-flow/3d-flow-around-sphere/sphere-adapt.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/3d-periodic-hills/periodic-hills.prm
+++ b/examples/incompressible-flow/3d-periodic-hills/periodic-hills.prm
@@ -114,8 +114,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/3d-periodic-hills/periodic-hills.prm
+++ b/examples/incompressible-flow/3d-periodic-hills/periodic-hills.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020, 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/3d-ribbon-mixer-cad-aware/ribbon-gls.prm
+++ b/examples/incompressible-flow/3d-ribbon-mixer-cad-aware/ribbon-gls.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/3d-ribbon-mixer-cad-aware/ribbon-gls.prm
+++ b/examples/incompressible-flow/3d-ribbon-mixer-cad-aware/ribbon-gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/3d-ribbon-mixer/ribbon-gls.prm
+++ b/examples/incompressible-flow/3d-ribbon-mixer/ribbon-gls.prm
@@ -25,8 +25,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/3d-ribbon-mixer/ribbon-gls.prm
+++ b/examples/incompressible-flow/3d-ribbon-mixer/ribbon-gls.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-based.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-based.prm
@@ -25,8 +25,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-based.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-based.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free-validation.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free-validation.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free-validation.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free-validation.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 3
-  set pressure order = 3
+  set velocity degree = 3
+  set pressure degree = 3
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
@@ -25,8 +25,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 2
+  set velocity degree = 2
+  set pressure degree = 2
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
+++ b/examples/incompressible-flow/3d-taylor-green-vortex/tgv-matrix-free.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/turbulent-cylinder.prm
+++ b/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/turbulent-cylinder.prm
@@ -101,8 +101,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/turbulent-cylinder.prm
+++ b/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/turbulent-cylinder.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/incompressible-flow/3d-turbulent-taylor-couette/tc-matrix-free.prm
+++ b/examples/incompressible-flow/3d-turbulent-taylor-couette/tc-matrix-free.prm
@@ -82,8 +82,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2 #3 for Q3
-  set pressure order = 2 #3 for Q3
+  set velocity degree = 2 #3 for Q3
+  set pressure degree = 2 #3 for Q3
 end
 
 #---------------------------------------------------

--- a/examples/incompressible-flow/3d-turbulent-taylor-couette/tc-matrix-free.prm
+++ b/examples/incompressible-flow/3d-turbulent-taylor-couette/tc-matrix-free.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/3d-dam-break/3d-dam-break.prm
+++ b/examples/multiphysics/3d-dam-break/3d-dam-break.prm
@@ -63,8 +63,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/3d-dam-break/3d-dam-break.prm
+++ b/examples/multiphysics/3d-dam-break/3d-dam-break.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/3d-dam-break/3d-dam-break.prm
+++ b/examples/multiphysics/3d-dam-break/3d-dam-break.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/air-bubble-compression/air-bubble-compression.prm
+++ b/examples/multiphysics/air-bubble-compression/air-bubble-compression.prm
@@ -189,9 +189,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set cls order      = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set cls degree      = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/bubble-detachment-shear-flow/bubble-detachment-shear-flow.prm
+++ b/examples/multiphysics/bubble-detachment-shear-flow/bubble-detachment-shear-flow.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/bubble-detachment-shear-flow/parametric_sweep/bubble-detachment-shear-flow.prm
+++ b/examples/multiphysics/bubble-detachment-shear-flow/parametric_sweep/bubble-detachment-shear-flow.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/bubble-detachment-shear-flow/parametric_sweep/bubble-detachment-shear-flow.prm
+++ b/examples/multiphysics/bubble-detachment-shear-flow/parametric_sweep/bubble-detachment-shear-flow.prm
@@ -48,10 +48,10 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set phase cahn hilliard order     = 1
-  set potential cahn hilliard order = 1
-  set velocity order                = 1
-  set pressure order                = 1
+  set phase cahn hilliard degree     = 1
+  set potential cahn hilliard degree = 1
+  set velocity degree                = 1
+  set pressure degree                = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/bubble-detachment-shear-flow/parametric_sweep/bubble-detachment-shear-flow.prm
+++ b/examples/multiphysics/bubble-detachment-shear-flow/parametric_sweep/bubble-detachment-shear-flow.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/capillary-wave/capillary-wave-TSM-0_95.prm
+++ b/examples/multiphysics/capillary-wave/capillary-wave-TSM-0_95.prm
@@ -145,9 +145,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set cls order      = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set cls degree      = 1
 end
 
 # --------------------------------------------------

--- a/examples/multiphysics/capillary-wave/capillary-wave-TSM-0_95.prm
+++ b/examples/multiphysics/capillary-wave/capillary-wave-TSM-0_95.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/capillary-wave/capillary-wave-TSM-0_95.prm
+++ b/examples/multiphysics/capillary-wave/capillary-wave-TSM-0_95.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/capillary-wave/capillary-wave.tpl
+++ b/examples/multiphysics/capillary-wave/capillary-wave.tpl
@@ -145,9 +145,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set cls order      = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set cls degree      = 1
 end
 
 # --------------------------------------------------

--- a/examples/multiphysics/capillary-wave/capillary-wave.tpl
+++ b/examples/multiphysics/capillary-wave/capillary-wave.tpl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/concentric-heat-exchanger/concentric-heat-exchanger.prm
+++ b/examples/multiphysics/concentric-heat-exchanger/concentric-heat-exchanger.prm
@@ -42,9 +42,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/concentric-heat-exchanger/concentric-heat-exchanger.prm
+++ b/examples/multiphysics/concentric-heat-exchanger/concentric-heat-exchanger.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/cooling_fin/fin.prm
+++ b/examples/multiphysics/cooling_fin/fin.prm
@@ -21,7 +21,7 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set temperature order = 2
+  set temperature degree = 2
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/cooling_fin/fin.prm
+++ b/examples/multiphysics/cooling_fin/fin.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/dam-break/dam-break-Martin-and-Moyce.prm
+++ b/examples/multiphysics/dam-break/dam-break-Martin-and-Moyce.prm
@@ -153,8 +153,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/fichera_oven/fichera_oven.prm
+++ b/examples/multiphysics/fichera_oven/fichera_oven.prm
@@ -40,8 +40,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set electromagnetics trial order = 3
-  set electromagnetics test order  = 4
+  set electromagnetics trial degree = 3
+  set electromagnetics test degree  = 4
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/melting-cavity/melting-cavity-darcy.prm
+++ b/examples/multiphysics/melting-cavity/melting-cavity-darcy.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/melting-cavity/melting-cavity-darcy.prm
+++ b/examples/multiphysics/melting-cavity/melting-cavity-darcy.prm
@@ -188,8 +188,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/melting-cavity/melting-cavity-stasis-constraint.prm
+++ b/examples/multiphysics/melting-cavity/melting-cavity-stasis-constraint.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/melting-cavity/melting-cavity-stasis-constraint.prm
+++ b/examples/multiphysics/melting-cavity/melting-cavity-stasis-constraint.prm
@@ -182,8 +182,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/melting-cavity/melting-cavity.prm
+++ b/examples/multiphysics/melting-cavity/melting-cavity.prm
@@ -184,8 +184,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/melting-cavity/melting-cavity.prm
+++ b/examples/multiphysics/melting-cavity/melting-cavity.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/melting-cavity/melting-cavity.prm
+++ b/examples/multiphysics/melting-cavity/melting-cavity.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra10k.prm
+++ b/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra10k.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra10k.prm
+++ b/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra10k.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra10k.prm
+++ b/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra10k.prm
@@ -29,9 +29,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra1M.prm
+++ b/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra1M.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra1M.prm
+++ b/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra1M.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra1M.prm
+++ b/examples/multiphysics/rayleigh-benard-convection/rayleigh-benard-convection-Ra1M.prm
@@ -29,9 +29,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability.prm
+++ b/examples/multiphysics/rayleigh-taylor-instability/rayleigh-taylor-instability.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/rising-bubble/3D/rising-bubble-3d.tpl
+++ b/examples/multiphysics/rising-bubble/3D/rising-bubble-3d.tpl
@@ -206,8 +206,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/rising-bubble/rising-bubble-alge.prm
+++ b/examples/multiphysics/rising-bubble/rising-bubble-alge.prm
@@ -197,8 +197,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/rising-bubble/rising-bubble-geo.prm
+++ b/examples/multiphysics/rising-bubble/rising-bubble-geo.prm
@@ -199,8 +199,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/rising-bubble/rising-bubble-proj.prm
+++ b/examples/multiphysics/rising-bubble/rising-bubble-proj.prm
@@ -198,8 +198,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0002/sloshing-in-rectangular-tank_Re0002.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0002/sloshing-in-rectangular-tank_Re0002.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0002/sloshing-in-rectangular-tank_Re0002.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0002/sloshing-in-rectangular-tank_Re0002.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0002/sloshing-in-rectangular-tank_Re0002.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0002/sloshing-in-rectangular-tank_Re0002.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0020/sloshing-in-rectangular-tank_Re0020.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0020/sloshing-in-rectangular-tank_Re0020.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0020/sloshing-in-rectangular-tank_Re0020.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0020/sloshing-in-rectangular-tank_Re0020.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0020/sloshing-in-rectangular-tank_Re0020.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0020/sloshing-in-rectangular-tank_Re0020.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0200/sloshing-in-rectangular-tank_Re0200.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0200/sloshing-in-rectangular-tank_Re0200.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0200/sloshing-in-rectangular-tank_Re0200.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0200/sloshing-in-rectangular-tank_Re0200.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0200/sloshing-in-rectangular-tank_Re0200.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_0200/sloshing-in-rectangular-tank_Re0200.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_2000/sloshing-in-rectangular-tank_Re2000.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_2000/sloshing-in-rectangular-tank_Re2000.prm
@@ -27,8 +27,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_2000/sloshing-in-rectangular-tank_Re2000.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_2000/sloshing-in-rectangular-tank_Re2000.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_2000/sloshing-in-rectangular-tank_Re2000.prm
+++ b/examples/multiphysics/sloshing-in-rectangular-tank/sloshing_2000/sloshing-in-rectangular-tank_Re2000.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/static-bubble/static-bubble.prm
+++ b/examples/multiphysics/static-bubble/static-bubble.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/static-bubble/static-bubble.prm
+++ b/examples/multiphysics/static-bubble/static-bubble.prm
@@ -148,9 +148,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 2
-  set pressure order = 1
-  set cls order      = 1
+  set velocity degree = 2
+  set pressure degree = 1
+  set cls degree      = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/stefan-problem/stefan.prm
+++ b/examples/multiphysics/stefan-problem/stefan.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/stefan-problem/stefan.prm
+++ b/examples/multiphysics/stefan-problem/stefan.prm
@@ -24,9 +24,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/thermocapillary-droplet/capillary-migration-3d.tpl
+++ b/examples/multiphysics/thermocapillary-droplet/capillary-migration-3d.tpl
@@ -283,10 +283,10 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set cls order         = 1
-  set temperature order = 1
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set cls degree         = 1
+  set temperature degree = 1
 end
 
 # --------------------------------------------------

--- a/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer.prm
+++ b/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer.prm
@@ -26,9 +26,9 @@ subsection multiphysics
 end
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
 end
 
 # The problem is set in cm, seconds and grams

--- a/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer.prm
+++ b/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 set dimension = 3

--- a/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer_only_tracer.prm
+++ b/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer_only_tracer.prm
@@ -26,9 +26,9 @@ subsection multiphysics
 end
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set tracer order   = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set tracer degree   = 1
 end
 
 # The problem is set in cm, seconds and grams

--- a/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer_only_tracer.prm
+++ b/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer_only_tracer.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 set dimension = 3

--- a/examples/multiphysics/warming-up-viscous-fluid/warming-up-viscous-fluid.prm
+++ b/examples/multiphysics/warming-up-viscous-fluid/warming-up-viscous-fluid.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/multiphysics/warming-up-viscous-fluid/warming-up-viscous-fluid.prm
+++ b/examples/multiphysics/warming-up-viscous-fluid/warming-up-viscous-fluid.prm
@@ -24,9 +24,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order    = 1
-  set pressure order    = 1
-  set temperature order = 2
+  set velocity degree    = 1
+  set pressure degree    = 1
+  set temperature degree = 2
 end
 
 #---------------------------------------------------

--- a/examples/multiphysics/water-injection-in-a-closed-cell/water-injection-in-a-closed-cell.prm
+++ b/examples/multiphysics/water-injection-in-a-closed-cell/water-injection-in-a-closed-cell.prm
@@ -168,9 +168,9 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
-  set cls order      = 1
+  set velocity degree = 1
+  set pressure degree = 1
+  set cls degree      = 1
 end
 
 #---------------------------------------------------

--- a/examples/sharp-immersed-boundary/3d-rbf-static-mixer/lethe_sharp_simulation/flow_in_long_mixer.prm
+++ b/examples/sharp-immersed-boundary/3d-rbf-static-mixer/lethe_sharp_simulation/flow_in_long_mixer.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 set dimension = 3

--- a/examples/sharp-immersed-boundary/3d-rbf-static-mixer/lethe_sharp_simulation/flow_in_long_mixer.prm
+++ b/examples/sharp-immersed-boundary/3d-rbf-static-mixer/lethe_sharp_simulation/flow_in_long_mixer.prm
@@ -12,8 +12,8 @@ subsection simulation control
 end
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 subsection stabilization

--- a/examples/sharp-immersed-boundary/cylinder-with-sharp-interface/cylinder-with-sharp-interface.prm
+++ b/examples/sharp-immersed-boundary/cylinder-with-sharp-interface/cylinder-with-sharp-interface.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/sharp-immersed-boundary/cylinder-with-sharp-interface/cylinder-with-sharp-interface.prm
+++ b/examples/sharp-immersed-boundary/cylinder-with-sharp-interface/cylinder-with-sharp-interface.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/sharp-immersed-boundary/cylindrical-particle-drag-evaluation-with-sharp-interface/cylindrical-particle-drag-evaluation-with-sharp-interface.prm
+++ b/examples/sharp-immersed-boundary/cylindrical-particle-drag-evaluation-with-sharp-interface/cylindrical-particle-drag-evaluation-with-sharp-interface.prm
@@ -20,8 +20,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/sharp-immersed-boundary/cylindrical-particle-drag-evaluation-with-sharp-interface/cylindrical-particle-drag-evaluation-with-sharp-interface.prm
+++ b/examples/sharp-immersed-boundary/cylindrical-particle-drag-evaluation-with-sharp-interface/cylindrical-particle-drag-evaluation-with-sharp-interface.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/sharp-immersed-boundary/sedimentation-1-cuboid/sedimentation-1-cuboid.prm
+++ b/examples/sharp-immersed-boundary/sedimentation-1-cuboid/sedimentation-1-cuboid.prm
@@ -50,8 +50,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.prm
+++ b/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.prm
+++ b/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.prm
@@ -44,8 +44,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/sharp-immersed-boundary/sedimentation-64-particles/sedimentation-64-particles.prm
+++ b/examples/sharp-immersed-boundary/sedimentation-64-particles/sedimentation-64-particles.prm
@@ -43,8 +43,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/sharp-immersed-boundary/sedimentation-64-particles/sedimentation-64-particles.prm
+++ b/examples/sharp-immersed-boundary/sedimentation-64-particles/sedimentation-64-particles.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/sharp-immersed-boundary/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.prm
+++ b/examples/sharp-immersed-boundary/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/sharp-immersed-boundary/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.prm
+++ b/examples/sharp-immersed-boundary/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, 2026 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/sharp-immersed-boundary/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.prm
+++ b/examples/sharp-immersed-boundary/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/boycott-effect/boycott-effect.prm
+++ b/examples/unresolved-cfd-dem/boycott-effect/boycott-effect.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/boycott-effect/boycott-effect.prm
+++ b/examples/unresolved-cfd-dem/boycott-effect/boycott-effect.prm
@@ -28,8 +28,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/cylindrical-packed-bed/flow-in-bed.prm
+++ b/examples/unresolved-cfd-dem/cylindrical-packed-bed/flow-in-bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/cylindrical-packed-bed/flow-in-bed.prm
+++ b/examples/unresolved-cfd-dem/cylindrical-packed-bed/flow-in-bed.prm
@@ -20,8 +20,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-pcm-explicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-pcm-explicit.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-pcm-explicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-pcm-explicit.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-pcm-implicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-pcm-implicit.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-pcm-implicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-pcm-implicit.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-pcm-semi-implicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-pcm-semi-implicit.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-pcm-semi-implicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-pcm-semi-implicit.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-qcm-explicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-qcm-explicit.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-qcm-explicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-qcm-explicit.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-qcm-implicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-qcm-implicit.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-qcm-implicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-qcm-implicit.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-qcm-semi-implicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-qcm-semi-implicit.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-qcm-semi-implicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mb-fluidized-bed-modelA-qcm-semi-implicit.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mf-fluidized-bed-modelA-explicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mf-fluidized-bed-modelA-explicit.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mf-fluidized-bed-modelA-explicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mf-fluidized-bed-modelA-explicit.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mf-fluidized-bed-modelA-implicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mf-fluidized-bed-modelA-implicit.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mf-fluidized-bed-modelA-implicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mf-fluidized-bed-modelA-implicit.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mf-fluidized-bed-modelA-semi-implicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mf-fluidized-bed-modelA-semi-implicit.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mf-fluidized-bed-modelA-semi-implicit.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-fluidized-cylinder-bed/mf-fluidized-bed-modelA-semi-implicit.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/gas-solid-spouted-cylinder-bed/gas-solid-spouted-cylinder-bed.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-spouted-cylinder-bed/gas-solid-spouted-cylinder-bed.prm
@@ -35,8 +35,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/gas-solid-spouted-cylinder-bed/gas-solid-spouted-cylinder-bed.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-spouted-cylinder-bed/gas-solid-spouted-cylinder-bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/gas-solid-spouted-rectangular-bed/gas-solid-spouted-rectangular-bed.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-spouted-rectangular-bed/gas-solid-spouted-rectangular-bed.prm
@@ -36,8 +36,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/gas-solid-spouted-rectangular-bed/gas-solid-spouted-rectangular-bed.prm
+++ b/examples/unresolved-cfd-dem/gas-solid-spouted-rectangular-bed/gas-solid-spouted-rectangular-bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/liquid-solid-fluidized-bed/liquid-solid-fluidized-bed.prm
+++ b/examples/unresolved-cfd-dem/liquid-solid-fluidized-bed/liquid-solid-fluidized-bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/liquid-solid-fluidized-bed/liquid-solid-fluidized-bed.prm
+++ b/examples/unresolved-cfd-dem/liquid-solid-fluidized-bed/liquid-solid-fluidized-bed.prm
@@ -25,8 +25,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/pseudo-2d-gas-solid-fluidized-bed/gas-solid-fluidized-bed.prm
+++ b/examples/unresolved-cfd-dem/pseudo-2d-gas-solid-fluidized-bed/gas-solid-fluidized-bed.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/pseudo-2d-gas-solid-fluidized-bed/gas-solid-fluidized-bed.prm
+++ b/examples/unresolved-cfd-dem/pseudo-2d-gas-solid-fluidized-bed/gas-solid-fluidized-bed.prm
@@ -23,8 +23,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/examples/unresolved-cfd-dem/single-particle-sedimentation/single-particle-sedimentation.prm
+++ b/examples/unresolved-cfd-dem/single-particle-sedimentation/single-particle-sedimentation.prm
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 # Listing of Parameters

--- a/examples/unresolved-cfd-dem/single-particle-sedimentation/single-particle-sedimentation.prm
+++ b/examples/unresolved-cfd-dem/single-particle-sedimentation/single-particle-sedimentation.prm
@@ -24,8 +24,8 @@ end
 #---------------------------------------------------
 
 subsection FEM
-  set velocity order = 1
-  set pressure order = 1
+  set velocity degree = 1
+  set pressure degree = 1
 end
 
 #---------------------------------------------------

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1196,8 +1196,8 @@ namespace Parameters
   /**
    * @brief FEM - The finite element section
    * controls the properties of the finite element method. This section
-   * controls the order of polynomial integration and the number of quadrature
-   * points within the cells.
+   * controls the interpolation degree of polynomial integration
+   * and the number of quadrature points within the cells.
    */
   struct FEM
   {
@@ -1226,8 +1226,8 @@ namespace Parameters
     bool CLS_uses_dg;
 
     // Interpolation degree Cahn-Hilliard
-    unsigned int phase_cahn_hilliard_order;
-    unsigned int potential_cahn_hilliard_order;
+    unsigned int phase_cahn_hilliard_degree;
+    unsigned int potential_cahn_hilliard_degree;
 
     // Option for bubble enrichment functions
     bool enable_bubble_function_velocity;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1202,7 +1202,7 @@ namespace Parameters
   struct FEM
   {
     // Interpolation degree velocity
-    unsigned int velocity_order;
+    unsigned int velocity_degree;
 
     // Interpolation degree pressure
     unsigned int pressure_order;

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1201,31 +1201,31 @@ namespace Parameters
    */
   struct FEM
   {
-    // Interpolation order velocity
+    // Interpolation degree velocity
     unsigned int velocity_order;
 
-    // Interpolation order pressure
+    // Interpolation degree pressure
     unsigned int pressure_order;
 
-    // Interpolation order void fraction
+    // Interpolation degree void fraction
     unsigned int void_fraction_order;
 
-    // Interpolation order temperature
+    // Interpolation degree temperature
     unsigned int temperature_order;
 
-    // Interpolation order tracer
+    // Interpolation degree tracer
     unsigned int tracer_order;
 
     // Switch tracer to DG formulation instead of CG
     bool tracer_uses_dg;
 
-    // Interpolation order cls model
+    // Interpolation degree cls model
     unsigned int CLS_order;
 
     // Switch cls to DG formulation instead of CG
     bool CLS_uses_dg;
 
-    // Interpolation order Cahn-Hilliard
+    // Interpolation degree Cahn-Hilliard
     unsigned int phase_cahn_hilliard_order;
     unsigned int potential_cahn_hilliard_order;
 
@@ -1233,10 +1233,10 @@ namespace Parameters
     bool enable_bubble_function_velocity;
     bool enable_bubble_function_pressure;
 
-    /// Polynomial order for the different electromagnetics spaces.
-    /// The trial order sets the polynomial degree for the solution and the test
-    /// order is used for the computation of the cell matrix necessary when
-    /// solving a system using the DPG method.
+    /// Polynomial degree for the different electromagnetics spaces.
+    /// The trial degree sets the polynomial degree for the solution and the
+    /// test degree is used for the computation of the cell matrix necessary
+    /// when solving a system using the DPG method.
     unsigned int electromagnetics_trial_order;
     unsigned int electromagnetics_test_order;
 

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1205,22 +1205,22 @@ namespace Parameters
     unsigned int velocity_degree;
 
     // Interpolation degree pressure
-    unsigned int pressure_order;
+    unsigned int pressure_degree;
 
     // Interpolation degree void fraction
-    unsigned int void_fraction_order;
+    unsigned int void_fraction_degree;
 
     // Interpolation degree temperature
-    unsigned int temperature_order;
+    unsigned int temperature_degree;
 
     // Interpolation degree tracer
-    unsigned int tracer_order;
+    unsigned int tracer_degree;
 
     // Switch tracer to DG formulation instead of CG
     bool tracer_uses_dg;
 
     // Interpolation degree cls model
-    unsigned int CLS_order;
+    unsigned int CLS_degree;
 
     // Switch cls to DG formulation instead of CG
     bool CLS_uses_dg;
@@ -1237,8 +1237,8 @@ namespace Parameters
     /// The trial degree sets the polynomial degree for the solution and the
     /// test degree is used for the computation of the cell matrix necessary
     /// when solving a system using the DPG method.
-    unsigned int electromagnetics_trial_order;
-    unsigned int electromagnetics_test_order;
+    unsigned int electromagnetics_trial_degree;
+    unsigned int electromagnetics_test_degree;
 
     static void
     declare_parameters(ParameterHandler &prm);

--- a/include/solvers/cahn_hilliard.h
+++ b/include/solvers/cahn_hilliard.h
@@ -81,23 +81,23 @@ public:
         // for simplex meshes
         fe = std::make_shared<FESystem<dim>>(
           FE_SimplexP<dim>(
-            simulation_parameters.fem_parameters.phase_cahn_hilliard_order),
+            simulation_parameters.fem_parameters.phase_cahn_hilliard_degree),
           1,
-          FE_SimplexP<dim>(
-            simulation_parameters.fem_parameters.potential_cahn_hilliard_order),
+          FE_SimplexP<dim>(simulation_parameters.fem_parameters
+                             .potential_cahn_hilliard_degree),
           1);
         mapping         = std::make_shared<MappingFE<dim>>(*fe);
         cell_quadrature = std::make_shared<QGaussSimplex<dim>>(
           std::max(
-            simulation_parameters.fem_parameters.phase_cahn_hilliard_order,
+            simulation_parameters.fem_parameters.phase_cahn_hilliard_degree,
             simulation_parameters.fem_parameters
-              .potential_cahn_hilliard_order) +
+              .potential_cahn_hilliard_degree) +
           1);
         face_quadrature = std::make_shared<QGaussSimplex<dim - 1>>(
           std::max(
-            simulation_parameters.fem_parameters.phase_cahn_hilliard_order,
+            simulation_parameters.fem_parameters.phase_cahn_hilliard_degree,
             simulation_parameters.fem_parameters
-              .potential_cahn_hilliard_order) +
+              .potential_cahn_hilliard_degree) +
           1);
         ;
       }
@@ -106,25 +106,25 @@ public:
         // Usual case, for quad/hex meshes
         fe = std::make_shared<FESystem<dim>>(
           FE_Q<dim>(
-            simulation_parameters.fem_parameters.phase_cahn_hilliard_order),
+            simulation_parameters.fem_parameters.phase_cahn_hilliard_degree),
           1,
-          FE_Q<dim>(
-            simulation_parameters.fem_parameters.potential_cahn_hilliard_order),
+          FE_Q<dim>(simulation_parameters.fem_parameters
+                      .potential_cahn_hilliard_degree),
           1);
         mapping         = std::make_shared<MappingQ<dim>>(std::max(
-          simulation_parameters.fem_parameters.phase_cahn_hilliard_order,
-          simulation_parameters.fem_parameters.potential_cahn_hilliard_order));
+          simulation_parameters.fem_parameters.phase_cahn_hilliard_degree,
+          simulation_parameters.fem_parameters.potential_cahn_hilliard_degree));
         cell_quadrature = std::make_shared<QGauss<dim>>(
           std::max(
-            simulation_parameters.fem_parameters.phase_cahn_hilliard_order,
+            simulation_parameters.fem_parameters.phase_cahn_hilliard_degree,
             simulation_parameters.fem_parameters
-              .potential_cahn_hilliard_order) +
+              .potential_cahn_hilliard_degree) +
           1);
         face_quadrature = std::make_shared<QGauss<dim - 1>>(
           std::max(
-            simulation_parameters.fem_parameters.phase_cahn_hilliard_order,
+            simulation_parameters.fem_parameters.phase_cahn_hilliard_degree,
             simulation_parameters.fem_parameters
-              .potential_cahn_hilliard_order) +
+              .potential_cahn_hilliard_degree) +
           1);
       }
 

--- a/include/solvers/cls_curvature_projection.h
+++ b/include/solvers/cls_curvature_projection.h
@@ -60,7 +60,7 @@ public:
       {
         // For simplex meshes
         this->fe = std::make_shared<FE_SimplexP<dim>>(
-          this->simulation_parameters.fem_parameters.CLS_order);
+          this->simulation_parameters.fem_parameters.CLS_degree);
         this->mapping = std::make_shared<MappingFE<dim>>(*this->fe);
         this->cell_quadrature =
           std::make_shared<QGaussSimplex<dim>>(this->fe->degree + 1);
@@ -69,7 +69,7 @@ public:
       {
         // Usual case, for quad/hex meshes
         this->fe = std::make_shared<FE_Q<dim>>(
-          this->simulation_parameters.fem_parameters.CLS_order);
+          this->simulation_parameters.fem_parameters.CLS_degree);
         this->mapping = std::make_shared<MappingQ<dim>>(this->fe->degree);
         this->cell_quadrature =
           std::make_shared<QGauss<dim>>(this->fe->degree + 1);

--- a/include/solvers/cls_pde_based_interface_reinitialization.h
+++ b/include/solvers/cls_pde_based_interface_reinitialization.h
@@ -77,7 +77,7 @@ public:
       {
         // For simplex meshes
         this->fe = std::make_shared<FE_SimplexP<dim>>(
-          this->simulation_parameters.fem_parameters.CLS_order);
+          this->simulation_parameters.fem_parameters.CLS_degree);
         this->mapping = std::make_shared<MappingFE<dim>>(*this->fe);
         this->cell_quadrature =
           std::make_shared<QGaussSimplex<dim>>(this->fe->degree + 1);
@@ -86,7 +86,7 @@ public:
       {
         // Usual case, for quad/hex meshes
         this->fe = std::make_shared<FE_Q<dim>>(
-          this->simulation_parameters.fem_parameters.CLS_order);
+          this->simulation_parameters.fem_parameters.CLS_degree);
         this->mapping = std::make_shared<MappingQ<dim>>(this->fe->degree);
         this->cell_quadrature =
           std::make_shared<QGauss<dim>>(this->fe->degree + 1);

--- a/include/solvers/cls_phase_gradient_projection.h
+++ b/include/solvers/cls_phase_gradient_projection.h
@@ -82,7 +82,7 @@ public:
       {
         // For simplex meshes
         const FE_SimplexP<dim> subequation_fe(
-          this->simulation_parameters.fem_parameters.CLS_order);
+          this->simulation_parameters.fem_parameters.CLS_degree);
         this->fe      = std::make_shared<FESystem<dim>>(subequation_fe, dim);
         this->mapping = std::make_shared<MappingFE<dim>>(*this->fe);
 
@@ -93,7 +93,7 @@ public:
       {
         // Usual case, for quad/hex meshes
         const FE_Q<dim> subequation_fe(
-          this->simulation_parameters.fem_parameters.CLS_order);
+          this->simulation_parameters.fem_parameters.CLS_degree);
         this->fe      = std::make_shared<FESystem<dim>>(subequation_fe, dim);
         this->mapping = std::make_shared<MappingQ<dim>>(this->fe->degree);
 

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -101,7 +101,7 @@ public:
       {
         // for simplex meshes
         fe = std::make_shared<FE_SimplexP<dim>>(
-          simulation_parameters.fem_parameters.temperature_order);
+          simulation_parameters.fem_parameters.temperature_degree);
         temperature_mapping = std::make_shared<MappingFE<dim>>(*fe);
         cell_quadrature = std::make_shared<QGaussSimplex<dim>>(fe->degree + 1);
         face_quadrature =
@@ -111,7 +111,7 @@ public:
       {
         // Usual case, for quad/hex meshes
         fe = std::make_shared<FE_Q<dim>>(
-          simulation_parameters.fem_parameters.temperature_order);
+          simulation_parameters.fem_parameters.temperature_degree);
         temperature_mapping = std::make_shared<MappingQ<dim>>(fe->degree);
         cell_quadrature     = std::make_shared<QGauss<dim>>(fe->degree + 1);
         face_quadrature     = std::make_shared<QGauss<dim - 1>>(fe->degree + 1);

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -874,7 +874,7 @@ protected:
    */
   SDIRKVectors sdirk_vectors;
 
-  // Finite element order used
+  // Finite element degree used
   const unsigned int velocity_fem_degree;
   const unsigned int pressure_fem_degree;
   unsigned int       number_quadrature_points;

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -74,7 +74,7 @@ public:
       {
         // for simplex meshes
         fe = std::make_shared<FE_SimplexP<dim>>(
-          simulation_parameters.fem_parameters.tracer_order);
+          simulation_parameters.fem_parameters.tracer_degree);
         mapping         = std::make_shared<MappingFE<dim>>(*fe);
         cell_quadrature = std::make_shared<QGaussSimplex<dim>>(fe->degree + 1);
         face_quadrature =
@@ -90,10 +90,10 @@ public:
         // Usual case, for quad/hex meshes
         if (simulation_parameters.fem_parameters.tracer_uses_dg)
           fe = std::make_shared<FE_DGQ<dim>>(
-            simulation_parameters.fem_parameters.tracer_order);
+            simulation_parameters.fem_parameters.tracer_degree);
         else
           fe = std::make_shared<FE_Q<dim>>(
-            simulation_parameters.fem_parameters.tracer_order);
+            simulation_parameters.fem_parameters.tracer_degree);
         // The mapping must be a minimum of degree 1. This is necessary in the
         // DG method since DG_Q(0) elements are adequate but a mapping of degree
         // 0 does not make sense.

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1826,20 +1826,20 @@ namespace Parameters
   {
     prm.enter_subsection("FEM");
     {
-      velocity_order            = prm.get_integer("velocity degree");
-      pressure_order            = prm.get_integer("pressure degree");
-      void_fraction_order       = prm.get_integer("void fraction degree");
-      temperature_order         = prm.get_integer("temperature degree");
-      tracer_order              = prm.get_integer("tracer degree");
+      velocity_degree           = prm.get_integer("velocity degree");
+      pressure_degree           = prm.get_integer("pressure degree");
+      void_fraction_degree      = prm.get_integer("void fraction degree");
+      temperature_degree        = prm.get_integer("temperature degree");
+      tracer_degree             = prm.get_integer("tracer degree");
       tracer_uses_dg            = prm.get_bool("tracer uses dg");
-      CLS_order                 = prm.get_integer("cls degree");
+      CLS_degree                = prm.get_integer("cls degree");
       CLS_uses_dg               = prm.get_bool("cls uses dg");
       phase_cahn_hilliard_order = prm.get_integer("phase cahn hilliard degree");
       potential_cahn_hilliard_order =
         prm.get_integer("potential cahn hilliard degree");
-      electromagnetics_trial_order =
+      electromagnetics_trial_degree =
         prm.get_integer("electromagnetics trial degree");
-      electromagnetics_test_order =
+      electromagnetics_test_degree =
         prm.get_integer("electromagnetics test degree");
       enable_bubble_function_velocity =
         prm.get_bool("enable bubble function velocity");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1826,16 +1826,17 @@ namespace Parameters
   {
     prm.enter_subsection("FEM");
     {
-      velocity_degree           = prm.get_integer("velocity degree");
-      pressure_degree           = prm.get_integer("pressure degree");
-      void_fraction_degree      = prm.get_integer("void fraction degree");
-      temperature_degree        = prm.get_integer("temperature degree");
-      tracer_degree             = prm.get_integer("tracer degree");
-      tracer_uses_dg            = prm.get_bool("tracer uses dg");
-      CLS_degree                = prm.get_integer("cls degree");
-      CLS_uses_dg               = prm.get_bool("cls uses dg");
-      phase_cahn_hilliard_order = prm.get_integer("phase cahn hilliard degree");
-      potential_cahn_hilliard_order =
+      velocity_degree      = prm.get_integer("velocity degree");
+      pressure_degree      = prm.get_integer("pressure degree");
+      void_fraction_degree = prm.get_integer("void fraction degree");
+      temperature_degree   = prm.get_integer("temperature degree");
+      tracer_degree        = prm.get_integer("tracer degree");
+      tracer_uses_dg       = prm.get_bool("tracer uses dg");
+      CLS_degree           = prm.get_integer("cls degree");
+      CLS_uses_dg          = prm.get_bool("cls uses dg");
+      phase_cahn_hilliard_degree =
+        prm.get_integer("phase cahn hilliard degree");
+      potential_cahn_hilliard_degree =
         prm.get_integer("potential cahn hilliard degree");
       electromagnetics_trial_degree =
         prm.get_integer("electromagnetics trial degree");

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1730,33 +1730,33 @@ namespace Parameters
     {
       prm.declare_entry("velocity degree",
                         "1",
-                        Patterns::Integer(),
-                        "interpolation degree velocity");
+                        Patterns::Integer(0),
+                        "interpolation degree for velocity");
       prm.declare_alias("velocity degree", "velocity order", true);
       prm.declare_entry("pressure degree",
                         "1",
-                        Patterns::Integer(),
-                        "interpolation degree pressure");
+                        Patterns::Integer(0),
+                        "interpolation degree for pressure");
       prm.declare_alias("pressure degree", "pressure order", true);
       prm.declare_entry("void fraction degree",
                         "1",
-                        Patterns::Integer(),
-                        "interpolation degree void fraction");
+                        Patterns::Integer(0),
+                        "interpolation degree for void fraction");
       prm.declare_alias("void fraction degree", "void fraction order", true);
       prm.declare_entry("temperature degree",
                         "1",
-                        Patterns::Integer(),
-                        "interpolation degree temperature");
+                        Patterns::Integer(0),
+                        "interpolation degree for temperature");
       prm.declare_alias("temperature degree", "temperature order", true);
       prm.declare_entry("tracer degree",
                         "1",
-                        Patterns::Integer(),
-                        "interpolation degree tracer");
+                        Patterns::Integer(0),
+                        "interpolation degree for tracer");
       prm.declare_alias("tracer degree", "tracer order", true);
       prm.declare_entry("cls degree",
                         "1",
-                        Patterns::Integer(),
-                        "interpolation degree cls");
+                        Patterns::Integer(0),
+                        "interpolation degree for cls");
       prm.declare_alias("cls degree", "VOF degree");
       prm.declare_alias("cls degree", "cls order", true);
       prm.declare_alias("cls degree", "VOF order", true);
@@ -1764,7 +1764,7 @@ namespace Parameters
         "phase cahn hilliard degree",
         "1",
         Patterns::Integer(),
-        "interpolation degree phase parameter in the Cahn-Hilliard equations");
+        "interpolation degree phase parameter for the Cahn-Hilliard equations");
       prm.declare_alias("phase cahn hilliard degree",
                         "phase cahn hilliard order",
                         true);
@@ -1772,7 +1772,7 @@ namespace Parameters
         "potential cahn hilliard degree",
         "1",
         Patterns::Integer(),
-        "interpolation degree chemical potential in the Cahn-Hilliard equations");
+        "interpolation degree chemical potential for the Cahn-Hilliard equations");
       prm.declare_alias("potential cahn hilliard degree",
                         "potential cahn hilliard order",
                         true);
@@ -1806,15 +1806,17 @@ namespace Parameters
         "Switch CLS to Discontinuous Galerkin (DG) formulation");
       prm.declare_alias("cls uses dg", "VOF uses dg", true);
 
-      prm.declare_entry("enable bubble function velocity",
-                        "false",
-                        Patterns::Bool(),
-                        "Enable bubble enrichment function for velocity field");
+      prm.declare_entry(
+        "enable bubble function velocity",
+        "false",
+        Patterns::Bool(),
+        "Enable bubble enrichment function for the velocity field");
 
-      prm.declare_entry("enable bubble function pressure",
-                        "false",
-                        Patterns::Bool(),
-                        "Enable bubble enrichment function for pressure field");
+      prm.declare_entry(
+        "enable bubble function pressure",
+        "false",
+        Patterns::Bool(),
+        "Enable bubble enrichment function for the pressure field");
     }
     prm.leave_subsection();
   }

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1728,51 +1728,70 @@ namespace Parameters
   {
     prm.enter_subsection("FEM");
     {
-      prm.declare_entry("velocity order",
+      prm.declare_entry("velocity degree",
                         "1",
                         Patterns::Integer(),
-                        "interpolation order velocity");
-      prm.declare_entry("pressure order",
+                        "interpolation degree velocity");
+      prm.declare_alias("velocity degree", "velocity order", true);
+      prm.declare_entry("pressure degree",
                         "1",
                         Patterns::Integer(),
-                        "interpolation order pressure");
-      prm.declare_entry("void fraction order",
+                        "interpolation degree pressure");
+      prm.declare_alias("pressure degree", "pressure order", true);
+      prm.declare_entry("void fraction degree",
                         "1",
                         Patterns::Integer(),
-                        "interpolation order void fraction");
-      prm.declare_entry("temperature order",
+                        "interpolation degree void fraction");
+      prm.declare_alias("void fraction degree", "void fraction order", true);
+      prm.declare_entry("temperature degree",
                         "1",
                         Patterns::Integer(),
-                        "interpolation order temperature");
-      prm.declare_entry("tracer order",
+                        "interpolation degree temperature");
+      prm.declare_alias("temperature degree", "temperature order", true);
+      prm.declare_entry("tracer degree",
                         "1",
                         Patterns::Integer(),
-                        "interpolation order tracer");
-      prm.declare_entry("cls order",
+                        "interpolation degree tracer");
+      prm.declare_alias("tracer degree", "tracer order", true);
+      prm.declare_entry("cls degree",
                         "1",
                         Patterns::Integer(),
-                        "interpolation order tracer");
-      prm.declare_alias("cls order", "VOF order", true);
+                        "interpolation degree cls");
+      prm.declare_alias("cls degree", "VOF degree");
+      prm.declare_alias("cls degree", "cls order", true);
+      prm.declare_alias("cls degree", "VOF order", true);
       prm.declare_entry(
-        "phase cahn hilliard order",
+        "phase cahn hilliard degree",
         "1",
         Patterns::Integer(),
-        "interpolation order phase parameter in the Cahn-Hilliard equations");
+        "interpolation degree phase parameter in the Cahn-Hilliard equations");
+      prm.declare_alias("phase cahn hilliard degree",
+                        "phase cahn hilliard order",
+                        true);
       prm.declare_entry(
-        "potential cahn hilliard order",
+        "potential cahn hilliard degree",
         "1",
         Patterns::Integer(),
-        "interpolation order chemical potential in the Cahn-Hilliard equations");
+        "interpolation degree chemical potential in the Cahn-Hilliard equations");
+      prm.declare_alias("potential cahn hilliard degree",
+                        "potential cahn hilliard order",
+                        true);
       prm.declare_entry(
-        "electromagnetics trial order",
+        "electromagnetics trial degree",
         "1",
         Patterns::Integer(),
-        "interpolation order for the trial space of the electromagnetics physics (time-harmonic Maxwell equations).");
+        "interpolation degree for the trial space of the electromagnetics physics (time-harmonic Maxwell equations).");
+      prm.declare_alias("electromagnetics trial degree",
+                        "electromagnetics trial order",
+                        true);
       prm.declare_entry(
-        "electromagnetics test order",
+        "electromagnetics test degree",
         "2",
         Patterns::Integer(),
-        "interpolation order for the test space of the electromagnetics physics (time-harmonic Maxwell equations).");
+        "interpolation degree for the test space of the electromagnetics physics (time-harmonic Maxwell equations).");
+      prm.declare_alias("electromagnetics test degree",
+                        "electromagnetics test order",
+                        true);
 
       prm.declare_entry(
         "tracer uses dg",
@@ -1805,21 +1824,21 @@ namespace Parameters
   {
     prm.enter_subsection("FEM");
     {
-      velocity_order            = prm.get_integer("velocity order");
-      pressure_order            = prm.get_integer("pressure order");
-      void_fraction_order       = prm.get_integer("void fraction order");
-      temperature_order         = prm.get_integer("temperature order");
-      tracer_order              = prm.get_integer("tracer order");
+      velocity_order            = prm.get_integer("velocity degree");
+      pressure_order            = prm.get_integer("pressure degree");
+      void_fraction_order       = prm.get_integer("void fraction degree");
+      temperature_order         = prm.get_integer("temperature degree");
+      tracer_order              = prm.get_integer("tracer degree");
       tracer_uses_dg            = prm.get_bool("tracer uses dg");
-      CLS_order                 = prm.get_integer("cls order");
+      CLS_order                 = prm.get_integer("cls degree");
       CLS_uses_dg               = prm.get_bool("cls uses dg");
-      phase_cahn_hilliard_order = prm.get_integer("phase cahn hilliard order");
+      phase_cahn_hilliard_order = prm.get_integer("phase cahn hilliard degree");
       potential_cahn_hilliard_order =
-        prm.get_integer("potential cahn hilliard order");
+        prm.get_integer("potential cahn hilliard degree");
       electromagnetics_trial_order =
-        prm.get_integer("electromagnetics trial order");
+        prm.get_integer("electromagnetics trial degree");
       electromagnetics_test_order =
-        prm.get_integer("electromagnetics test order");
+        prm.get_integer("electromagnetics test degree");
       enable_bubble_function_velocity =
         prm.get_bool("enable bubble function velocity");
       enable_bubble_function_pressure =

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -106,7 +106,7 @@ FluidDynamicsSharp<dim>::generate_cut_cells_map()
   // overconstrained. We therefore only have to check when the velocity order
   // == 1.
   const bool mapping_overconstrained_cells =
-    this->simulation_parameters.fem_parameters.velocity_order == 1;
+    this->simulation_parameters.fem_parameters.velocity_degree == 1;
 
   cut_cells_map.clear();
   cells_inside_map.clear();
@@ -1036,16 +1036,16 @@ FluidDynamicsSharp<dim>::force_on_ib()
   // Initalize fe value objects in order to do calculation with it later
   QGauss<dim>            q_formula(this->number_quadrature_points);
   MappingQ<dim - 1, dim> local_face_map(
-    (2 > this->simulation_parameters.fem_parameters.velocity_order) ?
+    (2 > this->simulation_parameters.fem_parameters.velocity_degree) ?
       2 :
-      this->simulation_parameters.fem_parameters.velocity_order);
+      this->simulation_parameters.fem_parameters.velocity_degree);
 
   FESystem<dim - 1, dim> local_face_fe(
     FE_Q<dim - 1, dim>(
-      this->simulation_parameters.fem_parameters.velocity_order),
+      this->simulation_parameters.fem_parameters.velocity_degree),
     dim,
     FE_Q<dim - 1, dim>(
-      this->simulation_parameters.fem_parameters.pressure_order),
+      this->simulation_parameters.fem_parameters.pressure_degree),
     1);
   FEValues<dim - 1, dim> fe_face_projection_values(local_face_map,
                                                    local_face_fe,
@@ -1443,7 +1443,7 @@ FluidDynamicsSharp<dim>::force_on_ib()
                               try
                                 {
                                   if (this->simulation_parameters.fem_parameters
-                                        .velocity_order > 1)
+                                        .velocity_degree > 1)
                                     {
                                       FullMatrix<double> interpolation_matrix(
                                         local_face_dof_indices.size(),

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -27,7 +27,7 @@ FluidDynamicsVANS<dim>::FluidDynamicsVANS(
         PhysicsID::void_fraction),
       &particle_handler,
       this->cfd_dem_simulation_parameters.cfd_parameters.fem_parameters
-        .void_fraction_order,
+        .void_fraction_degree,
       this->cfd_dem_simulation_parameters.cfd_parameters.mesh.simplex,
       this->pcout)
   , has_periodic_boundaries(false)

--- a/source/fem-dem/fluid_dynamics_vans_matrix_free.cc
+++ b/source/fem-dem/fluid_dynamics_vans_matrix_free.cc
@@ -561,7 +561,7 @@ FluidDynamicsVANSMatrixFree<dim>::FluidDynamicsVANSMatrixFree(
         PhysicsID::void_fraction),
       &particle_handler,
       this->cfd_dem_simulation_parameters.cfd_parameters.fem_parameters
-        .void_fraction_order,
+        .void_fraction_degree,
       this->cfd_dem_simulation_parameters.cfd_parameters.mesh.simplex,
       this->pcout)
   , has_periodic_boundaries(false)

--- a/source/solvers/cls.cc
+++ b/source/solvers/cls.cc
@@ -72,7 +72,7 @@ ConservativeLevelSet<dim>::ConservativeLevelSet(
     {
       // for simplex meshes
       fe = std::make_shared<FE_SimplexP<dim>>(
-        simulation_parameters.fem_parameters.CLS_order);
+        simulation_parameters.fem_parameters.CLS_degree);
       mapping         = std::make_shared<MappingFE<dim>>(*fe);
       cell_quadrature = std::make_shared<QGaussSimplex<dim>>(fe->degree + 1);
       face_quadrature =
@@ -84,12 +84,12 @@ ConservativeLevelSet<dim>::ConservativeLevelSet(
       if (simulation_parameters.fem_parameters.CLS_uses_dg)
         {
           fe = std::make_shared<FE_DGQ<dim>>(
-            simulation_parameters.fem_parameters.CLS_order);
+            simulation_parameters.fem_parameters.CLS_degree);
         }
       else
         {
           fe = std::make_shared<FE_Q<dim>>(
-            simulation_parameters.fem_parameters.CLS_order);
+            simulation_parameters.fem_parameters.CLS_degree);
         }
       // Mapping has to be at least Q1, but DGQ0 is allowed
       mapping = std::make_shared<MappingQ<dim>>(std::max(fe->degree, uint(1)));

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -2669,13 +2669,13 @@ FluidDynamicsMatrixFree<dim>::FluidDynamicsMatrixFree(
   : NavierStokesBase<dim, VectorType, IndexSet>(nsparam)
 {
   AssertThrow(
-    nsparam.fem_parameters.velocity_order ==
-      nsparam.fem_parameters.pressure_order,
+    nsparam.fem_parameters.velocity_degree ==
+      nsparam.fem_parameters.pressure_degree,
     dealii::ExcMessage(
       "Matrix free Navier-Stokes does not support different orders for the velocity and the pressure!"));
 
   this->fe = std::make_shared<FESystem<dim>>(
-    FE_Q<dim>(nsparam.fem_parameters.velocity_order), dim + 1);
+    FE_Q<dim>(nsparam.fem_parameters.velocity_degree), dim + 1);
 
   // Initialize solution shared_ptr
   multiphysics_present_solution =

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -95,11 +95,11 @@ HeatTransfer<dim>::assemble_nitsche_heat_restriction(bool assemble_matrix)
               // if (dim == 2)
               //   h_cell =
               //     std::sqrt(4. * cell->measure() / M_PI) /
-              //     this->simulation_parameters.fem_parameters.velocity_order;
+              //     this->simulation_parameters.fem_parameters.velocity_degree;
               // else if (dim == 3)
               //   h_cell =
               //     pow(6 * cell->measure() / M_PI, 1. / 3.) /
-              //     this->simulation_parameters.fem_parameters.velocity_order;
+              //     this->simulation_parameters.fem_parameters.velocity_degree;
               //  Penalty parameter is disabled for heat transfer from since we
               //  don't necessarily want to strictly impose a Dirichlet BC
               const double penalty_parameter =

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -59,18 +59,18 @@ NavierStokesBase<dim, VectorType, DofsType>::NavierStokesBase(
                     TimerOutput::wall_times)
   , simulation_parameters(p_nsparam)
   , flow_control(simulation_parameters.flow_control)
-  , velocity_fem_degree(p_nsparam.fem_parameters.velocity_order)
-  , pressure_fem_degree(p_nsparam.fem_parameters.pressure_order)
-  , number_quadrature_points(p_nsparam.fem_parameters.velocity_order + 1)
+  , velocity_fem_degree(p_nsparam.fem_parameters.velocity_degree)
+  , pressure_fem_degree(p_nsparam.fem_parameters.pressure_degree)
+  , number_quadrature_points(p_nsparam.fem_parameters.velocity_degree + 1)
   , mesh_controller(p_nsparam.mesh_adaptation.maximum_number_elements)
 {
   if (simulation_parameters.mesh.simplex)
     {
       // for simplex meshes
       const FE_SimplexP<dim> velocity_fe(
-        p_nsparam.fem_parameters.velocity_order);
+        p_nsparam.fem_parameters.velocity_degree);
       const FE_SimplexP<dim> pressure_fe(
-        p_nsparam.fem_parameters.pressure_order);
+        p_nsparam.fem_parameters.pressure_degree);
       fe = std::make_shared<FESystem<dim>>(velocity_fe, dim, pressure_fe, 1);
 
       AssertThrow(
@@ -97,17 +97,17 @@ NavierStokesBase<dim, VectorType, DofsType>::NavierStokesBase(
 
       if (p_nsparam.fem_parameters.enable_bubble_function_velocity)
         fe_u = std::make_shared<FE_Q_Bubbles<dim>>(
-          p_nsparam.fem_parameters.velocity_order);
+          p_nsparam.fem_parameters.velocity_degree);
       else
         fe_u =
-          std::make_shared<FE_Q<dim>>(p_nsparam.fem_parameters.velocity_order);
+          std::make_shared<FE_Q<dim>>(p_nsparam.fem_parameters.velocity_degree);
 
       if (p_nsparam.fem_parameters.enable_bubble_function_pressure)
         fe_p = std::make_shared<FE_Q_Bubbles<dim>>(
-          p_nsparam.fem_parameters.pressure_order);
+          p_nsparam.fem_parameters.pressure_degree);
       else
         fe_p =
-          std::make_shared<FE_Q<dim>>(p_nsparam.fem_parameters.pressure_order);
+          std::make_shared<FE_Q<dim>>(p_nsparam.fem_parameters.pressure_degree);
 
       fe              = std::make_shared<FESystem<dim>>(*fe_u, dim, *fe_p, 1);
       mapping         = std::make_shared<MappingQ<dim>>(velocity_fem_degree);

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -3010,7 +3010,7 @@ NavierStokesBase<dim, VectorType, DofsType>::write_output_results(
       DataOutFaces<dim> data_out_faces;
 
       // Add the additional flag to enable high-order cells output when the
-      // velocity interpolation order is larger than 1
+      // velocity interpolation degree is larger than 1
       DataOutBase::VtkFlags flags;
       if (this->velocity_fem_degree > 1)
         flags.write_higher_order_cells = true;

--- a/source/solvers/time_harmonic_maxwell.cc
+++ b/source/solvers/time_harmonic_maxwell.cc
@@ -44,43 +44,43 @@ TimeHarmonicMaxwell<dim>::TimeHarmonicMaxwell(
       AssertThrow(dim == 3, TimeHarmonicMaxwellDimensionNotSupported(dim));
 
       AssertThrow(
-        simulation_parameters.fem_parameters.electromagnetics_trial_order <
-          simulation_parameters.fem_parameters.electromagnetics_test_order,
+        simulation_parameters.fem_parameters.electromagnetics_trial_degree <
+          simulation_parameters.fem_parameters.electromagnetics_test_degree,
         ExcMessage(
           "The DPG method requires the test space to be of higher order than the trial space."));
 
       // Usual case, for quad/hex meshes
       fe_trial_interior = std::make_shared<FESystem<dim>>(
         FE_DGQ<dim>(
-          simulation_parameters.fem_parameters.electromagnetics_trial_order) ^
+          simulation_parameters.fem_parameters.electromagnetics_trial_degree) ^
           dim,
         FE_DGQ<dim>(
-          simulation_parameters.fem_parameters.electromagnetics_trial_order) ^
+          simulation_parameters.fem_parameters.electromagnetics_trial_degree) ^
           dim,
         FE_DGQ<dim>(
-          simulation_parameters.fem_parameters.electromagnetics_trial_order) ^
+          simulation_parameters.fem_parameters.electromagnetics_trial_degree) ^
           dim,
         FE_DGQ<dim>(
-          simulation_parameters.fem_parameters.electromagnetics_trial_order) ^
+          simulation_parameters.fem_parameters.electromagnetics_trial_degree) ^
           dim);
       fe_trial_skeleton = std::make_shared<FESystem<dim>>(
         FE_Nedelec<dim>(
-          simulation_parameters.fem_parameters.electromagnetics_trial_order),
+          simulation_parameters.fem_parameters.electromagnetics_trial_degree),
         FE_Nedelec<dim>(
-          simulation_parameters.fem_parameters.electromagnetics_trial_order),
+          simulation_parameters.fem_parameters.electromagnetics_trial_degree),
         FE_Nedelec<dim>(
-          simulation_parameters.fem_parameters.electromagnetics_trial_order),
+          simulation_parameters.fem_parameters.electromagnetics_trial_degree),
         FE_Nedelec<dim>(
-          simulation_parameters.fem_parameters.electromagnetics_trial_order));
+          simulation_parameters.fem_parameters.electromagnetics_trial_degree));
       fe_test = std::make_shared<FESystem<dim>>(
         FE_Nedelec<dim>(
-          simulation_parameters.fem_parameters.electromagnetics_test_order),
+          simulation_parameters.fem_parameters.electromagnetics_test_degree),
         FE_Nedelec<dim>(
-          simulation_parameters.fem_parameters.electromagnetics_test_order),
+          simulation_parameters.fem_parameters.electromagnetics_test_degree),
         FE_Nedelec<dim>(
-          simulation_parameters.fem_parameters.electromagnetics_test_order),
+          simulation_parameters.fem_parameters.electromagnetics_test_degree),
         FE_Nedelec<dim>(
-          simulation_parameters.fem_parameters.electromagnetics_test_order));
+          simulation_parameters.fem_parameters.electromagnetics_test_degree));
       mapping = std::make_shared<MappingQ<dim>>(fe_trial_interior->degree);
       cell_quadrature = std::make_shared<QGauss<dim>>(fe_test->degree + 1);
       face_quadrature = std::make_shared<QGauss<dim - 1>>(fe_test->degree + 1);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The FEM subsection parameters `velocity order`, `pressure order`, `temperature order`, `tracer order`, `cls order` (and its alias `VOF order`), `void fraction order`, `phase cahn hilliard order`, `potential cahn hilliard order`, `electromagnetics trial order`, and `electromagnetics test order` have been renamed to use `degree` instead of `order` (e.g., `velocity degree`, `pressure degree`). The parameter name `degree` is more adequate, since it refers to the degree of the underlying shape functions that are used. The old names are kept as deprecated aliases and will continue to work but will trigger a deprecation warning. All examples, application tests, and documentation have been updated to use the new names.

### Testing

No test output is affected.

### Documentation

The parameter name (X order vs X degree) have been replaced in the .rst file and in the .rst for all examples.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] Changelog (CHANGELOG.md) is up to date if the refactor affects the user experience or the codebase

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If any future works is planned, an issue is opened
- [x] The PR description is cleaned and ready for merge