### PR TITLE
Sharp ib stencil degree

### DIFF
--- a/applications_tests/lethe-fluid-sharp/almost_blocked_channels.prm
+++ b/applications_tests/lethe-fluid-sharp/almost_blocked_channels.prm
@@ -104,7 +104,7 @@ subsection particles
   set number of particles = 3
 
   subsection extrapolation function
-    set stencil order = 1
+    set stencil degree = 1
     set length ratio  = 1
   end
 

--- a/applications_tests/lethe-fluid-sharp/almost_blocked_channels.prm
+++ b/applications_tests/lethe-fluid-sharp/almost_blocked_channels.prm
@@ -105,7 +105,7 @@ subsection particles
 
   subsection extrapolation function
     set stencil degree = 1
-    set length ratio  = 1
+    set length ratio   = 1
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/cavatappi_composite_test.prm
+++ b/applications_tests/lethe-fluid-sharp/cavatappi_composite_test.prm
@@ -97,7 +97,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/check_point.prm
+++ b/applications_tests/lethe-fluid-sharp/check_point.prm
@@ -101,7 +101,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/couette2d_gls.prm
+++ b/applications_tests/lethe-fluid-sharp/couette2d_gls.prm
@@ -107,7 +107,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = true
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
   end
 
   subsection particle info 0

--- a/applications_tests/lethe-fluid-sharp/couette2d_gls_poisson.prm
+++ b/applications_tests/lethe-fluid-sharp/couette2d_gls_poisson.prm
@@ -107,7 +107,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
   end
 
   subsection particle info 0

--- a/applications_tests/lethe-fluid-sharp/coupled_moving_stokes.prm
+++ b/applications_tests/lethe-fluid-sharp/coupled_moving_stokes.prm
@@ -172,7 +172,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
     set length ratio  = 2
   end
 

--- a/applications_tests/lethe-fluid-sharp/coupled_moving_stokes.prm
+++ b/applications_tests/lethe-fluid-sharp/coupled_moving_stokes.prm
@@ -173,7 +173,7 @@ subsection particles
 
   subsection extrapolation function
     set stencil degree = 2
-    set length ratio  = 2
+    set length ratio   = 2
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/flow_around_cone_deathstar.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_cone_deathstar.prm
@@ -82,7 +82,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
   end
 
   subsection input file

--- a/applications_tests/lethe-fluid-sharp/flow_around_cuthollowsphere.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_cuthollowsphere.prm
@@ -111,7 +111,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/flow_around_ellipsoid_rectangle.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_ellipsoid_rectangle.prm
@@ -111,7 +111,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/flow_around_multiple_objects.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_multiple_objects.prm
@@ -101,7 +101,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
   end
 
   subsection input file

--- a/applications_tests/lethe-fluid-sharp/flow_around_rbf.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_rbf.prm
@@ -110,7 +110,7 @@ subsection particles
 
   subsection extrapolation function
     set stencil degree = 1
-    set length ratio  = 5
+    set length ratio   = 5
   end
 
   subsection particle info 0

--- a/applications_tests/lethe-fluid-sharp/flow_around_rbf.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_rbf.prm
@@ -109,7 +109,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 1
+    set stencil degree = 1
     set length ratio  = 5
   end
 

--- a/applications_tests/lethe-fluid-sharp/flow_around_torus.prm
+++ b/applications_tests/lethe-fluid-sharp/flow_around_torus.prm
@@ -111,7 +111,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/generators/check_point_generator.prm
+++ b/applications_tests/lethe-fluid-sharp/generators/check_point_generator.prm
@@ -107,7 +107,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/load_particles_from_file_test.prm
+++ b/applications_tests/lethe-fluid-sharp/load_particles_from_file_test.prm
@@ -110,7 +110,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
     set length ratio  = 1
   end
 

--- a/applications_tests/lethe-fluid-sharp/load_particles_from_file_test.prm
+++ b/applications_tests/lethe-fluid-sharp/load_particles_from_file_test.prm
@@ -111,7 +111,7 @@ subsection particles
 
   subsection extrapolation function
     set stencil degree = 2
-    set length ratio  = 1
+    set length ratio   = 1
   end
 
   subsection input file

--- a/applications_tests/lethe-fluid-sharp/minimal_crown_refinement.prm
+++ b/applications_tests/lethe-fluid-sharp/minimal_crown_refinement.prm
@@ -87,7 +87,7 @@ subsection particles
 
   subsection extrapolation function
     set length ratio  = 1
-    set stencil order = 2
+    set stencil degree = 2
   end
 
   subsection output

--- a/applications_tests/lethe-fluid-sharp/minimal_crown_refinement.prm
+++ b/applications_tests/lethe-fluid-sharp/minimal_crown_refinement.prm
@@ -86,7 +86,7 @@ subsection particles
   set number of particles = 1
 
   subsection extrapolation function
-    set length ratio  = 1
+    set length ratio   = 1
     set stencil degree = 2
   end
 

--- a/applications_tests/lethe-fluid-sharp/moving_ib_gls.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_ib_gls.prm
@@ -100,7 +100,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = true
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
     set length ratio  = 1.1
   end
 

--- a/applications_tests/lethe-fluid-sharp/moving_ib_gls.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_ib_gls.prm
@@ -101,7 +101,7 @@ subsection particles
 
   subsection extrapolation function
     set stencil degree = 6
-    set length ratio  = 1.1
+    set length ratio   = 1.1
   end
 
   subsection input file

--- a/applications_tests/lethe-fluid-sharp/moving_ib_gls_poisson.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_ib_gls_poisson.prm
@@ -100,7 +100,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
     set length ratio  = 1.1
   end
 

--- a/applications_tests/lethe-fluid-sharp/moving_ib_gls_poisson.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_ib_gls_poisson.prm
@@ -101,7 +101,7 @@ subsection particles
 
   subsection extrapolation function
     set stencil degree = 6
-    set length ratio  = 1.1
+    set length ratio   = 1.1
   end
 
   subsection input file

--- a/applications_tests/lethe-fluid-sharp/moving_rectangle.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_rectangle.prm
@@ -70,7 +70,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = true
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
   end
 
   subsection input file

--- a/applications_tests/lethe-fluid-sharp/moving_stokes.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes.prm
@@ -180,7 +180,7 @@ subsection particles
 
   subsection extrapolation function
     set stencil degree = 6
-    set length ratio  = 2
+    set length ratio   = 2
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/moving_stokes.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes.prm
@@ -179,7 +179,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
     set length ratio  = 2
   end
 

--- a/applications_tests/lethe-fluid-sharp/moving_stokes_2d.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes_2d.prm
@@ -151,7 +151,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
     set length ratio  = 2
   end
 

--- a/applications_tests/lethe-fluid-sharp/moving_stokes_2d.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes_2d.prm
@@ -152,7 +152,7 @@ subsection particles
 
   subsection extrapolation function
     set stencil degree = 6
-    set length ratio  = 2
+    set length ratio   = 2
   end
 
   subsection input file

--- a/applications_tests/lethe-fluid-sharp/moving_stokes_2d_output_control.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes_2d_output_control.prm
@@ -155,7 +155,7 @@ subsection particles
 
   subsection extrapolation function
     set stencil degree = 6
-    set length ratio  = 2
+    set length ratio   = 2
   end
 
   subsection output

--- a/applications_tests/lethe-fluid-sharp/moving_stokes_2d_output_control.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes_2d_output_control.prm
@@ -154,7 +154,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
     set length ratio  = 2
   end
 

--- a/applications_tests/lethe-fluid-sharp/moving_stokes_distance_coarsening.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes_distance_coarsening.prm
@@ -157,7 +157,7 @@ subsection particles
 
   subsection extrapolation function
     set stencil degree = 6
-    set length ratio  = 2
+    set length ratio   = 2
   end
 
   subsection input file

--- a/applications_tests/lethe-fluid-sharp/moving_stokes_distance_coarsening.prm
+++ b/applications_tests/lethe-fluid-sharp/moving_stokes_distance_coarsening.prm
@@ -156,7 +156,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
     set length ratio  = 2
   end
 

--- a/applications_tests/lethe-fluid-sharp/opencascade/static_stokes_step.prm
+++ b/applications_tests/lethe-fluid-sharp/opencascade/static_stokes_step.prm
@@ -167,7 +167,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/pp_contact_test.prm
+++ b/applications_tests/lethe-fluid-sharp/pp_contact_test.prm
@@ -100,7 +100,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
   end
 
   subsection input file

--- a/applications_tests/lethe-fluid-sharp/pp_lubrication_test.prm
+++ b/applications_tests/lethe-fluid-sharp/pp_lubrication_test.prm
@@ -84,7 +84,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/pw_contact_test.prm
+++ b/applications_tests/lethe-fluid-sharp/pw_contact_test.prm
@@ -100,7 +100,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/pw_lubrication_test.prm
+++ b/applications_tests/lethe-fluid-sharp/pw_lubrication_test.prm
@@ -100,7 +100,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/pw_moving_wall_contact.prm
+++ b/applications_tests/lethe-fluid-sharp/pw_moving_wall_contact.prm
@@ -113,7 +113,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/pw_rolling_test.prm
+++ b/applications_tests/lethe-fluid-sharp/pw_rolling_test.prm
@@ -92,7 +92,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
   set number of particles                     = 1
   subsection extrapolation function
-    set length ratio  = 2
+    set length ratio   = 2
     set stencil degree = 3
   end
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/pw_rolling_test.prm
+++ b/applications_tests/lethe-fluid-sharp/pw_rolling_test.prm
@@ -93,7 +93,7 @@ subsection particles
   set number of particles                     = 1
   subsection extrapolation function
     set length ratio  = 2
-    set stencil order = 3
+    set stencil degree = 3
   end
   subsection local mesh refinement
     set initial refinement                = 4

--- a/applications_tests/lethe-fluid-sharp/pw_rotating_wall_contact.prm
+++ b/applications_tests/lethe-fluid-sharp/pw_rotating_wall_contact.prm
@@ -119,7 +119,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/rbf_sphere_mms.prm
+++ b/applications_tests/lethe-fluid-sharp/rbf_sphere_mms.prm
@@ -150,7 +150,7 @@ subsection particles
 
   subsection extrapolation function
     set stencil degree = 1
-    set length ratio  = 1
+    set length ratio   = 1
   end
 
   subsection particle info 0

--- a/applications_tests/lethe-fluid-sharp/rbf_sphere_mms.prm
+++ b/applications_tests/lethe-fluid-sharp/rbf_sphere_mms.prm
@@ -149,7 +149,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 1
+    set stencil degree = 1
     set length ratio  = 1
   end
 

--- a/applications_tests/lethe-fluid-sharp/rbf_sphere_mms_adaptive.prm
+++ b/applications_tests/lethe-fluid-sharp/rbf_sphere_mms_adaptive.prm
@@ -163,7 +163,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 1
+    set stencil degree = 1
     set length ratio  = 5
   end
 

--- a/applications_tests/lethe-fluid-sharp/rbf_sphere_mms_adaptive.prm
+++ b/applications_tests/lethe-fluid-sharp/rbf_sphere_mms_adaptive.prm
@@ -164,7 +164,7 @@ subsection particles
 
   subsection extrapolation function
     set stencil degree = 1
-    set length ratio  = 5
+    set length ratio   = 5
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/sphere_mms_pressure_scaling.prm
+++ b/applications_tests/lethe-fluid-sharp/sphere_mms_pressure_scaling.prm
@@ -158,7 +158,7 @@ subsection particles
 
   subsection extrapolation function
     set stencil degree = 1
-    set length ratio  = 1
+    set length ratio   = 1
   end
 
   subsection particle info 0

--- a/applications_tests/lethe-fluid-sharp/sphere_mms_pressure_scaling.prm
+++ b/applications_tests/lethe-fluid-sharp/sphere_mms_pressure_scaling.prm
@@ -157,7 +157,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 1
+    set stencil degree = 1
     set length ratio  = 1
   end
 

--- a/applications_tests/lethe-fluid-sharp/sphere_power_law_ramp.prm
+++ b/applications_tests/lethe-fluid-sharp/sphere_power_law_ramp.prm
@@ -123,7 +123,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
   end
 
   subsection particle info 0

--- a/applications_tests/lethe-fluid-sharp/spinning_cone.prm
+++ b/applications_tests/lethe-fluid-sharp/spinning_cone.prm
@@ -82,7 +82,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/spooky_composite_test.prm
+++ b/applications_tests/lethe-fluid-sharp/spooky_composite_test.prm
@@ -97,7 +97,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/static_stokes.prm
+++ b/applications_tests/lethe-fluid-sharp/static_stokes.prm
@@ -176,7 +176,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/steady_couette_sphere.prm
+++ b/applications_tests/lethe-fluid-sharp/steady_couette_sphere.prm
@@ -107,7 +107,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = true
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/steady_couette_sphere_poisson.prm
+++ b/applications_tests/lethe-fluid-sharp/steady_couette_sphere_poisson.prm
@@ -107,7 +107,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/taylorcouette2d_carreau_gls.prm
+++ b/applications_tests/lethe-fluid-sharp/taylorcouette2d_carreau_gls.prm
@@ -102,7 +102,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = true
 
   subsection extrapolation function
-    set stencil order = 6
+    set stencil degree = 6
   end
 
   subsection particle info 0

--- a/applications_tests/lethe-fluid-sharp/tracer_around_sphere.prm
+++ b/applications_tests/lethe-fluid-sharp/tracer_around_sphere.prm
@@ -132,7 +132,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 1
+    set stencil degree = 1
   end
   subsection output
     set calculate force = false

--- a/applications_tests/lethe-fluid-sharp/tube_shape_test.prm
+++ b/applications_tests/lethe-fluid-sharp/tube_shape_test.prm
@@ -97,7 +97,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
   end
 
   subsection local mesh refinement

--- a/applications_tests/lethe-fluid-sharp/two_non_sphere_contact.prm
+++ b/applications_tests/lethe-fluid-sharp/two_non_sphere_contact.prm
@@ -111,7 +111,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
   set number of particles                     = 2
   subsection extrapolation function
-    set length ratio  = 2
+    set length ratio   = 2
     set stencil degree = 2
   end
 

--- a/applications_tests/lethe-fluid-sharp/two_non_sphere_contact.prm
+++ b/applications_tests/lethe-fluid-sharp/two_non_sphere_contact.prm
@@ -112,7 +112,7 @@ subsection particles
   set number of particles                     = 2
   subsection extrapolation function
     set length ratio  = 2
-    set stencil order = 2
+    set stencil degree = 2
   end
 
   subsection local mesh refinement

--- a/doc/source/examples/sharp-immersed-boundary/3d-composite-mixer-with-pbt-impeller/3d-composite-mixer-with-pbt-impeller.rst
+++ b/doc/source/examples/sharp-immersed-boundary/3d-composite-mixer-with-pbt-impeller/3d-composite-mixer-with-pbt-impeller.rst
@@ -95,7 +95,7 @@ The section defining each parameter for the particles has certain requirements:
       set number of particles                     = 1
       set assemble Navier-Stokes inside particles = false
       subsection extrapolation function
-        set stencil order = 2
+        set stencil degree = 2
         set length ratio  = 3
       end
       subsection local mesh refinement

--- a/doc/source/examples/sharp-immersed-boundary/3d-rbf-static-mixer/3d-rbf-static-mixer.rst
+++ b/doc/source/examples/sharp-immersed-boundary/3d-rbf-static-mixer/3d-rbf-static-mixer.rst
@@ -245,7 +245,7 @@ This section defines each parameter for the particles and has certain requiremen
 
       subsection extrapolation function
         set length ratio  = 4
-        set stencil order = 1
+        set stencil degree = 1
       end
 
       subsection local mesh refinement

--- a/doc/source/examples/sharp-immersed-boundary/cylinder-with-sharp-interface/cylinder-with-sharp-interface.rst
+++ b/doc/source/examples/sharp-immersed-boundary/cylinder-with-sharp-interface/cylinder-with-sharp-interface.rst
@@ -127,7 +127,7 @@ In this case, we want to define a circular boundary of radius 0.5 centered at (8
     
 * ``number of particles`` is set to ``1`` as we only want one particle.
 
-* ``stencil degree`` is set to ``2`` as this is the highest order that is compatible with the FEM scheme and it does not lead to Runge instability. The highest order of stencil compatible with a FEM scheme is defined by the polynomial order of the scheme time the number of dimensions: in this case, 2.
+* ``stencil degree`` is set to ``2`` as this is the highest degree that is compatible with the FEM scheme and it does not lead to Runge instability. The highest degree of stencil compatible with a FEM scheme is defined by the polynomial degree of the scheme time the number of dimensions: in this case, 2.
 
 * ``initial refinement`` is set to 0. In this case, the initial mesh is small enough compared to the particle size. It is therefore not necessary to pre-refine the mesh around the particle.
 

--- a/doc/source/examples/sharp-immersed-boundary/cylinder-with-sharp-interface/cylinder-with-sharp-interface.rst
+++ b/doc/source/examples/sharp-immersed-boundary/cylinder-with-sharp-interface/cylinder-with-sharp-interface.rst
@@ -108,7 +108,7 @@ In this case, we want to define a circular boundary of radius 0.5 centered at (8
     subsection particles
       set number of particles                     = 1
       subsection extrapolation function
-        set stencil order = 2
+        set stencil degree = 2
       end
       subsection local mesh refinement
         set initial refinement                = 0
@@ -127,7 +127,7 @@ In this case, we want to define a circular boundary of radius 0.5 centered at (8
     
 * ``number of particles`` is set to ``1`` as we only want one particle.
 
-* ``stencil order`` is set to ``2`` as this is the highest order that is compatible with the FEM scheme and it does not lead to Runge instability. The highest order of stencil compatible with a FEM scheme is defined by the polynomial order of the scheme time the number of dimensions: in this case, 2.
+* ``stencil degree`` is set to ``2`` as this is the highest order that is compatible with the FEM scheme and it does not lead to Runge instability. The highest order of stencil compatible with a FEM scheme is defined by the polynomial order of the scheme time the number of dimensions: in this case, 2.
 
 * ``initial refinement`` is set to 0. In this case, the initial mesh is small enough compared to the particle size. It is therefore not necessary to pre-refine the mesh around the particle.
 

--- a/doc/source/examples/sharp-immersed-boundary/cylindrical-particle-drag-evaluation-with-sharp-interface/cylindrical-particle-drag-evaluation-with-sharp-interface.rst
+++ b/doc/source/examples/sharp-immersed-boundary/cylindrical-particle-drag-evaluation-with-sharp-interface/cylindrical-particle-drag-evaluation-with-sharp-interface.rst
@@ -84,7 +84,7 @@ The ``local mesh refinement`` is set to 3 to ensure we resolve the boundary laye
     set number of particles                     = 1
     set assemble Navier-Stokes inside particles = false
     subsection extrapolation function
-      set stencil order = 2
+      set stencil degree = 2
       set length ratio  = 1
     end
     subsection local mesh refinement

--- a/doc/source/examples/sharp-immersed-boundary/inclined-3d-composite-mixer-with-pbt-impeller/inclined-3d-composite-mixer-with-pbt-impeller.rst
+++ b/doc/source/examples/sharp-immersed-boundary/inclined-3d-composite-mixer-with-pbt-impeller/inclined-3d-composite-mixer-with-pbt-impeller.rst
@@ -239,7 +239,7 @@ The parameters used to define the impeller are based on the :doc:`../3d-composit
       set number of particles                     = 1
       set assemble Navier-Stokes inside particles = false
       subsection extrapolation function
-        set stencil order = 2
+        set stencil degree = 2
         set length ratio  = 3
       end
       subsection local mesh refinement

--- a/doc/source/examples/sharp-immersed-boundary/sedimentation-1-cuboid/sedimentation-1-cuboid.rst
+++ b/doc/source/examples/sharp-immersed-boundary/sedimentation-1-cuboid/sedimentation-1-cuboid.rst
@@ -156,7 +156,7 @@ IB Particles
     subsection particles
       subsection extrapolation function
         set length ratio  = 2
-        set stencil order = 3
+        set stencil degree = 3
       end
 
       subsection local mesh refinement

--- a/doc/source/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.rst
+++ b/doc/source/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.rst
@@ -312,7 +312,7 @@ In this subsection, we define most of the parameters that are related to the par
 
 * The ``number of particles`` is set to one as we only want one particle.
 
-* ``stencil degree`` is set to 3 as this is the highest order we can use for this case, and it will not lead to Runge instability.
+* ``stencil degree`` is set to 3 as this is the highest degree we can use for this case, and it will not lead to Runge instability.
 
 * ``refine mesh inside radius factor`` is set to 0.8. This creates a mesh refinement around the particle that avoids having hanging nodes in the calculation and helps ensure a small enough mesh around the particle.
 

--- a/doc/source/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.rst
+++ b/doc/source/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.rst
@@ -272,7 +272,7 @@ IB Particles
       set number of particles                     = 1
       subsection extrapolation function
         set length ratio  = 2
-        set stencil order = 3
+        set stencil degree = 3
       end
       
       subsection local mesh refinement
@@ -312,7 +312,7 @@ In this subsection, we define most of the parameters that are related to the par
 
 * The ``number of particles`` is set to one as we only want one particle.
 
-* ``stencil order`` is set to 3 as this is the highest order we can use for this case, and it will not lead to Runge instability.
+* ``stencil degree`` is set to 3 as this is the highest order we can use for this case, and it will not lead to Runge instability.
 
 * ``refine mesh inside radius factor`` is set to 0.8. This creates a mesh refinement around the particle that avoids having hanging nodes in the calculation and helps ensure a small enough mesh around the particle.
 

--- a/doc/source/examples/sharp-immersed-boundary/sedimentation-64-particles/sedimentation-64-particles.rst
+++ b/doc/source/examples/sharp-immersed-boundary/sedimentation-64-particles/sedimentation-64-particles.rst
@@ -263,7 +263,7 @@ IB Particles
       
       subsection extrapolation function
         set length ratio  = 2
-        set stencil order = 2
+        set stencil degree = 2
       end
       
       subsection local mesh refinement
@@ -292,7 +292,7 @@ IB Particles
 
 In this subsection, we define most of the parameters that are related to the particle.
 
-* The ``stencil order`` is set to 2 since it improves the results in the force evaluation step and does not make the matrix resolution significantly harder.
+* The ``stencil degree`` is set to 2 since it improves the results in the force evaluation step and does not make the matrix resolution significantly harder.
 
 * The ``refine mesh inside radius factor`` is set to 0. This creates a mesh refinement inside the particle that avoids having hanging nodes in the calculation and helps ensure a small enough mesh around the particle.
 

--- a/doc/source/examples/sharp-immersed-boundary/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.rst
+++ b/doc/source/examples/sharp-immersed-boundary/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.rst
@@ -191,7 +191,7 @@ In this case, we want to define a spherical boundary of radius :math:`0.5`, with
       set number of particles                     = 1
       set assemble Navier-Stokes inside particles = false
       subsection extrapolation function
-        set stencil order = 2
+        set stencil degree = 2
         set length ratio  = 1
       end
       subsection local mesh refinement

--- a/doc/source/parameters/sharp-immersed-boundary/sharp-immersed-boundary.rst
+++ b/doc/source/parameters/sharp-immersed-boundary/sharp-immersed-boundary.rst
@@ -15,7 +15,7 @@ This subsection contains the parameters related to the sharp immersed boundary s
       
       subsection extrapolation function
         set length ratio         = 4
-        set stencil order        = 2
+        set stencil degree       = 2
         set enable extrapolation = true
       end
       
@@ -106,15 +106,15 @@ This subsection contains the parameters related to the sharp immersed boundary s
 * The ``assemble Navier-Stokes inside particles`` parameter determines if the Navier-Stokes equations are solved inside the particles or not. If the Navier-Stokes equations are not solved (the parameter is false), the solver will solve a Poisson equation for each variable in the problem. This eliminates the need to define a reference value for the pressure.
 
 * The ``extrapolation function`` subsection contains the parameters associated with the extrapolation function used to impose the sharp immersed boundary condition.
-    * The ``stencil order`` parameter controls the order of the Lagrange polynomial used to impose the sharp interface immersed boundary condition. The order of the stencil should be higher than or equal to the order of interpolation of the underlying FEM scheme (e.g. for Q2Q2 elements use ``stencil order=2``). We suggest using the same order as the velocity field in most cases since it improves the condition number of the matrix.
+    * The ``stencil degree`` parameter controls the degree of the Lagrange polynomial used to impose the sharp interface immersed boundary condition. The degree of the stencil should be higher than or equal to the interpolation degree of the underlying FEM scheme (e.g. for Q2Q2 elements use ``stencil degree=2``). We suggest using the same degree as the velocity field in most cases since it improves the condition number of the matrix.
 
     .. note::
-	    The stencil order used does not alter the order of convergence of the solution.
+	    The stencil degree used does not alter the order of convergence of the solution.
 
     * The ``length ratio`` parameter controls the length of the zone used to define the Lagrange polynomial (see `this article <https://www.sciencedirect.com/science/article/pii/S0045793022000780?via%3Dihub>`_ for more details). The length ratio should be kept as small as possible and above 1. When using a Cartesian homogenous mesh (aspect ratio of 1), the length ratio should be 1.
 
     .. tip::
-	    A good starting value is twice the average aspect ratio of the elements in the mesh multiplied by the order of the underlying FEM scheme.
+	    A good starting value is twice the average aspect ratio of the elements in the mesh multiplied by the degree of the underlying FEM scheme.
 
     * The ``enable extrapolation`` parameter controls if extrapolation is used to impose the immersed boundary condition. For debugging purposes, this parameter can be set to ``false``; the particle velocity will then be imposed on velocity degrees of freedom of cells cut by the particle directly, which effectively amplifies the volume occupied by the solid.
 
@@ -184,7 +184,7 @@ This subsection contains the parameters related to the sharp immersed boundary s
     .. warning::
 	    If ``contact search radius factor`` :math:`\leq 1`, an error is thrown.
 	    
-	* The ``enable lubrication force`` parameter enables or disables the use of lubrication forces. This parameter must be set to ``false`` when using a non-newtonian fluid rheology.
+    * The ``enable lubrication force`` parameter enables or disables the use of lubrication forces. This parameter must be set to ``false`` when using a non-newtonian fluid rheology.
     
     * The ``explicit contact impulsion`` parameter enables or disables the use of explicit contact impulsion evaluation in the resolution of the coupling of the particle. When it is set to true, this parameter results in the code only performing the DEM calculation once per CFD time step and using the resulting contact impulsion to evaluate all the other Newton's iterations. This reduces the number of times the DEM calculation is made. However, since the position is still implicitly evaluated in the absence of contact, the cut cell mapping must be performed at each Newton iteration.
 
@@ -348,6 +348,7 @@ The following parameter and subsection are all inside the subsection ``particle 
 	For a particle to be accounted for in the fluid mesh, it has to overlap at least one vertex of this fluid mesh. If the initial mesh is too coarse in regards to the particle size, the particle may not be captured if it does not intersect the outer mesh walls. To avoid this, a box refinement can be added around the particle (See Box refinement documentation).
 
 Mesh refinement
+---------------
 The mesh is refined on multiple occasions during the simulations, and it can be slightly confusing to understand the sequence of refinement. There are 3 pre-simulation refinement steps. The first is the **global mesh refinement**. It is set by the ``initial refinement`` parameter in the ``mesh`` subsection.
 The second refinement is inside the **box refinement zone**, set by the ``initial refinement`` in the ``box refinement`` subsection. Lastly, the **near-particle zone** is refined, defined by the ``initial refinement`` parameter in the ``particles`` subsection.
 Therefore, the near-particle zone around each particle is refined ``mesh``:``initial refinement`` + ``box``:``initial refinement`` + ``particle``:``initial refinement`` times before the simulations starts.

--- a/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer.prm
+++ b/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer.prm
@@ -122,7 +122,7 @@ subsection particles
 
   subsection extrapolation function
     set length ratio  = 4
-    set stencil order = 1
+    set stencil degree = 1
   end
 
   subsection local mesh refinement

--- a/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer.prm
+++ b/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer.prm
@@ -121,7 +121,7 @@ subsection particles
   set number of particles                     = 1
 
   subsection extrapolation function
-    set length ratio  = 4
+    set length ratio   = 4
     set stencil degree = 1
   end
 

--- a/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer_only_tracer.prm
+++ b/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer_only_tracer.prm
@@ -119,7 +119,7 @@ subsection particles
 
   subsection extrapolation function
     set length ratio  = 4
-    set stencil order = 1
+    set stencil degree = 1
   end
 
   subsection local mesh refinement

--- a/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer_only_tracer.prm
+++ b/examples/multiphysics/tracer_through_static_mixer/flow_in_long_mixer_only_tracer.prm
@@ -118,7 +118,7 @@ subsection particles
   set number of particles                     = 1
 
   subsection extrapolation function
-    set length ratio  = 4
+    set length ratio   = 4
     set stencil degree = 1
   end
 

--- a/examples/sharp-immersed-boundary/3d-composite-mixer-with-pbt-impeller/mixer.prm
+++ b/examples/sharp-immersed-boundary/3d-composite-mixer-with-pbt-impeller/mixer.prm
@@ -127,7 +127,7 @@ subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
     set length ratio  = 3
   end
   subsection local mesh refinement

--- a/examples/sharp-immersed-boundary/3d-composite-mixer-with-pbt-impeller/mixer.prm
+++ b/examples/sharp-immersed-boundary/3d-composite-mixer-with-pbt-impeller/mixer.prm
@@ -128,7 +128,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
   subsection extrapolation function
     set stencil degree = 2
-    set length ratio  = 3
+    set length ratio   = 3
   end
   subsection local mesh refinement
     set initial refinement                = 3

--- a/examples/sharp-immersed-boundary/3d-opencascade-mixer-with-pbt-impeller/mixer.prm
+++ b/examples/sharp-immersed-boundary/3d-opencascade-mixer-with-pbt-impeller/mixer.prm
@@ -127,7 +127,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
   subsection extrapolation function
     set stencil degree = 2
-    set length ratio  = 3
+    set length ratio   = 3
   end
   subsection local mesh refinement
     set initial refinement                = 4

--- a/examples/sharp-immersed-boundary/3d-opencascade-mixer-with-pbt-impeller/mixer.prm
+++ b/examples/sharp-immersed-boundary/3d-opencascade-mixer-with-pbt-impeller/mixer.prm
@@ -126,7 +126,7 @@ subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
     set length ratio  = 3
   end
   subsection local mesh refinement

--- a/examples/sharp-immersed-boundary/3d-rbf-static-mixer/lethe_sharp_simulation/flow_in_long_mixer.prm
+++ b/examples/sharp-immersed-boundary/3d-rbf-static-mixer/lethe_sharp_simulation/flow_in_long_mixer.prm
@@ -57,7 +57,7 @@ subsection particles
   set number of particles                     = 1
 
   subsection extrapolation function
-    set length ratio  = 4
+    set length ratio   = 4
     set stencil degree = 1
   end
 

--- a/examples/sharp-immersed-boundary/3d-rbf-static-mixer/lethe_sharp_simulation/flow_in_long_mixer.prm
+++ b/examples/sharp-immersed-boundary/3d-rbf-static-mixer/lethe_sharp_simulation/flow_in_long_mixer.prm
@@ -58,7 +58,7 @@ subsection particles
 
   subsection extrapolation function
     set length ratio  = 4
-    set stencil order = 1
+    set stencil degree = 1
   end
 
   subsection local mesh refinement

--- a/examples/sharp-immersed-boundary/cylinder-with-sharp-interface/cylinder-with-sharp-interface.prm
+++ b/examples/sharp-immersed-boundary/cylinder-with-sharp-interface/cylinder-with-sharp-interface.prm
@@ -116,7 +116,7 @@ subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
   end
   subsection local mesh refinement
     set initial refinement = 0

--- a/examples/sharp-immersed-boundary/cylindrical-particle-drag-evaluation-with-sharp-interface/cylindrical-particle-drag-evaluation-with-sharp-interface.prm
+++ b/examples/sharp-immersed-boundary/cylindrical-particle-drag-evaluation-with-sharp-interface/cylindrical-particle-drag-evaluation-with-sharp-interface.prm
@@ -122,7 +122,7 @@ subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
     set length ratio  = 1
   end
   subsection local mesh refinement

--- a/examples/sharp-immersed-boundary/cylindrical-particle-drag-evaluation-with-sharp-interface/cylindrical-particle-drag-evaluation-with-sharp-interface.prm
+++ b/examples/sharp-immersed-boundary/cylindrical-particle-drag-evaluation-with-sharp-interface/cylindrical-particle-drag-evaluation-with-sharp-interface.prm
@@ -123,7 +123,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
   subsection extrapolation function
     set stencil degree = 2
-    set length ratio  = 1
+    set length ratio   = 1
   end
   subsection local mesh refinement
     set initial refinement                = 3

--- a/examples/sharp-immersed-boundary/inclined-3d-composite-mixer-with-pbt-impeller/mixer.prm
+++ b/examples/sharp-immersed-boundary/inclined-3d-composite-mixer-with-pbt-impeller/mixer.prm
@@ -116,7 +116,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
   subsection extrapolation function
     set stencil degree = 2
-    set length ratio  = 3
+    set length ratio   = 3
   end
   subsection local mesh refinement
     set initial refinement                = 6

--- a/examples/sharp-immersed-boundary/inclined-3d-composite-mixer-with-pbt-impeller/mixer.prm
+++ b/examples/sharp-immersed-boundary/inclined-3d-composite-mixer-with-pbt-impeller/mixer.prm
@@ -115,7 +115,7 @@ subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
     set length ratio  = 3
   end
   subsection local mesh refinement

--- a/examples/sharp-immersed-boundary/sedimentation-1-cuboid/sedimentation-1-cuboid.prm
+++ b/examples/sharp-immersed-boundary/sedimentation-1-cuboid/sedimentation-1-cuboid.prm
@@ -98,7 +98,7 @@ end
 subsection particles
   subsection extrapolation function
     set length ratio  = 2
-    set stencil order = 3
+    set stencil degree = 3
   end
 
   subsection local mesh refinement

--- a/examples/sharp-immersed-boundary/sedimentation-1-cuboid/sedimentation-1-cuboid.prm
+++ b/examples/sharp-immersed-boundary/sedimentation-1-cuboid/sedimentation-1-cuboid.prm
@@ -97,7 +97,7 @@ end
 
 subsection particles
   subsection extrapolation function
-    set length ratio  = 2
+    set length ratio   = 2
     set stencil degree = 3
   end
 

--- a/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.prm
+++ b/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.prm
@@ -102,7 +102,7 @@ subsection particles
   set number of particles                     = 1
   subsection extrapolation function
     set length ratio  = 2
-    set stencil order = 3
+    set stencil degree = 3
   end
 
   subsection local mesh refinement

--- a/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.prm
+++ b/examples/sharp-immersed-boundary/sedimentation-1-particle/sedimentation-1-particle.prm
@@ -101,7 +101,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
   set number of particles                     = 1
   subsection extrapolation function
-    set length ratio  = 2
+    set length ratio   = 2
     set stencil degree = 3
   end
 

--- a/examples/sharp-immersed-boundary/sedimentation-64-particles/sedimentation-64-particles.prm
+++ b/examples/sharp-immersed-boundary/sedimentation-64-particles/sedimentation-64-particles.prm
@@ -111,7 +111,7 @@ subsection particles
 
   subsection extrapolation function
     set length ratio  = 2
-    set stencil order = 2
+    set stencil degree = 2
   end
 
   subsection local mesh refinement

--- a/examples/sharp-immersed-boundary/sedimentation-64-particles/sedimentation-64-particles.prm
+++ b/examples/sharp-immersed-boundary/sedimentation-64-particles/sedimentation-64-particles.prm
@@ -110,7 +110,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
 
   subsection extrapolation function
-    set length ratio  = 2
+    set length ratio   = 2
     set stencil degree = 2
   end
 

--- a/examples/sharp-immersed-boundary/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.prm
+++ b/examples/sharp-immersed-boundary/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.prm
@@ -166,7 +166,7 @@ subsection particles
   set number of particles                     = 1
   set assemble Navier-Stokes inside particles = false
   subsection extrapolation function
-    set stencil order = 2
+    set stencil degree = 2
     set length ratio  = 1
   end
   subsection local mesh refinement

--- a/examples/sharp-immersed-boundary/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.prm
+++ b/examples/sharp-immersed-boundary/sphere-carreau-with-sharp-interface/sphere-carreau-with-sharp-interface.prm
@@ -167,7 +167,7 @@ subsection particles
   set assemble Navier-Stokes inside particles = false
   subsection extrapolation function
     set stencil degree = 2
-    set length ratio  = 1
+    set length ratio   = 1
   end
   subsection local mesh refinement
     set initial refinement                = 2

--- a/include/core/ib_stencil.h
+++ b/include/core/ib_stencil.h
@@ -142,7 +142,7 @@ private:
   /**
    * @brief Return the points on the reference 1D element for the polynomial base.
    *
-   * @param[in] degree Order of the stencil.
+   * @param[in] degree Degree of the stencil.
    */
   void
   p_base(unsigned int degree);

--- a/include/core/ib_stencil.h
+++ b/include/core/ib_stencil.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2021-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_ib_stencil_h
@@ -39,10 +39,10 @@ public:
    * position as well as the DOF position. Depending on the degree, the output
    * variable "point" change definition. In the case of stencil degrees 1 to 4
    * the variable point returns the position of the DOF directly. In the case of
-   * high degree stencil, it returns the position of the point that is on the IB.
-   * The variable "interpolation points" return the points used to define the
-   * cell used for the stencil definition and the locations of the points used
-   * in the stencil calculation.
+   * high degree stencil, it returns the position of the point that is on the
+   * IB. The variable "interpolation points" return the points used to define
+   * the cell used for the stencil definition and the locations of the points
+   * used in the stencil calculation.
    *
    * @param[in] degree Stencil degree.
    *

--- a/include/core/ib_stencil.h
+++ b/include/core/ib_stencil.h
@@ -145,7 +145,7 @@ private:
    * @param[in] degree Degree of the stencil.
    */
   void
-  p_base(unsigned int degree);
+  p_base(const unsigned int degree);
 
   /**
    * @brief Points of the reference 1D stencil.

--- a/include/core/ib_stencil.h
+++ b/include/core/ib_stencil.h
@@ -22,29 +22,29 @@ class IBStencil
 public:
   /**
    * @brief Return the number of points used by the interpolation stencil (excluding the
-   *  dof itself) for a stencil of a given order.
+   *  dof itself) for a stencil of a given degree.
    *
-   * @param[in] order Stencil order.
+   * @param[in] degree Stencil degree.
    *
    * @return Number of points used by the interpolation stencil.
    */
   virtual unsigned int
-  number_of_interpolation_support_points(const unsigned int order);
+  number_of_interpolation_support_points(const unsigned int degree);
 
   /**
    * @brief Find the DOF at which we try to apply the IB by interpolation
    * and the location of the support points to do so.
    *
-   * Define the points for the IB stencil, based on the order and the particle
-   * position as well as the DOF position. Depending on the order, the output
-   * variable "point" change definition. In the case of stencil orders 1 to 4
+   * Define the points for the IB stencil, based on the degree and the particle
+   * position as well as the DOF position. Depending on the degree, the output
+   * variable "point" change definition. In the case of stencil degrees 1 to 4
    * the variable point returns the position of the DOF directly. In the case of
-   * high order stencil, it returns the position of the point that is on the IB.
+   * high degree stencil, it returns the position of the point that is on the IB.
    * The variable "interpolation points" return the points used to define the
    * cell used for the stencil definition and the locations of the points used
    * in the stencil calculation.
    *
-   * @param[in] order Stencil order.
+   * @param[in] degree Stencil degree.
    *
    * @param[in] length_ratio Length ratio between the 2 side of the stencil.
    *
@@ -59,7 +59,7 @@ public:
    */
   virtual std::tuple<Point<dim>, std::vector<Point<dim>>>
   support_points_for_interpolation(
-    const unsigned int                                    order,
+    const unsigned int                                    degree,
     const double                                          length_ratio,
     IBParticle<dim>                                      &p,
     const Point<dim>                                     &dof_point,
@@ -69,7 +69,7 @@ public:
    * @brief See overloaded function.
    */
   virtual std::tuple<Point<dim>, std::vector<Point<dim>>>
-  support_points_for_interpolation(const unsigned int order,
+  support_points_for_interpolation(const unsigned int degree,
                                    const double       length_ratio,
                                    IBParticle<dim>   &p,
                                    const Point<dim>  &dof_point);
@@ -105,12 +105,12 @@ public:
    * coefficient of the DOF to the coefficient of the farthest interpolation
    * point (sorted by increasing distance).
    *
-   * @param[in] order Stencil order.
+   * @param[in] degree Stencil degree.
    *
    * @param[in] length_ratio Length ratio between the 2 side of the stencil.
    */
   virtual std::vector<double>
-  coefficients(const unsigned int order, const double length_ratio);
+  coefficients(const unsigned int degree, const double length_ratio);
 
   /**
    * @brief Return the velocity of the IB used in the RHS of the equation.
@@ -142,10 +142,10 @@ private:
   /**
    * @brief Return the points on the reference 1D element for the polynomial base.
    *
-   * @param[in] order Order of the stencil.
+   * @param[in] degree Order of the stencil.
    */
   void
-  p_base(unsigned int order);
+  p_base(unsigned int degree);
 
   /**
    * @brief Points of the reference 1D stencil.

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1801,8 +1801,8 @@ namespace Parameters
     // solved inside the particles.
     bool assemble_navier_stokes_inside;
 
-    // Polynomial order of the IB stencil
-    unsigned int order;
+    // Polynomial degree of the IB stencil
+    unsigned int stencil_degree;
     // The length ratio used for the stencil calculation of the IB condition.
     double length_ratio;
     // Boolean controlling whether extrapolation is used to impose the

--- a/release_notes/current/2026_06_15_Blais.md
+++ b/release_notes/current/2026_06_15_Blais.md
@@ -2,4 +2,4 @@
 
 ### Deprecated
 
-- MAJOR The `stencil order` parameter of the sharp immersed boundary method (in the `particles/extrapolation function` subsection) has been renamed to `stencil degree`. The name `degree` is more adequate, since it refers to the degree of the Lagrange polynomial used by the stencil. The old name is kept as a deprecated alias and will continue to work but will trigger a deprecation warning. All examples, application tests, and documentation have been updated to use the new name. [#](https://github.com/chaos-polymtl/lethe/pull/)
+- MAJOR The `stencil order` parameter of the sharp immersed boundary method (in the `particles/extrapolation function` subsection) has been renamed to `stencil degree`. The name `degree` is more adequate, since it refers to the degree of the Lagrange polynomial used by the stencil. The old name is kept as a deprecated alias and will continue to work but will trigger a deprecation warning. All examples, application tests, and documentation have been updated to use the new name. [#2023](https://github.com/chaos-polymtl/lethe/pull/2023)

--- a/release_notes/current/2026_06_15_Blais.md
+++ b/release_notes/current/2026_06_15_Blais.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/06/15
+
+### Deprecated
+
+- MAJOR The `stencil order` parameter of the sharp immersed boundary method (in the `particles/extrapolation function` subsection) has been renamed to `stencil degree`. The name `degree` is more adequate, since it refers to the degree of the Lagrange polynomial used by the stencil. The old name is kept as a deprecated alias and will continue to work but will trigger a deprecation warning. All examples, application tests, and documentation have been updated to use the new name. [#](https://github.com/chaos-polymtl/lethe/pull/)

--- a/source/core/ib_stencil.cc
+++ b/source/core/ib_stencil.cc
@@ -26,6 +26,8 @@ template <int dim>
 void
 IBStencil<dim>::p_base(const unsigned int degree)
 {
+  AssertThrow(degree > 0,
+              ExcMessage("IB stencil degree must be greater than 0."));
   using numbers::PI;
   // Define the sampling point position of the stencil on the reference 1D
   // stencil 0 to 1, 1 being the position of the DOF.

--- a/source/core/ib_stencil.cc
+++ b/source/core/ib_stencil.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2021-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/ib_stencil.h>
@@ -8,7 +8,8 @@
 
 template <int dim>
 unsigned int
-IBStencil<dim>::number_of_interpolation_support_points(const unsigned int degree)
+IBStencil<dim>::number_of_interpolation_support_points(
+  const unsigned int degree)
 {
   // The number of points used in the stencil excluding the DOF is equal to the
   // degree.

--- a/source/core/ib_stencil.cc
+++ b/source/core/ib_stencil.cc
@@ -8,51 +8,51 @@
 
 template <int dim>
 unsigned int
-IBStencil<dim>::number_of_interpolation_support_points(const unsigned int order)
+IBStencil<dim>::number_of_interpolation_support_points(const unsigned int degree)
 {
   // The number of points used in the stencil excluding the DOF is equal to the
-  // order.
-  unsigned int nb_points = order;
+  // degree.
+  unsigned int nb_points = degree;
 
   // In the case where the cell is used directly to find the solution at
   // the IB only one point is needed.
-  if (order > 4)
+  if (degree > 4)
     nb_points = 1;
   return nb_points;
 }
 
 template <int dim>
 void
-IBStencil<dim>::p_base(const unsigned int order)
+IBStencil<dim>::p_base(const unsigned int degree)
 {
   using numbers::PI;
   // Define the sampling point position of the stencil on the reference 1D
   // stencil 0 to 1, 1 being the position of the DOF.
-  reference_points.resize(order + 1);
-  for (unsigned int i = 0; i < order + 1; ++i)
+  reference_points.resize(degree + 1);
+  for (unsigned int i = 0; i < degree + 1; ++i)
     {
-      reference_points[i] = 0.5 * (1 - cos(PI * i / order));
+      reference_points[i] = 0.5 * (1 - cos(PI * i / degree));
     }
 }
 
 template <int dim>
 std::vector<double>
-IBStencil<dim>::coefficients(const unsigned int order,
+IBStencil<dim>::coefficients(const unsigned int degree,
                              const double       length_ratio)
 {
-  p_base(order);
+  p_base(degree);
   // Initialize the coefficient vector
-  std::vector<double> coef(order + 1);
+  std::vector<double> coef(degree + 1);
 
-  FullMatrix<double> vandermonde(order + 1, order + 1);
-  FullMatrix<double> stencil(order + 1, order + 1);
-  FullMatrix<double> inv_vandermonde(order + 1, order + 1);
+  FullMatrix<double> vandermonde(degree + 1, degree + 1);
+  FullMatrix<double> stencil(degree + 1, degree + 1);
+  FullMatrix<double> inv_vandermonde(degree + 1, degree + 1);
 
-  Vector<double> rhs(order + 1);
+  Vector<double> rhs(degree + 1);
   // Define the Vandermonde matrix
-  for (unsigned int i = 0; i < order + 1; ++i)
+  for (unsigned int i = 0; i < degree + 1; ++i)
     {
-      for (unsigned int j = 0; j < order + 1; ++j)
+      for (unsigned int j = 0; j < degree + 1; ++j)
         {
           vandermonde[i][j] = std::pow(reference_points[i], j);
         }
@@ -62,24 +62,24 @@ IBStencil<dim>::coefficients(const unsigned int order,
   inv_vandermonde.invert(vandermonde);
 
   // Multiply each line of the inverted matrix by (1+length_ratio)^i
-  for (unsigned int i = 0; i < order + 1; ++i)
+  for (unsigned int i = 0; i < degree + 1; ++i)
     {
-      for (unsigned int j = 0; j < order + 1; ++j)
+      for (unsigned int j = 0; j < degree + 1; ++j)
         {
           stencil[i][j] = inv_vandermonde[i][j] * rhs[i];
         }
     }
   // Sum the columns to get the coefficients.
-  for (unsigned int i = 0; i < order + 1; ++i)
+  for (unsigned int i = 0; i < degree + 1; ++i)
     {
-      for (unsigned int j = 0; j < order + 1; ++j)
+      for (unsigned int j = 0; j < degree + 1; ++j)
         {
-          coef[order - i] += stencil[j][i];
+          coef[degree - i] += stencil[j][i];
         }
     }
 
-  // Fill the coefficient vector based on the order.
-  if (order > 4)
+  // Fill the coefficient vector based on the degree.
+  if (degree > 4)
     {
       // In this case the cell is directly used to find the solution at the IB
       // position. In this case only one point is needed (the position of the
@@ -94,22 +94,22 @@ IBStencil<dim>::coefficients(const unsigned int order,
 template <int dim>
 std::tuple<Point<dim>, std::vector<Point<dim>>>
 IBStencil<dim>::support_points_for_interpolation(
-  const unsigned int                                    order,
+  const unsigned int                                    degree,
   const double                                          length_ratio,
   IBParticle<dim>                                      &p,
   const Point<dim>                                     &dof_point,
   const typename DoFHandler<dim>::active_cell_iterator &cell_guess)
 {
-  // Create the vector of points used for the stencil based on the order of the
+  // Create the vector of points used for the stencil based on the degree of the
   // stencil. Also return the DOF position or the position of the point on the
   // IB depending on if the cell is used directly.
-  p_base(order);
+  p_base(degree);
   Point<dim> point;
   Point<dim> surface_point;
   p.closest_surface_point(dof_point, surface_point, cell_guess);
   std::vector<Point<dim>> interpolation_points;
 
-  if (order > 4)
+  if (degree > 4)
     {
       // In this case the cell is directly used to find the solution at the IB
       // position. In this case only one point is needed (the position of the
@@ -125,14 +125,14 @@ IBStencil<dim>::support_points_for_interpolation(
     }
   else
     {
-      interpolation_points.resize(order);
+      interpolation_points.resize(degree);
       Tensor<1, dim, double> vect_ib = dof_point - surface_point;
       point                          = dof_point;
-      for (unsigned int i = 1; i < order + 1; ++i)
+      for (unsigned int i = 1; i < degree + 1; ++i)
         {
           interpolation_points[i - 1] =
             dof_point +
-            vect_ib * (1 - reference_points[order - i]) / (length_ratio);
+            vect_ib * (1 - reference_points[degree - i]) / (length_ratio);
         }
     }
   return {point, interpolation_points};
@@ -140,21 +140,21 @@ IBStencil<dim>::support_points_for_interpolation(
 
 template <int dim>
 std::tuple<Point<dim>, std::vector<Point<dim>>>
-IBStencil<dim>::support_points_for_interpolation(const unsigned int order,
+IBStencil<dim>::support_points_for_interpolation(const unsigned int degree,
                                                  const double      length_ratio,
                                                  IBParticle<dim>  &p,
                                                  const Point<dim> &dof_point)
 {
-  // Create the vector of points used for the stencil based on the order of the
+  // Create the vector of points used for the stencil based on the degree of the
   // stencil. Also return the DOF position or the position of the point on the
   // IB depending on if the cell is used directly.
-  p_base(order);
+  p_base(degree);
   Point<dim> point;
   Point<dim> surface_point;
   p.closest_surface_point(dof_point, surface_point);
   std::vector<Point<dim>> interpolation_points;
 
-  if (order > 4)
+  if (degree > 4)
     {
       // In this case the cell is directly used to find the solution at the IB
       // position. In this case only one point is needed (the position of the
@@ -170,14 +170,14 @@ IBStencil<dim>::support_points_for_interpolation(const unsigned int order,
     }
   else
     {
-      interpolation_points.resize(order);
+      interpolation_points.resize(degree);
       Tensor<1, dim, double> vect_ib = dof_point - surface_point;
       point                          = dof_point;
-      for (unsigned int i = 1; i < order + 1; ++i)
+      for (unsigned int i = 1; i < degree + 1; ++i)
         {
           interpolation_points[i - 1] =
             dof_point +
-            vect_ib * (1 - reference_points[order - i]) / (length_ratio);
+            vect_ib * (1 - reference_points[degree - i]) / (length_ratio);
         }
     }
   return {point, interpolation_points};
@@ -206,7 +206,7 @@ Point<dim>
 IBStencil<dim>::point_for_cell_detection(IBParticle<dim>  &p,
                                          const Point<dim> &dof_point)
 {
-  // Create the vector of points used for the stencil based on the order of the
+  // Create the vector of points used for the stencil based on the degree of the
   // stencil. Also return the DOF position or the position of the point on the
   // IB depending on if the cell is used directly
 

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3926,7 +3926,7 @@ namespace Parameters
         prm.declare_entry(
           "stencil degree",
           "2",
-          Patterns::Integer(),
+          Patterns::Integer(1),
           "The polynomial degree used in the extrapolation function");
         prm.declare_alias("stencil degree", "stencil order", true);
         prm.declare_entry(

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3924,10 +3924,11 @@ namespace Parameters
       prm.enter_subsection("extrapolation function");
       {
         prm.declare_entry(
-          "stencil order",
+          "stencil degree",
           "2",
           Patterns::Integer(),
-          "The polynomial order used in the extrapolation function");
+          "The polynomial degree used in the extrapolation function");
+        prm.declare_alias("stencil degree", "stencil order", true);
         prm.declare_entry(
           "length ratio",
           "4",
@@ -4149,7 +4150,7 @@ namespace Parameters
     {
       prm.enter_subsection("extrapolation function");
       {
-        order                = prm.get_integer("stencil order");
+        stencil_degree       = prm.get_integer("stencil degree");
         length_ratio         = prm.get_double("length ratio");
         enable_extrapolation = prm.get_bool("enable extrapolation");
         prm.leave_subsection();

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -1411,7 +1411,7 @@ FluidDynamicsSharp<dim>::force_on_ib()
                                   // Use the results from a previously evaluated
                                   // extrapolation. This step comes with an
                                   // error due to the curvature of the surface
-                                  // in Q2 and higher order elements.
+                                  // in Q2 and higher degree elements.
                                   local_face_viscous_stress_tensor[i] =
                                     force_eval[local_face_dof_indices[i]].first;
                                   local_face_pressure_tensor[i] =
@@ -3399,7 +3399,8 @@ FluidDynamicsSharp<dim>::sharp_edge()
                           update_quadrature_points | update_JxW_values);
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
 
-  int degree = this->simulation_parameters.particlesParameters->stencil_degree;
+  const unsigned int degree =
+    this->simulation_parameters.particlesParameters->stencil_degree;
   double length_ratio =
     this->simulation_parameters.particlesParameters->length_ratio;
 

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -4038,7 +4038,7 @@ FluidDynamicsSharp<dim>::sharp_edge()
                         {
                           // Applied equation on dof that have no equation
                           // defined for them. those DOF become Dummy dof. This
-                          // is useful for high order cells or when a dof is
+                          // is useful for high degree cells or when a dof is
                           // only element of cells that are cut.
                           unsigned int global_index_overwrite =
                             local_dof_indices[i];

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -104,10 +104,10 @@ FluidDynamicsSharp<dim>::generate_cut_cells_map()
   // When the finite element order > 1, overconstrained cells are impossible
   // since there is always at least a DOF inside the element that is not
   // overconstrained. We therefore only have to check when the velocity order
-// When the finite element degree > 1, overconstrained cells are impossible
-// since there is always at least a DOF inside the element that is not
-// overconstrained. We therefore only have to check when the velocity degree
-// == 1.
+  // When the finite element degree > 1, overconstrained cells are impossible
+  // since there is always at least a DOF inside the element that is not
+  // overconstrained. We therefore only have to check when the velocity degree
+  // == 1.
   const bool mapping_overconstrained_cells =
     this->simulation_parameters.fem_parameters.velocity_degree == 1;
 
@@ -1068,7 +1068,8 @@ FluidDynamicsSharp<dim>::force_on_ib()
            .density_is_constant(),
          RequiresConstantDensity("FluidDynamicsSharp<dim>::force_on_ib"));
 
-  unsigned int  degree = this->simulation_parameters.particlesParameters->stencil_degree;
+  unsigned int degree =
+    this->simulation_parameters.particlesParameters->stencil_degree;
   auto density_model =
     this->simulation_parameters.physical_properties_manager.get_density(0);
   std::map<field, double> field_values;

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -3396,7 +3396,7 @@ FluidDynamicsSharp<dim>::sharp_edge()
                           update_quadrature_points | update_JxW_values);
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
 
-  int    degree = this->simulation_parameters.particlesParameters->stencil_degree;
+  int degree = this->simulation_parameters.particlesParameters->stencil_degree;
   double length_ratio =
     this->simulation_parameters.particlesParameters->length_ratio;
 

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -104,7 +104,10 @@ FluidDynamicsSharp<dim>::generate_cut_cells_map()
   // When the finite element order > 1, overconstrained cells are impossible
   // since there is always at least a DOF inside the element that is not
   // overconstrained. We therefore only have to check when the velocity order
-  // == 1.
+// When the finite element degree > 1, overconstrained cells are impossible
+// since there is always at least a DOF inside the element that is not
+// overconstrained. We therefore only have to check when the velocity degree
+// == 1.
   const bool mapping_overconstrained_cells =
     this->simulation_parameters.fem_parameters.velocity_degree == 1;
 
@@ -1065,7 +1068,7 @@ FluidDynamicsSharp<dim>::force_on_ib()
            .density_is_constant(),
          RequiresConstantDensity("FluidDynamicsSharp<dim>::force_on_ib"));
 
-  int  degree = this->simulation_parameters.particlesParameters->stencil_degree;
+  unsigned int  degree = this->simulation_parameters.particlesParameters->stencil_degree;
   auto density_model =
     this->simulation_parameters.physical_properties_manager.get_density(0);
   std::map<field, double> field_values;

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -1074,7 +1074,7 @@ FluidDynamicsSharp<dim>::force_on_ib()
   double length_ratio =
     this->simulation_parameters.particlesParameters->length_ratio;
   IBStencil<dim>      stencil;
-  std::vector<double> ib_coef = stencil.coefficients(order, length_ratio);
+  std::vector<double> ib_coef = stencil.coefficients(degree, length_ratio);
 
   // Rheological model for viscosity properties
   double     kinematic_viscosity;
@@ -3401,7 +3401,7 @@ FluidDynamicsSharp<dim>::sharp_edge()
     this->simulation_parameters.particlesParameters->length_ratio;
 
   IBStencil<dim>      stencil;
-  std::vector<double> ib_coef = stencil.coefficients(order, length_ratio);
+  std::vector<double> ib_coef = stencil.coefficients(degree, length_ratio);
 
   unsigned int n_q_points = q_formula.size();
 

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -1065,7 +1065,7 @@ FluidDynamicsSharp<dim>::force_on_ib()
            .density_is_constant(),
          RequiresConstantDensity("FluidDynamicsSharp<dim>::force_on_ib"));
 
-  int  order = this->simulation_parameters.particlesParameters->order;
+  int  degree = this->simulation_parameters.particlesParameters->stencil_degree;
   auto density_model =
     this->simulation_parameters.physical_properties_manager.get_density(0);
   std::map<field, double> field_values;
@@ -1257,7 +1257,7 @@ FluidDynamicsSharp<dim>::force_on_ib()
                                       auto [point, interpolation_points] =
                                         stencil
                                           .support_points_for_interpolation(
-                                            order,
+                                            degree,
                                             length_ratio,
                                             particles[p],
                                             support_points
@@ -3396,7 +3396,7 @@ FluidDynamicsSharp<dim>::sharp_edge()
                           update_quadrature_points | update_JxW_values);
   const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
 
-  int    order = this->simulation_parameters.particlesParameters->order;
+  int    degree = this->simulation_parameters.particlesParameters->stencil_degree;
   double length_ratio =
     this->simulation_parameters.particlesParameters->length_ratio;
 
@@ -3691,14 +3691,14 @@ FluidDynamicsSharp<dim>::sharp_edge()
                           this->system_matrix.clear_row(global_index_overwrite);
 
                           // Define the points for the IB stencil based on the
-                          // order, particle position, and DOF position. The
+                          // degree, particle position, and DOF position. The
                           // definition of the output variable "point" changes
-                          // depending on the order. In the case of stencil
-                          // orders 1 to 4, the variable point returns the
+                          // depending on the degree. In the case of stencil
+                          // degrees 1 to 4, the variable point returns the
                           // position of the DOF directly. In the case of higher
-                          // order stencil (5 or more), it returns the position
+                          // degree stencil (5 or more), it returns the position
                           // of the point that is on the IB. This is because
-                          // stencil orders higher than four are not
+                          // stencil degrees higher than four are not
                           // implemented. The function extrapolates the element
                           // at the particle's surface in these cases. To do so,
                           // we use the point at the surface of the particle.
@@ -3709,7 +3709,7 @@ FluidDynamicsSharp<dim>::sharp_edge()
 
                           auto [point, interpolation_points] =
                             stencil.support_points_for_interpolation(
-                              order,
+                              degree,
                               length_ratio,
                               particles[ib_particle_id],
                               support_points[local_dof_indices[i]],
@@ -3773,7 +3773,7 @@ FluidDynamicsSharp<dim>::sharp_edge()
                             point_in_cell = cell_cut->point_inside(
                               interpolation_points
                                 [stencil.number_of_interpolation_support_points(
-                                   order) -
+                                   degree) -
                                  1]);
                           else
                             point_in_cell = cell_cut->point_inside(
@@ -3862,7 +3862,7 @@ FluidDynamicsSharp<dim>::sharp_edge()
                                       //  Define the solution at each point used
                                       //  for the stencil and applied the
                                       //  stencil for the specific DOF. For
-                                      //  stencils of order 4 or higher, the
+                                      //  stencils of degree 4 or higher, the
                                       //  stencil is defined through direct
                                       //  extrapolation of the cell_cut. This
                                       //  can only be done when using a


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

When we carried out Pr #1994 the finite element order were renamed to degree everywhere. This PR does the same for the stencil order parameter used in the sharp-edge immersed boundary method. It also fixes some rendering quirks in the documentation. This PR closes #2002 

### Testing

No new tests added.

### Documentation

Nothing except fix some spacing issues in the documentation.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] An entry describing the change has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If any future work is planned, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR