### PR TITLE
Add a missing include in sub simulation control

### DIFF
--- a/source/core/sub_simulation_control.cc
+++ b/source/core/sub_simulation_control.cc
@@ -3,6 +3,8 @@
 
 #include <core/sub_simulation_control.h>
 
+#include <cmath>
+
 
 SubSimulationControlDEM::SubSimulationControlDEM(
   const DEMSubIterationLogic iteration_logic,


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The is a missing cmath include in the sub_simulation_control.cc

### Solution

Add missing include

### Testing

All tests pass.

### Documentation

Nothing to document.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge