### PR TITLE
Fix box refinement transformation and increase max number of box refinements

### DIFF
--- a/applications_tests/lethe-fluid/multiple-box-refinement-2d.output
+++ b/applications_tests/lethe-fluid/multiple-box-refinement-2d.output
@@ -3,24 +3,24 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 3267
    Volume of triangulation:      1.600000e+01
 Initial refinement in box 0 - Step  1 of 1
-   Number of active cells:       1816
-   Number of degrees of freedom: 5775
+   Number of active cells:       1780
+   Number of degrees of freedom: 5658
    Volume of triangulation:      1.600000e+01
 Initial refinement in box 1 - Step  1 of 2
-   Number of active cells:       2242
-   Number of degrees of freedom: 7131
+   Number of active cells:       1933
+   Number of degrees of freedom: 6159
    Volume of triangulation:      1.600000e+01
 Initial refinement in box 1 - Step  2 of 2
-   Number of active cells:       3976
-   Number of degrees of freedom: 12495
+   Number of active cells:       2587
+   Number of degrees of freedom: 8217
    Volume of triangulation:      1.600000e+01
 Initial refinement in box 2 - Step  1 of 1
-   Number of active cells:       4234
-   Number of degrees of freedom: 13356
+   Number of active cells:       2845
+   Number of degrees of freedom: 9090
    Volume of triangulation:      1.600000e+01
 
 *****************************
 Steady iteration:        1/1
 *****************************
 cells error_velocity error_pressure 
- 4234 5.159242e-02 - 2.072664e-01 - 
+ 2845 5.121499e-02 - 2.139113e-01 - 

--- a/applications_tests/lethe-fluid/multiple-box-refinement-2d.prm
+++ b/applications_tests/lethe-fluid/multiple-box-refinement-2d.prm
@@ -50,7 +50,7 @@ subsection box refinement
       set grid type              = hyper_cube
       set grid arguments         = -0.75 : 0.75 : false
       set initial rotation angle = 0.78540 # pi/4
-      set initial translation    = 1, 0
+      set initial translation    = 1, 0, 0
       set scale                  = 1.25
     end
     set additional refinement = 1

--- a/applications_tests/lethe-fluid/multiple-box-refinement-2d.prm
+++ b/applications_tests/lethe-fluid/multiple-box-refinement-2d.prm
@@ -50,6 +50,7 @@ subsection box refinement
       set grid type              = hyper_cube
       set grid arguments         = -0.75 : 0.75 : false
       set initial rotation angle = 0.78540 # pi/4
+      set initial translation    = 1, 0
       set scale                  = 1.25
     end
     set additional refinement = 1

--- a/applications_tests/lethe-fluid/multiple-box-refinement-3d.output
+++ b/applications_tests/lethe-fluid/multiple-box-refinement-3d.output
@@ -3,24 +3,24 @@ Running on 1 MPI rank(s)...
    Number of degrees of freedom: 2916
    Volume of triangulation:      8.000000e+00
 Initial refinement in box 0 - Step  1 of 1
-   Number of active cells:       1128
-   Number of degrees of freedom: 6284
+   Number of active cells:       1072
+   Number of degrees of freedom: 5984
    Volume of triangulation:      8.000000e+00
 Initial refinement in box 1 - Step  1 of 2
-   Number of active cells:       1184
-   Number of degrees of freedom: 6676
+   Number of active cells:       1128
+   Number of degrees of freedom: 6312
    Volume of triangulation:      8.000000e+00
 Initial refinement in box 1 - Step  2 of 2
-   Number of active cells:       2052
-   Number of degrees of freedom: 11292
+   Number of active cells:       1184
+   Number of degrees of freedom: 6704
    Volume of triangulation:      8.000000e+00
 Initial refinement in box 2 - Step  1 of 1
-   Number of active cells:       2318
-   Number of degrees of freedom: 12820
+   Number of active cells:       1555
+   Number of degrees of freedom: 8816
    Volume of triangulation:      8.000000e+00
 
 *****************************
 Steady iteration:        1/1
 *****************************
 cells error_velocity error_pressure 
- 2318 9.955825e-02 - 3.888292e-01 - 
+ 1555 1.002467e-01 - 3.400124e-01 - 

--- a/applications_tests/lethe-fluid/multiple-box-refinement-3d.prm
+++ b/applications_tests/lethe-fluid/multiple-box-refinement-3d.prm
@@ -49,6 +49,7 @@ subsection box refinement
       set grid arguments         = -0.25,-0.25,-0.5 : 0.25,0.25,0.5 : false
       set initial rotation axis  = 1, 0, 0
       set initial rotation angle = 0.78540 # pi/4
+      set initial translation    = 0, 0.5,0
       set scale                  = 1.25
     end
     set additional refinement = 1

--- a/doc/source/parameters/cfd/box_refinement.rst
+++ b/doc/source/parameters/cfd/box_refinement.rst
@@ -30,7 +30,7 @@ The box refinement section allows for a specific region in the grid to be finer 
 * The ``number of refinement boxes`` corresponds to the number of refinement boxes we want to introduce.
 
   .. attention::
-    At the moment, the software only supports up to :math:`5` different boxes.
+    At the moment, the software only supports up to :math:`20` different boxes.
 
 * The ``subsection box 0`` includes information regarding the 1st refinement box.
 

--- a/doc/source/parameters/cfd/mesh.rst
+++ b/doc/source/parameters/cfd/mesh.rst
@@ -93,7 +93,7 @@ This subsection provides information of the simulation geometry and its mesh. Th
 * The ``initial translation`` parameter provides a way to move the mesh in space prior to simulating the problem. It can be useful when space-dependent functions are used, but that generating a translated mesh is inconvenient or impossible.
 
   .. attention::
-    If the mesh is defined in a 2D space, the third component of ``initial translation`` (:math:`z`-component) is ignored and the mesh translates in :math:`x` and :math:`y` only.
+    Regardless of the dimension of the problem, 3 components (:math:`x`, :math:`y`, and :math:`z`) must be specified for the ``initial translation``. If the mesh is defined in a 2D space, the third component of ``initial translation`` (:math:`z`-component) is ignored and the mesh translates in :math:`x` and :math:`y` only.
 
 * The ``initial rotation axis`` and ``initial rotation angle`` parameters provide another way to move the mesh prior to simulating the problem.
 

--- a/include/core/grids.h
+++ b/include/core/grids.h
@@ -149,7 +149,8 @@ refine_triangulation_at_boundaries(
 }
 
 /**
- * @brief Apply scaling, translation and rotation to the mesh in the listed order.
+ * @brief Apply scaling, rotation and translation to the mesh in the listed
+ * order.
  *
  * @tparam dim An integer that denotes the dimensionality of the geometry.
  * @tparam spacedim An integer that denotes the dimension of the space occupied

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1663,7 +1663,7 @@ namespace Parameters
      * @remark A maximal value has to be initialized to fill the vectors with
      * parameter declarations.
      */
-    const unsigned int max_number_of_refinement_boxes = 5;
+    const unsigned int max_number_of_refinement_boxes = 20;
 
     /**
      * Shared pointer of a vector of GMSH and deal.II meshes representing

--- a/release_notes/current/2026_06_18_Alphonius.md
+++ b/release_notes/current/2026_06_18_Alphonius.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/06/18
+
+### Fixed
+
+- MAJOR For box refinements, the transformations of translation and rotation were applied in the wrong order resulting in a less intuitive transformation. We reoder them here so that the rotation comes first and then the translation. The existing application tests were updated to include a combined transformation of rotation, translation and scaling. The maximum number of box refinement is also increased to 20. [#2038](https://github.com/chaos-polymtl/lethe/pull/2038)

--- a/release_notes/current/2026_06_18_Alphonius.md
+++ b/release_notes/current/2026_06_18_Alphonius.md
@@ -2,4 +2,4 @@
 
 ### Fixed
 
-- MAJOR For box refinements, the transformations of translation and rotation were applied in the wrong order resulting in a less intuitive transformation. We reoder them here so that the rotation comes first and then the translation. The existing application tests were updated to include a combined transformation of rotation, translation and scaling. The maximum number of box refinement is also increased to 20. [#2038](https://github.com/chaos-polymtl/lethe/pull/2038)
+- MAJOR For box refinements, the transformations of translation and rotation were applied in the wrong order resulting in a less intuitive transformation. We reorder them here so that the rotation comes first and then the translation. The existing application tests were updated to include a combined transformation of rotation, translation and scaling. The maximum number of box refinement is also increased to 20. [#2038](https://github.com/chaos-polymtl/lethe/pull/2038)

--- a/release_notes/current/2026_06_18_Alphonius.md
+++ b/release_notes/current/2026_06_18_Alphonius.md
@@ -2,4 +2,4 @@
 
 ### Fixed
 
-- MAJOR For box refinements, the transformations of translation and rotation were applied in the wrong order resulting in a less intuitive transformation. We reorder them here so that the rotation comes first and then the translation. The existing application tests were updated to include a combined transformation of rotation, translation and scaling. The maximum number of box refinement is also increased to 20. [#2038](https://github.com/chaos-polymtl/lethe/pull/2038)
+- MAJOR For box refinements, the transformations of translation and rotation were applied in the wrong order, resulting in a less intuitive transformation. We reorder them here so that the rotation comes first and then the translation. The existing application tests were updated to include a combined transformation of rotation, translation and scaling. The maximum number of box refinements is also increased to 20. [#2038](https://github.com/chaos-polymtl/lethe/pull/2038)

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -129,7 +129,7 @@ attach_grid_to_triangulation(Triangulation<dim, spacedim> &triangulation,
             mesh_parameters.grid_type,
             mesh_parameters.grid_arguments);
 
-          // Scale, translate, and rotate mesh
+          // Scale, rotate, and translate mesh
           apply_mesh_transformation(mesh_parameters, triangulation);
         }
 

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -586,34 +586,34 @@ apply_mesh_transformation(const Parameters::Mesh       &mesh_parameters,
   GridTools::scale(mesh_parameters.scale, triangulation);
   if constexpr (dim == 2 && spacedim == 2)
     {
+      // Box mesh rotation around the origin of the system coordinates
+      GridTools::rotate(mesh_parameters.rotation_angle, triangulation);
+
       // Box mesh translation
       Tensor<1, 2> translation_vector;
       translation_vector[0] = mesh_parameters.translation[0];
       translation_vector[1] = mesh_parameters.translation[1];
       GridTools::shift(translation_vector, triangulation);
-
-      // Box mesh rotation around the origin of the system coordinates
-      GridTools::rotate(mesh_parameters.rotation_angle, triangulation);
     }
   else if constexpr (dim == 2 && spacedim == 3)
     {
-      // Box mesh translation
-      GridTools::shift(mesh_parameters.translation, triangulation);
-
       // Box mesh rotation
       GridTools::rotate(mesh_parameters.rotation_axis,
                         mesh_parameters.rotation_angle,
                         triangulation);
+
+      // Box mesh translation
+      GridTools::shift(mesh_parameters.translation, triangulation);
     }
   else if constexpr (dim == 3)
     {
-      // Box mesh translation
-      GridTools::shift(mesh_parameters.translation, triangulation);
-
       // Box mesh rotation
       GridTools::rotate(mesh_parameters.rotation_axis,
                         mesh_parameters.rotation_angle,
                         triangulation);
+
+      // Box mesh translation
+      GridTools::shift(mesh_parameters.translation, triangulation);
     }
 }
 

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -875,7 +875,7 @@ NavierStokesBase<dim, VectorType, DofsType>::box_refine_mesh(const bool restart)
                     ->refinement_boxes_meshes)[i_box]
                   .grid_arguments);
 
-              // Apply mesh transformation (Scaling, translation, then rotation)
+              // Apply mesh transformation (Scaling, rotation, then translation)
               apply_mesh_transformation(
                 (*this->simulation_parameters.mesh_box_refinement
                     ->refinement_boxes_meshes)[i_box],
@@ -922,7 +922,7 @@ NavierStokesBase<dim, VectorType, DofsType>::box_refine_mesh(const bool restart)
                     ->refinement_boxes_meshes)[i_box]
                   .grid_arguments);
 
-              // Apply mesh transformation (Scaling, translation, then rotation)
+              // Apply mesh transformation (Scaling, rotation, then translation)
               apply_mesh_transformation(
                 (*this->simulation_parameters.mesh_box_refinement
                     ->refinement_boxes_meshes)[i_box],


### PR DESCRIPTION
### Description

For box refinements, the transformations of translation and rotation were applied in the wrong order resulting in a less intuitive transformation. This PR reorders so that the rotation is first and then translation. 
Here, we also increase the maximum number of box refinement to 20.

### Testing

The existing application tests were updated to include a combined transformation of rotation, translation and scaling.

### Documentation

User documentation was updated.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] An entry describing the origin of the bug as well as its fix has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR