### PR TITLE
Cmake instruction for the CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,17 +20,6 @@ endif()
 find_package(deal.II 9.7.0 QUIET REQUIRED
   HINTS "${deal.II_DIR}" "${DEAL_II_DIR}" "$ENV{DEAL_II_DIR}")
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  foreach(_flag
-          "-Wno-placement-new"
-          "-Wno-literal-suffix"
-          "-Wno-nonnull-compare")
-    string(REPLACE "${_flag}" "" DEAL_II_CXX_FLAGS "${DEAL_II_CXX_FLAGS}")
-    string(REPLACE "${_flag}" "" DEAL_II_CXX_FLAGS_DEBUG "${DEAL_II_CXX_FLAGS_DEBUG}")
-    string(REPLACE "${_flag}" "" DEAL_II_CXX_FLAGS_RELEASE "${DEAL_II_CXX_FLAGS_RELEASE}")
-  endforeach()
-endif()
-
 deal_ii_initialize_cached_variables()
 
 deal_ii_query_git_information(LETHE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ if(CMAKE_VERSION VERSION_LESS 3.12) # To support the version range
   cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 endif()
 
-
 # TARGET_SUPPORTS_SHARED_LIBS is set by PROJECT, but we have to call
 # FIND_PACKAGE before that, and deal.II's configuration calls
 # ADD_LIBRARY with the SHARED keyword, so setting
@@ -19,7 +18,6 @@ if(DEFINED deal.II_DIR)
 endif()
 find_package(deal.II 9.7.0 QUIET REQUIRED
   HINTS "${deal.II_DIR}" "${DEAL_II_DIR}" "$ENV{DEAL_II_DIR}")
-
 deal_ii_initialize_cached_variables()
 
 deal_ii_query_git_information(LETHE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,13 @@ if(CMAKE_VERSION VERSION_LESS 3.12) # To support the version range
   cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 endif()
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(
+          -Wno-unknown-warning-option
+          -Wno-unused-command-line-argument
+  )
+endif()
+
 # TARGET_SUPPORTS_SHARED_LIBS is set by PROJECT, but we have to call
 # FIND_PACKAGE before that, and deal.II's configuration calls
 # ADD_LIBRARY with the SHARED keyword, so setting
@@ -166,13 +173,6 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
                 "${CMAKE_BINARY_DIR}" "${CMAKE_SOURCE_DIR}")
     endif()
   endif()
-endif()
-
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(
-          -Wno-unknown-warning-option
-          -Wno-unused-command-line-argument
-  )
 endif()
 
 ADD_SUBDIRECTORY(doc/doxygen)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,6 @@ if(CMAKE_VERSION VERSION_LESS 3.12) # To support the version range
   cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 endif()
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(
-          -Wno-unknown-warning-option
-          -Wno-unused-command-line-argument
-  )
-endif()
 
 # TARGET_SUPPORTS_SHARED_LIBS is set by PROJECT, but we have to call
 # FIND_PACKAGE before that, and deal.II's configuration calls
@@ -25,6 +19,18 @@ if(DEFINED deal.II_DIR)
 endif()
 find_package(deal.II 9.7.0 QUIET REQUIRED
   HINTS "${deal.II_DIR}" "${DEAL_II_DIR}" "$ENV{DEAL_II_DIR}")
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  foreach(_flag
+          "-Wno-placement-new"
+          "-Wno-literal-suffix"
+          "-Wno-nonnull-compare")
+    string(REPLACE "${_flag}" "" DEAL_II_CXX_FLAGS "${DEAL_II_CXX_FLAGS}")
+    string(REPLACE "${_flag}" "" DEAL_II_CXX_FLAGS_DEBUG "${DEAL_II_CXX_FLAGS_DEBUG}")
+    string(REPLACE "${_flag}" "" DEAL_II_CXX_FLAGS_RELEASE "${DEAL_II_CXX_FLAGS_RELEASE}")
+  endforeach()
+endif()
+
 deal_ii_initialize_cached_variables()
 
 deal_ii_query_git_information(LETHE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,4 +168,11 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   endif()
 endif()
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(
+          -Wno-unknown-warning-option
+          -Wno-unused-command-line-argument
+  )
+endif()
+
 ADD_SUBDIRECTORY(doc/doxygen)

--- a/contrib/utilities/run_clang_tidy.sh
+++ b/contrib/utilities/run_clang_tidy.sh
@@ -42,7 +42,7 @@ echo "SRC-DIR=$SRC"
 
 # enable MPI (to get MPI warnings)
 # export compile commands (so that run-clang-tidy.py works)
-ARGS=("-D" "CMAKE_EXPORT_COMPILE_COMMANDS=ON" "-D" "CMAKE_BUILD_TYPE=Debug" "$@")
+ARGS=("-D" "CMAKE_EXPORT_COMPILE_COMMANDS=ON" "-D" "CMAKE_BUILD_TYPE=Debug" "-D" "CMAKE_CXX_FLAGS=-Wno-unknown-warning-option" "$@")
 
 # for a list of checks, see /.clang-tidy
 cat "$SRC/.clang-tidy"

--- a/release_notes/current/2026_06_18_Gaboriault.md
+++ b/release_notes/current/2026_06_18_Gaboriault.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/06/17
+
+### Removed
+
+- MINOR - MINOR Adds `-Wno-unknown-warning-option` to the CMake arguments in `run_clang_tidy.sh` to suppress spurious warnings caused by GCC-specific flags in deal.II that Clang does not recognize. [#2036](https://github.com/chaos-polymtl/lethe/pull/2036)


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

The clang tiddy github action was having a lot a warning. I think it is due to dealii being compile with gcc and lethe with clang. (Not sure) 

This PR tries to fix this issue by telling clang to ignore some warning that he doesn't understand. 


Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [X] Lethe documentation is up to date
- [X] The branch is rebased onto master
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [X] If parameters are modified, the tests and the documentation of examples are up to date
- [x] An entry describing the change has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`

Pull request related list:
- [X] No other PR is open related to this refactoring
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature)
- [X] If any future work is planned, an issue is opened
- [X] The PR description is clean and is ready to be used as the commit message when merging the PR