### PR TITLE
Fix clang compilation warnings

### DIFF
--- a/include/dem/load_balancing.h
+++ b/include/dem/load_balancing.h
@@ -182,23 +182,20 @@ public:
    * Attach the correct functions to the signals inside
    * parallel::distributed::Triangulation, which will be called every time the
    * load balancing or refinement functions are called.
-   *
-   * TODO: Remove preprocessor directives after deal.ii v.9.6 release
    */
   inline void
   connect_weight_signals()
   {
     triangulation->signals.weight.connect(
       [&](const typename Triangulation<dim>::cell_iterator &cell,
-          const typename Triangulation<dim>::CellStatus) -> unsigned int {
+          const CellStatus) -> unsigned int {
         return static_cast<int>(cell_weight_function->value(cell->center()));
       });
 
     triangulation->signals.weight.connect(
       [&](const typename parallel::distributed::Triangulation<
             dim>::cell_iterator &cell,
-          const typename parallel::distributed::Triangulation<dim>::CellStatus
-            status) -> unsigned int {
+          const CellStatus       status) -> unsigned int {
         return this->calculate_total_cell_weight(cell, status);
       });
   }
@@ -207,8 +204,6 @@ public:
    * @brief Connects the weight signals of the cells to the triangulation with
    * the mobility status. Cells are reconnected when load balancing is checked
    * with the new mobility status.
-   *
-   * TODO: Remove preprocessor directives after deal.ii v.9.6 release
    */
   inline void
   connect_mobility_status_weight_signals()

--- a/release_notes/current/2026_06_14_Blais.md
+++ b/release_notes/current/2026_06_14_Blais.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/06/14
+
+### Fixed
+
+- MINOR The two weight-signal lambdas in `LagrangianLoadBalancing::connect_weight_signals()` used the deprecated nested `Triangulation<dim>::CellStatus` typedef, which triggered `-Wdeprecated-declarations` warnings under clang. They now use the global `dealii::CellStatus` enum, consistent with the rest of the load balancing code. The obsolete `TODO: Remove preprocessor directives after deal.ii v.9.6 release` comments were also removed. [#](https://github.com/chaos-polymtl/lethe/pull/)


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The two weight-signal lambdas in `LagrangianLoadBalancing::connect_weight_signals()` used the deprecated nested `Triangulation<dim>::CellStatus` typedef, which triggered `-Wdeprecated-declarations` warnings under clang. This is fixed by using the modern deal.II syntax.

### Testing

All test are not affected

### Documentation

Nothing to document

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] An entry describing the change has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If any future work is planned, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR