### PR TITLE
Refactor the way the DEM boundary ids are stored and read from parameters

### DIFF
--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -18,6 +18,8 @@
 
 #include <deal.II/base/parameter_handler.h>
 
+#include <map>
+#include <set>
 #include <string>
 
 using namespace dealii;
@@ -761,8 +763,10 @@ namespace Parameters
     /**
      * @brief Boundary conditions for DEM simulations.
      *
-     * This structure stores the boundary types, motion parameters, and
-     * periodic boundary information for each boundary of the DEM domain.
+     * This structure stores the motion parameters and periodic boundary
+     * information for each boundary of the DEM domain. A boundary's type is
+     * encoded by which container holds it (see outlet_boundaries below); fixed
+     * walls are the default and are not stored in any container.
      */
     struct BCDEM
     {
@@ -770,55 +774,38 @@ namespace Parameters
       /// Number of DEM boundary conditions.
       unsigned int DEM_BC_number;
 
-      /**
-       * @brief Type of boundary condition applied to a DEM domain boundary.
-       */
-      enum class BoundaryType
-      {
-        /// Static wall
-        fixed_wall,
-        /// Open boundary where particles may exit (outlet)
-        outlet,
-        /// Translating boundary at the velocity
-        /// BCDEM::boundary_translational_velocity.
-        translational,
-        /// Rotating boundary described with BCDEM::boundary_rotational_vector,
-        /// BCDEM::point_on_rotation_axis, and BCDEM::boundary_rotational_speed.
-        rotational,
-        /// Periodic boundary in the specified BCDEM::periodic_direction
-        periodic
-      };
+      /// Boundary ids designated as outlets. A boundary's DEM boundary
+      /// condition type is encoded by which container holds it: outlets here,
+      /// translational/rotational boundaries in the motion maps below, and
+      /// periodic boundaries in periodic_neighbor_id. Fixed walls (the default)
+      /// appear in none of these containers.
+      std::set<types::boundary_id> outlet_boundaries;
 
-      /// Boundary condition type for each boundary.
-      std::vector<BoundaryType> bc_types;
-
-      /// Boundary IDs designated as outlets.
-      std::vector<unsigned int> outlet_boundaries;
-
-      /// Index of boundary conditions that are periodic.
-      std::vector<unsigned int> periodic_bc_index;
-
-      /// Translational velocity of each moving boundary.
-      std::unordered_map<unsigned int, Tensor<1, 3>>
+      /// Translational velocity of each translational boundary, keyed by the
+      /// mesh boundary id. Only translational boundaries have an entry.
+      std::map<types::boundary_id, Tensor<1, 3>>
         boundary_translational_velocity;
 
-      /// Rotational speed of each rotating boundary (rad/s).
-      std::unordered_map<unsigned int, double> boundary_rotational_speed;
+      /// Rotational speed (rad/s) of each rotational boundary, keyed by the
+      /// mesh boundary id. Only rotational boundaries have an entry.
+      std::map<types::boundary_id, double> boundary_rotational_speed;
 
-      /// Rotational axis vector of each rotating boundary.
-      std::unordered_map<unsigned int, Tensor<1, 3>> boundary_rotational_vector;
+      /// Rotational axis vector of each rotational boundary, keyed by the mesh
+      /// boundary id. Only rotational boundaries have an entry.
+      std::map<types::boundary_id, Tensor<1, 3>> boundary_rotational_vector;
 
-      /// Point on the rotational axis of each rotating boundary.
-      std::unordered_map<unsigned int, Point<3>> point_on_rotation_axis;
+      /// Point on the rotational axis of each rotational boundary, keyed by the
+      /// mesh boundary id. Only rotational boundaries have an entry.
+      std::map<types::boundary_id, Point<3>> point_on_rotation_axis;
 
-      /// Principal periodic boundary IDs.
-      std::unordered_map<unsigned int, types::boundary_id> periodic_boundary_0;
+      /// Neighbor periodic boundary id for each periodic boundary pair, keyed
+      /// by the principal periodic boundary id (periodic id 0 -> periodic id
+      /// 1).
+      std::map<types::boundary_id, types::boundary_id> periodic_neighbor_id;
 
-      /// Secondary periodic boundary IDs.
-      std::unordered_map<unsigned int, types::boundary_id> periodic_boundary_1;
-
-      /// Directions of periodicity.
-      std::unordered_map<unsigned int, unsigned int> periodic_direction;
+      /// Direction of periodicity for each periodic boundary pair, keyed by the
+      /// principal periodic boundary id (periodic id 0).
+      std::map<types::boundary_id, unsigned int> periodic_direction;
 
       /**
        * @brief Declare the parameters in the parameter handler.
@@ -849,36 +836,14 @@ namespace Parameters
        * @brief Parse boundary condition parameters for a single boundary.
        *
        * @param[in] prm The parameter handler.
-       * @param[in] i_bc Index of the boundary condition subsection.
        */
       void
-      parse_boundary_conditions(const ParameterHandler &prm,
-                                const unsigned int      i_bc);
+      parse_boundary_conditions(const ParameterHandler &prm);
 
     private:
+      /// Maximum number of boundary condition subsections declared in the
+      /// parameter handler.
       unsigned int DEM_BC_number_max = 10;
-
-      /**
-       * @brief Initialize the containers used to store boundary condition
-       * parameters.
-       *
-       * @param[in,out] boundary_trans_velocity Translational velocities.
-       * @param[in,out] boundary_rot_speed Rotational speeds.
-       * @param[in,out] boundary_rot_vector Rotational axis vectors.
-       * @param[in,out] point_on_rot_axis Points on rotation axes.
-       * @param[in,out] outlet_boundaries_id Outlet boundary IDs.
-       * @param[in,out] boundaries_types Boundary types.
-       * @param[in,out] periodic_bc_ind Index of periodic BCs.
-       */
-      void
-      initialize_containers(
-        std::unordered_map<unsigned int, Tensor<1, 3>> &boundary_trans_velocity,
-        std::unordered_map<unsigned int, double>       &boundary_rot_speed,
-        std::unordered_map<unsigned int, Tensor<1, 3>> &boundary_rot_vector,
-        std::unordered_map<unsigned int, Point<3>>     &point_on_rot_axis,
-        std::vector<unsigned int>                      &outlet_boundaries_id,
-        std::vector<BoundaryType>                      &boundaries_types,
-        std::vector<unsigned int>                      &periodic_bc_ind) const;
     };
 
     /**

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -843,7 +843,7 @@ namespace Parameters
     private:
       /// Maximum number of boundary condition subsections declared in the
       /// parameter handler.
-      unsigned int DEM_BC_number_max = 10;
+      static constexpr unsigned int max_number_of_dem_boundary_conditions = 10;
     };
 
     /**

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -753,7 +753,7 @@ namespace Parameters
        * @param[in,out] prm The parameter handler.
        */
       void
-      parse_floating_wall(ParameterHandler &prm);
+      parse_floating_wall(const ParameterHandler &prm);
 
     private:
       unsigned int max_number_floating_walls = 9;

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -772,7 +772,7 @@ namespace Parameters
     {
     public:
       /// Number of DEM boundary conditions.
-      unsigned int DEM_BC_number;
+      unsigned int number_of_dem_boundary_conditions;
 
       /// Boundary ids designated as outlets. A boundary's DEM boundary
       /// condition type is encoded by which container holds it: outlets here,

--- a/include/dem/find_boundary_cells_information.h
+++ b/include/dem/find_boundary_cells_information.h
@@ -203,8 +203,8 @@ private:
   // Structure that contains the necessary information for boundaries
   std::map<int, boundary_cells_info_struct<dim>> boundary_cells_information;
 
-  // A vector that contains the geometrical information of all (global) boundary
-  // cells. This vector is used in the
+  // A structure that contains the geometrical information of all (global)
+  // boundary cells. This structure is used in the
   // add_cells_with_boundary_lines_to_boundary_cells function
   std::map<int, boundary_cells_info_struct<dim>>
     global_boundary_cells_information;

--- a/include/dem/find_boundary_cells_information.h
+++ b/include/dem/find_boundary_cells_information.h
@@ -93,13 +93,13 @@ public:
    * Carries out updating the boundary information (point on boundary face and
    * its normal vector) after moving the grid.
    *
-   * @param updated_boundary_points_and_normal_vectors Normal vector and a point
+   * @param new_boundary_points_and_normal_vectors Normal vector and a point
    * on the boundary faces which are updated after motion of the grid
    */
   void
   update_boundary_info_after_grid_motion(
     typename DEM::dem_data_structures<dim>::boundary_points_and_normal_vectors
-      &updated_boundary_points_and_normal_vectors);
+      &new_boundary_points_and_normal_vectors);
 
 private:
   /**
@@ -134,14 +134,7 @@ private:
    * particle-line contact, boundary lines and a point locating on each line are
    * obtained
    *
-   * @param boundary_cells_with_faces A vector which contains all the boundary
-   * cells which has atleast one boundary face
    * @param triangulation Triangulation to access the information of the cells
-   * @param boundary_cells_with_lines A vector of tuples which contains the
-   * cells with boundary lines and locations of the beginning and ending
-   * vertices of the boundary line
-   * @param boundary_cells_with_points A vector of pairs which contains the
-   * cells with boundary points, and the location of the point
    */
   void
   find_particle_point_and_line_contact_cells(
@@ -175,8 +168,6 @@ private:
    * @param triangulation Triangulation to access the information of the cells
    * @param floating_wall_properties Properties of floating walls specified in
    * the parameter handler file
-   * @param boundary_cells_for_floating_walls An unordered_set which contains
-   * all the boundary cells of floating walls
    * @param maximum_cell_diameter Maximum cell length in the triangulation
    */
   void
@@ -194,6 +185,7 @@ private:
    * cells. This function is used to solve the problem of late contact detection
    * in triangulations with curved boundaries.
    *
+   * @param triangulation Triangulation used in the DEM simulation
    * @param boundary_cells_information A container that contains the information
    * of all the boundary cells with boundary faces
    * @param outlet_boundaries A set which contains the outlet boundary IDs
@@ -212,7 +204,7 @@ private:
   std::map<int, boundary_cells_info_struct<dim>> boundary_cells_information;
 
   // A vector that contains the geometrical information of all (global) boundary
-  // cells. This vector is used in
+  // cells. This vector is used in the
   // add_cells_with_boundary_lines_to_boundary_cells function
   std::map<int, boundary_cells_info_struct<dim>>
     global_boundary_cells_information;

--- a/include/dem/find_boundary_cells_information.h
+++ b/include/dem/find_boundary_cells_information.h
@@ -189,7 +189,7 @@ private:
    * @param boundary_cells_information A container that contains the information
    * of all the boundary cells with boundary faces
    * @param outlet_boundaries A set which contains the outlet boundary IDs
-   * @param global_boundary_cells_information A vector that contains the geometrical
+   * @param global_boundary_cells_information A map that contains the geometrical
    * information of all (global) boundary cells
    */
   void

--- a/include/dem/find_boundary_cells_information.h
+++ b/include/dem/find_boundary_cells_information.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_find_boundary_cells_information_h
@@ -13,6 +13,7 @@
 
 #include <deal.II/grid/grid_tools.h>
 
+#include <set>
 #include <vector>
 
 using namespace dealii;
@@ -38,7 +39,7 @@ public:
    * @param triangulation Triangulation to access the information of the cells
    * @param floating_wall_properties Properties of floating walls specified in
    * the parameter handler file
-   * @param outlet_boundaries A vector which contains the outlet boundary IDs
+   * @param outlet_boundaries A set which contains the outlet boundary IDs
    * @param check_diamond_cells If true, the diamond shaped cells are found
    * and added to the particle-wall contact search cells
    * @param expand_particle_wall_contact_search If true, expands the
@@ -51,14 +52,14 @@ public:
   build(
     const parallel::distributed::Triangulation<dim>  &triangulation,
     const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
-    const std::vector<unsigned int>                  &outlet_boundaries,
+    const std::set<types::boundary_id>               &outlet_boundaries,
     const bool                                       &check_diamond_cells,
     const bool               &expand_particle_wall_contact_search,
     const ConditionalOStream &pcout);
 
   void
   build(const parallel::distributed::Triangulation<dim> &triangulation,
-        const std::vector<unsigned int>                 &outlet_boundaries,
+        const std::set<types::boundary_id>              &outlet_boundaries,
         const bool                                      &check_diamond_cells,
         const ConditionalOStream                        &pcout);
 
@@ -107,12 +108,12 @@ private:
    * locating on the face are obtained
    *
    * @param triangulation Triangulation to access the information of the cells
-   * @param outlet_boundaries A vector which contains the outlet boundary IDs
+   * @param outlet_boundaries A set which contains the outlet boundary IDs
    */
   void
   find_boundary_cells_information(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    const std::vector<unsigned int>                 &outlet_boundaries);
+    const std::set<types::boundary_id>              &outlet_boundaries);
 
   /**
    * Loops over all the cells to find boundary cells, find the global boundary
@@ -121,12 +122,12 @@ private:
    * stores all the boundary cells with faces.
    *
    * @param triangulation Triangulation to access the information of the cells
-   * @param outlet_boundaries A vector which contains the outlet boundary IDs
+   * @param outlet_boundaries A set which contains the outlet boundary IDs
    */
   void
   find_global_boundary_cells_with_faces(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    const std::vector<unsigned int>                 &outlet_boundaries);
+    const std::set<types::boundary_id>              &outlet_boundaries);
 
   /**
    * Loops over all the cells to find cells which should be searched for
@@ -156,14 +157,14 @@ private:
    * cell.
    *
    * @param triangulation Triangulation to access the information of the cells
-   * @param outlet_boundaries A vector which contains the outlet boundary IDs
+   * @param outlet_boundaries A set which contains the outlet boundary IDs
    * @param check_diamond_cells If true, the diamond shaped cells are found and added to the particle-wall contact search cells
    * @param pcout
    */
   void
   add_cells_with_boundary_lines_to_boundary_cells(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    const std::vector<unsigned int>                 &outlet_boundaries,
+    const std::set<types::boundary_id>              &outlet_boundaries,
     const bool                                      &check_diamond_cells,
     const ConditionalOStream                        &pcout);
 
@@ -195,14 +196,14 @@ private:
    *
    * @param boundary_cells_information A container that contains the information
    * of all the boundary cells with boundary faces
-   * @param outlet_boundaries A vector which contains the outlet boundary IDs
+   * @param outlet_boundaries A set which contains the outlet boundary IDs
    * @param global_boundary_cells_information A vector that contains the geometrical
    * information of all (global) boundary cells
    */
   void
   add_boundary_neighbors_of_boundary_cells(
     const parallel::distributed::Triangulation<dim> &triangulation,
-    const std::vector<unsigned int>                 &outlet_boundaries,
+    const std::set<types::boundary_id>              &outlet_boundaries,
     std::map<int, boundary_cells_info_struct<dim>>  &boundary_cells_information,
     const std::map<int, boundary_cells_info_struct<dim>>
       &global_boundary_cells_information);

--- a/include/dem/particle_wall_contact_force.h
+++ b/include/dem/particle_wall_contact_force.h
@@ -190,14 +190,14 @@ protected:
 
     const auto rotational_vector_it =
       this->boundary_rotational_vector.find(boundary_id);
-    const Tensor<1, 3> boundary_rotational_vector =
+    const Tensor<1, 3> boundary_rotation =
       (rotational_vector_it != this->boundary_rotational_vector.end()) ?
         rotational_vector_it->second :
         Tensor<1, 3>();
 
     const auto rotation_point_it =
       this->point_on_rotation_vector.find(boundary_id);
-    const Point<3> point_on_rotation_vector =
+    const Point<3> point_on_axis_of_rotation =
       (rotation_point_it != this->point_on_rotation_vector.end()) ?
         rotation_point_it->second :
         Point<3>();
@@ -205,13 +205,12 @@ protected:
     // Getting vector pointing from the contact point to the origin of the
     // rotation axis
     Tensor<1, 3> vector_to_rotating_axis =
-      contact_point - point_on_rotation_vector;
+      contact_point - point_on_axis_of_rotation;
 
     // Removing the rotating axis component of that vector
     vector_to_rotating_axis =
       vector_to_rotating_axis -
-      (vector_to_rotating_axis * boundary_rotational_vector) *
-        boundary_rotational_vector;
+      (vector_to_rotating_axis * boundary_rotation) * boundary_rotation;
 
     // Defining relative contact velocity using the convention
     // v_ij = v_j - v_i
@@ -220,7 +219,7 @@ protected:
       cross_product_3d((-0.5 * particle_properties[PropertiesIndex::dp] *
                         particle_angular_velocity),
                        normal_vector) +
-      cross_product_3d(boundary_rotational_speed * boundary_rotational_vector,
+      cross_product_3d(boundary_rotational_speed * boundary_rotation,
                        vector_to_rotating_axis);
 
     // Calculating normal relative velocity

--- a/include/dem/particle_wall_contact_force.h
+++ b/include/dem/particle_wall_contact_force.h
@@ -17,6 +17,7 @@
 
 #include <boost/math/special_functions.hpp>
 
+#include <map>
 #include <vector>
 
 using namespace dealii;
@@ -167,27 +168,59 @@ protected:
       particle_location +
       0.5 * particle_properties[PropertiesIndex::dp] * normal_vector;
 
+    // Look up the boundary motion for this boundary. Boundaries without a
+    // translational or rotational DEM boundary condition simply have no entry
+    // in the maps, in which case the corresponding contribution is zero. The
+    // maps are looked up with find() rather than operator[] to avoid inserting
+    // entries during the contact force evaluation.
+    const auto translational_velocity_it =
+      this->boundary_translational_velocity_map.find(boundary_id);
+    const Tensor<1, 3> boundary_translational_velocity =
+      (translational_velocity_it !=
+       this->boundary_translational_velocity_map.end()) ?
+        translational_velocity_it->second :
+        Tensor<1, 3>();
+
+    const auto rotational_speed_it =
+      this->boundary_rotational_speed_map.find(boundary_id);
+    const double boundary_rotational_speed =
+      (rotational_speed_it != this->boundary_rotational_speed_map.end()) ?
+        rotational_speed_it->second :
+        0.;
+
+    const auto rotational_vector_it =
+      this->boundary_rotational_vector.find(boundary_id);
+    const Tensor<1, 3> boundary_rotational_vector =
+      (rotational_vector_it != this->boundary_rotational_vector.end()) ?
+        rotational_vector_it->second :
+        Tensor<1, 3>();
+
+    const auto rotation_point_it =
+      this->point_on_rotation_vector.find(boundary_id);
+    const Point<3> point_on_rotation_vector =
+      (rotation_point_it != this->point_on_rotation_vector.end()) ?
+        rotation_point_it->second :
+        Point<3>();
+
     // Getting vector pointing from the contact point to the origin of the
     // rotation axis
     Tensor<1, 3> vector_to_rotating_axis =
-      contact_point - this->point_on_rotation_vector[boundary_id];
+      contact_point - point_on_rotation_vector;
 
     // Removing the rotating axis component of that vector
-    vector_to_rotating_axis = vector_to_rotating_axis -
-                              (vector_to_rotating_axis *
-                               this->boundary_rotational_vector[boundary_id]) *
-                                this->boundary_rotational_vector[boundary_id];
+    vector_to_rotating_axis =
+      vector_to_rotating_axis -
+      (vector_to_rotating_axis * boundary_rotational_vector) *
+        boundary_rotational_vector;
 
     // Defining relative contact velocity using the convention
     // v_ij = v_j - v_i
     Tensor<1, 3> contact_relative_velocity =
-      this->boundary_translational_velocity_map[boundary_id] -
-      particle_velocity +
+      boundary_translational_velocity - particle_velocity +
       cross_product_3d((-0.5 * particle_properties[PropertiesIndex::dp] *
                         particle_angular_velocity),
                        normal_vector) +
-      cross_product_3d(this->boundary_rotational_speed_map[boundary_id] *
-                         this->boundary_rotational_vector[boundary_id],
+      cross_product_3d(boundary_rotational_speed * boundary_rotational_vector,
                        vector_to_rotating_axis);
 
     // Calculating normal relative velocity
@@ -1076,13 +1109,13 @@ private:
   const double        dmt_cut_off_threshold;
   const double        f_coefficient_epsd;
 
-  std::unordered_map<unsigned int, double> boundary_rotational_speed_map;
-  std::unordered_map<unsigned int, Tensor<1, 3>>
+  std::map<types::boundary_id, double> boundary_rotational_speed_map;
+  std::map<types::boundary_id, Tensor<1, 3>>
     boundary_translational_velocity_map;
-  std::unordered_map<unsigned int, Tensor<1, 3>> boundary_rotational_vector;
-  std::unordered_map<unsigned int, Point<3>>     point_on_rotation_vector;
-  const unsigned int                             vertices_per_triangle = 3;
-  Point<3>                                       center_mass_container;
+  std::map<types::boundary_id, Tensor<1, 3>> boundary_rotational_vector;
+  std::map<types::boundary_id, Point<3>>     point_on_rotation_vector;
+  const unsigned int                         vertices_per_triangle = 3;
+  Point<3>                                   center_mass_container;
 
   // Containers
   typedef std::vector<

--- a/include/dem/periodic_boundaries_manipulator.h
+++ b/include/dem/periodic_boundaries_manipulator.h
@@ -21,14 +21,13 @@ using namespace dealii;
 /**
  * This class corresponds to a manipulator of the particles crossing periodic
  * cells in DEM. It maps cell information of the pairs of periodic cells
- * and manipulate the particles location when they cross periodic boundaries,
+ * and manipulate the particles' location when they cross periodic boundaries,
  * i.e. when a particle cross a periodic boundary (0 or 1) its location is
  * modified with the offset between faces of periodic cells on periodic
  * boundaries.
  *
- * @note Currently the code only supports one pair of periodic boundaries and
- * those boundaries must be parallel and aligned with an axis of the domain
- * (e.g., x axis).
+ * @note Currently the code only supports periodic boundaries that are
+ * parallel and aligned with an axis of the domain (e.g., x axis).
  */
 
 template <int dim>
@@ -48,7 +47,7 @@ public:
   set_periodic_boundaries_information(
     const std::map<types::boundary_id, unsigned int> &periodic_directions)
   {
-    // If function is reached and the map is not empty
+    // If this function is reached and the map is not empty
     if (periodic_directions.empty())
       return;
 

--- a/include/dem/periodic_boundaries_manipulator.h
+++ b/include/dem/periodic_boundaries_manipulator.h
@@ -12,6 +12,7 @@
 
 #include <deal.II/particles/particle_handler.h>
 
+#include <map>
 #include <unordered_map>
 #include <vector>
 
@@ -39,20 +40,16 @@ public:
   /**
    * @brief Sets the periodic boundaries parameters.
    *
-   * @param[in] periodic_boundary_ids_0 Map of IDs of the first boundary of each
-   * PB pair.
-   * @param[in] periodic_directions Map of perpendicular axes of each PB pair.
-   * @param[in] periodic_bc_ind Index of the PB conditions in the .prm file.
+   * @param[in] periodic_directions Map of perpendicular axes of each PB pair,
+   * keyed by the principal periodic boundary id (periodic id 0). The keys are
+   * the principal periodic boundary ids.
    */
   void
   set_periodic_boundaries_information(
-    const std::unordered_map<unsigned int, types::boundary_id>
-      &periodic_boundary_ids_0,
-    const std::unordered_map<unsigned int, unsigned int> &periodic_directions,
-    const std::vector<unsigned int>                      &periodic_bc_ind)
+    const std::map<types::boundary_id, unsigned int> &periodic_directions)
   {
-    // If function is reached and vectors are not empty
-    if (periodic_boundary_ids_0.empty())
+    // If function is reached and the map is not empty
+    if (periodic_directions.empty())
       return;
 
     periodic_boundaries_enabled = true;
@@ -60,9 +57,7 @@ public:
     // Communicate to the action manager that there are periodic boundaries
     DEMActionManager::get_action_manager()->set_periodic_boundaries_enabled();
 
-    this->periodic_boundaries_ids = periodic_boundary_ids_0;
-    this->directions              = periodic_directions;
-    this->periodic_bc_index       = periodic_bc_ind;
+    this->directions = periodic_directions;
 
     // Initialize offset map
     this->periodic_offsets.clear();
@@ -125,25 +120,16 @@ public:
   }
 
   /**
-   * @brief Return the index of the periodic boundary conditions in the .prm.
+   * @brief Return the directions of the periodic boundary pairs, keyed by the
+   * principal periodic boundary id (periodic id 0). The keys are the principal
+   * periodic boundary ids.
    *
-   * @return Index of the periodic boundary conditions.
+   * @return Map of periodic directions keyed by principal periodic boundary id.
    */
-  inline const std::vector<unsigned int> &
-  get_periodic_bc_index() const
+  inline const std::map<types::boundary_id, unsigned int> &
+  get_periodic_directions() const
   {
-    return periodic_bc_index;
-  }
-
-  /**
-   * @brief Return the mesh IDs of the principal periodic boundaries
-   *
-   * @return Mesh IDS of the principal periodic boundaries.
-   */
-  inline const std::unordered_map<unsigned int, types::boundary_id> &
-  get_periodic_boundaries_ids() const
-  {
-    return periodic_boundaries_ids;
+    return directions;
   }
 
   /**
@@ -210,26 +196,10 @@ private:
 
   /**
    * @brief Direction of the periodic boundaries, it is the perpendicular axis
-   * of the periodic boundaries. Keys of this map are periodic boundary
-   * condition indices in the .prm (subsection numbers)
+   * of the periodic boundaries. Keys of this map are the principal periodic
+   * boundary ids (periodic id 0).
    */
-  std::unordered_map<unsigned int, unsigned int> directions;
-
-  /**
-   * @brief Index of the boundary conditions in the .prm (subsection numbers)
-   * that correspond to periodic boundary conditions.
-   */
-  std::vector<unsigned int> periodic_bc_index;
-
-  /**
-   * @brief Mesh ID of the first periodic boundary for all periodic boundary
-   * pairs. No need to store the second one since they are linked on the
-   * triangulation, and accessible through functions on cells on the boundary
-   * condition 0.
-   *    Map key: index of BC from .prm
-   *    Map value: ID of a primary periodic boundary
-   */
-  std::unordered_map<unsigned int, types::boundary_id> periodic_boundaries_ids;
+  std::map<types::boundary_id, unsigned int> directions;
 
   /**
    * @brief Map storing offset distance between periodic boundaries, keyed by

--- a/include/fem-dem/particle_projector.h
+++ b/include/fem-dem/particle_projector.h
@@ -37,16 +37,14 @@ using namespace dealii;
  * @brief Calculate the area of intersection between a circular (2D) particle and a circle. \
  *                                                                                          \
  * @param[in] r_particle Radius of the particle                                             \
- *                                                                                          \
  * @param[in] r_circle Radius of the circle                                                 \
- *                                                                                          \
  * @param[in] neighbor_distance Distance between the particle and the circle                \
  */                                                                                         \
 #
 inline double
-particle_circle_intersection_2d(double r_particle,
-                                double r_circle,
-                                double neighbor_distance)
+particle_circle_intersection_2d(const double r_particle,
+                                const double r_circle,
+                                const double neighbor_distance)
 {
   return pow(r_particle, 2) * Utilities::fixed_power<-1, double>(
                                 cos((pow(neighbor_distance, 2) +
@@ -72,9 +70,9 @@ particle_circle_intersection_2d(double r_particle,
  */
 
 inline double
-particle_sphere_intersection_3d(double r_particle,
-                                double r_sphere,
-                                double neighbor_distance)
+particle_sphere_intersection_3d(const double r_particle,
+                                const double r_sphere,
+                                const double neighbor_distance)
 {
   return M_PI *
          Utilities::fixed_power<2, double>(r_sphere + r_particle -

--- a/include/fem-dem/particle_projector.h
+++ b/include/fem-dem/particle_projector.h
@@ -33,15 +33,16 @@
 
 using namespace dealii;
 
-/**
- * @brief Calculate the area of intersection between a circular (2D) particle and a circle.
- *
- * @param[in] r_particle Radius of the particle
- *
- * @param[in] r_circle Radius of the circle
- *
- * @param[in] neighbor_distance Distance between the particle and the circle
- */
+/**                                                                                         \
+ * @brief Calculate the area of intersection between a circular (2D) particle and a circle. \
+ *                                                                                          \
+ * @param[in] r_particle Radius of the particle                                             \
+ *                                                                                          \
+ * @param[in] r_circle Radius of the circle                                                 \
+ *                                                                                          \
+ * @param[in] neighbor_distance Distance between the particle and the circle                \
+ */                                                                                         \
+#
 inline double
 particle_circle_intersection_2d(double r_particle,
                                 double r_circle,

--- a/release_notes/current/2026_06_14_Blais_2.md
+++ b/release_notes/current/2026_06_14_Blais_2.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/06/14
+
+### Changed
+
+- MAJOR This PR refactors the handling of DEM boundary conditions. The `BoundaryType` enum and its parallel `bc_types`/`periodic_bc_index` containers are removed; a boundary's type is now encoded by which container holds it (outlets, motion maps, or periodic neighbors), with fixed walls being the default. The boundary condition containers are keyed by mesh boundary id and periodic boundaries are keyed by their principal periodic id. This change does not affect the parameter file format or simulation results. [#2021](https://github.com/chaos-polymtl/lethe/pull/2021)

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -1528,7 +1528,9 @@ namespace Parameters
                           Patterns::Integer(),
                           "Number of boundary conditions");
 
-        for (unsigned int counter = 0; counter < DEM_BC_number_max; ++counter)
+        for (unsigned int counter = 0;
+             counter < max_number_of_dem_boundary_conditions;
+             ++counter)
           { // Example: "boundary condition 0"
             prm.enter_subsection("boundary condition " +
                                  Utilities::int_to_string(counter, 1));

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -1546,9 +1546,12 @@ namespace Parameters
     {
       prm.enter_subsection("DEM boundary conditions");
 
-      DEM_BC_number = prm.get_integer("number of boundary conditions");
+      number_of_dem_boundary_conditions =
+        prm.get_integer("number of boundary conditions");
 
-      for (unsigned int counter = 0; counter < DEM_BC_number; ++counter)
+      for (unsigned int counter = 0;
+           counter < number_of_dem_boundary_conditions;
+           ++counter)
         {
           prm.enter_subsection("boundary condition " +
                                Utilities::int_to_string(counter, 1));

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -1500,7 +1500,7 @@ namespace Parameters
 
     template <int dim>
     void
-    FloatingWalls<dim>::parse_floating_wall(ParameterHandler &prm)
+    FloatingWalls<dim>::parse_floating_wall(const ParameterHandler &prm)
     {
       // Position
       Point<dim> wall_point(
@@ -1675,7 +1675,7 @@ namespace Parameters
         }
       else
         {
-          throw(std::runtime_error("Invalid boundary condition type "));
+          AssertThrow(false, ExcMessage("Invalid DEM boundary condition type"));
         }
     }
 

--- a/source/core/parameters_lagrangian.cc
+++ b/source/core/parameters_lagrangian.cc
@@ -1548,20 +1548,12 @@ namespace Parameters
 
       DEM_BC_number = prm.get_integer("number of boundary conditions");
 
-      initialize_containers(boundary_translational_velocity,
-                            boundary_rotational_speed,
-                            boundary_rotational_vector,
-                            point_on_rotation_axis,
-                            outlet_boundaries,
-                            bc_types,
-                            periodic_bc_index);
-
       for (unsigned int counter = 0; counter < DEM_BC_number; ++counter)
         {
           prm.enter_subsection("boundary condition " +
                                Utilities::int_to_string(counter, 1));
           {
-            parse_boundary_conditions(prm, counter);
+            parse_boundary_conditions(prm);
           }
           prm.leave_subsection();
         }
@@ -1625,31 +1617,27 @@ namespace Parameters
     }
 
     void
-    BCDEM::parse_boundary_conditions(const ParameterHandler &prm,
-                                     const unsigned int      i_bc)
+    BCDEM::parse_boundary_conditions(const ParameterHandler &prm)
     {
       const unsigned int boundary_id   = prm.get_integer("boundary id");
       const std::string  boundary_type = prm.get("type");
 
       if (boundary_type == "outlet")
         {
-          this->bc_types.push_back(BoundaryType::outlet);
-          this->outlet_boundaries.push_back(boundary_id);
+          this->outlet_boundaries.insert(boundary_id);
         }
       else if (boundary_type == "translational")
         {
-          this->bc_types.push_back(BoundaryType::translational);
           Tensor<1, 3> translational_velocity;
           translational_velocity[0] = prm.get_double("speed x");
           translational_velocity[1] = prm.get_double("speed y");
           translational_velocity[2] = prm.get_double("speed z");
 
-          this->boundary_translational_velocity.at(boundary_id) =
+          this->boundary_translational_velocity[boundary_id] =
             translational_velocity;
         }
       else if (boundary_type == "rotational")
         {
-          this->bc_types.push_back(BoundaryType::rotational);
           double rotational_speed = prm.get_double("rotational speed");
 
           // Read the rotational vector from a list of doubles
@@ -1664,55 +1652,31 @@ namespace Parameters
           Tensor<1, 3> point_on_rotation_axis_tensor =
             value_string_to_tensor<3>(prm.get("point on rotational vector"));
 
-          this->boundary_rotational_speed.at(boundary_id) = rotational_speed;
-          this->boundary_rotational_vector.at(boundary_id) =
+          this->boundary_rotational_speed[boundary_id] = rotational_speed;
+          this->boundary_rotational_vector[boundary_id] =
             rotational_vector / rotational_vector.norm();
-          this->point_on_rotation_axis.at(boundary_id) =
+          this->point_on_rotation_axis[boundary_id] =
             point_on_rotation_axis_tensor;
         }
       else if (boundary_type == "fixed_wall")
         {
-          this->bc_types.push_back(BoundaryType::fixed_wall);
+          // Fixed walls are the default: they are not stored in any container.
         }
       else if (boundary_type == "periodic")
         {
-          this->bc_types.push_back(BoundaryType::periodic);
-          this->periodic_bc_index.push_back(i_bc);
-          this->periodic_boundary_0[i_bc] = prm.get_integer("periodic id 0");
-          this->periodic_boundary_1[i_bc] = prm.get_integer("periodic id 1");
-          this->periodic_direction[i_bc] =
+          // Periodic boundary conditions are keyed by the principal periodic
+          // boundary id (periodic id 0) rather than the "boundary id" field.
+          const types::boundary_id periodic_id_0 =
+            prm.get_integer("periodic id 0");
+          this->periodic_neighbor_id[periodic_id_0] =
+            prm.get_integer("periodic id 1");
+          this->periodic_direction[periodic_id_0] =
             prm.get_integer("periodic direction");
         }
       else
         {
           throw(std::runtime_error("Invalid boundary condition type "));
         }
-    }
-
-    void
-    BCDEM::initialize_containers(
-      std::unordered_map<unsigned int, Tensor<1, 3>> &boundary_trans_velocity,
-      std::unordered_map<unsigned int, double>       &boundary_rot_speed,
-      std::unordered_map<unsigned int, Tensor<1, 3>> &boundary_rot_vector,
-      std::unordered_map<unsigned int, Point<3>>     &point_on_rot_axis,
-      std::vector<unsigned int>                      &outlet_boundaries_id,
-      std::vector<BoundaryType>                      &boundaries_types,
-      std::vector<unsigned int>                      &periodic_bc_ind) const
-    {
-      Tensor<1, 3> zero_tensor({0.0, 0.0, 0.0});
-
-      for (unsigned int counter = 0; counter < DEM_BC_number_max; ++counter)
-        {
-          boundary_trans_velocity.insert({counter, zero_tensor});
-          boundary_rot_speed.insert({counter, 0});
-          boundary_rot_vector.insert({counter, zero_tensor});
-          point_on_rot_axis.insert({counter, Point<3>(zero_tensor)});
-        }
-
-      // NOTE This first vector should not be initialized this big.
-      outlet_boundaries_id.reserve(DEM_BC_number);
-      boundaries_types.reserve(DEM_BC_number);
-      periodic_bc_ind.reserve(DEM_BC_number);
     }
 
     template <int dim>

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -29,6 +29,7 @@
 #include <sys/stat.h>
 
 #include <numbers>
+#include <ranges>
 #include <sstream>
 #include <utility>
 
@@ -299,8 +300,8 @@ DEMSolver<dim, PropertiesIndex>::setup_triangulation_dependent_parameters()
     periodic_boundaries_object.get_combined_periodic_offsets());
 
   // Set the periodic offsets of the periodic boundary pairs for other classes
-  for (auto const &[pb_id, direction] :
-       periodic_boundaries_object.get_periodic_directions())
+  for (const auto &pb_id :
+       periodic_boundaries_object.get_periodic_directions() | std::views::keys)
     {
       particle_particle_contact_force_object->set_periodic_offset(
         periodic_boundaries_object.get_periodic_offset_distance(pb_id), pb_id);

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -117,13 +117,13 @@ DEMSolver<dim, PropertiesIndex>::setup_parameters()
   // Set up the solid objects
   setup_solid_objects();
 
-  // Check if there are any periodic boundaries. If any periodic boundary is
-  // found, set the information for all periodic boundaries.
+  // Check whether periodic boundaries are present. If at least one periodic
+  // boundary is found, initialize the information for all periodic boundaries.
   if (!parameters.boundary_conditions.periodic_direction.empty())
     periodic_boundaries_object.set_periodic_boundaries_information(
       parameters.boundary_conditions.periodic_direction);
 
-  // Assign gravity/acceleration
+  // Assign gravity
   g = parameters.lagrangian_physical_properties.g;
 
   // If this is a restart simulation

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -118,21 +118,10 @@ DEMSolver<dim, PropertiesIndex>::setup_parameters()
   setup_solid_objects();
 
   // Check if there are any periodic boundaries. If any periodic boundary is
-  // found, set the information for all periodic boundaries and break loop.
-  for (unsigned int i_bc = 0;
-       i_bc < parameters.boundary_conditions.bc_types.size();
-       ++i_bc)
-    {
-      if (parameters.boundary_conditions.bc_types[i_bc] ==
-          Parameters::Lagrangian::BCDEM::BoundaryType::periodic)
-        {
-          periodic_boundaries_object.set_periodic_boundaries_information(
-            parameters.boundary_conditions.periodic_boundary_0,
-            parameters.boundary_conditions.periodic_direction,
-            parameters.boundary_conditions.periodic_bc_index);
-          break;
-        }
-    }
+  // found, set the information for all periodic boundaries.
+  if (!parameters.boundary_conditions.periodic_direction.empty())
+    periodic_boundaries_object.set_periodic_boundaries_information(
+      parameters.boundary_conditions.periodic_direction);
 
   // Assign gravity/acceleration
   g = parameters.lagrangian_physical_properties.g;
@@ -310,22 +299,11 @@ DEMSolver<dim, PropertiesIndex>::setup_triangulation_dependent_parameters()
     periodic_boundaries_object.get_combined_periodic_offsets());
 
   // Set the periodic offsets of the periodic boundary pairs for other classes
-  auto const &periodic_bc_index =
-    periodic_boundaries_object.get_periodic_bc_index();
-  auto const &periodic_boundaries_ids =
-    periodic_boundaries_object.get_periodic_boundaries_ids();
-
-  for (const unsigned int pbc_index : periodic_bc_index)
+  for (auto const &[pb_id, direction] :
+       periodic_boundaries_object.get_periodic_directions())
     {
-      auto it = periodic_boundaries_ids.find(pbc_index);
-      if (it != periodic_boundaries_ids.end())
-        {
-          auto const &pb_id = it->second;
-
-          particle_particle_contact_force_object->set_periodic_offset(
-            periodic_boundaries_object.get_periodic_offset_distance(pb_id),
-            pb_id);
-        }
+      particle_particle_contact_force_object->set_periodic_offset(
+        periodic_boundaries_object.get_periodic_offset_distance(pb_id), pb_id);
     }
 
   // Set up the local and ghost cells (if ASC enabled)
@@ -355,22 +333,18 @@ DEMSolver<dim, PropertiesIndex>::setup_background_dofs()
       background_constraints.reinit(background_dh.locally_owned_dofs(),
                                     locally_relevant_dofs);
 
-      // Loop over the unordered_map of periodic boundary conditions.
-      for (auto const &[bc_index, id0] :
-           parameters.boundary_conditions.periodic_boundary_0)
+      // Loop over the periodic boundary conditions, keyed by the principal
+      // periodic boundary id (id0).
+      for (auto const &[id0, id1] :
+           parameters.boundary_conditions.periodic_neighbor_id)
         {
-          const types::boundary_id id1 =
-            parameters.boundary_conditions.periodic_boundary_1.at(bc_index);
           const unsigned int direction =
-            parameters.boundary_conditions.periodic_direction.at(bc_index);
+            parameters.boundary_conditions.periodic_direction.at(id0);
 
           // Default boundaries contain information for periodic boundary
           // conditions that indicate id0 and id1 are 0 as default value To
           // ensure these default values are not parsed, only make the
           // periodicity constraints if id0 and id1 are distinct
-          // TODO - Refactor the way the DEM boundary conditions are stored to
-          // get rid of the vectors storage structure and use a map directly
-          // instead.
           if (id0 != id1)
             DoFTools::make_periodicity_constraints(
               background_dh, id0, id1, direction, background_constraints);

--- a/source/dem/find_boundary_cells_information.cc
+++ b/source/dem/find_boundary_cells_information.cc
@@ -559,13 +559,12 @@ BoundaryCellsInformation<dim>::add_cells_with_boundary_lines_to_boundary_cells(
 
                                   // Check if faces are on a wall boundary
                                   // (not outlet nor periodic)
-                                  bool face_one_is_wall, face_two_is_wall;
-                                  face_one_is_wall =
+                                  const bool face_one_is_wall =
                                     (!outlet_boundaries.contains(
                                        face_one->boundary_id()) &&
                                      !cell_one->has_periodic_neighbor(
                                        face_id_one));
-                                  face_two_is_wall =
+                                  const bool face_two_is_wall =
                                     (!outlet_boundaries.contains(
                                        face_two->boundary_id()) &&
                                      !cell_two->has_periodic_neighbor(

--- a/source/dem/find_boundary_cells_information.cc
+++ b/source/dem/find_boundary_cells_information.cc
@@ -26,7 +26,7 @@ void
 BoundaryCellsInformation<dim>::build(
   const parallel::distributed::Triangulation<dim>  &triangulation,
   const Parameters::Lagrangian::FloatingWalls<dim> &floating_wall_properties,
-  const std::vector<unsigned int>                  &outlet_boundaries,
+  const std::set<types::boundary_id>               &outlet_boundaries,
   const bool                                       &check_diamond_cells,
   const bool               &expand_particle_wall_contact_search,
   const ConditionalOStream &pcout)
@@ -97,7 +97,7 @@ template <int dim>
 void
 BoundaryCellsInformation<dim>::build(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const std::vector<unsigned int>                 &outlet_boundaries,
+  const std::set<types::boundary_id>              &outlet_boundaries,
   const bool                                      &check_diamond_cells,
   const ConditionalOStream                        &pcout)
 {
@@ -129,7 +129,7 @@ template <int dim>
 void
 BoundaryCellsInformation<dim>::find_boundary_cells_information(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const std::vector<unsigned int>                 &outlet_boundaries)
+  const std::set<types::boundary_id>              &outlet_boundaries)
 {
   // Initializing output_vector and a search_vector (containing boundary_id and
   // cell) to avoid replication of a boundary face. All the found boundary faces
@@ -157,11 +157,8 @@ BoundaryCellsInformation<dim>::find_boundary_cells_information(
         {
           // We search to see if the boundary is defined as an outlet, periodic
           // or not. If it is not defined as one of those, we proceed.
-          int  face_id = cell->face_iterator_to_index(face);
-          bool is_outlet =
-            std::find(outlet_boundaries.begin(),
-                      outlet_boundaries.end(),
-                      face->boundary_id()) != outlet_boundaries.end();
+          int  face_id     = cell->face_iterator_to_index(face);
+          bool is_outlet   = outlet_boundaries.contains(face->boundary_id());
           bool is_periodic = cell->has_periodic_neighbor(face_id);
 
           if (!is_outlet && !is_periodic)
@@ -463,7 +460,7 @@ template <int dim>
 void
 BoundaryCellsInformation<dim>::find_global_boundary_cells_with_faces(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const std::vector<unsigned int>                 &outlet_boundaries)
+  const std::set<types::boundary_id>              &outlet_boundaries)
 {
   // Iterating over the active cells in the triangulation
   for (const auto &cell : triangulation.active_cell_iterators())
@@ -473,9 +470,7 @@ BoundaryCellsInformation<dim>::find_global_boundary_cells_with_faces(
         {
           // We search to see if the boundary is defined as an outlet or
           // not. If it is not defined as an outlet we proceed.
-          if (std::find(outlet_boundaries.begin(),
-                        outlet_boundaries.end(),
-                        face->boundary_id()) == outlet_boundaries.end())
+          if (!outlet_boundaries.contains(face->boundary_id()))
             {
               // Check to see if the face is located at boundary
               if (face->at_boundary())
@@ -491,7 +486,7 @@ template <int dim>
 void
 BoundaryCellsInformation<dim>::add_cells_with_boundary_lines_to_boundary_cells(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const std::vector<unsigned int>                 &outlet_boundaries,
+  const std::set<types::boundary_id>              &outlet_boundaries,
   const bool                                      &check_diamond_cells,
   const ConditionalOStream                        &pcout)
 {
@@ -566,17 +561,13 @@ BoundaryCellsInformation<dim>::add_cells_with_boundary_lines_to_boundary_cells(
                                   // (not outlet nor periodic)
                                   bool face_one_is_wall, face_two_is_wall;
                                   face_one_is_wall =
-                                    (std::find(outlet_boundaries.begin(),
-                                               outlet_boundaries.end(),
-                                               face_one->boundary_id()) ==
-                                       outlet_boundaries.end() &&
+                                    (!outlet_boundaries.contains(
+                                       face_one->boundary_id()) &&
                                      !cell_one->has_periodic_neighbor(
                                        face_id_one));
                                   face_two_is_wall =
-                                    (std::find(outlet_boundaries.begin(),
-                                               outlet_boundaries.end(),
-                                               face_two->boundary_id()) ==
-                                       outlet_boundaries.end() &&
+                                    (!outlet_boundaries.contains(
+                                       face_two->boundary_id()) &&
                                      !cell_two->has_periodic_neighbor(
                                        face_id_two));
 
@@ -714,7 +705,7 @@ template <int dim>
 void
 BoundaryCellsInformation<dim>::add_boundary_neighbors_of_boundary_cells(
   const parallel::distributed::Triangulation<dim> &triangulation,
-  const std::vector<unsigned int>                 &outlet_boundaries,
+  const std::set<types::boundary_id>              &outlet_boundaries,
   std::map<int, boundary_cells_info_struct<dim>>  &boundary_cells_information,
   const std::map<int, boundary_cells_info_struct<dim>>
     &global_boundary_cells_information)
@@ -749,10 +740,7 @@ BoundaryCellsInformation<dim>::add_boundary_neighbors_of_boundary_cells(
                       unsigned int face_id =
                         neighbor->face_iterator_to_index(face);
                       bool face_is_wall =
-                        (std::find(outlet_boundaries.begin(),
-                                   outlet_boundaries.end(),
-                                   face->boundary_id()) ==
-                           outlet_boundaries.end() &&
+                        (!outlet_boundaries.contains(face->boundary_id()) &&
                          !neighbor->has_periodic_neighbor(face_id));
 
                       if (face_is_wall)

--- a/source/dem/find_boundary_cells_information.cc
+++ b/source/dem/find_boundary_cells_information.cc
@@ -224,7 +224,7 @@ template <int dim>
 void
 BoundaryCellsInformation<dim>::update_boundary_info_after_grid_motion(
   typename DEM::dem_data_structures<dim>::boundary_points_and_normal_vectors
-    &updated_boundary_points_and_normal_vectors)
+    &new_boundary_points_and_normal_vectors)
 {
   // If there is no grid motion, exit the function
   if (!DEMActionManager::get_action_manager()->check_grid_motion_enabled())
@@ -271,7 +271,7 @@ BoundaryCellsInformation<dim>::update_boundary_info_after_grid_motion(
                     quad_point =
                       point_nd_to_3d(fe_face_values.quadrature_point(0));
 
-                  updated_boundary_points_and_normal_vectors[cell->face_index(
+                  new_boundary_points_and_normal_vectors[cell->face_index(
                     face_id)] = std::make_pair(normal_vector, quad_point);
                 }
             }

--- a/source/dem/find_boundary_cells_information.cc
+++ b/source/dem/find_boundary_cells_information.cc
@@ -157,9 +157,10 @@ BoundaryCellsInformation<dim>::find_boundary_cells_information(
         {
           // We search to see if the boundary is defined as an outlet, periodic
           // or not. If it is not defined as one of those, we proceed.
-          int  face_id     = cell->face_iterator_to_index(face);
-          bool is_outlet   = outlet_boundaries.contains(face->boundary_id());
-          bool is_periodic = cell->has_periodic_neighbor(face_id);
+          const int  face_id = cell->face_iterator_to_index(face);
+          const bool is_outlet =
+            outlet_boundaries.contains(face->boundary_id());
+          const bool is_periodic = cell->has_periodic_neighbor(face_id);
 
           if (!is_outlet && !is_periodic)
             {

--- a/source/dem/periodic_boundaries_manipulator.cc
+++ b/source/dem/periodic_boundaries_manipulator.cc
@@ -13,6 +13,7 @@
 #include <deal.II/fe/fe_values.h>
 
 #include <algorithm>
+#include <ranges>
 #include <unordered_map>
 
 using namespace dealii;
@@ -77,7 +78,7 @@ PeriodicBoundariesManipulator<dim>::map_periodic_cells(
 
   // Temp storage to calculate offsets only once per ID
   std::map<types::boundary_id, bool> offset_calculated;
-  for (auto const &[primary_mesh_id, direction] : directions)
+  for (const auto &primary_mesh_id : directions | std::views::keys)
     offset_calculated[primary_mesh_id] = false;
 
   // Iterating over the active cells in the triangulation
@@ -93,7 +94,7 @@ PeriodicBoundariesManipulator<dim>::map_periodic_cells(
                   const types::boundary_id face_boundary_id =
                     face->boundary_id();
 
-                  // Check if face matches any of the principal PB IDs
+                  // Check if the face matches any of the principal PB IDs
                   auto it = directions.find(face_boundary_id);
                   if (it != directions.end())
                     {
@@ -147,7 +148,7 @@ PeriodicBoundariesManipulator<dim>::check_and_move_particles(
        &particles_in_cell,
   bool &particle_has_been_moved)
 {
-  // Retrieve correct offset for this specific boundary interaction.
+  // Retrieve the correct offset for this specific boundary interaction.
   // boundaries_cells_content contains a single cell on a periodic boundary
   // and its associated periodic cell. The offset between these cells is
   // obtained from periodic_offsets to displace particles across these cells.

--- a/source/dem/periodic_boundaries_manipulator.cc
+++ b/source/dem/periodic_boundaries_manipulator.cc
@@ -77,8 +77,8 @@ PeriodicBoundariesManipulator<dim>::map_periodic_cells(
 
   // Temp storage to calculate offsets only once per ID
   std::map<types::boundary_id, bool> offset_calculated;
-  for (auto [bc_index, id] : periodic_boundaries_ids)
-    offset_calculated[id] = false;
+  for (auto const &[primary_mesh_id, direction] : directions)
+    offset_calculated[primary_mesh_id] = false;
 
   // Iterating over the active cells in the triangulation
   for (const auto &cell : triangulation.active_cell_iterators())
@@ -92,50 +92,40 @@ PeriodicBoundariesManipulator<dim>::map_periodic_cells(
                 {
                   unsigned int face_boundary_id = face->boundary_id();
 
-                  // Check if face matches any of the PB IDs
-                  for (const unsigned int pbc_index : periodic_bc_index)
+                  // Check if face matches any of the principal PB IDs
+                  auto it = directions.find(face_boundary_id);
+                  if (it != directions.end())
                     {
-                      auto it = periodic_boundaries_ids.find(pbc_index);
-                      if (it != periodic_boundaries_ids.end())
+                      // Get direction corresponding to this periodic boundary
+                      const unsigned int current_direction = it->second;
+
+                      periodic_boundaries_cells_info_struct<dim>
+                                   boundaries_information;
+                      unsigned int face_id = cell->face_iterator_to_index(face);
+
+                      get_periodic_boundaries_info(cell,
+                                                   face_id,
+                                                   boundaries_information);
+
+                      // Insert into multimap
+                      // One entry per boundary found
+                      periodic_boundaries_cells_information.insert(
+                        {boundaries_information.cell
+                           ->global_active_cell_index(),
+                         boundaries_information});
+
+                      // Calculate offset if not yet done for this PB ID
+                      if (!offset_calculated[face_boundary_id])
                         {
-                          auto const &primary_mesh_id = it->second;
+                          Tensor<1, dim> offset;
+                          offset[current_direction] =
+                            boundaries_information
+                              .point_on_periodic_face[current_direction] -
+                            boundaries_information
+                              .point_on_face[current_direction];
 
-                          if (face_boundary_id == primary_mesh_id)
-                            {
-                              // Get direction corresponding to this BC index
-                              unsigned int current_direction =
-                                directions.at(pbc_index);
-
-                              periodic_boundaries_cells_info_struct<dim>
-                                           boundaries_information;
-                              unsigned int face_id =
-                                cell->face_iterator_to_index(face);
-
-                              get_periodic_boundaries_info(
-                                cell, face_id, boundaries_information);
-
-                              // Insert into multimap
-                              // One entry per boundary found
-                              periodic_boundaries_cells_information.insert(
-                                {boundaries_information.cell
-                                   ->global_active_cell_index(),
-                                 boundaries_information});
-
-                              // Calculate offset if not yet done for this PB ID
-                              if (!offset_calculated[face_boundary_id])
-                                {
-                                  Tensor<1, dim> offset;
-                                  offset[current_direction] =
-                                    boundaries_information
-                                      .point_on_periodic_face
-                                        [current_direction] -
-                                    boundaries_information
-                                      .point_on_face[current_direction];
-
-                                  periodic_offsets[face_boundary_id]  = offset;
-                                  offset_calculated[face_boundary_id] = true;
-                                }
-                            }
+                          periodic_offsets[face_boundary_id]  = offset;
+                          offset_calculated[face_boundary_id] = true;
                         }
                     }
                 }

--- a/source/dem/periodic_boundaries_manipulator.cc
+++ b/source/dem/periodic_boundaries_manipulator.cc
@@ -90,7 +90,8 @@ PeriodicBoundariesManipulator<dim>::map_periodic_cells(
               // Iterating over cell faces
               for (const auto &face : cell->face_iterators())
                 {
-                  const types::boundary_id face_boundary_id = face->boundary_id();
+                  const types::boundary_id face_boundary_id =
+                    face->boundary_id();
 
                   // Check if face matches any of the principal PB IDs
                   auto it = directions.find(face_boundary_id);

--- a/source/dem/periodic_boundaries_manipulator.cc
+++ b/source/dem/periodic_boundaries_manipulator.cc
@@ -116,7 +116,8 @@ PeriodicBoundariesManipulator<dim>::map_periodic_cells(
                            ->global_active_cell_index(),
                          boundaries_information});
 
-                      // Calculate offset if not yet done for this PB ID
+                      // Calculate offset if it has not yet been done for this
+                      // periodic boundary id
                       if (!offset_calculated[face_boundary_id])
                         {
                           Tensor<1, dim> offset;

--- a/source/dem/periodic_boundaries_manipulator.cc
+++ b/source/dem/periodic_boundaries_manipulator.cc
@@ -90,7 +90,7 @@ PeriodicBoundariesManipulator<dim>::map_periodic_cells(
               // Iterating over cell faces
               for (const auto &face : cell->face_iterators())
                 {
-                  unsigned int face_boundary_id = face->boundary_id();
+                  const types::boundary_id face_boundary_id = face->boundary_id();
 
                   // Check if face matches any of the principal PB IDs
                   auto it = directions.find(face_boundary_id);

--- a/source/dem/read_mesh.cc
+++ b/source/dem/read_mesh.cc
@@ -23,7 +23,7 @@ read_mesh(const Parameters::Mesh   &mesh_parameters,
   attach_grid_to_triangulation(triangulation, mesh_parameters);
 
   // Check if there are periodic boundaries
-  if (!bc_params.periodic_bc_index.empty())
+  if (!bc_params.periodic_direction.empty())
     match_periodic_boundaries(triangulation, bc_params);
 
   if (!restart)
@@ -60,12 +60,12 @@ match_periodic_boundaries(Triangulation<dim, spacedim>        &triangulation,
     typename Triangulation<dim, spacedim>::cell_iterator>>
     periodicity_vector;
 
-  for (const auto &i_bc : bc_param.periodic_bc_index)
+  for (const auto &[id0, id1] : bc_param.periodic_neighbor_id)
     {
       GridTools::collect_periodic_faces(triangulation,
-                                        bc_param.periodic_boundary_0.at(i_bc),
-                                        bc_param.periodic_boundary_1.at(i_bc),
-                                        bc_param.periodic_direction.at(i_bc),
+                                        id0,
+                                        id1,
+                                        bc_param.periodic_direction.at(id0),
                                         periodicity_vector);
     }
   triangulation.add_periodicity(periodicity_vector);

--- a/source/dem/read_mesh.cc
+++ b/source/dem/read_mesh.cc
@@ -28,9 +28,10 @@ read_mesh(const Parameters::Mesh   &mesh_parameters,
     ExcMessage(
       "There is a mismatch between the size of the periodic_direction and the periodic_neighbor_id maps"));
 
-  // Check if there are periodic boundaries
-  if (!bc_params.periodic_direction.empty() &&
-      !bc_params.periodic_neighbor_id.empty())
+  // Check if there are periodic boundaries, this can be done by checking either
+  // the size of the direction map or the neighbor_id map. Since they both have
+  // the same size, it does not matter.
+  if (!bc_params.periodic_direction.empty())
     match_periodic_boundaries(triangulation, bc_params);
 
   if (!restart)

--- a/source/dem/read_mesh.cc
+++ b/source/dem/read_mesh.cc
@@ -22,8 +22,15 @@ read_mesh(const Parameters::Mesh   &mesh_parameters,
 
   attach_grid_to_triangulation(triangulation, mesh_parameters);
 
+  AssertThrow(
+    bc_params.periodic_direction.size() ==
+      bc_params.periodic_neighbor_id.size(),
+    ExcMessage(
+      "There is a mismatch between the size of the periodic_direction and the periodic_neighbor_id maps"));
+
   // Check if there are periodic boundaries
-  if (!bc_params.periodic_direction.empty())
+  if (!bc_params.periodic_direction.empty() &&
+      !bc_params.periodic_neighbor_id.empty())
     match_periodic_boundaries(triangulation, bc_params);
 
   if (!restart)

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -17,6 +17,7 @@
 #include <fem-dem/postprocessing_cfd_dem.h>
 
 #include <fstream>
+#include <ranges>
 #include <sstream>
 
 // Constructor for the class CFD-DEM class
@@ -232,8 +233,8 @@ CFDDEMSolver<dim>::initialize_dem_parameters()
     periodic_boundaries_object.get_combined_periodic_offsets());
 
   // Set the periodic offsets of the periodic boundary pairs for other classes
-  for (auto const &[pb_id, direction] :
-       periodic_boundaries_object.get_periodic_directions())
+  for (const auto &pb_id :
+       periodic_boundaries_object.get_periodic_directions() | std::views::keys)
     {
       particle_particle_contact_force_object->set_periodic_offset(
         periodic_boundaries_object.get_periodic_offset_distance(pb_id), pb_id);

--- a/source/fem-dem/cfd_dem_coupling.cc
+++ b/source/fem-dem/cfd_dem_coupling.cc
@@ -124,22 +124,12 @@ CFDDEMSolver<dim>::dem_setup_parameters()
   report_rayleigh_time_ratio();
 
   // Check if there are periodic boundaries
-  for (unsigned int i_bc = 0;
-       i_bc < dem_parameters.boundary_conditions.bc_types.size();
-       ++i_bc)
+  if (!dem_parameters.boundary_conditions.periodic_direction.empty())
     {
-      if (dem_parameters.boundary_conditions.bc_types[i_bc] ==
-          Parameters::Lagrangian::BCDEM::BoundaryType::periodic)
-        {
-          dem_action_manager->set_periodic_boundaries_enabled();
+      dem_action_manager->set_periodic_boundaries_enabled();
 
-          periodic_boundaries_object.set_periodic_boundaries_information(
-            dem_parameters.boundary_conditions.periodic_boundary_0,
-            dem_parameters.boundary_conditions.periodic_direction,
-            dem_parameters.boundary_conditions.periodic_bc_index);
-
-          break;
-        }
+      periodic_boundaries_object.set_periodic_boundaries_information(
+        dem_parameters.boundary_conditions.periodic_direction);
     }
 
   insertion_object = set_insertion_type<dim, CFDDEMProperties::PropertiesIndex>(
@@ -242,21 +232,11 @@ CFDDEMSolver<dim>::initialize_dem_parameters()
     periodic_boundaries_object.get_combined_periodic_offsets());
 
   // Set the periodic offsets of the periodic boundary pairs for other classes
-  auto const &periodic_bc_index =
-    periodic_boundaries_object.get_periodic_bc_index();
-  auto const &periodic_boundaries_ids =
-    periodic_boundaries_object.get_periodic_boundaries_ids();
-
-  for (const unsigned int pbc_index : periodic_bc_index)
+  for (auto const &[pb_id, direction] :
+       periodic_boundaries_object.get_periodic_directions())
     {
-      auto it = periodic_boundaries_ids.find(pbc_index);
-      if (it != periodic_boundaries_ids.end())
-        {
-          auto const &pb_id = it->second;
-          particle_particle_contact_force_object->set_periodic_offset(
-            periodic_boundaries_object.get_periodic_offset_distance(pb_id),
-            pb_id);
-        }
+      particle_particle_contact_force_object->set_periodic_offset(
+        periodic_boundaries_object.get_periodic_offset_distance(pb_id), pb_id);
     }
 
   // Find cell neighbors

--- a/source/fem-dem/cfd_dem_coupling_matrix_free.cc
+++ b/source/fem-dem/cfd_dem_coupling_matrix_free.cc
@@ -21,6 +21,8 @@
 #include <fem-dem/fluid_dynamics_vans_matrix_free_operators.h>
 #include <fem-dem/postprocessing_cfd_dem.h>
 
+#include <ranges>
+
 
 // Constructor for the class CFD-DEM class
 template <int dim>
@@ -225,12 +227,13 @@ CFDDEMMatrixFree<dim>::initialize_dem_parameters()
     periodic_boundaries_object.get_combined_periodic_offsets());
 
   // Set the periodic offsets of the periodic boundary pairs for other classes
-  for (auto const &[pb_id, direction] :
-       periodic_boundaries_object.get_periodic_directions())
+  for (const auto &pb_id :
+       periodic_boundaries_object.get_periodic_directions() | std::views::keys)
     {
       particle_particle_contact_force_object->set_periodic_offset(
         periodic_boundaries_object.get_periodic_offset_distance(pb_id), pb_id);
     }
+
 
   // Find cell neighbors
   contact_manager.execute_cell_neighbors_search(

--- a/source/fem-dem/cfd_dem_coupling_matrix_free.cc
+++ b/source/fem-dem/cfd_dem_coupling_matrix_free.cc
@@ -134,22 +134,12 @@ CFDDEMMatrixFree<dim>::dem_setup_parameters()
   report_rayleigh_time_ratio();
 
   // Check if there are periodic boundaries
-  for (unsigned int i_bc = 0;
-       i_bc < dem_parameters.boundary_conditions.bc_types.size();
-       ++i_bc)
+  if (!dem_parameters.boundary_conditions.periodic_direction.empty())
     {
-      if (dem_parameters.boundary_conditions.bc_types[i_bc] ==
-          Parameters::Lagrangian::BCDEM::BoundaryType::periodic)
-        {
-          dem_action_manager->set_periodic_boundaries_enabled();
+      dem_action_manager->set_periodic_boundaries_enabled();
 
-          periodic_boundaries_object.set_periodic_boundaries_information(
-            dem_parameters.boundary_conditions.periodic_boundary_0,
-            dem_parameters.boundary_conditions.periodic_direction,
-            dem_parameters.boundary_conditions.periodic_bc_index);
-
-          break;
-        }
+      periodic_boundaries_object.set_periodic_boundaries_information(
+        dem_parameters.boundary_conditions.periodic_direction);
     }
 
   insertion_object = set_insertion_type<dim, CFDDEMProperties::PropertiesIndex>(
@@ -235,21 +225,11 @@ CFDDEMMatrixFree<dim>::initialize_dem_parameters()
     periodic_boundaries_object.get_combined_periodic_offsets());
 
   // Set the periodic offsets of the periodic boundary pairs for other classes
-  auto const &periodic_bc_index =
-    periodic_boundaries_object.get_periodic_bc_index();
-  auto const &periodic_boundaries_ids =
-    periodic_boundaries_object.get_periodic_boundaries_ids();
-
-  for (const unsigned int pbc_index : periodic_bc_index)
+  for (auto const &[pb_id, direction] :
+       periodic_boundaries_object.get_periodic_directions())
     {
-      auto it = periodic_boundaries_ids.find(pbc_index);
-      if (it != periodic_boundaries_ids.end())
-        {
-          auto const &pb_id = it->second;
-          particle_particle_contact_force_object->set_periodic_offset(
-            periodic_boundaries_object.get_periodic_offset_distance(pb_id),
-            pb_id);
-        }
+      particle_particle_contact_force_object->set_periodic_offset(
+        periodic_boundaries_object.get_periodic_offset_distance(pb_id), pb_id);
     }
 
   // Find cell neighbors

--- a/source/fem-dem/ib_particles_dem.cc
+++ b/source/fem-dem/ib_particles_dem.cc
@@ -37,30 +37,19 @@ IBParticlesDEM<dim>::is_boundary_excluded(
   if (!boundary_conditions_parameters)
     return false;
 
-  const auto &outlet_boundaries =
-    boundary_conditions_parameters->outlet_boundaries;
-  if (std::ranges::find(outlet_boundaries, boundary_id) !=
-      outlet_boundaries.end())
+  if (boundary_conditions_parameters->outlet_boundaries.contains(boundary_id))
     return true;
 
-  const auto &bc_types = boundary_conditions_parameters->bc_types;
-  const bool  has_periodic =
-    std::ranges::find(bc_types,
-                      Parameters::Lagrangian::BCDEM::BoundaryType::periodic) !=
-    bc_types.end();
-  if (has_periodic)
-    {
-      const auto &pb0 = boundary_conditions_parameters->periodic_boundary_0;
-      const auto &pb1 = boundary_conditions_parameters->periodic_boundary_1;
-      if (std::ranges::any_of(pb0,
-                              [boundary_id](const auto &p) {
-                                return p.second == boundary_id;
-                              }) ||
-          std::ranges::any_of(pb1, [boundary_id](const auto &p) {
-            return p.second == boundary_id;
-          }))
-        return true;
-    }
+  // A boundary is periodic if it is a principal periodic boundary (a key of
+  // periodic_neighbor_id) or a neighbor periodic boundary (one of its values).
+  const auto &periodic_neighbor_id =
+    boundary_conditions_parameters->periodic_neighbor_id;
+  if (periodic_neighbor_id.contains(boundary_id) ||
+      std::ranges::any_of(periodic_neighbor_id, [boundary_id](const auto &p) {
+        return p.second == boundary_id;
+      }))
+    return true;
+
   return false;
 }
 

--- a/tests/dem/boundary_cells_and_faces.cc
+++ b/tests/dem/boundary_cells_and_faces.cc
@@ -35,7 +35,7 @@ test()
                             true);
   int refinement_number = 2;
   triangulation.refine_global(refinement_number);
-  std::vector<unsigned int> outlet_boundaries;
+  std::set<types::boundary_id> outlet_boundaries;
 
   // Fining boundary cells information
   BoundaryCellsInformation<dim> boundary_cells_object;

--- a/tests/dem/combined_periodic_offsets.cc
+++ b/tests/dem/combined_periodic_offsets.cc
@@ -59,23 +59,14 @@ test()
   // neighbours to trigger the offset computation in map_periodic_cells.
   triangulation.refine_global(2);
 
-  // Configure the manipulator with one periodic pair per direction. Use
-  // the primary face id (2*d) as both the BC index key and the principal
-  // boundary id.
-  std::unordered_map<unsigned int, types::boundary_id> primary_ids;
-  std::unordered_map<unsigned int, unsigned int>       directions;
-  std::vector<unsigned int>                            bc_indices;
+  // Configure the manipulator with one periodic pair per direction. The
+  // direction map is keyed by the principal periodic boundary id (2*d).
+  std::map<types::boundary_id, unsigned int> periodic_directions;
   for (int d = 0; d < dim; ++d)
-    {
-      primary_ids[d] = 2 * d;
-      directions[d]  = d;
-      bc_indices.push_back(d);
-    }
+    periodic_directions[2 * d] = d;
 
   PeriodicBoundariesManipulator<dim> manipulator;
-  manipulator.set_periodic_boundaries_information(primary_ids,
-                                                  directions,
-                                                  bc_indices);
+  manipulator.set_periodic_boundaries_information(periodic_directions);
 
   typename DEM::dem_data_structures<dim>::periodic_boundaries_cells_info
     cells_info;

--- a/tests/dem/normal_force.cc
+++ b/tests/dem/normal_force.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 /**
@@ -123,7 +123,7 @@ test()
 
   // Finding boundary cells
   BoundaryCellsInformation<dim> boundary_cells_object;
-  std::vector<unsigned int>     outlet_boundaries;
+  std::set<types::boundary_id>  outlet_boundaries;
 
   boundary_cells_object.build(
     tr,

--- a/tests/dem/particle_point_contact.cc
+++ b/tests/dem/particle_point_contact.cc
@@ -102,7 +102,7 @@ test()
 
   // Construct boundary cells object and build it
   BoundaryCellsInformation<dim> boundary_cells_object;
-  std::vector<unsigned int>     outlet_boundaries;
+  std::set<types::boundary_id>  outlet_boundaries;
   boundary_cells_object.build(
     tr,
     outlet_boundaries,

--- a/tests/dem/particle_wall_contact_force_linear.cc
+++ b/tests/dem/particle_wall_contact_force_linear.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 /**
@@ -121,7 +121,7 @@ test()
 
   // Finding boundary cells
   BoundaryCellsInformation<dim> boundary_cells_object;
-  std::vector<unsigned int>     outlet_boundaries;
+  std::set<types::boundary_id>  outlet_boundaries;
   boundary_cells_object.build(
     tr,
     outlet_boundaries,

--- a/tests/dem/particle_wall_contact_force_nonlinear.cc
+++ b/tests/dem/particle_wall_contact_force_nonlinear.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 /**
@@ -121,7 +121,7 @@ test()
 
   // Finding boundary cells
   BoundaryCellsInformation<dim> boundary_cells_object;
-  std::vector<unsigned int>     outlet_boundaries;
+  std::set<types::boundary_id>  outlet_boundaries;
   boundary_cells_object.build(
     tr,
     outlet_boundaries,

--- a/tests/dem/particle_wall_contact_pairs.cc
+++ b/tests/dem/particle_wall_contact_pairs.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 /**
@@ -77,7 +77,7 @@ test()
   // Calling find_boundary_cells_information function to find the information of
   // boundary cells
   BoundaryCellsInformation<dim> boundary_cells_object;
-  std::vector<unsigned int>     outlet_boundaries;
+  std::set<types::boundary_id>  outlet_boundaries;
   boundary_cells_object.build(
     tr,
     outlet_boundaries,

--- a/tests/dem/particle_wall_fine_search.cc
+++ b/tests/dem/particle_wall_fine_search.cc
@@ -71,7 +71,7 @@ test()
   // Calling find_boundary_cells_information function to find the information of
   // boundary cells
   BoundaryCellsInformation<dim> boundary_cells_object;
-  std::vector<unsigned int>     outlet_boundaries;
+  std::set<types::boundary_id>  outlet_boundaries;
   boundary_cells_object.build(
     tr,
     outlet_boundaries,

--- a/tests/dem/particle_wall_thermal_conductance.cc
+++ b/tests/dem/particle_wall_thermal_conductance.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 /**
@@ -140,7 +140,7 @@ test()
 
   // Finding boundary cells
   BoundaryCellsInformation<dim> boundary_cells_object;
-  std::vector<unsigned int>     outlet_boundaries;
+  std::set<types::boundary_id>  outlet_boundaries;
   boundary_cells_object.build(
     tr,
     outlet_boundaries,

--- a/tests/dem/post_collision_velocity.cc
+++ b/tests/dem/post_collision_velocity.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 /**
@@ -122,7 +122,7 @@ test(double coefficient_of_restitution)
 
   // Finding boundary cells
   BoundaryCellsInformation<dim> boundary_cells_object;
-  std::vector<unsigned int>     outlet_boundaries;
+  std::set<types::boundary_id>  outlet_boundaries;
   boundary_cells_object.build(
     tr,
     outlet_boundaries,


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The boundary conditions for DEM were stored in a vector like fashion, which  made it such that two IDs were always existing. A vector id (which was related to the number of the boundary condition section) and the real boundary id. This PR refactors this by just using maps where the key is the real boundary ID.
Instead of working with boundary-> types and then applying the variables, we already pre-calculate which wall is what boundary since this is really more convenient for DEM.

### Testing

No test results were changed (which is what is expected)

### Documentation

Nothing to be changed here.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] An entry describing the change has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If any future work is planned, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR