### PR TITLE
Clang fix output path

### DIFF
--- a/release_notes/current/2026_06_12_Blais.md
+++ b/release_notes/current/2026_06_12_Blais.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/06/12
+
+### Fixed
+
+- MINOR The output folder creation process now uses `std::filesystem::create_directories` instead of `std::filesystem::create_directory`. This ensures that nested output paths whose parent directory (the `out/` in `out/duck`) does not yet exist are created correctly. The previous behavior threw a `filesystem_error` when an intermediate directory was missing. [#](https://github.com/chaos-polymtl/lethe/pull/)

--- a/source/core/utilities.cc
+++ b/source/core/utilities.cc
@@ -364,7 +364,7 @@ fill_string_vectors_from_file(
 void
 create_output_folder(const std::string &dirname)
 {
-  std::filesystem::create_directory(dirname);
+  std::filesystem::create_directories(dirname);
 }
 
 void


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The folder creation in make_output_directory could sometimes fail if one of the parent folder did not exist.


### Solution

The generation of the output folder now uses `std::filesystem::create_directories` instead of `std::filesystem::create_directory`. This enables the creation of a full output path that does not exist.

### Testing

Tested rapidly on my machine, works well. It's a cheap change.

### Documentation

Nothing to document.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] An entry describing the origin of the bug as well as its fix has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR