### PR TITLE
Add Tracer Documentation

### DIFF
--- a/doc/source/theory/multiphysics/passive_tracer/passive_tracer_equations.rst
+++ b/doc/source/theory/multiphysics/passive_tracer/passive_tracer_equations.rst
@@ -5,15 +5,15 @@ Passive Tracer Equations
 Lethe allows the simulation of a passive tracer, which is governed by the equation:
 
 .. math::
-    \frac{\partial T}{\partial t} + \mathbf{u} \cdot \nabla T - \kappa \nabla^2 T + S = 0
+    \frac{\partial C}{\partial t} + \mathbf{u} \cdot \nabla C - \kappa \nabla^2 C + f = 0
 
 where:
 
-* :math:`T` is the tracer concentration;
+* :math:`C` is the tracer concentration;
 * :math:`\mathbf{u}` is the velocity of the fluid;
 * :math:`\nabla` is the `del operator <https://en.wikipedia.org/wiki/Del>`_;
 * :math:`\kappa` is the diffusivity coefficient;
-* :math:`S` is the tracer source term per unit of mass.
+* :math:`f` is the tracer source term per unit of mass.
 
 ==========================
 Finite Element Formulation
@@ -22,31 +22,44 @@ Finite Element Formulation
 To obtain the finite element discretization, we start from the strong form previously presented and integrate it over a domain :math:`\Omega` with boundary :math:`\Gamma` such that:
 
 .. math::
-    \int_{\Omega} \left( \frac{\partial T}{\partial t} + \mathbf{u} \cdot \nabla T - \kappa \nabla^2 T - S \right) d\Omega = 0
+    \int_{\Omega} \left( \frac{\partial C}{\partial t} + \mathbf{u} \cdot \nabla C - \kappa \nabla^2 C - f \right) \: d\Omega = 0
 
 To obtain the corresponding weak form, we multiply the equation above by a test function :math:`q` and apply integration by parts on the Laplacian term:
 
 .. math::
-    \int_{\Omega} q \frac{\partial T}{\partial t} d\Omega + \int_{\Omega} q \mathbf{u} \cdot \nabla T d\Omega + \int_{\Omega} \nabla q \kappa \nabla T d\Omega - \int_{\Omega} q S d\Omega = 0
+    F(C) := (q, \partial_t C)_{\Omega} + (q, \mathbf{u} \cdot \nabla C)_{\Omega} + (\nabla q, \kappa \: \nabla C)_{\Omega} - (q, f)_{\Omega} = 0
 
-Using the discrete form of the tracer concentration field :math:`T = \sum_j T_j \phi_j` and the test function :math:`q = \phi_i`:
+To ensure that the integral is well defined in the domain :math:`\Omega`, we use appropriate solution spaces:
 
 .. math::
-    \int_{\Omega} \phi_i \frac{\partial \phi_j}{\partial t} d\Omega + \int_{\Omega} \phi_i \mathbf{u} \cdot \nabla \phi_j d\Omega + \int_{\Omega} \nabla \phi_i \kappa \nabla \phi_j d\Omega - \int_{\Omega} \phi_i S d\Omega = 0
+    C \in \mathcal{C} (\Omega) = \mathcal{H}^1 (\Omega), \qquad q \in \mathcal{Q} (\Omega) = \mathcal{L}^2 (\Omega)
+
+and the weak formulation is formulated as finding :math:`C \in \mathcal{C} (\Omega) \times (0, T]` such that 
+
+.. math::
+    (q, \partial_t C)_{\Omega} + (q, \mathbf{u} \cdot \nabla C)_{\Omega} + (\nabla q, \kappa \: \nabla C)_{\Omega} - (q, f)_{\Omega} = 0 \qquad \forall \: q \in \mathcal{Q}
 
 ========================
 Stabilization Techniques
 ========================
 
-The GLS stabilization term added is given by:
+Two stabilization terms are added to the weak form of the passive tracer equation:
 
 .. math::
-    a_{GLS} = \int_{\Omega} \tau (\mathbf{u} \cdot \nabla q) \mathrm{R}(T),
+   F(C)_{\text{stab}} := F(C) + \underbrace{\int_{\Omega} \tau \: (\mathbf{u} \cdot \nabla q) \: \mathrm{R}(C)}_{a_{\text{GLS}}} + \underbrace{(v_{\text{DCDD}} \nabla q, \mathbf{d}_{\text{DCDD}} \cdot \nabla C)}_{a_{\text{DCDD}}}
 
-where :math:`\mathrm{R}(T)` is the strong residual of the governing equation. The stabilization parameter definition herein used is the one presented by `Tezduyar (1992) <https://doi.org/10.1016/0045-7825(92)90141-6>`_ and presented in the `Fluid Dynamics <../fluid_dynamics/stabilization.html>`_ subsection.
+In the GLS stabilization :math:`a_{\text{GLS}}`, :math:`\mathrm{R}(C)` is the strong residual of the governing equation, and the stabilization parameter :math:`\tau_k` is the one presented by `Tezduyar (1992) <https://doi.org/10.1016/0045-7825(92)90141-6>`_:
 
-====================
-Shock-capturing term
-====================
+.. math::
 
-**Under construction**
+   \tau = \left[ \left( \frac{1}{\Delta t} \right)^{2} + \left( \frac{2 |\mathrm{u}|}{h_{\text{conv}}} \right)^{2} + 9 \left( \frac{4 \nu}{h^2_{\text{diff}}} \right)^{2} \right]^{-1/2}
+
+where :math:`\Delta t` is the time step, and :math:`h_{\text{conv}}` and :math:`h_{\text{diff}}` are the size of the element related to the convection transport and diffusion mechanism, respectively. In Lethe, both element sizes are set to the diameter of a sphere having a volume equivalent to that of the cell. 
+
+.. note::
+    The same definition of the stabilization parameter is used in the `Fluid Dynamics <../fluid_dynamics/stabilization.html>`_ solver.
+
+The second stabilization term is a Discontinuity-Capturing Directional Dissipation (DCDD) shock-capturing scheme proposed by `Tezduyar (2003) <https://doi.org/10.1002/fld.505>`_ that aims to deal with crosswind oscillations. 
+
+.. note::
+    The DCDD shock-capturing scheme is also used in the `CLS <../../multiphase/cfd/cls.html>`_ and `Heat Transfer <../heat_transfer/heat_transfer.html>`_ modules. The CLS DCDD implementation is detailed `here <https://doi.org/10.1016/j.cpc.2025.109880>`_, and it is analogous to the tracer module.

--- a/doc/source/theory/multiphysics/passive_tracer/passive_tracer_equations.rst
+++ b/doc/source/theory/multiphysics/passive_tracer/passive_tracer_equations.rst
@@ -15,6 +15,9 @@ where:
 * :math:`\kappa` is the diffusivity coefficient;
 * :math:`f` is the tracer source term per unit of mass.
 
+.. important::
+    The tracer can be advected with the same velocity of the fluid, or a `drift velocity <../../../parameters/cfd/tracer_drift_velocity.html>`_ can be added. A reactive tracer feature also allows the prescription of a tracer consumption rate.
+
 To obtain the finite element discretization, we start from the strong form previously presented and integrate it over a domain :math:`\Omega` with boundary :math:`\Gamma` such that:
 
 .. math::
@@ -42,9 +45,9 @@ Stabilization Techniques
 Two stabilization terms are added to the weak form of the passive tracer equation:
 
 .. math::
-   F(C)_{\text{stab}} := F(C) + \underbrace{\int_{\Omega} \tau \: (\mathbf{u} \cdot \nabla q) \: \mathrm{R}(C)}_{a_{\text{GLS}}} + \underbrace{(v_{\text{DCDD}} \nabla q, \mathbf{d}_{\text{DCDD}} \cdot \nabla C)}_{a_{\text{DCDD}}}
+   F(C)_{\text{stab}} := F(C) + \underbrace{(\tau \: [\mathbf{u} \cdot \nabla q], \: \mathcal{R}(C))}_{a_{\text{GLS}}} + \underbrace{(v_{\text{DCDD}} \nabla q, \: \mathbf{d}_{\text{DCDD}} \cdot \nabla C)}_{a_{\text{DCDD}}}
 
-In the GLS stabilization :math:`a_{\text{GLS}}`, :math:`\mathrm{R}(C)` is the strong residual of the governing equation, and the stabilization parameter :math:`\tau_k` is the one presented by `Tezduyar (1992) <https://doi.org/10.1016/0045-7825(92)90141-6>`_:
+In the GLS stabilization :math:`a_{\text{GLS}}`, :math:`\mathcal{R}(C)` is the strong residual of the governing equation, and the stabilization parameter :math:`\tau_k` is defined as in `Tezduyar (1992) <https://doi.org/10.1016/0045-7825(92)90141-6>`_:
 
 .. math::
 
@@ -52,10 +55,10 @@ In the GLS stabilization :math:`a_{\text{GLS}}`, :math:`\mathrm{R}(C)` is the st
 
 where :math:`\Delta t` is the time step, and :math:`h_{\text{conv}}` and :math:`h_{\text{diff}}` are the size of the element related to the convection transport and diffusion mechanism, respectively. In Lethe, both element sizes are set to the diameter of a sphere having a volume equivalent to that of the cell. 
 
-.. note::
+.. seealso::
     The same definition of the stabilization parameter is used in the `Fluid Dynamics <../fluid_dynamics/stabilization.html>`_ solver.
 
 The second stabilization term is a Discontinuity-Capturing Directional Dissipation (DCDD) shock-capturing scheme proposed by `Tezduyar (2003) <https://doi.org/10.1002/fld.505>`_ that aims to deal with crosswind oscillations. 
 
-.. note::
+.. seealso::
     The DCDD shock-capturing scheme is also used in the `CLS <../../multiphase/cfd/cls.html>`_ and `Heat Transfer <../heat_transfer/heat_transfer.html>`_ modules. The CLS DCDD implementation is detailed `here <https://doi.org/10.1016/j.cpc.2025.109880>`_, and it is analogous to the tracer module.

--- a/doc/source/theory/multiphysics/passive_tracer/passive_tracer_equations.rst
+++ b/doc/source/theory/multiphysics/passive_tracer/passive_tracer_equations.rst
@@ -15,10 +15,6 @@ where:
 * :math:`\kappa` is the diffusivity coefficient;
 * :math:`f` is the tracer source term per unit of mass.
 
-==========================
-Finite Element Formulation
-==========================
-
 To obtain the finite element discretization, we start from the strong form previously presented and integrate it over a domain :math:`\Omega` with boundary :math:`\Gamma` such that:
 
 .. math::

--- a/doc/source/theory/multiphysics/passive_tracer/passive_tracer_equations.rst
+++ b/doc/source/theory/multiphysics/passive_tracer/passive_tracer_equations.rst
@@ -2,4 +2,51 @@
 Passive Tracer Equations
 =========================
 
+Lethe allows the simulation of a passive tracer, which is governed by the equation:
+
+.. math::
+    \frac{\partial T}{\partial t} + \mathbf{u} \cdot \nabla T - \kappa \nabla^2 T + S = 0
+
+where:
+
+* :math:`T` is the tracer concentration;
+* :math:`\mathbf{u}` is the velocity of the fluid;
+* :math:`\nabla` is the `del operator <https://en.wikipedia.org/wiki/Del>`_;
+* :math:`\kappa` is the diffusivity coefficient;
+* :math:`S` is the tracer source term per unit of mass.
+
+==========================
+Finite Element Formulation
+==========================
+
+To obtain the finite element discretization, we start from the strong form previously presented and integrate it over a domain :math:`\Omega` with boundary :math:`\Gamma` such that:
+
+.. math::
+    \int_{\Omega} \left( \frac{\partial T}{\partial t} + \mathbf{u} \cdot \nabla T - \kappa \nabla^2 T - S \right) d\Omega = 0
+
+To obtain the corresponding weak form, we multiply the equation above by a test function :math:`q` and apply integration by parts on the Laplacian term:
+
+.. math::
+    \int_{\Omega} q \frac{\partial T}{\partial t} d\Omega + \int_{\Omega} q \mathbf{u} \cdot \nabla T d\Omega + \int_{\Omega} \nabla q \kappa \nabla T d\Omega - \int_{\Omega} q S d\Omega = 0
+
+Using the discrete form of the tracer concentration field :math:`T = \sum_j T_j \phi_j` and the test function :math:`q = \phi_i`:
+
+.. math::
+    \int_{\Omega} \phi_i \frac{\partial \phi_j}{\partial t} d\Omega + \int_{\Omega} \phi_i \mathbf{u} \cdot \nabla \phi_j d\Omega + \int_{\Omega} \nabla \phi_i \kappa \nabla \phi_j d\Omega - \int_{\Omega} \phi_i S d\Omega = 0
+
+========================
+Stabilization Techniques
+========================
+
+The GLS stabilization term added is given by:
+
+.. math::
+    a_{GLS} = \int_{\Omega} \tau (\mathbf{u} \cdot \nabla q) \mathrm{R}(T),
+
+where :math:`\mathrm{R}(T)` is the strong residual of the governing equation. The stabilization parameter definition herein used is the one presented by `Tezduyar (1992) <https://doi.org/10.1016/0045-7825(92)90141-6>`_ and presented in the `Fluid Dynamics <../fluid_dynamics/stabilization.html>`_ subsection.
+
+====================
+Shock-capturing term
+====================
+
 **Under construction**

--- a/doc/source/theory/multiphysics/passive_tracer/passive_tracer_equations.rst
+++ b/doc/source/theory/multiphysics/passive_tracer/passive_tracer_equations.rst
@@ -2,31 +2,31 @@
 Passive Tracer Equations
 =========================
 
-Lethe allows the simulation of a passive tracer, which is governed by the equation:
+Lethe allows the simulation of a passive tracer, which is governed by the following advection-diffusion equation:
 
 .. math::
-    \frac{\partial C}{\partial t} + \mathbf{u} \cdot \nabla C - \kappa \nabla^2 C + f = 0,
+    \frac{\partial C}{\partial t} + \mathbf{u} \cdot \nabla C - D \nabla^2 C + f = 0,
 
 where:
 
 * :math:`C` is the tracer concentration;
 * :math:`\mathbf{u}` is the velocity of the fluid;
 * :math:`\nabla` is the `del operator <https://en.wikipedia.org/wiki/Del>`_;
-* :math:`\kappa` is the diffusivity coefficient;
+* :math:`D` is the diffusivity coefficient;
 * :math:`f` is the tracer source term per unit of mass.
 
 .. important::
-    The tracer can be advected with the same velocity of the fluid, or a `drift velocity <../../../parameters/cfd/tracer_drift_velocity.html>`_ can be added. A reactive tracer feature also allows the prescription of a tracer consumption rate.
+    The tracer is advected by the fluid velocity, to which can be added a `drift velocity <../../../parameters/cfd/tracer_drift_velocity.html>`_. A reactive tracer feature also allows the prescription of a tracer consumption rate.
 
-To obtain the finite element discretization, we start from the strong form previously presented and integrate it over a domain :math:`\Omega` with boundary :math:`\Gamma` such that:
-
-.. math::
-    \int_{\Omega} \left( \frac{\partial C}{\partial t} + \mathbf{u} \cdot \nabla C - \kappa \nabla^2 C - f \right) \: d\Omega = 0.
-
-To obtain the corresponding weak form, we multiply the equation above by a test function :math:`q` and apply integration by parts on the Laplacian term:
+To obtain the finite element discretization, we start from the strong form previously presented, multiply it by a test function :math:`q`, then integrate it over the domain :math:`\Omega` with boundary :math:`\Gamma` such that:
 
 .. math::
-    F(C) := (q, \partial_t C)_{\Omega} + (q, \mathbf{u} \cdot \nabla C)_{\Omega} + (\nabla q, \kappa \: \nabla C)_{\Omega} - (q, f)_{\Omega} = 0.
+    \int_{\Omega} q \: \left( \frac{\partial C}{\partial t} + \mathbf{u} \cdot \nabla C - D \nabla^2 C - f \right) \: d\Omega = 0.
+
+To obtain the corresponding weak form, we then apply integration by parts on the Laplacian term:
+
+.. math::
+    F(C) := (q, \partial_t C)_{\Omega} + (q, \mathbf{u} \cdot \nabla C)_{\Omega} + (\nabla q, D \: \nabla C)_{\Omega} - (q, f)_{\Omega} = 0.
 
 To ensure that the integral is well defined in the domain :math:`\Omega`, we use appropriate solution spaces:
 
@@ -39,7 +39,7 @@ Both DG and CG tracer formulations are available in Lethe (see how to assign the
 The weak formulation is written as: find :math:`C \in \mathcal{C} (\Omega) \times (0, T]` such that 
 
 .. math::
-    (q, \partial_t C)_{\Omega} + (q, \mathbf{u} \cdot \nabla C)_{\Omega} + (\nabla q, \kappa \: \nabla C)_{\Omega} - (q, f)_{\Omega} = 0 \qquad \forall \: q \in \mathcal{Q}.
+    (q, \partial_t C)_{\Omega} + (q, \mathbf{u} \cdot \nabla C)_{\Omega} + (\nabla q, D \: \nabla C)_{\Omega} - (q, f)_{\Omega} = 0 \qquad \forall \: q \in \mathcal{Q}.
 
 ========================
 Stabilization Techniques

--- a/doc/source/theory/multiphysics/passive_tracer/passive_tracer_equations.rst
+++ b/doc/source/theory/multiphysics/passive_tracer/passive_tracer_equations.rst
@@ -5,7 +5,7 @@ Passive Tracer Equations
 Lethe allows the simulation of a passive tracer, which is governed by the equation:
 
 .. math::
-    \frac{\partial C}{\partial t} + \mathbf{u} \cdot \nabla C - \kappa \nabla^2 C + f = 0
+    \frac{\partial C}{\partial t} + \mathbf{u} \cdot \nabla C - \kappa \nabla^2 C + f = 0,
 
 where:
 
@@ -21,22 +21,25 @@ where:
 To obtain the finite element discretization, we start from the strong form previously presented and integrate it over a domain :math:`\Omega` with boundary :math:`\Gamma` such that:
 
 .. math::
-    \int_{\Omega} \left( \frac{\partial C}{\partial t} + \mathbf{u} \cdot \nabla C - \kappa \nabla^2 C - f \right) \: d\Omega = 0
+    \int_{\Omega} \left( \frac{\partial C}{\partial t} + \mathbf{u} \cdot \nabla C - \kappa \nabla^2 C - f \right) \: d\Omega = 0.
 
 To obtain the corresponding weak form, we multiply the equation above by a test function :math:`q` and apply integration by parts on the Laplacian term:
 
 .. math::
-    F(C) := (q, \partial_t C)_{\Omega} + (q, \mathbf{u} \cdot \nabla C)_{\Omega} + (\nabla q, \kappa \: \nabla C)_{\Omega} - (q, f)_{\Omega} = 0
+    F(C) := (q, \partial_t C)_{\Omega} + (q, \mathbf{u} \cdot \nabla C)_{\Omega} + (\nabla q, \kappa \: \nabla C)_{\Omega} - (q, f)_{\Omega} = 0.
 
 To ensure that the integral is well defined in the domain :math:`\Omega`, we use appropriate solution spaces:
 
 .. math::
-    C \in \mathcal{C} (\Omega) = \mathcal{H}^1 (\Omega), \qquad q \in \mathcal{Q} (\Omega) = \mathcal{L}^2 (\Omega)
+    C \in \mathcal{C} (\Omega) = \mathcal{H}^1 (\Omega), \qquad q \in \mathcal{Q} (\Omega) = \mathcal{H}^1 (\Omega),
 
-and the weak formulation is formulated as finding :math:`C \in \mathcal{C} (\Omega) \times (0, T]` such that 
+noting that this solution space for :math:`q` is suitable for a Continuous Galerkin formulation. If a Discontinuous Galerkin framework is assumed, the appropriate solution is defined in :math:`\mathcal{L}^2 (\Omega)`. 
+Both DG and CG tracer formulations are available in Lethe (see how to assign them in the `FEM parameters <../../../parameters/cfd/fem.html>`_ section).
+
+The weak formulation is written as: find :math:`C \in \mathcal{C} (\Omega) \times (0, T]` such that 
 
 .. math::
-    (q, \partial_t C)_{\Omega} + (q, \mathbf{u} \cdot \nabla C)_{\Omega} + (\nabla q, \kappa \: \nabla C)_{\Omega} - (q, f)_{\Omega} = 0 \qquad \forall \: q \in \mathcal{Q}
+    (q, \partial_t C)_{\Omega} + (q, \mathbf{u} \cdot \nabla C)_{\Omega} + (\nabla q, \kappa \: \nabla C)_{\Omega} - (q, f)_{\Omega} = 0 \qquad \forall \: q \in \mathcal{Q}.
 
 ========================
 Stabilization Techniques
@@ -45,13 +48,13 @@ Stabilization Techniques
 Two stabilization terms are added to the weak form of the passive tracer equation:
 
 .. math::
-   F(C)_{\text{stab}} := F(C) + \underbrace{(\tau \: [\mathbf{u} \cdot \nabla q], \: \mathcal{R}(C))}_{a_{\text{GLS}}} + \underbrace{(v_{\text{DCDD}} \nabla q, \: \mathbf{d}_{\text{DCDD}} \cdot \nabla C)}_{a_{\text{DCDD}}}
+   F(C)_{\text{stab}} := F(C) + \underbrace{(\tau \: [\mathbf{u} \cdot \nabla q], \: \mathcal{R}(C))}_{a_{\text{GLS}}} + \underbrace{(v_{\text{DCDD}} \nabla q, \: \mathbf{d}_{\text{DCDD}} \cdot \nabla C)}_{a_{\text{DCDD}}} ,
 
-In the GLS stabilization :math:`a_{\text{GLS}}`, :math:`\mathcal{R}(C)` is the strong residual of the governing equation, and the stabilization parameter :math:`\tau_k` is defined as in `Tezduyar (1992) <https://doi.org/10.1016/0045-7825(92)90141-6>`_:
+In the GLS stabilization term :math:`a_{\text{GLS}}`, :math:`\mathcal{R}(C)` is the strong residual of the governing equation, and the stabilization parameter :math:`\tau_k` is defined as in `Tezduyar (1992) <https://doi.org/10.1016/0045-7825(92)90141-6>`_:
 
 .. math::
 
-   \tau = \left[ \left( \frac{1}{\Delta t} \right)^{2} + \left( \frac{2 |\mathrm{u}|}{h_{\text{conv}}} \right)^{2} + 9 \left( \frac{4 \nu}{h^2_{\text{diff}}} \right)^{2} \right]^{-1/2}
+   \tau = \left[ \left( \frac{1}{\Delta t} \right)^{2} + \left( \frac{2 |\mathrm{u}|}{h_{\text{conv}}} \right)^{2} + 9 \left( \frac{4 \nu}{h^2_{\text{diff}}} \right)^{2} \right]^{-1/2},
 
 where :math:`\Delta t` is the time step, and :math:`h_{\text{conv}}` and :math:`h_{\text{diff}}` are the size of the element related to the convection transport and diffusion mechanism, respectively. In Lethe, both element sizes are set to the diameter of a sphere having a volume equivalent to that of the cell. 
 
@@ -61,4 +64,4 @@ where :math:`\Delta t` is the time step, and :math:`h_{\text{conv}}` and :math:`
 The second stabilization term is a Discontinuity-Capturing Directional Dissipation (DCDD) shock-capturing scheme proposed by `Tezduyar (2003) <https://doi.org/10.1002/fld.505>`_ that aims to deal with crosswind oscillations. 
 
 .. seealso::
-    The DCDD shock-capturing scheme is also used in the `CLS <../../multiphase/cfd/cls.html>`_ and `Heat Transfer <../heat_transfer/heat_transfer.html>`_ modules. The CLS DCDD implementation is detailed `here <https://doi.org/10.1016/j.cpc.2025.109880>`_, and it is analogous to the tracer module.
+    The DCDD shock-capturing scheme is also used in the `CLS <../../multiphase/cfd/cls.html>`_ and `Heat Transfer <../heat_transfer/heat_transfer.html>`_ modules. The CLS DCDD implementation is detailed in `this publication <https://doi.org/10.1016/j.cpc.2025.109880>`_, and it is analogous to the tracer module.

--- a/include/core/mortar_coupling_manager.h
+++ b/include/core/mortar_coupling_manager.h
@@ -1105,8 +1105,8 @@ public:
   using value_type        = typename FEPointIntegrator::value_type;
 
   ScalarCouplingEvaluation(const Mapping<dim>    &mapping,
-                         const DoFHandler<dim> &dof_handler,
-                         const unsigned int     first_selected_component = 0);
+                           const DoFHandler<dim> &dof_handler,
+                           const unsigned int     first_selected_component = 0);
 
   unsigned int
   data_size() const override;

--- a/include/core/mortar_coupling_manager.h
+++ b/include/core/mortar_coupling_manager.h
@@ -1098,13 +1098,13 @@ private:
 
 
 template <int dim, int n_components, typename Number>
-class CouplingEvaluationSIPG : public CouplingEvaluationBase<dim, Number>
+class ScalarCouplingEvaluation : public CouplingEvaluationBase<dim, Number>
 {
 public:
   using FEPointIntegrator = FEPointEvaluation<n_components, dim, dim, Number>;
   using value_type        = typename FEPointIntegrator::value_type;
 
-  CouplingEvaluationSIPG(const Mapping<dim>    &mapping,
+  ScalarCouplingEvaluation(const Mapping<dim>    &mapping,
                          const DoFHandler<dim> &dof_handler,
                          const unsigned int     first_selected_component = 0);
 

--- a/include/core/mortar_coupling_manager.h
+++ b/include/core/mortar_coupling_manager.h
@@ -1098,15 +1098,15 @@ private:
 
 
 template <int dim, int n_components, typename Number>
-class ScalarCouplingEvaluation : public CouplingEvaluationBase<dim, Number>
+class ScalarCouplingEvaluationSIPG : public CouplingEvaluationBase<dim, Number>
 {
 public:
   using FEPointIntegrator = FEPointEvaluation<n_components, dim, dim, Number>;
   using value_type        = typename FEPointIntegrator::value_type;
 
-  ScalarCouplingEvaluation(const Mapping<dim>    &mapping,
-                           const DoFHandler<dim> &dof_handler,
-                           const unsigned int     first_selected_component = 0);
+  ScalarCouplingEvaluationSIPG(const Mapping<dim>    &mapping,
+                               const DoFHandler<dim> &dof_handler,
+                               const unsigned int first_selected_component = 0);
 
   unsigned int
   data_size() const override;
@@ -1146,7 +1146,7 @@ public:
 };
 
 template <int dim, typename Number>
-class NavierStokesCouplingEvaluation
+class NavierStokesCouplingEvaluationSIPG
   : public CouplingEvaluationBase<dim, Number>
 {
 public:
@@ -1161,14 +1161,14 @@ public:
    * @param[in] dof_handler DoFHandler associated to the triangulation
    * @param[in] kinematic_vicosity Kinematic viscosity
    */
-  NavierStokesCouplingEvaluation(const Mapping<dim>    &mapping,
-                                 const DoFHandler<dim> &dof_handler,
-                                 const double           kinematic_viscosity);
+  NavierStokesCouplingEvaluationSIPG(const Mapping<dim>    &mapping,
+                                     const DoFHandler<dim> &dof_handler,
+                                     const double kinematic_viscosity);
 
   /**
    * @brief Default destructor
    */
-  virtual ~NavierStokesCouplingEvaluation() = default;
+  virtual ~NavierStokesCouplingEvaluationSIPG() = default;
 
   unsigned int
   data_size() const override;

--- a/include/solvers/fluid_dynamics_matrix_free_operators.h
+++ b/include/solvers/fluid_dynamics_matrix_free_operators.h
@@ -478,7 +478,7 @@ public:
    */
   std::shared_ptr<MortarManagerBase<dim>>        mortar_manager_mf;
   std::shared_ptr<CouplingOperator<dim, double>> mortar_coupling_operator_mf;
-  std::shared_ptr<NavierStokesCouplingEvaluation<dim, double>>
+  std::shared_ptr<NavierStokesCouplingEvaluationSIPG<dim, double>>
     mortar_coupling_evaluator_mf;
 
 protected:

--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -893,7 +893,7 @@ protected:
   // Mortar coupling manager and operator
   std::shared_ptr<MortarManagerBase<dim>>        mortar_manager;
   std::shared_ptr<CouplingOperator<dim, double>> mortar_coupling_operator;
-  std::shared_ptr<NavierStokesCouplingEvaluation<dim, double>>
+  std::shared_ptr<NavierStokesCouplingEvaluationSIPG<dim, double>>
     mortar_coupling_evaluator;
 
   // Mapping cache used in rotor mesh rotation in mortar method

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -35,8 +35,8 @@
 /*
  * Implementation of tracer as an auxiliary physics.
  * Equation solved:
- * dT/dt +  u * gradT = D * div(grad T) + f
- * with T the tracer function, D the diffusivity and f the forcing
+ * dC/dt +  u * gradC = k * div(grad C) + f
+ * where C is the tracer concentration, k the diffusivity and f the forcing
  */
 
 DeclException1(

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -35,8 +35,8 @@
 /*
  * Implementation of tracer as an auxiliary physics.
  * Equation solved:
- * dC/dt +  u * gradC = k * div(grad C) + f
- * where C is the tracer concentration, k the diffusivity and f the forcing
+ * dC/dt +  u * gradC = D * div(grad C) + f
+ * where C is the tracer concentration, D the diffusivity and f the forcing
  */
 
 DeclException1(

--- a/release_notes/current/2026_06_09_Campos.md
+++ b/release_notes/current/2026_06_09_Campos.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/06/09
+
+### Added
+
+- MINOR This PR adds the passive tracer documentation. Also, the tracer concentration variable in the code was changed from `T` to `C` so that it is distinct from the temperature variable. [#2017](https://github.com/chaos-polymtl/lethe/pull/2017)

--- a/source/core/mortar_coupling_manager.cc
+++ b/source/core/mortar_coupling_manager.cc
@@ -1765,9 +1765,9 @@ CouplingOperator<dim, Number>::add_system_matrix_entries(
 }
 
 
-/*-------------- CouplingEvaluationSIPG -------------------------------*/
+/*-------------- ScalarCouplingEvaluation -------------------------------*/
 template <int dim, int n_components, typename Number>
-CouplingEvaluationSIPG<dim, n_components, Number>::CouplingEvaluationSIPG(
+ScalarCouplingEvaluation<dim, n_components, Number>::ScalarCouplingEvaluation(
   const Mapping<dim>    &mapping,
   const DoFHandler<dim> &dof_handler,
   const unsigned int     first_selected_component)
@@ -1788,14 +1788,14 @@ CouplingEvaluationSIPG<dim, n_components, Number>::CouplingEvaluationSIPG(
 
 template <int dim, int n_components, typename Number>
 unsigned int
-CouplingEvaluationSIPG<dim, n_components, Number>::data_size() const
+ScalarCouplingEvaluation<dim, n_components, Number>::data_size() const
 {
   return n_components * 2;
 }
 
 template <int dim, int n_components, typename Number>
 const std::vector<unsigned int> &
-CouplingEvaluationSIPG<dim, n_components, Number>::get_relevant_dof_indices()
+ScalarCouplingEvaluation<dim, n_components, Number>::get_relevant_dof_indices()
   const
 {
   return relevant_dof_indices;
@@ -1803,7 +1803,7 @@ CouplingEvaluationSIPG<dim, n_components, Number>::get_relevant_dof_indices()
 
 template <int dim, int n_components, typename Number>
 void
-CouplingEvaluationSIPG<dim, n_components, Number>::local_reinit(
+ScalarCouplingEvaluation<dim, n_components, Number>::local_reinit(
   const typename Triangulation<dim>::cell_iterator &cell,
   const ArrayView<const Point<dim, Number>>        &points) const
 {
@@ -1812,7 +1812,7 @@ CouplingEvaluationSIPG<dim, n_components, Number>::local_reinit(
 
 template <int dim, int n_components, typename Number>
 void
-CouplingEvaluationSIPG<dim, n_components, Number>::local_evaluate(
+ScalarCouplingEvaluation<dim, n_components, Number>::local_evaluate(
   const CouplingEvaluationData<dim, Number> &data,
   const Vector<Number>                      &buffer,
   const unsigned int                         ptr_q,
@@ -1844,7 +1844,7 @@ CouplingEvaluationSIPG<dim, n_components, Number>::local_evaluate(
 
 template <int dim, int n_components, typename Number>
 void
-CouplingEvaluationSIPG<dim, n_components, Number>::local_integrate(
+ScalarCouplingEvaluation<dim, n_components, Number>::local_integrate(
   const CouplingEvaluationData<dim, Number> &data,
   Vector<Number>                            &buffer,
   const unsigned int                         ptr_q,
@@ -2154,14 +2154,14 @@ template void
 CouplingOperator<3, double>::add_diagonal_entries(
   LinearAlgebra::distributed::Vector<float> &) const;
 
-template class CouplingEvaluationSIPG<1, 1, double>;
-template class CouplingEvaluationSIPG<1, 2, double>;
-template class CouplingEvaluationSIPG<2, 1, double>;
-template class CouplingEvaluationSIPG<2, 2, double>;
-template class CouplingEvaluationSIPG<2, 3, double>;
-template class CouplingEvaluationSIPG<3, 1, double>;
-template class CouplingEvaluationSIPG<3, 3, double>;
-template class CouplingEvaluationSIPG<3, 4, double>;
+template class ScalarCouplingEvaluation<1, 1, double>;
+template class ScalarCouplingEvaluation<1, 2, double>;
+template class ScalarCouplingEvaluation<2, 1, double>;
+template class ScalarCouplingEvaluation<2, 2, double>;
+template class ScalarCouplingEvaluation<2, 3, double>;
+template class ScalarCouplingEvaluation<3, 1, double>;
+template class ScalarCouplingEvaluation<3, 3, double>;
+template class ScalarCouplingEvaluation<3, 4, double>;
 
 template class NavierStokesCouplingEvaluation<2, double>;
 template class NavierStokesCouplingEvaluation<3, double>;

--- a/source/core/mortar_coupling_manager.cc
+++ b/source/core/mortar_coupling_manager.cc
@@ -1765,12 +1765,12 @@ CouplingOperator<dim, Number>::add_system_matrix_entries(
 }
 
 
-/*-------------- ScalarCouplingEvaluation -------------------------------*/
+/*-------------- ScalarCouplingEvaluationSIPG -------------------------------*/
 template <int dim, int n_components, typename Number>
-ScalarCouplingEvaluation<dim, n_components, Number>::ScalarCouplingEvaluation(
-  const Mapping<dim>    &mapping,
-  const DoFHandler<dim> &dof_handler,
-  const unsigned int     first_selected_component)
+ScalarCouplingEvaluationSIPG<dim, n_components, Number>::
+  ScalarCouplingEvaluationSIPG(const Mapping<dim>    &mapping,
+                               const DoFHandler<dim> &dof_handler,
+                               const unsigned int     first_selected_component)
   : fe_sub(dof_handler.get_fe().base_element(
              dof_handler.get_fe()
                .component_to_base_index(first_selected_component)
@@ -1788,22 +1788,22 @@ ScalarCouplingEvaluation<dim, n_components, Number>::ScalarCouplingEvaluation(
 
 template <int dim, int n_components, typename Number>
 unsigned int
-ScalarCouplingEvaluation<dim, n_components, Number>::data_size() const
+ScalarCouplingEvaluationSIPG<dim, n_components, Number>::data_size() const
 {
   return n_components * 2;
 }
 
 template <int dim, int n_components, typename Number>
 const std::vector<unsigned int> &
-ScalarCouplingEvaluation<dim, n_components, Number>::get_relevant_dof_indices()
-  const
+ScalarCouplingEvaluationSIPG<dim, n_components, Number>::
+  get_relevant_dof_indices() const
 {
   return relevant_dof_indices;
 }
 
 template <int dim, int n_components, typename Number>
 void
-ScalarCouplingEvaluation<dim, n_components, Number>::local_reinit(
+ScalarCouplingEvaluationSIPG<dim, n_components, Number>::local_reinit(
   const typename Triangulation<dim>::cell_iterator &cell,
   const ArrayView<const Point<dim, Number>>        &points) const
 {
@@ -1812,7 +1812,7 @@ ScalarCouplingEvaluation<dim, n_components, Number>::local_reinit(
 
 template <int dim, int n_components, typename Number>
 void
-ScalarCouplingEvaluation<dim, n_components, Number>::local_evaluate(
+ScalarCouplingEvaluationSIPG<dim, n_components, Number>::local_evaluate(
   const CouplingEvaluationData<dim, Number> &data,
   const Vector<Number>                      &buffer,
   const unsigned int                         ptr_q,
@@ -1844,7 +1844,7 @@ ScalarCouplingEvaluation<dim, n_components, Number>::local_evaluate(
 
 template <int dim, int n_components, typename Number>
 void
-ScalarCouplingEvaluation<dim, n_components, Number>::local_integrate(
+ScalarCouplingEvaluationSIPG<dim, n_components, Number>::local_integrate(
   const CouplingEvaluationData<dim, Number> &data,
   Vector<Number>                            &buffer,
   const unsigned int                         ptr_q,
@@ -1898,13 +1898,13 @@ ScalarCouplingEvaluation<dim, n_components, Number>::local_integrate(
 }
 
 
-/*----------- NavierStokesCouplingEvaluation -------------------------*/
+/*----------- NavierStokesCouplingEvaluationSIPG -------------------------*/
 
 template <int dim, typename Number>
-NavierStokesCouplingEvaluation<dim, Number>::NavierStokesCouplingEvaluation(
-  const Mapping<dim>    &mapping,
-  const DoFHandler<dim> &dof_handler,
-  const double           kinematic_viscosity)
+NavierStokesCouplingEvaluationSIPG<dim, Number>::
+  NavierStokesCouplingEvaluationSIPG(const Mapping<dim>    &mapping,
+                                     const DoFHandler<dim> &dof_handler,
+                                     const double           kinematic_viscosity)
   : fe_sub_u(dof_handler.get_fe().base_element(
                dof_handler.get_fe().component_to_base_index(0).first),
              dim)
@@ -1929,21 +1929,22 @@ NavierStokesCouplingEvaluation<dim, Number>::NavierStokesCouplingEvaluation(
 
 template <int dim, typename Number>
 unsigned int
-NavierStokesCouplingEvaluation<dim, Number>::data_size() const
+NavierStokesCouplingEvaluationSIPG<dim, Number>::data_size() const
 {
   return 4 * dim;
 }
 
 template <int dim, typename Number>
 const std::vector<unsigned int> &
-NavierStokesCouplingEvaluation<dim, Number>::get_relevant_dof_indices() const
+NavierStokesCouplingEvaluationSIPG<dim, Number>::get_relevant_dof_indices()
+  const
 {
   return relevant_dof_indices;
 }
 
 template <int dim, typename Number>
 void
-NavierStokesCouplingEvaluation<dim, Number>::local_reinit(
+NavierStokesCouplingEvaluationSIPG<dim, Number>::local_reinit(
   const typename Triangulation<dim>::cell_iterator &cell,
   const ArrayView<const Point<dim, Number>>        &points) const
 {
@@ -1953,7 +1954,7 @@ NavierStokesCouplingEvaluation<dim, Number>::local_reinit(
 
 template <int dim, typename Number>
 void
-NavierStokesCouplingEvaluation<dim, Number>::local_evaluate(
+NavierStokesCouplingEvaluationSIPG<dim, Number>::local_evaluate(
   const CouplingEvaluationData<dim, Number> &data,
   const Vector<Number>                      &buffer,
   const unsigned int                         ptr_q,
@@ -1999,7 +2000,7 @@ NavierStokesCouplingEvaluation<dim, Number>::local_evaluate(
 
 template <int dim, typename Number>
 void
-NavierStokesCouplingEvaluation<dim, Number>::local_integrate(
+NavierStokesCouplingEvaluationSIPG<dim, Number>::local_integrate(
   const CouplingEvaluationData<dim, Number> &data,
   Vector<Number>                            &buffer,
   const unsigned int                         ptr_q,
@@ -2154,17 +2155,17 @@ template void
 CouplingOperator<3, double>::add_diagonal_entries(
   LinearAlgebra::distributed::Vector<float> &) const;
 
-template class ScalarCouplingEvaluation<1, 1, double>;
-template class ScalarCouplingEvaluation<1, 2, double>;
-template class ScalarCouplingEvaluation<2, 1, double>;
-template class ScalarCouplingEvaluation<2, 2, double>;
-template class ScalarCouplingEvaluation<2, 3, double>;
-template class ScalarCouplingEvaluation<3, 1, double>;
-template class ScalarCouplingEvaluation<3, 3, double>;
-template class ScalarCouplingEvaluation<3, 4, double>;
+template class ScalarCouplingEvaluationSIPG<1, 1, double>;
+template class ScalarCouplingEvaluationSIPG<1, 2, double>;
+template class ScalarCouplingEvaluationSIPG<2, 1, double>;
+template class ScalarCouplingEvaluationSIPG<2, 2, double>;
+template class ScalarCouplingEvaluationSIPG<2, 3, double>;
+template class ScalarCouplingEvaluationSIPG<3, 1, double>;
+template class ScalarCouplingEvaluationSIPG<3, 3, double>;
+template class ScalarCouplingEvaluationSIPG<3, 4, double>;
 
-template class NavierStokesCouplingEvaluation<2, double>;
-template class NavierStokesCouplingEvaluation<3, double>;
+template class NavierStokesCouplingEvaluationSIPG<2, double>;
+template class NavierStokesCouplingEvaluationSIPG<3, double>;
 
 template std::vector<unsigned int>
 compute_number_interface_cells<2>(

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -1762,7 +1762,8 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
 
               // Coupling evaluator
               this->mg_operators[level]->mortar_coupling_evaluator_mf =
-                std::make_shared<NavierStokesCouplingEvaluation<dim, double>>(
+                std::make_shared<
+                  NavierStokesCouplingEvaluationSIPG<dim, double>>(
                   *level_mapping,
                   level_dof_handler,
                   physical_properties_manager->get_rheology()
@@ -3132,7 +3133,7 @@ FluidDynamicsMatrixFree<dim>::reinit_mortar_operators_mf()
 
   // Create mortar coupling evaluator
   this->system_operator->mortar_coupling_evaluator_mf =
-    std::make_shared<NavierStokesCouplingEvaluation<dim, double>>(
+    std::make_shared<NavierStokesCouplingEvaluationSIPG<dim, double>>(
       *this->get_mapping(),
       *this->dof_handler,
       this->physical_properties_manager->get_rheology()

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2146,7 +2146,7 @@ NavierStokesBase<dim, VectorType, DofsType>::reinit_mortar_operators()
 
   // Create mortar coupling evaluator
   this->mortar_coupling_evaluator =
-    std::make_shared<NavierStokesCouplingEvaluation<dim, double>>(
+    std::make_shared<NavierStokesCouplingEvaluationSIPG<dim, double>>(
       *this->get_mapping(),
       *this->dof_handler,
       this->simulation_parameters.physical_properties_manager

--- a/source/solvers/tracer_assemblers.cc
+++ b/source/solvers/tracer_assemblers.cc
@@ -39,9 +39,9 @@ TracerAssemblerCore<dim>::assemble_matrix(
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
       // Gather into local variables the relevant fields
-      const double         diffusivity     = diffusivity_vector[q];
-      const Tensor<1, dim> tracer_gradient = scratch_data.tracer_gradients[q];
-      const Tensor<1, dim> velocity        = scratch_data.velocity_values[q];
+      const double          diffusivity     = diffusivity_vector[q];
+      const Tensor<1, dim> &tracer_gradient = scratch_data.tracer_gradients[q];
+      const Tensor<1, dim> &velocity        = scratch_data.velocity_values[q];
 
       // Store JxW in local variable for faster access;
       const double JxW = JxW_vec[q];
@@ -102,22 +102,22 @@ TracerAssemblerCore<dim>::assemble_matrix(
 
       for (unsigned int j = 0; j < n_dofs; ++j)
         {
-          const Tensor<1, dim> grad_phi_C_j = scratch_data.grad_phi[q][j];
-          const double laplacian_phi_C_j    = scratch_data.laplacian_phi[q][j];
+          const Tensor<1, dim> &grad_phi_C_j = scratch_data.grad_phi[q][j];
+          const double &laplacian_phi_C_j    = scratch_data.laplacian_phi[q][j];
           strong_jacobian_vec[q][j] +=
             velocity * grad_phi_C_j - diffusivity * laplacian_phi_C_j;
         }
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
-          const auto phi_C_i      = scratch_data.phi[q][i];
-          const auto grad_phi_C_i = scratch_data.grad_phi[q][i];
+          const double         &phi_C_i      = scratch_data.phi[q][i];
+          const Tensor<1, dim> &grad_phi_C_i = scratch_data.grad_phi[q][i];
 
           for (unsigned int j = 0; j < n_dofs; ++j)
             {
-              const Tensor<1, dim> grad_phi_C_j = scratch_data.grad_phi[q][j];
+              const Tensor<1, dim> &grad_phi_C_j = scratch_data.grad_phi[q][j];
 
-              // Weak form : - k * laplacian C +  u * gradC - f = 0
+              // Weak form : - D * laplacian C +  u * gradC - f = 0
               local_matrix(i, j) += (diffusivity * grad_phi_C_i * grad_phi_C_j +
                                      phi_C_i * velocity * grad_phi_C_j) *
                                     JxW;
@@ -171,12 +171,12 @@ TracerAssemblerCore<dim>::assemble_rhs(
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
       // Gather into local variables the relevant fields
-      const double         diffusivity     = diffusivity_vector[q];
-      const Tensor<1, dim> tracer_gradient = scratch_data.tracer_gradients[q];
-      const Tensor<1, dim> previous_tracer_gradient =
+      const double          diffusivity     = diffusivity_vector[q];
+      const Tensor<1, dim> &tracer_gradient = scratch_data.tracer_gradients[q];
+      const Tensor<1, dim> &previous_tracer_gradient =
         scratch_data.previous_tracer_gradients[q];
-      const double         tracer_laplacian = scratch_data.tracer_laplacians[q];
-      const Tensor<1, dim> velocity         = scratch_data.velocity_values[q];
+      const double &tracer_laplacian = scratch_data.tracer_laplacians[q];
+      const Tensor<1, dim> &velocity = scratch_data.velocity_values[q];
 
       // Store JxW in local variable for faster access;
       const double JxW = JxW_vec[q];
@@ -225,10 +225,10 @@ TracerAssemblerCore<dim>::assemble_rhs(
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
-          const auto phi_C_i      = scratch_data.phi[q][i];
-          const auto grad_phi_C_i = scratch_data.grad_phi[q][i];
+          const double         &phi_C_i      = scratch_data.phi[q][i];
+          const Tensor<1, dim> &grad_phi_C_i = scratch_data.grad_phi[q][i];
 
-          // rhs for : - k * laplacian C +  u * grad C - f = 0
+          // RHS for: - D * laplacian C +  u * grad C - f = 0
           local_rhs(i) -= (diffusivity * grad_phi_C_i * tracer_gradient +
                            phi_C_i * velocity * tracer_gradient -
                            scratch_data.source[q] * phi_C_i) *
@@ -271,24 +271,24 @@ TracerAssemblerDGCore<dim>::assemble_matrix(
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
       // Gather into local variables the relevant fields
-      const double         diffusivity = diffusivity_vector[q];
-      const Tensor<1, dim> velocity    = scratch_data.velocity_values[q];
-      const double velocity_divergence = scratch_data.velocity_divergences[q];
+      const double          diffusivity = diffusivity_vector[q];
+      const Tensor<1, dim> &velocity    = scratch_data.velocity_values[q];
+      const double &velocity_divergence = scratch_data.velocity_divergences[q];
 
       // Store JxW in local variable for faster access;
       const double JxW = JxW_vec[q];
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
-          const auto grad_phi_C_i = scratch_data.grad_phi[q][i];
-          const auto phi_C_i      = scratch_data.phi[q][i];
+          const double         &phi_C_i      = scratch_data.phi[q][i];
+          const Tensor<1, dim> &grad_phi_C_i = scratch_data.grad_phi[q][i];
 
           for (unsigned int j = 0; j < n_dofs; ++j)
             {
-              const Tensor<1, dim> grad_phi_C_j = scratch_data.grad_phi[q][j];
-              const auto           phi_C_j      = scratch_data.phi[q][j];
+              const double         &phi_C_j      = scratch_data.phi[q][j];
+              const Tensor<1, dim> &grad_phi_C_j = scratch_data.grad_phi[q][j];
 
-              // Weak form of: - k * laplacian C + u * gradC - f = 0
+              // Weak form of: - D * laplacian C + u * gradC - f = 0
               // Note that the advection term has been weakened for it to appear
               // explicitly in the weak form as a boundary term.
               local_matrix(i, j) += (diffusivity * grad_phi_C_i * grad_phi_C_j -
@@ -327,21 +327,21 @@ TracerAssemblerDGCore<dim>::assemble_rhs(
   for (unsigned int q = 0; q < n_q_points; ++q)
     {
       // Gather into local variables the relevant fields
-      const double         diffusivity     = diffusivity_vector[q];
-      const double         tracer_value    = scratch_data.tracer_values[q];
-      const Tensor<1, dim> tracer_gradient = scratch_data.tracer_gradients[q];
-      const Tensor<1, dim> velocity        = scratch_data.velocity_values[q];
-      const double velocity_divergence = scratch_data.velocity_divergences[q];
+      const double          diffusivity     = diffusivity_vector[q];
+      const double         &tracer_value    = scratch_data.tracer_values[q];
+      const Tensor<1, dim> &tracer_gradient = scratch_data.tracer_gradients[q];
+      const Tensor<1, dim> &velocity        = scratch_data.velocity_values[q];
+      const double &velocity_divergence = scratch_data.velocity_divergences[q];
 
       // Store JxW in local variable for faster access;
       const double JxW = JxW_vec[q];
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
-          const auto phi_C_i      = scratch_data.phi[q][i];
-          const auto grad_phi_C_i = scratch_data.grad_phi[q][i];
+          const double         &phi_C_i      = scratch_data.phi[q][i];
+          const Tensor<1, dim> &grad_phi_C_i = scratch_data.grad_phi[q][i];
 
-          // rhs for : - k * laplacian C + u * grad C - f = 0
+          // RHS for: - D * laplacian C + u * grad C - f = 0
           local_rhs(i) -= (diffusivity * grad_phi_C_i * tracer_gradient -
                            grad_phi_C_i * velocity * tracer_value -
                            scratch_data.source[q] * phi_C_i) *
@@ -754,7 +754,7 @@ TracerAssemblerReaction<dim>::assemble_matrix(
       // It comes from the derivative -d/dC (k * C) = -(k + C*dk/dC).
       for (unsigned int j = 0; j < n_dofs; ++j)
         {
-          const auto phi_C_j = scratch_data.phi[q][j];
+          const double &phi_C_j = scratch_data.phi[q][j];
           strong_jacobian_vec[q][j] +=
             -(reaction_coeff +
               scratch_data.grad_tracer_reaction_prefactor[q] * C) *

--- a/source/solvers/tracer_assemblers.cc
+++ b/source/solvers/tracer_assemblers.cc
@@ -234,9 +234,11 @@ TracerAssemblerCore<dim>::assemble_rhs(
                            scratch_data.source[q] * phi_C_i) *
                           JxW;
 
+          // GLS stabilization
           local_rhs(i) -=
             tau * (strong_residual_vec[q] * (grad_phi_C_i * velocity)) * JxW;
 
+          // DCDD shock-capturing
           local_rhs(i) -=
             vdcdd *
             scalar_product(grad_phi_C_i, dcdd_factor * tracer_gradient) * JxW;

--- a/source/solvers/tracer_assemblers.cc
+++ b/source/solvers/tracer_assemblers.cc
@@ -31,7 +31,6 @@ TracerAssemblerCore<dim>::assemble_matrix(
   const double dt  = time_steps_vector[0];
   const double sdt = 1. / dt;
 
-
   // Copy data elements
   auto &strong_jacobian_vec = copy_data.strong_jacobian;
   auto &local_matrix        = copy_data.local_matrix;
@@ -46,6 +45,13 @@ TracerAssemblerCore<dim>::assemble_matrix(
 
       // Store JxW in local variable for faster access;
       const double JxW = JxW_vec[q];
+
+      // Implementation of a Discontinuity-Capturing Directional Dissipation
+      // (DCDD) shock capturing scheme. For more information see Tezduyar,
+      // T. E. (2003). Computation of moving boundaries and interfaces and
+      // stabilization parameters. International Journal for Numerical
+      // Methods in Fluids, 43(5), 555-575. Our implementation is based on
+      // equations (70) and (79), which are adapted for the tracer solver.
 
       // We use the previous concentration for the shock capture if the
       // simulation is transient
@@ -79,8 +85,6 @@ TracerAssemblerCore<dim>::assemble_matrix(
             pow(tracer_gradient_for_dcdd_norm * h, order - 1) :
           0;
 
-
-
       // Calculation of the magnitude of the velocity for the
       // stabilization parameter
       const double u_mag = std::max(velocity.norm(), tolerance);
@@ -98,36 +102,36 @@ TracerAssemblerCore<dim>::assemble_matrix(
 
       for (unsigned int j = 0; j < n_dofs; ++j)
         {
-          const Tensor<1, dim> grad_phi_T_j = scratch_data.grad_phi[q][j];
-          const double laplacian_phi_T_j    = scratch_data.laplacian_phi[q][j];
+          const Tensor<1, dim> grad_phi_C_j = scratch_data.grad_phi[q][j];
+          const double laplacian_phi_C_j    = scratch_data.laplacian_phi[q][j];
           strong_jacobian_vec[q][j] +=
-            velocity * grad_phi_T_j - diffusivity * laplacian_phi_T_j;
+            velocity * grad_phi_C_j - diffusivity * laplacian_phi_C_j;
         }
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
-          const auto phi_T_i      = scratch_data.phi[q][i];
-          const auto grad_phi_T_i = scratch_data.grad_phi[q][i];
+          const auto phi_C_i      = scratch_data.phi[q][i];
+          const auto grad_phi_C_i = scratch_data.grad_phi[q][i];
 
           for (unsigned int j = 0; j < n_dofs; ++j)
             {
-              const Tensor<1, dim> grad_phi_T_j = scratch_data.grad_phi[q][j];
+              const Tensor<1, dim> grad_phi_C_j = scratch_data.grad_phi[q][j];
 
-              // Weak form : - D * laplacian T +  u * gradT - f=0
-              local_matrix(i, j) += (diffusivity * grad_phi_T_i * grad_phi_T_j +
-                                     phi_T_i * velocity * grad_phi_T_j) *
+              // Weak form : - k * laplacian C +  u * gradC - f = 0
+              local_matrix(i, j) += (diffusivity * grad_phi_C_i * grad_phi_C_j +
+                                     phi_C_i * velocity * grad_phi_C_j) *
                                     JxW;
 
-
-
+              // GLS stabilization
               local_matrix(i, j) += tau * strong_jacobian_vec[q][j] *
-                                    (grad_phi_T_i * velocity) * JxW;
+                                    (grad_phi_C_i * velocity) * JxW;
 
+              // DCDD shock-capturing
               local_matrix(i, j) +=
                 (vdcdd *
-                   scalar_product(grad_phi_T_i, dcdd_factor * grad_phi_T_j) +
-                 d_vdcdd * grad_phi_T_j.norm() *
-                   scalar_product(grad_phi_T_i,
+                   scalar_product(grad_phi_C_i, dcdd_factor * grad_phi_C_j) +
+                 d_vdcdd * grad_phi_C_j.norm() *
+                   scalar_product(grad_phi_C_i,
                                   dcdd_factor * tracer_gradient)) *
                 JxW;
             }
@@ -221,21 +225,21 @@ TracerAssemblerCore<dim>::assemble_rhs(
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
-          const auto phi_T_i      = scratch_data.phi[q][i];
-          const auto grad_phi_T_i = scratch_data.grad_phi[q][i];
+          const auto phi_C_i      = scratch_data.phi[q][i];
+          const auto grad_phi_C_i = scratch_data.grad_phi[q][i];
 
-          // rhs for : - D * laplacian T +  u * grad T - f=0
-          local_rhs(i) -= (diffusivity * grad_phi_T_i * tracer_gradient +
-                           phi_T_i * velocity * tracer_gradient -
-                           scratch_data.source[q] * phi_T_i) *
+          // rhs for : - k * laplacian C +  u * grad C - f = 0
+          local_rhs(i) -= (diffusivity * grad_phi_C_i * tracer_gradient +
+                           phi_C_i * velocity * tracer_gradient -
+                           scratch_data.source[q] * phi_C_i) *
                           JxW;
 
           local_rhs(i) -=
-            tau * (strong_residual_vec[q] * (grad_phi_T_i * velocity)) * JxW;
+            tau * (strong_residual_vec[q] * (grad_phi_C_i * velocity)) * JxW;
 
           local_rhs(i) -=
             vdcdd *
-            scalar_product(grad_phi_T_i, dcdd_factor * tracer_gradient) * JxW;
+            scalar_product(grad_phi_C_i, dcdd_factor * tracer_gradient) * JxW;
         }
     } // end loop on quadrature points
 }
@@ -332,18 +336,18 @@ TracerAssemblerDGCore<dim>::assemble_rhs(
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
-          const auto phi_T_i      = scratch_data.phi[q][i];
-          const auto grad_phi_T_i = scratch_data.grad_phi[q][i];
+          const auto phi_C_i      = scratch_data.phi[q][i];
+          const auto grad_phi_C_i = scratch_data.grad_phi[q][i];
 
-          // rhs for : - D * laplacian T + u * grad T - f=0
-          local_rhs(i) -= (diffusivity * grad_phi_T_i * tracer_gradient -
-                           grad_phi_T_i * velocity * tracer_value -
-                           scratch_data.source[q] * phi_T_i) *
+          // rhs for : - k * laplacian C + u * grad C - f = 0
+          local_rhs(i) -= (diffusivity * grad_phi_C_i * tracer_gradient -
+                           grad_phi_C_i * velocity * tracer_value -
+                           scratch_data.source[q] * phi_C_i) *
                           JxW;
 
           // This term is added to correct for the influence of the
           // non-divergence-free velocity field on the concentration.
-          local_rhs(i) -= -phi_T_i * velocity_divergence * tracer_value * JxW;
+          local_rhs(i) -= -phi_C_i * velocity_divergence * tracer_value * JxW;
         }
     } // end loop on quadrature points
 }
@@ -748,11 +752,11 @@ TracerAssemblerReaction<dim>::assemble_matrix(
       // It comes from the derivative -d/dC (k * C) = -(k + C*dk/dC).
       for (unsigned int j = 0; j < n_dofs; ++j)
         {
-          const auto phi_T_j = scratch_data.phi[q][j];
+          const auto phi_C_j = scratch_data.phi[q][j];
           strong_jacobian_vec[q][j] +=
             -(reaction_coeff +
               scratch_data.grad_tracer_reaction_prefactor[q] * C) *
-            phi_T_j;
+            phi_C_j;
         }
 
       // Store JxW in a local variable for faster access.
@@ -760,13 +764,13 @@ TracerAssemblerReaction<dim>::assemble_matrix(
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
-          const auto &phi_T_i = scratch_data.phi[q][i];
+          const auto &phi_C_i = scratch_data.phi[q][i];
 
           for (unsigned int j = 0; j < n_dofs; ++j)
             {
-              const auto &phi_T_j = scratch_data.phi[q][j];
+              const auto &phi_C_j = scratch_data.phi[q][j];
 
-              local_matrix(i, j) += reaction_coeff * phi_T_i * phi_T_j * JxW;
+              local_matrix(i, j) += reaction_coeff * phi_C_i * phi_C_j * JxW;
             }
         }
     } // end loop on quadrature points
@@ -807,7 +811,7 @@ TracerAssemblerReaction<dim>::assemble_rhs(
           const auto &phi_T_i = scratch_data.phi[q][i];
 
           // Add reaction term to the RHS
-          local_rhs(i) -= k[q] * phi_T_i * C * JxW;
+          local_rhs(i) -= k[q] * phi_C_i * C * JxW;
         }
     } // end loop on quadrature points
 }

--- a/source/solvers/tracer_assemblers.cc
+++ b/source/solvers/tracer_assemblers.cc
@@ -278,25 +278,25 @@ TracerAssemblerDGCore<dim>::assemble_matrix(
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
-          const auto grad_phi_T_i = scratch_data.grad_phi[q][i];
-          const auto phi_T_i      = scratch_data.phi[q][i];
+          const auto grad_phi_C_i = scratch_data.grad_phi[q][i];
+          const auto phi_C_i      = scratch_data.phi[q][i];
 
           for (unsigned int j = 0; j < n_dofs; ++j)
             {
-              const Tensor<1, dim> grad_phi_T_j = scratch_data.grad_phi[q][j];
-              const auto           phi_T_j      = scratch_data.phi[q][j];
+              const Tensor<1, dim> grad_phi_C_j = scratch_data.grad_phi[q][j];
+              const auto           phi_C_j      = scratch_data.phi[q][j];
 
-              // Weak form of: - D * laplacian T + u * gradT - f=0
+              // Weak form of: - k * laplacian C + u * gradC - f = 0
               // Note that the advection term has been weakened for it to appear
               // explicitly in the weak form as a boundary term.
-              local_matrix(i, j) += (diffusivity * grad_phi_T_i * grad_phi_T_j -
-                                     grad_phi_T_i * velocity * phi_T_j) *
+              local_matrix(i, j) += (diffusivity * grad_phi_C_i * grad_phi_C_j -
+                                     grad_phi_C_i * velocity * phi_C_j) *
                                     JxW;
 
               // This term is added to correct for the influence of the
               // non-divergence-free velocity field on the concentration.
               local_matrix(i, j) +=
-                -phi_T_i * velocity_divergence * phi_T_j * JxW;
+                -phi_C_i * velocity_divergence * phi_C_j * JxW;
             }
         }
     } // end loop on quadrature points
@@ -808,7 +808,7 @@ TracerAssemblerReaction<dim>::assemble_rhs(
 
       for (unsigned int i = 0; i < n_dofs; ++i)
         {
-          const auto &phi_T_i = scratch_data.phi[q][i];
+          const auto &phi_C_i = scratch_data.phi[q][i];
 
           // Add reaction term to the RHS
           local_rhs(i) -= k[q] * phi_C_i * C * JxW;

--- a/tests/mortar/poisson_matrix_based.cc
+++ b/tests/mortar/poisson_matrix_based.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 /**

--- a/tests/mortar/poisson_matrix_based.cc
+++ b/tests/mortar/poisson_matrix_based.cc
@@ -85,7 +85,7 @@ public:
     const std::shared_ptr<CouplingEvaluationBase<dim, double>>
       mortar_coupling_evaluator =
         std::make_shared<ScalarCouplingEvaluation<dim, 1, double>>(mapping,
-                                                                 dof_handler);
+                                                                   dof_handler);
 
     // create coupling operator
     mortar_coupling_operator =

--- a/tests/mortar/poisson_matrix_based.cc
+++ b/tests/mortar/poisson_matrix_based.cc
@@ -84,8 +84,8 @@ public:
     // create coupling evaluator
     const std::shared_ptr<CouplingEvaluationBase<dim, double>>
       mortar_coupling_evaluator =
-        std::make_shared<ScalarCouplingEvaluation<dim, 1, double>>(mapping,
-                                                                   dof_handler);
+        std::make_shared<ScalarCouplingEvaluationSIPG<dim, 1, double>>(
+          mapping, dof_handler);
 
     // create coupling operator
     mortar_coupling_operator =

--- a/tests/mortar/poisson_matrix_based.cc
+++ b/tests/mortar/poisson_matrix_based.cc
@@ -84,7 +84,7 @@ public:
     // create coupling evaluator
     const std::shared_ptr<CouplingEvaluationBase<dim, double>>
       mortar_coupling_evaluator =
-        std::make_shared<CouplingEvaluationSIPG<dim, 1, double>>(mapping,
+        std::make_shared<ScalarCouplingEvaluation<dim, 1, double>>(mapping,
                                                                  dof_handler);
 
     // create coupling operator

--- a/tests/mortar/poisson_matrix_based_nonlinear_01.cc
+++ b/tests/mortar/poisson_matrix_based_nonlinear_01.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 /**

--- a/tests/mortar/poisson_matrix_based_nonlinear_01.cc
+++ b/tests/mortar/poisson_matrix_based_nonlinear_01.cc
@@ -90,7 +90,7 @@ public:
     // create coupling evaluator
     const std::shared_ptr<CouplingEvaluationBase<dim, double>>
       mortar_coupling_evaluator =
-        std::make_shared<CouplingEvaluationSIPG<dim, 1, double>>(mapping,
+        std::make_shared<ScalarCouplingEvaluation<dim, 1, double>>(mapping,
                                                                  dof_handler);
 
     // create coupling operator

--- a/tests/mortar/poisson_matrix_based_nonlinear_01.cc
+++ b/tests/mortar/poisson_matrix_based_nonlinear_01.cc
@@ -90,8 +90,8 @@ public:
     // create coupling evaluator
     const std::shared_ptr<CouplingEvaluationBase<dim, double>>
       mortar_coupling_evaluator =
-        std::make_shared<ScalarCouplingEvaluation<dim, 1, double>>(mapping,
-                                                                   dof_handler);
+        std::make_shared<ScalarCouplingEvaluationSIPG<dim, 1, double>>(
+          mapping, dof_handler);
 
     // create coupling operator
     mortar_coupling_operator =

--- a/tests/mortar/poisson_matrix_based_nonlinear_01.cc
+++ b/tests/mortar/poisson_matrix_based_nonlinear_01.cc
@@ -91,7 +91,7 @@ public:
     const std::shared_ptr<CouplingEvaluationBase<dim, double>>
       mortar_coupling_evaluator =
         std::make_shared<ScalarCouplingEvaluation<dim, 1, double>>(mapping,
-                                                                 dof_handler);
+                                                                   dof_handler);
 
     // create coupling operator
     mortar_coupling_operator =

--- a/tests/mortar/poisson_matrix_based_nonlinear_02.cc
+++ b/tests/mortar/poisson_matrix_based_nonlinear_02.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 /**

--- a/tests/mortar/poisson_matrix_based_nonlinear_02.cc
+++ b/tests/mortar/poisson_matrix_based_nonlinear_02.cc
@@ -108,7 +108,7 @@ public:
     const std::shared_ptr<CouplingEvaluationBase<dim, double>>
       mortar_coupling_evaluator =
         std::make_shared<ScalarCouplingEvaluation<dim, 1, double>>(mapping,
-                                                                 dof_handler);
+                                                                   dof_handler);
 
     // create coupling operator
     mortar_coupling_operator =

--- a/tests/mortar/poisson_matrix_based_nonlinear_02.cc
+++ b/tests/mortar/poisson_matrix_based_nonlinear_02.cc
@@ -107,8 +107,8 @@ public:
     // create coupling evaluator
     const std::shared_ptr<CouplingEvaluationBase<dim, double>>
       mortar_coupling_evaluator =
-        std::make_shared<ScalarCouplingEvaluation<dim, 1, double>>(mapping,
-                                                                   dof_handler);
+        std::make_shared<ScalarCouplingEvaluationSIPG<dim, 1, double>>(
+          mapping, dof_handler);
 
     // create coupling operator
     mortar_coupling_operator =

--- a/tests/mortar/poisson_matrix_based_nonlinear_02.cc
+++ b/tests/mortar/poisson_matrix_based_nonlinear_02.cc
@@ -107,7 +107,7 @@ public:
     // create coupling evaluator
     const std::shared_ptr<CouplingEvaluationBase<dim, double>>
       mortar_coupling_evaluator =
-        std::make_shared<CouplingEvaluationSIPG<dim, 1, double>>(mapping,
+        std::make_shared<ScalarCouplingEvaluation<dim, 1, double>>(mapping,
                                                                  dof_handler);
 
     // create coupling operator

--- a/tests/mortar/tests.h
+++ b/tests/mortar/tests.h
@@ -503,10 +503,9 @@ public:
                const double                                  sip_factor = 1.0)
   {
     const std::shared_ptr<CouplingEvaluationBase<dim, Number>>
-      coupling_evaluator =
-        std::make_shared<ScalarCouplingEvaluation<dim, n_components, Number>>(
-          *matrix_free.get_mapping_info().mapping,
-          matrix_free.get_dof_handler());
+      coupling_evaluator = std::make_shared<
+        ScalarCouplingEvaluationSIPG<dim, n_components, Number>>(
+        *matrix_free.get_mapping_info().mapping, matrix_free.get_dof_handler());
 
     coupling_operator = std::make_shared<CouplingOperator<dim, Number>>(
       *matrix_free.get_mapping_info().mapping,
@@ -1286,10 +1285,9 @@ public:
                                                  rotate_pi);
 
     const std::shared_ptr<CouplingEvaluationBase<dim, Number>>
-      coupling_evaluator =
-        std::make_shared<ScalarCouplingEvaluation<dim, n_components, Number>>(
-          *matrix_free.get_mapping_info().mapping,
-          matrix_free.get_dof_handler());
+      coupling_evaluator = std::make_shared<
+        ScalarCouplingEvaluationSIPG<dim, n_components, Number>>(
+        *matrix_free.get_mapping_info().mapping, matrix_free.get_dof_handler());
 
     coupling_operator = std::make_shared<CouplingOperator<dim, Number>>(
       *matrix_free.get_mapping_info().mapping,

--- a/tests/mortar/tests.h
+++ b/tests/mortar/tests.h
@@ -504,7 +504,7 @@ public:
   {
     const std::shared_ptr<CouplingEvaluationBase<dim, Number>>
       coupling_evaluator =
-        std::make_shared<CouplingEvaluationSIPG<dim, n_components, Number>>(
+        std::make_shared<ScalarCouplingEvaluation<dim, n_components, Number>>(
           *matrix_free.get_mapping_info().mapping,
           matrix_free.get_dof_handler());
 
@@ -1287,7 +1287,7 @@ public:
 
     const std::shared_ptr<CouplingEvaluationBase<dim, Number>>
       coupling_evaluator =
-        std::make_shared<CouplingEvaluationSIPG<dim, n_components, Number>>(
+        std::make_shared<ScalarCouplingEvaluation<dim, n_components, Number>>(
           *matrix_free.get_mapping_info().mapping,
           matrix_free.get_dof_handler());
 


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the content of this documentation
       Is it related to Lethe documentation (simulation parameters or theory guide) or in-code documentation? -->

This PR adds the passive tracer documentation. Also, the tracer concentration variable in the code was changed from `T` to `C` so that it is distinct from the temperature variable.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

The class `CouplingEvaluationSIPG` in the mortar feature was renamed to `ScalarCouplingEvaluation` to improve its description. This is the class that will be used to couple the mortar and tracer features, which will be done in a future PR.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If any future work is planned, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR