### PR TITLE
Add timers for melt volume computation and cls mass conservation

### DIFF
--- a/release_notes/current/2026_06_02_Alphonius.md
+++ b/release_notes/current/2026_06_02_Alphonius.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/06/02
+
+### Added
+
+- MINOR Adds wall time monitoring for algebraic melt volume, geometric melt volume, and cls mass conservation post-processing. [#2007](https://github.com/chaos-polymtl/lethe/pull/2007)

--- a/source/solvers/cls.cc
+++ b/source/solvers/cls.cc
@@ -1407,6 +1407,8 @@ ConservativeLevelSet<dim>::postprocess(bool first_iteration)
 
   if (this->simulation_parameters.post_processing.calculate_mass_conservation)
     {
+      TimerOutput::Scope                            t(this->computing_timer,
+                           "Calculate mass conservation");
       const std::vector<Parameters::FluidIndicator> fluid_indicators = {
         Parameters::FluidIndicator::fluid0, Parameters::FluidIndicator::fluid1};
 

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -1183,6 +1183,8 @@ HeatTransfer<dim>::postprocess(bool first_iteration)
   // Algebraic melt volume
   if (simulation_parameters.post_processing.calculate_algebraic_melt_volume)
     {
+      TimerOutput::Scope t(this->computing_timer,
+                           "Calculate algebraic melt volume");
       AssertThrow(
         simulation_parameters.physical_properties_manager.has_phase_change(),
         MeltVolumeRequiresPhaseChange());
@@ -1197,6 +1199,8 @@ HeatTransfer<dim>::postprocess(bool first_iteration)
   // Geometric melt volume
   if (simulation_parameters.post_processing.calculate_geometric_melt_volume)
     {
+      TimerOutput::Scope t(this->computing_timer,
+                           "Calculate geometric melt volume");
       postprocess_geometric_melt_volume_and_surface();
       if (simulation_control->get_iteration_number() %
             this->simulation_parameters.post_processing.output_frequency ==


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

This PR simply adds timers for the calculation of algebraic melt volume, geometric melt volume and cls mass conservation for better profiling of cases.

### Testing

The timers were tested locally with a single track melt case.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge