### PR TITLE
Fix spelling mistake in install instruction

### DIFF
--- a/doc/source/installation/regular_installation.rst
+++ b/doc/source/installation/regular_installation.rst
@@ -104,7 +104,7 @@ After installation, add the following lines variable to your ``.bashrc`` :
 .. code-block:: text
   :class: copy-button
     
-    source cand/install/prefix/configuration/enable.sh
+    source candi/install/prefix/configuration/enable.sh
     export DEAL_II_DIR=cand/install/prefix/deal.II-v.<version>
 
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description
a character "i" was missing from candi at a location in the installation instructions



Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Copyright headers are present and up to date
- [ ] Lethe documentation is up to date
- [ ] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [ ] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [ ] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge