### PR TITLE
Add missing headers in prm files from Multiphysics examples

### DIFF
--- a/examples/multiphysics/stefan-problem/stefan.prm
+++ b/examples/multiphysics/stefan-problem/stefan.prm
@@ -135,6 +135,7 @@ end
 
 #---------------------------------------------------
 # Source term
+#---------------------------------------------------
 
 subsection source term
   subsection heat transfer

--- a/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer.prm
+++ b/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer.prm
@@ -1,7 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
+# Listing of Parameters
+#----------------------
+
 set dimension = 3
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
 
 subsection simulation control
   set method           = bdf1
@@ -13,6 +20,10 @@ subsection simulation control
   set output frequency = 5
 end
 
+#---------------------------------------------------
+# Restart
+#---------------------------------------------------
+
 subsection restart
   set checkpoint = true
   set frequency  = 5
@@ -20,16 +31,28 @@ subsection restart
   set restart    = false
 end
 
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+
 subsection multiphysics
   set fluid dynamics = true
   set tracer         = true
 end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
 
 subsection FEM
   set velocity degree = 1
   set pressure degree = 1
   set tracer degree   = 1
 end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
 
 # The problem is set in cm, seconds and grams
 
@@ -45,9 +68,17 @@ subsection physical properties
   end
 end
 
+#---------------------------------------------------
+# Stabilization
+#---------------------------------------------------
+
 subsection stabilization
   set pressure scaling factor = 1e2
 end
+
+#---------------------------------------------------
+# Initial Conditions
+#---------------------------------------------------
 
 subsection initial conditions
   set type = nodal
@@ -56,12 +87,20 @@ subsection initial conditions
   end
 end
 
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
+
 subsection mesh
   set type               = dealii
   set grid type          = subdivided_hyper_rectangle
   set grid arguments     = 6,1,1: -150,-25,-25: 150,25,25: true
   set initial refinement = 3
 end
+
+#---------------------------------------------------
+# Mesh Adaptation
+#---------------------------------------------------
 
 subsection mesh adaptation
   set type                 = adaptive
@@ -72,6 +111,10 @@ subsection mesh adaptation
   set min refinement level = 0
   set frequency            = 0
 end
+
+#---------------------------------------------------
+# IB Particles
+#---------------------------------------------------
 
 subsection particles
   set assemble Navier-Stokes inside particles = false
@@ -93,6 +136,10 @@ subsection particles
     set shape arguments = mixer_long.composite
   end
 end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
 
 subsection boundary conditions tracer
   set number         = 6
@@ -157,6 +204,10 @@ subsection boundary conditions
   end
 end
 
+#---------------------------------------------------
+# Multiphysics post-processing
+#---------------------------------------------------
+
 subsection post-processing
   set verbosity = verbose
 
@@ -168,9 +219,17 @@ subsection post-processing
   set tracer flow rate name      = tracer_flow_rate
 end
 
+#---------------------------------------------------
+# Timer
+#---------------------------------------------------
+
 subsection timer
   set type = iteration
 end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
 
 subsection non-linear solver
   subsection fluid dynamics
@@ -184,6 +243,10 @@ subsection non-linear solver
     set max iterations = 15
   end
 end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
 
 subsection linear solver
   subsection fluid dynamics

--- a/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer_only_tracer.prm
+++ b/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer_only_tracer.prm
@@ -1,7 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
+# Listing of Parameters
+#----------------------
+
 set dimension = 3
+
+#---------------------------------------------------
+# Simulation Control
+#---------------------------------------------------
 
 subsection simulation control
   set method           = bdf1
@@ -13,6 +20,10 @@ subsection simulation control
   set output frequency = 1
 end
 
+#---------------------------------------------------
+# Restart
+#---------------------------------------------------
+
 subsection restart
   set checkpoint = true
   set frequency  = 5
@@ -20,16 +31,28 @@ subsection restart
   set restart    = true
 end
 
+#---------------------------------------------------
+# Multiphysics
+#---------------------------------------------------
+
 subsection multiphysics
   set fluid dynamics = false
   set tracer         = true
 end
+
+#---------------------------------------------------
+# FEM
+#---------------------------------------------------
 
 subsection FEM
   set velocity degree = 1
   set pressure degree = 1
   set tracer degree   = 1
 end
+
+#---------------------------------------------------
+# Physical Properties
+#---------------------------------------------------
 
 # The problem is set in cm, seconds and grams
 
@@ -45,13 +68,25 @@ subsection physical properties
   end
 end
 
+#---------------------------------------------------
+# Stabilization
+#---------------------------------------------------
+
 subsection stabilization
   set pressure scaling factor = 1e2
 end
 
+#---------------------------------------------------
+# Initial Conditions
+#---------------------------------------------------
+
 subsection initial conditions
   set type = average_velocity_profile
 end
+
+#---------------------------------------------------
+# Mesh
+#---------------------------------------------------
 
 subsection mesh
   set type               = dealii
@@ -59,6 +94,10 @@ subsection mesh
   set grid arguments     = 6,1,1: -150,-25,-25: 150,25,25: true
   set initial refinement = 3
 end
+
+#---------------------------------------------------
+# Mesh Adaptation
+#---------------------------------------------------
 
 subsection mesh adaptation
   set type                 = adaptive
@@ -69,6 +108,10 @@ subsection mesh adaptation
   set min refinement level = 0
   set frequency            = 1000000
 end
+
+#---------------------------------------------------
+# IB Particles
+#---------------------------------------------------
 
 subsection particles
   set assemble Navier-Stokes inside particles = false
@@ -90,6 +133,10 @@ subsection particles
     set shape arguments = mixer_long.composite
   end
 end
+
+#---------------------------------------------------
+# Boundary Conditions
+#---------------------------------------------------
 
 subsection boundary conditions tracer
   set number         = 6
@@ -154,6 +201,10 @@ subsection boundary conditions
   end
 end
 
+#---------------------------------------------------
+# Multiphysics post-processing
+#---------------------------------------------------
+
 subsection post-processing
   set verbosity = verbose
 
@@ -165,9 +216,17 @@ subsection post-processing
   set tracer flow rate name      = tracer_flow_rate
 end
 
+#---------------------------------------------------
+# Timer
+#---------------------------------------------------
+
 subsection timer
   set type = iteration
 end
+
+#---------------------------------------------------
+# Non-Linear Solver Control
+#---------------------------------------------------
 
 subsection non-linear solver
   subsection fluid dynamics
@@ -181,6 +240,10 @@ subsection non-linear solver
     set max iterations = 15
   end
 end
+
+#---------------------------------------------------
+# Linear Solver Control
+#---------------------------------------------------
 
 subsection linear solver
   subsection fluid dynamics


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the issue with the bug (what part of the code, what are the side effects of the bug).
       How did the bug was found, do you know what commit introduced the bug? -->

Add missing section headers in prm files.

### Solution

<!-- How did you fix the bug?
       Is it a permanent or temporary fix? (if temporary, please open an issue) -->

### Testing

<!-- How has this been tested?
       What are the new test(s) that reproduce the bug?
       Are there changes and/or impacts on current tests, why?
       How did you ensure that the solution works? -->

### Documentation

<!-- Does this fix, modify or introduce new simulation parameters? If so, describe them. -->

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [ ] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is cleaned and ready for merge