### PR TITLE
Remove unused 'variable'

### DIFF
--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1607,9 +1607,6 @@ namespace Parameters
       adaptive
     } type;
 
-    /// Fields on which the mesh adaptation can be based
-    Variable variable;
-
     // Map containing the refinement variables
     std::map<Variable, MultipleAdaptationParameters> variables;
     // declaration for parsing variables

--- a/release_notes/current/2026_06_17_Alphonius.md
+++ b/release_notes/current/2026_06_17_Alphonius.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/06/17
+
+### Removed
+
+- MINOR Removes the unused ``variable`` in ``parameters.h``. As identified in issue [#2031](https://github.com/chaos-polymtl/lethe/issues/2031), it seems deprecated since PR [#585](https://github.com/chaos-polymtl/lethe/pull/585). [#2035](https://github.com/chaos-polymtl/lethe/pull/2035)


### PR DESCRIPTION
### Description

Removes the unused ``variable`` in ``parameters.h``. As identified in issue [#2031](https://github.com/chaos-polymtl/lethe/issues/2031), it seems deprecated since PR [#585](https://github.com/chaos-polymtl/lethe/pull/585).


### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [ ] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] An entry has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature)
- [ ] If the fix is temporary, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR