### PR TITLE
Add capability to use AMG preconditioner in HT

### DIFF
--- a/applications_tests/lethe-fluid/cls-velocity-extrapolation.prm
+++ b/applications_tests/lethe-fluid/cls-velocity-extrapolation.prm
@@ -197,6 +197,6 @@ subsection linear solver
     set verbosity         = quiet
     set relative residual = 1e-5
     set minimum residual  = 1e-9
-    set preconditioner    = amg
+    set preconditioner    = ilu
   end
 end

--- a/applications_tests/lethe-fluid/cls_phase_change_darcy_with_density.prm
+++ b/applications_tests/lethe-fluid/cls_phase_change_darcy_with_density.prm
@@ -245,6 +245,6 @@ subsection linear solver
     set max iters         = 5000
     set relative residual = 1e-6
     set minimum residual  = 1e-11
-    set preconditioner    = amg
+    set preconditioner    = ilu
   end
 end

--- a/applications_tests/lethe-fluid/heat_transfer_transient_conduction.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_transient_conduction.prm
@@ -181,22 +181,16 @@ subsection linear solver
     set verbosity                             = quiet
     set method                                = gmres
     set relative residual                     = 1e-3
-    set minimum residual                      = 1e-8
-    set preconditioner                        = ilu
-    set ilu preconditioner fill               = 0
-    set ilu preconditioner absolute tolerance = 1e-12
-    set ilu preconditioner relative tolerance = 1.00
+    set minimum residual                      = 1e-10
+    set preconditioner                        = amg
     set max krylov vectors                    = 200
   end
   subsection heat transfer
     set verbosity                             = quiet
     set method                                = gmres
     set relative residual                     = 1e-3
-    set minimum residual                      = 1e-8
-    set preconditioner                        = ilu
-    set ilu preconditioner fill               = 0
-    set ilu preconditioner absolute tolerance = 1e-12
-    set ilu preconditioner relative tolerance = 1.00
+    set minimum residual                      = 1e-10
+    set preconditioner                        = amg
     set max krylov vectors                    = 200
   end
 end

--- a/applications_tests/lethe-fluid/heat_transfer_transient_conduction.prm
+++ b/applications_tests/lethe-fluid/heat_transfer_transient_conduction.prm
@@ -178,19 +178,19 @@ end
 
 subsection linear solver
   subsection fluid dynamics
-    set verbosity                             = quiet
-    set method                                = gmres
-    set relative residual                     = 1e-3
-    set minimum residual                      = 1e-10
-    set preconditioner                        = amg
-    set max krylov vectors                    = 200
+    set verbosity          = quiet
+    set method             = gmres
+    set relative residual  = 1e-3
+    set minimum residual   = 1e-10
+    set preconditioner     = amg
+    set max krylov vectors = 200
   end
   subsection heat transfer
-    set verbosity                             = quiet
-    set method                                = gmres
-    set relative residual                     = 1e-3
-    set minimum residual                      = 1e-10
-    set preconditioner                        = amg
-    set max krylov vectors                    = 200
+    set verbosity          = quiet
+    set method             = gmres
+    set relative residual  = 1e-3
+    set minimum residual   = 1e-10
+    set preconditioner     = amg
+    set max krylov vectors = 200
   end
 end

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -315,6 +315,18 @@ public:
   solve_linear_system() override;
 
   /**
+   * @brief Set up the ILU preconditioner stored in ilu_preconditioner.
+   */
+  void
+  setup_ilu();
+
+  /**
+   * @brief Set up the AMG preconditioner stored in amg_preconditioner.
+   */
+  void
+  setup_amg();
+
+  /**
    * @brief Getter method to access the private attribute dof_handler for the
    * physic currently solved. NB : dof_handler is now passed to the
    * multiphysics interface at the end of the setup_dofs method.
@@ -796,6 +808,16 @@ private:
    * @brief The system matrix.
    */
   TrilinosWrappers::SparseMatrix system_matrix;
+
+  /**
+   * @brief ILU preconditioner used by the iterative linear solver.
+   */
+  std::shared_ptr<TrilinosWrappers::PreconditionILU> ilu_preconditioner;
+
+  /**
+   * @brief AMG preconditioner used by the iterative linear solver.
+   */
+  std::shared_ptr<TrilinosWrappers::PreconditionAMG> amg_preconditioner;
 
 
   /**

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -29,6 +29,7 @@
 
 #include <deal.II/grid/grid_tools.h>
 
+#include <deal.II/lac/trilinos_precondition.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/lac/trilinos_vector.h>
 

--- a/release_notes/current/2026_06_16_Blais.md
+++ b/release_notes/current/2026_06_16_Blais.md
@@ -1,0 +1,9 @@
+## [Master] - 2026/06/16
+
+### Added
+
+- MAJOR This PR adds the possibility to use the AMG preconditioner as the linear solver preconditioner for the Heat Transfer auxiliary physics. The preconditioner (`ilu` or `amg`) is selected through the existing `preconditioner` parameter of the heat transfer linear solver subsection. Assertions were also added to the Conservative Level Set, Tracer and Cahn-Hilliard solvers to indicate that the AMG preconditioner is not yet supported for those physics. [#PR](link)
+
+### Changed
+
+- MINOR This PR modifies an existing application test to use the AMG preconditioner for the heat transfer solver. [#PR](link)

--- a/release_notes/current/2026_06_16_Blais.md
+++ b/release_notes/current/2026_06_16_Blais.md
@@ -2,8 +2,8 @@
 
 ### Added
 
-- MAJOR This PR adds the possibility to use the AMG preconditioner as the linear solver preconditioner for the Heat Transfer auxiliary physics. The preconditioner (`ilu` or `amg`) is selected through the existing `preconditioner` parameter of the heat transfer linear solver subsection. Assertions were also added to the Conservative Level Set, Tracer and Cahn-Hilliard solvers to indicate that the AMG preconditioner is not yet supported for those physics. [#PR](link)
+- MAJOR This PR adds the possibility to use the AMG preconditioner as the linear solver preconditioner for the Heat Transfer auxiliary physics. The preconditioner (`ilu` or `amg`) is selected through the existing `preconditioner` parameter of the heat transfer linear solver subsection. Assertions were also added to the Conservative Level Set, Tracer and Cahn-Hilliard solvers to indicate that the AMG preconditioner is not yet supported for those physics. [#20232](https://github.com/chaos-polymtl/lethe/pull/2032)
 
 ### Changed
 
-- MINOR This PR modifies an existing application test to use the AMG preconditioner for the heat transfer solver. [#PR](link)
+- MINOR This PR modifies an existing application test (heat_transfer_transient_conduction) to use the AMG preconditioner for the heat transfer solver. [#2032](https://github.com/chaos-polymtl/lethe/pull/2032)

--- a/source/solvers/cahn_hilliard.cc
+++ b/source/solvers/cahn_hilliard.cc
@@ -1298,6 +1298,12 @@ CahnHilliard<dim>::solve_linear_system()
 {
   TimerOutput::Scope t(this->computing_timer, "Solve linear system");
 
+  AssertThrow(
+    simulation_parameters.linear_solver.at(PhysicsID::cahn_hilliard)
+        .preconditioner == Parameters::LinearSolver::PreconditionerType::ilu,
+    ExcMessage(
+      "The Cahn-Hilliard physics only supports the <ilu> preconditioner. The <amg> preconditioner is not yet implemented for this physics."));
+
   auto mpi_communicator = triangulation->get_mpi_communicator();
 
   const AffineConstraints<double> &constraints_used = this->zero_constraints;

--- a/source/solvers/cls.cc
+++ b/source/solvers/cls.cc
@@ -2850,6 +2850,12 @@ ConservativeLevelSet<dim>::solve_linear_system()
 {
   TimerOutput::Scope t(this->computing_timer, "Solve linear system");
 
+  AssertThrow(
+    simulation_parameters.linear_solver.at(PhysicsID::CLS).preconditioner ==
+      Parameters::LinearSolver::PreconditionerType::ilu,
+    ExcMessage(
+      "The Conservative Level Set physics only supports the <ilu> preconditioner. The <amg> preconditioner is not yet implemented for this physics."));
+
   auto mpi_communicator = this->triangulation->get_mpi_communicator();
 
   const AffineConstraints<double> &constraints_used = this->zero_constraints;

--- a/source/solvers/heat_transfer.cc
+++ b/source/solvers/heat_transfer.cc
@@ -1685,6 +1685,105 @@ HeatTransfer<dim>::set_initial_conditions()
 
 template <int dim>
 void
+HeatTransfer<dim>::setup_ilu()
+{
+  TimerOutput::Scope t(this->computing_timer, "Setup ILU");
+
+  const unsigned int ilu_fill =
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .ilu_precond_fill;
+  const double ilu_atol =
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .ilu_precond_atol;
+  const double ilu_rtol =
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .ilu_precond_rtol;
+  TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
+    ilu_fill, ilu_atol, ilu_rtol, 0);
+
+  ilu_preconditioner = std::make_shared<TrilinosWrappers::PreconditionILU>();
+
+  ilu_preconditioner->initialize(system_matrix, preconditionerOptions);
+}
+
+template <int dim>
+void
+HeatTransfer<dim>::setup_amg()
+{
+  TimerOutput::Scope t(this->computing_timer, "Setup AMG");
+
+  // Constant modes for the temperature scalar field
+  std::vector<std::vector<bool>> constant_modes;
+
+  ComponentMask components(1, true);
+  constant_modes =
+    DoFTools::extract_constant_modes(*this->dof_handler, components);
+
+  // The heat transfer operator is non-symmetric since heat transfer is always
+  // solved assuming that there can be advection
+  const bool elliptic              = false;
+  bool       higher_order_elements = false;
+  if (fe->degree > 1)
+    higher_order_elements = true;
+  const unsigned int n_cycles =
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .amg_n_cycles;
+  const bool w_cycle =
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .amg_w_cycles;
+  const double aggregation_threshold =
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .amg_aggregation_threshold;
+  const unsigned int smoother_sweeps =
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .amg_smoother_sweeps;
+  const unsigned int smoother_overlap =
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .amg_smoother_overlap;
+  const bool                                        output_details = false;
+  const char                                       *smoother_type  = "ILU";
+  const char                                       *coarse_type    = "ILU";
+  TrilinosWrappers::PreconditionAMG::AdditionalData preconditionerOptions(
+    elliptic,
+    higher_order_elements,
+    n_cycles,
+    w_cycle,
+    aggregation_threshold,
+    constant_modes,
+    smoother_sweeps,
+    smoother_overlap,
+    output_details,
+    smoother_type,
+    coarse_type);
+
+  Teuchos::ParameterList              parameter_ml;
+  std::unique_ptr<Epetra_MultiVector> distributed_constant_modes;
+  preconditionerOptions.set_parameters(parameter_ml,
+                                       distributed_constant_modes,
+                                       system_matrix);
+  const double ilu_fill =
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .amg_precond_ilu_fill;
+  const double ilu_atol =
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .amg_precond_ilu_atol;
+  const double ilu_rtol =
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .amg_precond_ilu_rtol;
+  parameter_ml.set("smoother: ifpack level-of-fill", ilu_fill);
+  parameter_ml.set("smoother: ifpack absolute threshold", ilu_atol);
+  parameter_ml.set("smoother: ifpack relative threshold", ilu_rtol);
+
+  parameter_ml.set("coarse: ifpack level-of-fill", ilu_fill);
+  parameter_ml.set("coarse: ifpack absolute threshold", ilu_atol);
+  parameter_ml.set("coarse: ifpack relative threshold", ilu_rtol);
+
+  amg_preconditioner = std::make_shared<TrilinosWrappers::PreconditionAMG>();
+  amg_preconditioner->initialize(system_matrix, parameter_ml);
+}
+
+template <int dim>
+void
 HeatTransfer<dim>::solve_linear_system()
 {
   TimerOutput::Scope t(this->computing_timer, "Solve linear system");
@@ -1713,22 +1812,6 @@ HeatTransfer<dim>::solve_linear_system()
   const double non_rescaled_linear_solver_tolerance =
     linear_solver_tolerance * rescale_metric;
 
-  const unsigned int ilu_fill =
-    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
-      .ilu_precond_fill;
-  const double ilu_atol =
-    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
-      .ilu_precond_atol;
-  const double ilu_rtol =
-    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
-      .ilu_precond_rtol;
-  TrilinosWrappers::PreconditionILU::AdditionalData preconditionerOptions(
-    ilu_fill, ilu_atol, ilu_rtol, 0);
-
-  TrilinosWrappers::PreconditionILU ilu_preconditioner;
-
-  ilu_preconditioner.initialize(system_matrix, preconditionerOptions);
-
   GlobalVectorType completely_distributed_solution(locally_owned_dofs,
                                                    mpi_communicator);
 
@@ -1747,11 +1830,32 @@ HeatTransfer<dim>::solve_linear_system()
 
   TrilinosWrappers::SolverGMRES solver(solver_control, solver_parameters);
 
+  const auto preconditioner_type =
+    simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
+      .preconditioner;
 
-  solver.solve(system_matrix,
-               completely_distributed_solution,
-               system_rhs,
-               ilu_preconditioner);
+  if (preconditioner_type == Parameters::LinearSolver::PreconditionerType::ilu)
+    {
+      setup_ilu();
+      solver.solve(system_matrix,
+                   completely_distributed_solution,
+                   system_rhs,
+                   *ilu_preconditioner);
+    }
+  else if (preconditioner_type ==
+           Parameters::LinearSolver::PreconditionerType::amg)
+    {
+      setup_amg();
+      solver.solve(system_matrix,
+                   completely_distributed_solution,
+                   system_rhs,
+                   *amg_preconditioner);
+    }
+  else
+    AssertThrow(
+      false,
+      ExcMessage(
+        "This linear solver does not support this preconditioner. Only <ilu> and <amg> preconditioners are supported."));
 
   if (simulation_parameters.linear_solver.at(PhysicsID::heat_transfer)
         .verbosity != Parameters::Verbosity::quiet)

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -1477,6 +1477,12 @@ Tracer<dim>::solve_linear_system()
 {
   TimerOutput::Scope t(this->computing_timer, "Solve linear system");
 
+  AssertThrow(
+    simulation_parameters.linear_solver.at(PhysicsID::tracer).preconditioner ==
+      Parameters::LinearSolver::PreconditionerType::ilu,
+    ExcMessage(
+      "The Tracer physics only supports the <ilu> preconditioner. The <amg> preconditioner is not yet implemented for this physics."));
+
   auto mpi_communicator = triangulation->get_mpi_communicator();
 
   const AffineConstraints<double> &constraints_used = this->zero_constraints;


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

Although the linear solver sections contained parameters for the AMG preconditioner for all physics, only fluid dynamics could use the AMG trilinos preconditioner (see #2029). This PR is a first step towards addressing #2029. It adds the AMG preconditioner to the heat transfer physics, but also introduces assertions to guard the other physics that do not support AMG agaisnt using AMG as a preconditioner.

This is a first intermediary PR that is meant to be a bit simpler to introduce AMG everywhere. In a follow-up PR I will introduce AMG for both the tracer and the CLS solver (although I am not sure to which extent it is worth it for them). For the Heat transfer it seems to behave quite well as a preconditioner, which is nice.


### Testing

I modified the heat_transfer_transient_conduction test to use AMG instead of ILU. None of the results have changed, which is what I expected.


### Documentation

Nothing to document here. Once I have finalized the follow up PR for CLS and tracer and have added assertions elsewhere, I will add a table in the documentation that describe which preconditioner is supported for which physics. In the meantime, I'll wait until this is all fully finished. 

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] An entry describing the new feature has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR