### PR TITLE
Add calculation frequency to post-processing

### DIFF
--- a/applications_tests/lethe-fluid/cls-velocity-extrapolation.output
+++ b/applications_tests/lethe-fluid/cls-velocity-extrapolation.output
@@ -34,12 +34,6 @@ CLS Mass Conservation
 Transient iteration: 1        Time: 0.04     Time step: 0.04     CFL: 0       
 *******************************************************************************
 
-----------------------
-CLS Mass Conservation
-----------------------
-    time     surface_fluid_0 geometric_surface_fluid_0 mass_per_length_fluid_0 length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 geometric_surface_fluid_1 mass_per_length_fluid_1 length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-4.000000e-02    1.998729e-01              1.999014e-01            1.998729e-04   2.001393e+00      -3.153181e-14       1.465966e-08    2.000127e+00              2.000099e+00            2.000127e+00   2.001393e+00      -2.930045e-11      -1.733959e-05         5.000000e-01 
-
 ********************************************************************************
 Transient iteration: 2        Time: 0.106    Time step: 0.066    CFL: 0.0369272
 ********************************************************************************
@@ -53,12 +47,6 @@ CLS Mass Conservation
 *******************************************************************************
 Transient iteration: 3        Time: 0.216    Time step: 0.11     CFL: 0.145625
 *******************************************************************************
-
-----------------------
-CLS Mass Conservation
-----------------------
-    time     surface_fluid_0 geometric_surface_fluid_0 mass_per_length_fluid_0 length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 geometric_surface_fluid_1 mass_per_length_fluid_1 length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-2.160000e-01    1.999235e-01              1.996885e-01            1.999235e-04   2.000893e+00      -1.193303e-13       6.879648e-08    2.000077e+00              2.000311e+00            2.000077e+00   2.000893e+00      -1.140422e-11      -7.161852e-05         5.000000e-01 
 
 *******************************************************************************
 Transient iteration: 4        Time: 0.319668 Time step: 0.103668 CFL: 0.42443 
@@ -74,12 +62,6 @@ CLS Mass Conservation
 Transient iteration: 5        Time: 0.401429 Time step: 0.0817608 CFL: 0.507179
 ********************************************************************************
 
-----------------------
-CLS Mass Conservation
-----------------------
-    time     surface_fluid_0 geometric_surface_fluid_0 mass_per_length_fluid_0 length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 geometric_surface_fluid_1 mass_per_length_fluid_1 length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-4.014292e-01    1.999579e-01              1.996843e-01            1.999579e-04   2.000678e+00      -6.319725e-14       9.027331e-08    2.000042e+00              2.000316e+00            2.000042e+00   2.000678e+00      -7.162197e-11      -9.275883e-05         5.000000e-01 
-
 ********************************************************************************
 Transient iteration: 6        Time: 0.474477 Time step: 0.0730481 CFL: 0.44771 
 ********************************************************************************
@@ -93,12 +75,6 @@ CLS Mass Conservation
 ********************************************************************************
 Transient iteration: 7        Time: 0.542935 Time step: 0.0684574 CFL: 0.426824
 ********************************************************************************
-
-----------------------
-CLS Mass Conservation
-----------------------
-    time     surface_fluid_0 geometric_surface_fluid_0 mass_per_length_fluid_0 length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 geometric_surface_fluid_1 mass_per_length_fluid_1 length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-5.429348e-01    1.999770e-01              1.998149e-01            1.999770e-04   2.000597e+00      -2.270175e-13       8.420472e-08    2.000023e+00              2.000185e+00            2.000023e+00   2.000597e+00      -2.980616e-11      -8.665868e-05         5.000000e-01 
 
 ********************************************************************************
 Transient iteration: 8        Time: 0.608582 Time step: 0.0656473 CFL: 0.417122
@@ -114,12 +90,6 @@ CLS Mass Conservation
 Transient iteration: 9        Time: 0.672579 Time step: 0.0639966 CFL: 0.410318
 ********************************************************************************
 
-----------------------
-CLS Mass Conservation
-----------------------
-    time     surface_fluid_0 geometric_surface_fluid_0 mass_per_length_fluid_0 length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 geometric_surface_fluid_1 mass_per_length_fluid_1 length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-6.725787e-01    1.999945e-01              1.997553e-01            1.999945e-04   2.000525e+00      -2.441034e-13       6.531042e-08    2.000006e+00              2.000245e+00            2.000006e+00   2.000525e+00       1.036358e-10      -6.776135e-05         5.000000e-01 
-
 ********************************************************************************
 Transient iteration: 10       Time: 0.735885 Time step: 0.0633065 CFL: 0.40436 
 ********************************************************************************
@@ -133,12 +103,6 @@ CLS Mass Conservation
 ********************************************************************************
 Transient iteration: 11       Time: 0.799503 Time step: 0.0636178 CFL: 0.398043
 ********************************************************************************
-
-----------------------
-CLS Mass Conservation
-----------------------
-    time     surface_fluid_0 geometric_surface_fluid_0 mass_per_length_fluid_0 length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 geometric_surface_fluid_1 mass_per_length_fluid_1 length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-7.995030e-01    2.000103e-01              1.998115e-01            2.000103e-04   2.000282e+00      -1.994260e-13       3.369316e-08    1.999990e+00              2.000189e+00            1.999990e+00   2.000282e+00       1.889823e-10      -3.550295e-05         5.000000e-01 
 
 ********************************************************************************
 Transient iteration: 12       Time: 0.864635 Time step: 0.0651318 CFL: 0.390702
@@ -154,12 +118,6 @@ CLS Mass Conservation
 Transient iteration: 13       Time: 0.931897 Time step: 0.0672624 CFL: 0.387329
 ********************************************************************************
 
-----------------------
-CLS Mass Conservation
-----------------------
-    time     surface_fluid_0 geometric_surface_fluid_0 mass_per_length_fluid_0 length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 geometric_surface_fluid_1 mass_per_length_fluid_1 length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-9.318972e-01    2.000242e-01              1.997687e-01            2.000242e-04   2.000158e+00      -1.515371e-13      -3.712595e-09    1.999976e+00              2.000231e+00            1.999976e+00   2.000158e+00       1.584907e-10       1.606462e-06         5.000000e-01 
-
 ********************************************************************************
 Transient iteration: 14       Time: 1.00169  Time step: 0.0697911 CFL: 0.385507
 ********************************************************************************
@@ -173,12 +131,6 @@ CLS Mass Conservation
 ********************************************************************************
 Transient iteration: 15       Time: 1.0744   Time step: 0.0727146 CFL: 0.383918
 ********************************************************************************
-
-----------------------
-CLS Mass Conservation
-----------------------
-    time     surface_fluid_0 geometric_surface_fluid_0 mass_per_length_fluid_0 length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 geometric_surface_fluid_1 mass_per_length_fluid_1 length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.074403e+00    2.000409e-01              1.997400e-01            2.000409e-04   2.000202e+00      -2.408599e-13      -3.842717e-08    1.999959e+00              2.000260e+00            1.999959e+00   2.000202e+00       2.491171e-10       3.666187e-05         5.000000e-01 
 
 ********************************************************************************
 Transient iteration: 16       Time: 1.15149  Time step: 0.0770904 CFL: 0.377295
@@ -194,12 +146,6 @@ CLS Mass Conservation
 Transient iteration: 17       Time: 1.23601  Time step: 0.0845188 CFL: 0.364844
 ********************************************************************************
 
-----------------------
-CLS Mass Conservation
-----------------------
-    time     surface_fluid_0 geometric_surface_fluid_0 mass_per_length_fluid_0 length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 geometric_surface_fluid_1 mass_per_length_fluid_1 length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.236012e+00    2.000568e-01              1.997961e-01            2.000568e-04   2.000294e+00      -1.965092e-13      -6.087420e-08    1.999943e+00              2.000204e+00            1.999943e+00   2.000294e+00       3.707694e-10       5.896845e-05         5.000000e-01 
-
 ********************************************************************************
 Transient iteration: 18       Time: 1.32898  Time step: 0.0929707 CFL: 0.348097
 ********************************************************************************
@@ -213,12 +159,6 @@ CLS Mass Conservation
 *******************************************************************************
 Transient iteration: 19       Time: 1.43125  Time step: 0.102268 CFL: 0.328105
 *******************************************************************************
-
-----------------------
-CLS Mass Conservation
-----------------------
-    time     surface_fluid_0 geometric_surface_fluid_0 mass_per_length_fluid_0 length_fluid_0 momentum-x_fluid_0 momentum-y_fluid_0 surface_fluid_1 geometric_surface_fluid_1 mass_per_length_fluid_1 length_fluid_1 momentum-x_fluid_1 momentum-y_fluid_1 sharpening_threshold 
-1.431250e+00    2.000778e-01              1.997479e-01            2.000778e-04   2.000377e+00      -1.134283e-13      -6.183007e-08    1.999922e+00              2.000252e+00            1.999922e+00   2.000377e+00       4.324060e-10       5.976764e-05         5.000000e-01 
 
 *******************************************************************************
 Transient iteration: 20       Time: 1.54374  Time step: 0.112495 CFL: 0.301612

--- a/applications_tests/lethe-fluid/cls-velocity-extrapolation.prm
+++ b/applications_tests/lethe-fluid/cls-velocity-extrapolation.prm
@@ -1,6 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024, 2026 The Lethe Authors
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
+#-------------------------------------------------------------------------------
+# DESCRIPTION:
+# This test simulates the damping of a gravity wave.
+# It checks the 2nd order velocity extrapolation when the time-stepping
+# scheme selected is bdf2.
+# The calculation frequency of the post-processed quantities is also checked
+# here.
+#-------------------------------------------------------------------------------
+
 # Listing of Parameters
 #----------------------
 
@@ -140,6 +149,8 @@ end
 #---------------------------------------------------
 
 subsection post-processing
+  set calculation frequency        = 2
+  set output frequency             = 2
   set verbosity                    = verbose
   set calculate average velocities = true
 end

--- a/doc/source/parameters/cfd/force_and_torque.rst
+++ b/doc/source/parameters/cfd/force_and_torque.rst
@@ -1,3 +1,7 @@
+..
+  SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
+  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+
 ============================
 Force and Torque Calculation
 ============================
@@ -8,28 +12,28 @@ This subsection controls the post-processing of the force and the torque on the 
 
   subsection forces
     # Enable calculation of force
-    set calculate force       = true
+    set calculate force = true
 
     # Enable calculation of torque
-    set calculate torque      = true
+    set calculate torque = true
 
     # Calculation frequency
     set calculation frequency = 1
 
     # File output force prefix
-    set force name            = force
+    set force name = force
 
     # File output torque prefix
-    set torque name           = torque
+    set torque name = torque
 
     # Output frequency
-    set output frequency      = 1
+    set output frequency = 1
 
-    # Calculation frequency
-    set output precision      = 10
+    # Precision of outputted values
+    set output precision = 10
 
     # State whether information from the non-linear solver should be printed (quiet or verbose).
-    set verbosity             = quiet
+    set verbosity = quiet
   end
 
 * ``calculate force`` enables the calculation of the force on all boundaries. If multiple walls bear the same ID, the total force for this ID will be calculated.

--- a/doc/source/parameters/cfd/post_processing.rst
+++ b/doc/source/parameters/cfd/post_processing.rst
@@ -11,15 +11,16 @@ This subsection controls the post-processing other than the forces and torque on
 .. code-block:: text
 
   subsection post-processing
-    set verbosity                        = quiet
-    set output frequency                 = 1
+    set verbosity             = quiet
+    set output frequency      = 1
+    set calculation frequency = 1
 
     #---------------------------------------------------
     # Fluid dynamic post-processing
     #---------------------------------------------------
     # Kinetic energy calculation
-    set calculate kinetic energy         = false
-    set kinetic energy name              = kinetic_energy
+    set calculate kinetic energy = false
+    set kinetic energy name      = kinetic_energy
 
     # Average velocities calculation
     set calculate average velocities      = false
@@ -30,50 +31,50 @@ This subsection controls the post-processing other than the forces and torque on
     set initial time for average temperature and heat flux = 0.0
 
     # Pressure drop calculation
-    set calculate pressure drop          = false
-    set pressure drop name               = pressure_drop
-    set inlet boundary id                = 0
-    set outlet boundary id               = 1
+    set calculate pressure drop = false
+    set pressure drop name      = pressure_drop
+    set inlet boundary id       = 0
+    set outlet boundary id      = 1
 
     # Flow rate at boundaries calculation
-    set calculate flow rate              = false
-    set flow rate name                   = flow_rate
+    set calculate flow rate = false
+    set flow rate name      = flow_rate
 
     # Enstrophy calculation
-    set calculate enstrophy              = false
-    set enstrophy name                   = enstrophy
+    set calculate enstrophy = false
+    set enstrophy name      = enstrophy
 
     # Viscous dissipation
-    set calculate viscous dissipation    = false
-    set viscous dissipation name         = viscous_dissipation
+    set calculate viscous dissipation = false
+    set viscous dissipation name      = viscous_dissipation
 
     # Pressure power
-    set calculate pressure power         = false
-    set pressure power name              = pressure_power
+    set calculate pressure power = false
+    set pressure power name      = pressure_power
 
     # Output Q-criterion
-    set output qcriterion                = true
+    set output qcriterion = true
 
     # Output vorticity
-    set output vorticity                 = true
+    set output vorticity = true
 
     # Output velocity gradient
-    set output velocity gradient         = true
+    set output velocity gradient = true
 
     #---------------------------------------------------
     # Physical properties post-processing
     #---------------------------------------------------
-    set calculate apparent viscosity     = false
-    set apparent viscosity name          = apparent_viscosity
+    set calculate apparent viscosity = false
+    set apparent viscosity name      = apparent_viscosity
 
     #---------------------------------------------------
     # Multiphysics post-processing
     #---------------------------------------------------
     # Tracer postprocessing
-    set calculate tracer statistics      = false
-    set tracer statistics name           = tracer_statistics
-    set calculate tracer flow rate       = false
-    set tracer flow rate name            = tracer_flow_rate
+    set calculate tracer statistics = false
+    set tracer statistics name      = tracer_statistics
+    set calculate tracer flow rate  = false
+    set tracer flow rate name       = tracer_flow_rate
 
     # Thermal postprocessing
     set postprocessed fluid               = both
@@ -89,29 +90,37 @@ This subsection controls the post-processing other than the forces and torque on
     set melting temperature               = 0
 
     # Multiphase postprocessing
-    set calculate barycenter             = false
-    set barycenter name                  = barycenter_information
-    set calculate mass conservation      = true
-    set mass conservation name           = mass_conservation_information
+    set calculate barycenter        = false
+    set barycenter name             = barycenter_information
+    set calculate mass conservation = true
+    set mass conservation name      = mass_conservation_information
 
     # Other Cahn-Hilliard postprocessing
-    set calculate phase statistics       = false
-    set phase statistics name            = phase_statistics
-    set calculate phase energy           = false
-    set phase energy name                = phase_energy
+    set calculate phase statistics = false
+    set phase statistics name      = phase_statistics
+    set calculate phase energy     = false
+    set phase energy name          = phase_energy
 
     #---------------------------------------------------
     # Multiphase post-processing
     #---------------------------------------------------
     # CFD-DEM postprocessing
-    set calculate volume phases          = false
-    set phase volumes name               = phase_volumes
+    set calculate volume phases = false
+    set phase volumes name      = phase_volumes
     
   end
 
 * ``verbosity``: enables the display of the post-processing values in the terminal. This does not affect the printing of output files. Choices are: ``quiet`` (default, no output) or ``verbose`` (output at every iteration).
 
+* ``calculation frequency``: frequency at which the post-processed quantities are computed.
+
+  .. note::
+    Regardless of the value of the ``calculation frequency``, the quantities will be post-processed at the first and last time steps.
+
 * ``output frequency``: frequency at which the enabled post-processing is outputted in the respective file. For ``output frequency = 1`` (default value), results are outputted at each iteration.
+
+  .. attention::
+    The ``output frequency`` must be a multiple of the ``calculation frequency``.
 
 * ``calculate kinetic energy``: controls if calculation of kinetic energy is enabled. 
     * ``kinetic energy name``: output filename for kinetic energy calculations.

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1077,7 +1077,7 @@ namespace Parameters
     /// average heat flux
     double initial_time_for_average_temp_and_hf;
 
-    /// Frequency of the calculation of the post-processed quantity
+    /// Frequency of the calculation of post-processed quantities
     unsigned int calculation_frequency;
 
     /// Frequency of the output

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -211,8 +211,14 @@ protected:
   virtual void
   postprocess(bool first_iteration)
   {
-    postprocess_fd(first_iteration);
-    multiphysics->postprocess(first_iteration);
+    if (simulation_control->get_iteration_number() %
+            this->simulation_parameters.post_processing.calculation_frequency ==
+          0 ||
+        first_iteration || simulation_control->is_at_end())
+      {
+        postprocess_fd(first_iteration);
+        multiphysics->postprocess(first_iteration);
+      }
 
     if (this->simulation_control->is_output_iteration())
       this->write_output_results(*this->present_solution);

--- a/release_notes/current/2026_06_03_Alphonius.md
+++ b/release_notes/current/2026_06_03_Alphonius.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/06/03
+
+### Added
+
+- MAJOR Adds the new parameter `calculation frequency` to the `post-processing` subsection. It indicates the frequency at which the post-processed quantities are computed. The `cls-velocity-extrapolation` application-test was updated to include this feature. This new parameter requires the `output frequency` to be a multiple of the `calculation frequency`. [#2010](https://github.com/chaos-polymtl/lethe/pull/2010)

--- a/release_notes/current/2026_06_03_Alphonius.md
+++ b/release_notes/current/2026_06_03_Alphonius.md
@@ -1,5 +1,0 @@
-## [Master] - 2026/06/03
-
-### Added
-
-- MAJOR Adds the new parameter `calculation frequency` to the `post-processing` subsection. It indicates the frequency at which the post-processed quantities are computed. The `cls-velocity-extrapolation` application-test was updated to include this feature. This new parameter requires the `output frequency` to be a multiple of the `calculation frequency`. [#2010](https://github.com/chaos-polymtl/lethe/pull/2010)

--- a/release_notes/current/2026_06_04_Alphonius.md
+++ b/release_notes/current/2026_06_04_Alphonius.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/06/04
+
+### Added
+
+- MAJOR Adds the new parameter `calculation frequency` to the `post-processing` subsection. It indicates the frequency at which the post-processed quantities are computed. This new parameter requires the `output frequency` to be a multiple of the `calculation frequency`. The `cls-velocity-extrapolation` application-test was updated to include this feature. [#2010](https://github.com/chaos-polymtl/lethe/pull/2010)

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -1880,7 +1880,7 @@ namespace Parameters
       prm.declare_entry("output precision",
                         "10",
                         Patterns::Integer(),
-                        "Calculation frequency");
+                        "Precision of the values outputted.");
       prm.declare_entry("calculation frequency",
                         "1",
                         Patterns::Integer(),
@@ -2313,6 +2313,11 @@ namespace Parameters
                         Patterns::Integer(),
                         "Output frequency");
 
+      prm.declare_entry("calculation frequency",
+                        "1",
+                        Patterns::Integer(),
+                        "Calculation frequency of post-processed quantities.");
+
       prm.declare_entry("calculate tracer statistics",
                         "false",
                         Patterns::Bool(),
@@ -2512,6 +2517,13 @@ namespace Parameters
       viscous_dissipation_output_name = prm.get("viscous dissipation name");
       apparent_viscosity_output_name  = prm.get("apparent viscosity name");
       output_frequency                = prm.get_integer("output frequency");
+      calculation_frequency = prm.get_integer("calculation frequency");
+
+      AssertThrow(
+        output_frequency % calculation_frequency == 0,
+        ExcMessage(
+          "The post-processing 'output frequency' must be a multiple of the 'calculation frequency'."));
+
       calculate_tracer_statistics = prm.get_bool("calculate tracer statistics");
       tracer_output_name          = prm.get("tracer statistics name");
       calculate_phase_statistics  = prm.get_bool("calculate phase statistics");


### PR DESCRIPTION
### Description

This PR adds the new parameter `calculation frequency` to the `post-processing` subsection. It indicates the frequency at which the post-processed quantities are computed. This new parameter requires the `output frequency` to be a multiple of the `calculation frequency`.

### Testing

The application-test `cls-velocity-extrapolation` was updated to include this feature.

### Documentation

Related documentation was updated.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] Changelog (CHANGELOG.md) is up to date
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature) excluding the responsible for the merge
- [x] If this PR closes an issue or is related to a project, it is linked in the "Projects" or "Development" section
- [x] If the fix is temporary, an issue is opened
- [ ] The PR description is cleaned and ready for merge