### PR TITLE
Dem fix distribution container

### DIFF
--- a/include/dem/distributions.h
+++ b/include/dem/distributions.h
@@ -396,8 +396,8 @@ using namespace Parameters::Lagrangian;
 inline void
 setup_distributions(const LagrangianPhysicalProperties &lpp,
                     std::vector<std::shared_ptr<Distribution>>
-                                &size_distribution_object_container,
-                    double      &maximum_particle_diameter,
+                                      &size_distribution_object_container,
+                    double            &maximum_particle_diameter,
                     const unsigned int mpi_process_id,
                     const ConditionalOStream &pcout)
 {

--- a/include/dem/distributions.h
+++ b/include/dem/distributions.h
@@ -38,11 +38,9 @@ public:
    *
    * @param[in] number_of_particles Number of particles inserted at a given
    * insertion time step.
-   * @param[out] particle_sizes Generated particle diameter values.
    */
-  virtual void
-  particle_size_sampling(const unsigned int  &number_of_particles,
-                         std::vector<double> &particle_sizes) = 0;
+  virtual std::vector<double>
+  particle_size_sampling(const unsigned int &number_of_particles) = 0;
 
   /**
    * @brief Return the minimum diameter for a certain distribution.
@@ -102,11 +100,9 @@ public:
    *
    * @param[in] number_of_particles Number of particles inserted at a given
    * insertion time step.
-   * @param[out] particle_sizes Generated particle diameter values.
    */
-  void
-  particle_size_sampling(const unsigned int  &number_of_particles,
-                         std::vector<double> &particle_sizes) override;
+  virtual std::vector<double>
+  particle_size_sampling(const unsigned int &number_of_particles) override;
 
   /**
    * @brief Find the minimum diameter a normal distribution.
@@ -183,11 +179,9 @@ public:
    *
    * @param[in] number_of_particles Number of particles inserted at a given
    * insertion time step.
-   * @param[out] particle_sizes Generated particle diameter values.
    */
-  void
-  particle_size_sampling(const unsigned int  &number_of_particles,
-                         std::vector<double> &particle_sizes) override;
+  virtual std::vector<double>
+  particle_size_sampling(const unsigned int &number_of_particles) override;
 
   /**
    * @brief Find the minimum diameter a normal distribution.
@@ -251,11 +245,9 @@ public:
    *
    * @param[in] number_of_particles Number of particles inserted at a given
    * insertion time step.
-   * @param[out] particle_sizes Generated particle diameter values.
    */
-  void
-  particle_size_sampling(const unsigned int  &number_of_particles,
-                         std::vector<double> &particle_sizes) override;
+  virtual std::vector<double>
+  particle_size_sampling(const unsigned int &number_of_particles) override;
 
   /**
    * @brief Find the minimum diameter of the uniform distribution.
@@ -329,11 +321,9 @@ public:
    *
    * @param[in] number_of_particles Number of particles inserted at a given
    * insertion time step.
-   * @param[out] particle_sizes Generated particle diameter values.
    */
-  void
-  particle_size_sampling(const unsigned int  &number_of_particles,
-                         std::vector<double> &particle_sizes) override;
+  virtual std::vector<double>
+  particle_size_sampling(const unsigned int &number_of_particles) override;
 
   /**
    * @brief Find the minimum diameter of the custom distribution.

--- a/include/dem/distributions.h
+++ b/include/dem/distributions.h
@@ -27,7 +27,7 @@ protected:
   double dia_max_cutoff;
 
 public:
-  std::vector<double> particle_sizes;
+  // std::vector<double> particle_sizes;
 
   /**
    * @brief Default destructor.
@@ -40,7 +40,8 @@ public:
    * @param number_of_particles Number of particle inserted at a given insertion time step.
    */
   virtual void
-  particle_size_sampling(const unsigned int &number_of_particles) = 0;
+  particle_size_sampling(const unsigned int  &number_of_particles,
+                         std::vector<double> &particle_sizes) = 0;
 
   /**
    * @brief Return the minimum diameter for a certain distribution.
@@ -102,7 +103,8 @@ public:
    * insertion time step.
    */
   void
-  particle_size_sampling(const unsigned int &number_of_particles) override;
+  particle_size_sampling(const unsigned int  &number_of_particles,
+                         std::vector<double> &particle_sizes) override;
 
   /**
    * @brief Find the minimum diameter a normal distribution.
@@ -181,7 +183,8 @@ public:
    * insertion time step.
    */
   void
-  particle_size_sampling(const unsigned int &number_of_particles) override;
+  particle_size_sampling(const unsigned int  &number_of_particles,
+                         std::vector<double> &particle_sizes) override;
 
   /**
    * @brief Find the minimum diameter a normal distribution.
@@ -246,7 +249,8 @@ public:
    * @param number_of_particles Number of particle inserted at a given insertion time step.
    */
   void
-  particle_size_sampling(const unsigned int &number_of_particles) override;
+  particle_size_sampling(const unsigned int  &number_of_particles,
+                         std::vector<double> &particle_sizes) override;
 
   /**
    * @brief Find the minimum diameter of the uniform distribution.
@@ -322,7 +326,8 @@ public:
    * insertion time step.
    */
   void
-  particle_size_sampling(const unsigned int &number_of_particles) override;
+  particle_size_sampling(const unsigned int  &number_of_particles,
+                         std::vector<double> &particle_sizes) override;
 
   /**
    * @brief Find the minimum diameter of the custom distribution.

--- a/include/dem/distributions.h
+++ b/include/dem/distributions.h
@@ -27,8 +27,6 @@ protected:
   double dia_max_cutoff;
 
 public:
-  // std::vector<double> particle_sizes;
-
   /**
    * @brief Default destructor.
    */
@@ -37,7 +35,10 @@ public:
   /**
    * @brief Carries out the size sampling of particles. This is the base class of
    * NormalDistribution, UniformDistribution and CustomDistribution classes.
-   * @param number_of_particles Number of particle inserted at a given insertion time step.
+   *
+   * @param[in] number_of_particles Number of particles inserted at a given
+   * insertion time step.
+   * @param[out] particle_sizes Generated particle diameter values.
    */
   virtual void
   particle_size_sampling(const unsigned int  &number_of_particles,
@@ -96,11 +97,12 @@ public:
                        &distribution_weighting_type);
 
   /**
-   * @brief Carries out the size sampling of each particle inserted at an insertion
-   * time step for the normal distribution.
+   * @brief Carries out the size sampling of each particle inserted at an
+   * insertion time step for the normal distribution.
    *
-   * @param[in] number_of_particles Number of particle inserted at a given
+   * @param[in] number_of_particles Number of particles inserted at a given
    * insertion time step.
+   * @param[out] particle_sizes Generated particle diameter values.
    */
   void
   particle_size_sampling(const unsigned int  &number_of_particles,
@@ -176,11 +178,12 @@ public:
                           &distribution_weighting_type);
 
   /**
-   * @brief Carries out the size sampling of each particle inserted at an insertion
-   * time step for the normal distribution.
+   * @brief Carries out the size sampling of each particle inserted at an
+   * insertion time step for the normal distribution.
    *
-   * @param[in] number_of_particles Number of particle inserted at a given
+   * @param[in] number_of_particles Number of particles inserted at a given
    * insertion time step.
+   * @param[out] particle_sizes Generated particle diameter values.
    */
   void
   particle_size_sampling(const unsigned int  &number_of_particles,
@@ -216,7 +219,7 @@ public:
 
 private:
   /**
-   * @brief Standard deviation of distribution of the normal distribution.
+   * @brief Standard deviation of the normal distribution.
    */
   const double sigma_ln;
 
@@ -235,7 +238,7 @@ class UniformDistribution : public Distribution
 {
 public:
   /**
-   * @brief The constructor store the parameters necessary to define the uniform
+   * @brief The constructor stores the parameters necessary to define the uniform
    * distribution.
    *
    * @param d_values Diameter values for each particle type.
@@ -243,10 +246,12 @@ public:
   UniformDistribution(const double &d_values);
 
   /**
-   * @brief Carries out the size sampling of every particle inserted at an insertion
-   * time step for the uniform distribution.
+   * @brief Carries out the size sampling of every particle inserted at an
+   * insertion time step for the uniform distribution.
    *
-   * @param number_of_particles Number of particle inserted at a given insertion time step.
+   * @param[in] number_of_particles Number of particles inserted at a given
+   * insertion time step.
+   * @param[out] particle_sizes Generated particle diameter values.
    */
   void
   particle_size_sampling(const unsigned int  &number_of_particles,
@@ -296,7 +301,7 @@ public:
    * distribution.
    *
    * @param[in] d_list Vector of diameter values.
-   * @param[in] d_probabilities Vector of probability values based on volume
+   * @param[in] d_probabilities Vector of probability values based on the volume
    * fraction with respect to each diameter value.
    * @param[in] prn_seed Pseudo-random number seed for the diameter generation.
    * @param[in] min_cutoff Minimum cutoff diameter.
@@ -319,11 +324,12 @@ public:
     const bool                                             interpolate);
 
   /**
-   * @brief Carries out the size sampling of each particle inserted at an insertion
-   * time step for the histogram distribution.
+   * @brief Carries out the size sampling of each particle inserted at an
+   * insertion time step for the histogram distribution.
    *
    * @param[in] number_of_particles Number of particles inserted at a given
    * insertion time step.
+   * @param[out] particle_sizes Generated particle diameter values.
    */
   void
   particle_size_sampling(const unsigned int  &number_of_particles,
@@ -359,13 +365,13 @@ public:
 
 private:
   /**
-   * Vector containing all the diameters values.
+   * Vector containing all the diameter values.
    */
   const std::vector<double> diameter_values;
 
   /**
    * @brief Vector containing cumulative probabilities associated with the
-   * diameter_values vector. The stored values are based on the number based
+   * diameter_values vector. The stored values are based on the number-based
    * CDF.
    */
   std::vector<double> number_based_cdf;
@@ -392,7 +398,7 @@ setup_distributions(const LagrangianPhysicalProperties &lpp,
                     std::vector<std::shared_ptr<Distribution>>
                                 &size_distribution_object_container,
                     double      &maximum_particle_diameter,
-                    unsigned int mpi_process_id,
+                    const unsigned int mpi_process_id,
                     const ConditionalOStream &pcout)
 {
   for (unsigned int particle_type = 0; particle_type < lpp.particle_type_number;

--- a/include/dem/insertion.h
+++ b/include/dem/insertion.h
@@ -209,7 +209,6 @@ protected:
   // For when the triangulation has changed (i.e. when load balancing)
   bool                        mark_for_update;
   boost::signals2::connection change_to_triangulation;
-
 };
 
 #endif /*lethe_insertion_h*/

--- a/include/dem/insertion.h
+++ b/include/dem/insertion.h
@@ -191,9 +191,6 @@ protected:
   // Maximum particle diameter
   double maximum_diameter;
 
-  // The number of inserted particles at this step on this processor
-  // unsigned int inserted_this_step_this_proc;
-
   // A distribution object that carries out the attribution of diameter to every
   // particle during an insertion time step
   std::vector<std::shared_ptr<Distribution>> distributions_objects;

--- a/include/dem/insertion.h
+++ b/include/dem/insertion.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_insertion_h
@@ -122,7 +122,7 @@ protected:
    * @brief Carries out assigning the properties of inserted particles.
    *
    * @param dem_parameters DEM parameters declared in the prm file.
-   * @param inserted_this_step_this_proc Number of particles that are inserted.
+   * @param inserted_this_step_this_proc Number of particles that are inserted
    * at each insertion step on each processor. This value can change in the last
    * insertion step to reach the desired number of particles.
    * @param current_inserting_particle_type Type of inserting particles.
@@ -154,9 +154,9 @@ protected:
     const ConditionalOStream       &pcout);
 
   /**
-   * @brief Find every cell that are completely and partially inside de the
+   * @brief Find all cells that are completely and partially inside de the
    * clearing box. For the cell completely inside the box, all the particles
-   * will be deleted. For those partially inside, a fine verification is
+   * will be deleted. For those partially inside, fine verification is
    * required.
    *
    * @param triangulation Triangulation to access the cells in which the
@@ -191,8 +191,8 @@ protected:
   // Maximum particle diameter
   double maximum_diameter;
 
-  // Inserted number of particles at this step on this processor
-  unsigned int inserted_this_step_this_proc;
+  // The number of inserted particles at this step on this processor
+  // unsigned int inserted_this_step_this_proc;
 
   // A distribution object that carries out the attribution of diameter to every
   // particle during an insertion time step
@@ -218,4 +218,4 @@ private:
   std::vector<double> particle_sizes;
 };
 
-#endif /* insertion_h */
+#endif /*lethe_insertion_h*/

--- a/include/dem/insertion.h
+++ b/include/dem/insertion.h
@@ -210,9 +210,6 @@ protected:
   bool                        mark_for_update;
   boost::signals2::connection change_to_triangulation;
 
-private:
-  // Stores particles diameters
-  std::vector<double> particle_sizes;
 };
 
 #endif /*lethe_insertion_h*/

--- a/include/dem/insertion_list.h
+++ b/include/dem/insertion_list.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2021-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_insertion_list_h

--- a/include/dem/insertion_list.h
+++ b/include/dem/insertion_list.h
@@ -11,11 +11,11 @@ class InsertionList : public Insertion<dim, PropertiesIndex>
 {
 public:
   /**
-   * @brief Insert particles using a list specific positions. This allows the
-   * insertion of any number of particles at a well-controlled location which is
-   * especially useful from a testing perspective. The code ensures that the
+   * @brief Insert particles using a list of specific positions. This allows the
+   * insertion of a low number of particles at a well-controlled location, which
+   * is especially useful from a testing perspective. The code ensures that the
    * number of positions provided in the x,y (and possibly z) direction is
-   * coherent. If more particles than the number of positions in the list is
+   * coherent. If more particles than the number of positions in the list are
    * requested, the class will continue inserting particles at the insertion
    * frequency using the list of positions. There is no mechanism in place that
    * prevents the overlap of these new particles with previous ones.
@@ -32,14 +32,15 @@ public:
                 const DEMSolverParameters<dim> &dem_parameters);
 
   /**
-   * @brief The InsertionList class inserts particles using a list specific position.
-   * This allows the insertion of any number of particles at a well-controled
-   * location which is especially useful from a testing perspective. The code
-   * ensures that the number of positions provided in the x,y (and possibly z)
-   * direction is coherent. If more particles than the number of position in the
-   * list are requested, the class will continue inserting particles at the
-   * insertion frequency using the list of position. There is no mechanism in
-   * place that prevents the overlap of these new particles with previous ones.
+   * @brief The InsertionList class inserts particles using a list of specific
+   * position. This allows the insertion of any number of particles at a
+   * well-controlled location, which is especially useful from a testing
+   * perspective. The code ensures that the number of positions provided in the
+   * x,y (and possibly z) direction is coherent. If more particles than the
+   * number of positions in the list are requested, the class will continue
+   * inserting particles at the insertion frequency using the list of positions.
+   * There is no mechanism in place that prevents the overlap of these new
+   * particles with previous ones.
    *
    * @param particle_handler The particle handler of particles which are being
    * inserted
@@ -55,25 +56,23 @@ public:
 
 
   /**
-   * @brief Carries out assigning the properties of inserted particles specificly
-   * for the list insertion method. In this method, the initial translationnal
-   * and angular velocities, the temperature and the diameter of each particles
-   * is set.
+   * @brief Carries out assigning the properties of inserted particles
+   * specifically for the list insertion method. In this method, the initial
+   * translation and angular velocities, the temperature and the diameter of
+   * each particle are set.
    *
    * @param dem_parameters DEM parameters declared in the .prm file
    * @param inserted_this_step_this_proc Number of particles that are inserted
    * at each insertion step on each processor. This value can change in the last
    * insertion step to reach the desired number of particles
-   * @param current_inserting_particle_type Type of inserting particles
-   * @param particle_properties Properties of all inserted particles at each insertion step
+   * @param particle_properties Properties of all inserted particles at each
+   * insertion step
    */
   void
   assign_particle_properties_for_list_insertion(
     const DEMSolverParameters<dim>   &dem_parameters,
     const unsigned int               &inserted_this_step_this_proc,
-    const unsigned int               &current_inserting_particle_type,
     std::vector<std::vector<double>> &particle_properties);
-
 
 
   /**

--- a/release_notes/current/2026_06_18_Gaboriault.md
+++ b/release_notes/current/2026_06_18_Gaboriault.md
@@ -2,4 +2,4 @@
 
 ### Removed
 
-- MINOR - MINOR Adds `-Wno-unknown-warning-option` to the CMake arguments in `run_clang_tidy.sh` to suppress spurious warnings caused by GCC-specific flags in deal.II that Clang does not recognize. [#2036](https://github.com/chaos-polymtl/lethe/pull/2036)
+- MINOR Adds `-Wno-unknown-warning-option` to the CMake arguments in `run_clang_tidy.sh` to suppress spurious warnings caused by GCC-specific flags in deal.II that Clang does not recognize. [#2036](https://github.com/chaos-polymtl/lethe/pull/2036)

--- a/release_notes/current/2026_06_19_Gaboriault.md
+++ b/release_notes/current/2026_06_19_Gaboriault.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/06/17
+
+### Fixed
+
+- MINOR The ``particle_sizes`` vector was kept as an attribute of the distribution class and wasn't resized after a particle insertion. This would result in a big ram usage. Now, this vector was removed, since the class does not need to keep track of the diameter values generated and the ``assign_properties`` function now passes a vector by reference. [#2041](https://github.com/chaos-polymtl/lethe/pull/2041)

--- a/source/dem/distributions.cc
+++ b/source/dem/distributions.cc
@@ -167,10 +167,11 @@ NormalDistribution::NormalDistribution(
 
 void
 NormalDistribution::particle_size_sampling(
-  const unsigned int &number_of_particles)
+  const unsigned int  &number_of_particles,
+  std::vector<double> &particle_sizes)
 {
-  this->particle_sizes.clear();
-  this->particle_sizes.reserve(number_of_particles);
+  particle_sizes.clear();
+  particle_sizes.reserve(number_of_particles);
 
   std::normal_distribution<> distribution{diameter_average, standard_deviation};
 
@@ -182,7 +183,7 @@ NormalDistribution::particle_size_sampling(
           temp_diameter < this->dia_max_cutoff)
         {
           n_created_diameter++;
-          this->particle_sizes.push_back(temp_diameter);
+          particle_sizes.push_back(temp_diameter);
         }
     }
 }
@@ -285,10 +286,11 @@ LogNormalDistribution::LogNormalDistribution(
 
 void
 LogNormalDistribution::particle_size_sampling(
-  const unsigned int &number_of_particles)
+  const unsigned int  &number_of_particles,
+  std::vector<double> &particle_sizes)
 {
-  this->particle_sizes.clear();
-  this->particle_sizes.reserve(number_of_particles);
+  particle_sizes.clear();
+  particle_sizes.reserve(number_of_particles);
 
   std::lognormal_distribution<> distribution{mu_ln, sigma_ln};
 
@@ -300,7 +302,7 @@ LogNormalDistribution::particle_size_sampling(
           temp_diameter < this->dia_max_cutoff)
         {
           n_created_diameter++;
-          this->particle_sizes.push_back(temp_diameter);
+          particle_sizes.push_back(temp_diameter);
         }
     }
 }
@@ -351,13 +353,14 @@ UniformDistribution::UniformDistribution(const double &d_values)
 
 void
 UniformDistribution::particle_size_sampling(
-  const unsigned int &number_of_particles)
+  const unsigned int  &number_of_particles,
+  std::vector<double> &particle_sizes)
 {
-  this->particle_sizes.clear();
-  this->particle_sizes.reserve(number_of_particles);
+  particle_sizes.clear();
+  particle_sizes.reserve(number_of_particles);
 
   for (unsigned int n = 0; n < number_of_particles; ++n)
-    this->particle_sizes.push_back(this->diameter_value);
+    particle_sizes.push_back(this->diameter_value);
 }
 
 double
@@ -625,10 +628,11 @@ CustomDistribution::CustomDistribution(
 
 void
 CustomDistribution::particle_size_sampling(
-  const unsigned int &number_of_particles)
+  const unsigned int  &number_of_particles,
+  std::vector<double> &particle_sizes)
 {
-  this->particle_sizes.clear();
-  this->particle_sizes.reserve(number_of_particles);
+  particle_sizes.clear();
+  particle_sizes.reserve(number_of_particles);
   unsigned int n_created_diameter = 0;
 
   // We sample a random number U between [0, CDF_max]
@@ -672,7 +676,7 @@ CustomDistribution::particle_size_sampling(
               sampled_diameter < this->dia_max_cutoff)
             {
               n_created_diameter++;
-              this->particle_sizes.push_back(sampled_diameter);
+              particle_sizes.push_back(sampled_diameter);
             }
         }
     }
@@ -699,7 +703,7 @@ CustomDistribution::particle_size_sampling(
               sampled_diameter < this->dia_max_cutoff)
             {
               n_created_diameter++;
-              this->particle_sizes.push_back(sampled_diameter);
+              particle_sizes.push_back(sampled_diameter);
             }
         }
     }

--- a/source/dem/distributions.cc
+++ b/source/dem/distributions.cc
@@ -165,12 +165,11 @@ NormalDistribution::NormalDistribution(
                          " be smaller than the \"maximum diameter cutoff\"."));
 }
 
-void
+std::vector<double>
 NormalDistribution::particle_size_sampling(
-  const unsigned int  &number_of_particles,
-  std::vector<double> &particle_sizes)
+  const unsigned int &number_of_particles)
 {
-  particle_sizes.clear();
+  std::vector<double> particle_sizes;
   particle_sizes.reserve(number_of_particles);
 
   std::normal_distribution<> distribution{diameter_average, standard_deviation};
@@ -186,6 +185,7 @@ NormalDistribution::particle_size_sampling(
           particle_sizes.push_back(temp_diameter);
         }
     }
+  return particle_sizes;
 }
 
 double
@@ -284,12 +284,11 @@ LogNormalDistribution::LogNormalDistribution(
 }
 
 
-void
+std::vector<double>
 LogNormalDistribution::particle_size_sampling(
-  const unsigned int  &number_of_particles,
-  std::vector<double> &particle_sizes)
+  const unsigned int &number_of_particles)
 {
-  particle_sizes.clear();
+  std::vector<double> particle_sizes;
   particle_sizes.reserve(number_of_particles);
 
   std::lognormal_distribution<> distribution{mu_ln, sigma_ln};
@@ -305,6 +304,7 @@ LogNormalDistribution::particle_size_sampling(
           particle_sizes.push_back(temp_diameter);
         }
     }
+  return particle_sizes;
 }
 
 double
@@ -351,16 +351,17 @@ UniformDistribution::UniformDistribution(const double &d_values)
   , diameter_value(d_values)
 {}
 
-void
+std::vector<double>
 UniformDistribution::particle_size_sampling(
-  const unsigned int  &number_of_particles,
-  std::vector<double> &particle_sizes)
+  const unsigned int &number_of_particles)
 {
-  particle_sizes.clear();
+  std::vector<double> particle_sizes;
   particle_sizes.reserve(number_of_particles);
 
   for (unsigned int n = 0; n < number_of_particles; ++n)
     particle_sizes.push_back(this->diameter_value);
+
+  return particle_sizes;
 }
 
 double
@@ -625,12 +626,11 @@ CustomDistribution::CustomDistribution(
     }
 }
 
-void
+std::vector<double>
 CustomDistribution::particle_size_sampling(
-  const unsigned int  &number_of_particles,
-  std::vector<double> &particle_sizes)
+  const unsigned int &number_of_particles)
 {
-  particle_sizes.clear();
+  std::vector<double> particle_sizes;
   particle_sizes.reserve(number_of_particles);
   unsigned int n_created_diameter = 0;
 
@@ -706,6 +706,7 @@ CustomDistribution::particle_size_sampling(
             }
         }
     }
+  return particle_sizes;
 }
 
 double

--- a/source/dem/distributions.cc
+++ b/source/dem/distributions.cc
@@ -401,9 +401,8 @@ CustomDistribution::CustomDistribution(
 {
   // Assuming that the diameter values are in ascending order. There is a check
   // for that right after
-  // Min cutoff : The default value is -1. If the does not change the default
-  // value, the minimum cutoff is set to the smallest diameter value - a small
-  // epsilon.
+  // Min cutoff: The default value is -1. If the value did not changed the
+  // minimum cutoff is set to the smallest diameter value - a small epsilon.
   if (min_cutoff < 0.)
     this->dia_min_cutoff = diameter_values[0] - 1e-8;
   else

--- a/source/dem/insertion.cc
+++ b/source/dem/insertion.cc
@@ -75,8 +75,9 @@ Insertion<dim, PropertiesIndex>::assign_particle_properties(
   auto physical_properties = dem_parameters.lagrangian_physical_properties;
 
   // Creating the particle diameter that will get inserted.
-  const std::vector<double> particle_sizes = distributions_objects[current_inserting_particle_type]
-    ->particle_size_sampling(inserted_this_step_this_proc);
+  const std::vector<double> particle_sizes =
+    distributions_objects[current_inserting_particle_type]
+      ->particle_size_sampling(inserted_this_step_this_proc);
 
   // A loop is defined over the number of particles which are going to be
   // inserted at this step

--- a/source/dem/insertion.cc
+++ b/source/dem/insertion.cc
@@ -74,11 +74,9 @@ Insertion<dim, PropertiesIndex>::assign_particle_properties(
   // TODO: MAYBE CHANGE THE INPUT TO PHYSICAL PROPERTIES DIRECTLY
   auto physical_properties = dem_parameters.lagrangian_physical_properties;
 
-  // Where the particle diameters will be stored.
-  std::vector<double> particle_sizes;
-
-  distributions_objects[current_inserting_particle_type]
-    ->particle_size_sampling(inserted_this_step_this_proc, particle_sizes);
+  // Creating the particle diameter that will get inserted.
+  const std::vector<double> particle_sizes = distributions_objects[current_inserting_particle_type]
+    ->particle_size_sampling(inserted_this_step_this_proc);
 
   // A loop is defined over the number of particles which are going to be
   // inserted at this step

--- a/source/dem/insertion.cc
+++ b/source/dem/insertion.cc
@@ -78,8 +78,11 @@ Insertion<dim, PropertiesIndex>::assign_particle_properties(
   // TODO: MAYBE CHANGE THE INPUT TO PHYSICAL PROPERTIES DIRECTLY
   auto physical_properties = dem_parameters.lagrangian_physical_properties;
 
+  // Where the particle diameters will be stored.
+  std::vector<double> particle_sizes;
+
   distributions_objects[current_inserting_particle_type]
-    ->particle_size_sampling(inserted_this_step_this_proc);
+    ->particle_size_sampling(inserted_this_step_this_proc, particle_sizes);
 
   // A loop is defined over the number of particles which are going to be
   // inserted at this step
@@ -89,18 +92,15 @@ Insertion<dim, PropertiesIndex>::assign_particle_properties(
     {
       double type = current_inserting_particle_type;
       // We make sure that the diameter is positive
-      double diameter =
-        std::abs(distributions_objects[current_inserting_particle_type]
-                   ->particle_sizes[particle_counter]);
-      double density =
-        physical_properties.density_particle[current_inserting_particle_type];
-      double vel_x   = dem_parameters.insertion_info.initial_vel[0];
-      double vel_y   = dem_parameters.insertion_info.initial_vel[1];
-      double vel_z   = dem_parameters.insertion_info.initial_vel[2];
-      double omega_x = dem_parameters.insertion_info.initial_omega[0];
-      double omega_y = dem_parameters.insertion_info.initial_omega[1];
-      double omega_z = dem_parameters.insertion_info.initial_omega[2];
-      double mass    = density * 4. / 3. * M_PI *
+      double diameter = std::abs(particle_sizes[particle_counter]);
+      double density  = physical_properties.density_particle[type];
+      double vel_x    = dem_parameters.insertion_info.initial_vel[0];
+      double vel_y    = dem_parameters.insertion_info.initial_vel[1];
+      double vel_z    = dem_parameters.insertion_info.initial_vel[2];
+      double omega_x  = dem_parameters.insertion_info.initial_omega[0];
+      double omega_y  = dem_parameters.insertion_info.initial_omega[1];
+      double omega_z  = dem_parameters.insertion_info.initial_omega[2];
+      double mass     = density * 4. / 3. * M_PI *
                     Utilities::fixed_power<3, double>(diameter * 0.5);
 
       std::vector<double> properties_of_one_particle{

--- a/source/dem/insertion.cc
+++ b/source/dem/insertion.cc
@@ -2,10 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <dem/insertion.h>
-#include <dem/insertion_file.h>
-#include <dem/insertion_list.h>
-#include <dem/insertion_plane.h>
-#include <dem/insertion_volume.h>
 
 #include <cmath>
 #include <sstream>

--- a/source/dem/insertion.cc
+++ b/source/dem/insertion.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <dem/insertion.h>

--- a/source/dem/insertion_list.cc
+++ b/source/dem/insertion_list.cc
@@ -149,9 +149,7 @@ InsertionList<dim, PropertiesIndex>::insert(
 
       // Assign inserted particles properties
       this->assign_particle_properties_for_list_insertion(
-        dem_parameters,
-        n_particles_to_insert_this_proc,
-        particle_properties);
+        dem_parameters, n_particles_to_insert_this_proc, particle_properties);
 
       // Insert the particles using the points and assigned properties
       particle_handler.insert_global_particles(

--- a/source/dem/insertion_list.cc
+++ b/source/dem/insertion_list.cc
@@ -11,9 +11,8 @@ DeclException2(DiameterSizeCoherence,
                << "Incoherent particle diameter lists: list x has " << arg1
                << " element(s) and list d has " << arg2 << " element(s).");
 
-/* @brief The constructor of list insertion class does not accomplish anything other
- * than check if the position list are of the coherent size and to
- * create the insertion_points member
+/* @brief The constructor checks if the position lists are of a coherent size
+ * relative to each-other and creates the insertion_points member
  */
 template <int dim, typename PropertiesIndex>
 InsertionList<dim, PropertiesIndex>::InsertionList(
@@ -27,7 +26,7 @@ InsertionList<dim, PropertiesIndex>::InsertionList(
   , remaining_particles_of_each_type(
       dem_parameters.lagrangian_physical_properties.number.at(0))
 {
-  // Initializing current inserting particle type
+  // Initializing the current inserting particle type
   current_inserting_particle_type = 0;
 
   const std::vector<double> &list_x  = dem_parameters.insertion_info.list_x;
@@ -47,7 +46,7 @@ InsertionList<dim, PropertiesIndex>::InsertionList(
   // particles
   if (list_d[0] < 0)
     {
-      double particle_average_diameter =
+      const double particle_average_diameter =
         dem_parameters.lagrangian_physical_properties.particle_average_diameter
           .at(current_inserting_particle_type);
       list_d.assign(list_x.size(), particle_average_diameter);
@@ -126,7 +125,7 @@ InsertionList<dim, PropertiesIndex>::insert(
       insertion_points_on_proc_this_step.reserve(
         n_particles_to_insert_this_proc);
 
-      // Because the list insertion is made to insert only a few particles
+      // Because the list insertion is made to insert only a few particles,
       // only processor 0 manages the insertion of these particles
       if (this_mpi_process == 0)
         {
@@ -137,7 +136,7 @@ InsertionList<dim, PropertiesIndex>::insert(
             }
         }
 
-      // Obtain global bounding boxes
+      // Get global bounding boxes
       const auto my_bounding_box =
         GridTools::compute_mesh_predicate_bounding_box(
           triangulation, IteratorFilters::LocallyOwnedCell());
@@ -152,7 +151,6 @@ InsertionList<dim, PropertiesIndex>::insert(
       this->assign_particle_properties_for_list_insertion(
         dem_parameters,
         n_particles_to_insert_this_proc,
-        current_inserting_particle_type,
         particle_properties);
 
       // Insert the particles using the points and assigned properties
@@ -161,7 +159,7 @@ InsertionList<dim, PropertiesIndex>::insert(
         global_bounding_boxes,
         particle_properties);
 
-      // Update number of particles remaining to be inserted
+      // Updated number of particles remaining to be inserted
       remaining_particles_of_each_type -= n_total_particles_to_insert;
 
 
@@ -180,7 +178,6 @@ InsertionList<dim, PropertiesIndex>::
   assign_particle_properties_for_list_insertion(
     const DEMSolverParameters<dim>   &dem_parameters,
     const unsigned int               &inserted_this_step_this_proc,
-    const unsigned int               &current_inserting_particle_type,
     std::vector<std::vector<double>> &particle_properties)
 {
   // Clearing and resizing particle_properties
@@ -196,18 +193,17 @@ InsertionList<dim, PropertiesIndex>::
        particle_counter < inserted_this_step_this_proc;
        ++particle_counter)
     {
-      double type     = current_inserting_particle_type;
-      double diameter = this->diameters[particle_counter];
-      double density =
-        physical_properties.density_particle[current_inserting_particle_type];
-      double vel_x   = this->velocities[particle_counter][0];
-      double vel_y   = this->velocities[particle_counter][1];
-      double vel_z   = this->velocities[particle_counter][2];
-      double omega_x = this->angular_velocities[particle_counter][0];
-      double omega_y = this->angular_velocities[particle_counter][1];
-      double omega_z = this->angular_velocities[particle_counter][2];
-      double mass    = density * 4. / 3. * M_PI *
-                    Utilities::fixed_power<3, double>(diameter * 0.5);
+      const double type     = current_inserting_particle_type;
+      const double diameter = this->diameters[particle_counter];
+      const double density  = physical_properties.density_particle[type];
+      const double vel_x    = this->velocities[particle_counter][0];
+      const double vel_y    = this->velocities[particle_counter][1];
+      const double vel_z    = this->velocities[particle_counter][2];
+      const double omega_x  = this->angular_velocities[particle_counter][0];
+      const double omega_y  = this->angular_velocities[particle_counter][1];
+      const double omega_z  = this->angular_velocities[particle_counter][2];
+      const double mass     = density * 4. / 3. * M_PI *
+                          Utilities::fixed_power<3, double>(diameter * 0.5);
 
       std::vector<double> properties_of_one_particle{
         type, diameter, mass, vel_x, vel_y, vel_z, omega_x, omega_y, omega_z};

--- a/source/dem/insertion_volume.cc
+++ b/source/dem/insertion_volume.cc
@@ -120,7 +120,7 @@ InsertionVolume<dim, PropertiesIndex>::insert(
       else
         {
           first_id = this_mpi_process * inserted_this_step_this_proc;
-          last_id = (this_mpi_process + 1) * inserted_this_step_this_proc;
+          last_id  = (this_mpi_process + 1) * inserted_this_step_this_proc;
         }
 
       // Looping through the particles on each process and finding their

--- a/source/dem/insertion_volume.cc
+++ b/source/dem/insertion_volume.cc
@@ -119,8 +119,8 @@ InsertionVolume<dim, PropertiesIndex>::insert(
       // For the processes 1 : n-1
       else
         {
-          first_id = this_mpi_process * this->inserted_this_step_this_proc;
-          last_id = (this_mpi_process + 1) * this->inserted_this_step_this_proc;
+          first_id = this_mpi_process * inserted_this_step_this_proc;
+          last_id = (this_mpi_process + 1) * inserted_this_step_this_proc;
         }
 
       // Looping through the particles on each process and finding their

--- a/source/dem/insertion_volume.cc
+++ b/source/dem/insertion_volume.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/utilities.h>
@@ -7,7 +7,7 @@
 
 using namespace DEM;
 
-// The constructor of volume insertion class. In the constructor, we
+// The constructor of the volume insertion class. In the constructor, we
 // investigate if the insertion box is adequately large to handle the desired
 // number of inserted particles. The number of insertion points in each
 // direction (number_of_particles_x_direction, number_of_particles_y_direction
@@ -25,13 +25,13 @@ InsertionVolume<dim, PropertiesIndex>::InsertionVolume(
   , particles_of_each_type_remaining(
       dem_parameters.lagrangian_physical_properties.number.at(0))
 {
-  // Initializing current inserting particle type
+  // Initializing the current inserting particle type
   current_inserting_particle_type = 0;
   this->inserted_this_step        = 0;
   this->maximum_diameter          = maximum_particle_diameter;
 }
 
-// The main insertion function. Insert_global_function is utilized to insert
+// The main insertion function. Insert_global_function is used to insert
 // the particles
 template <int dim, typename PropertiesIndex>
 void
@@ -49,7 +49,7 @@ InsertionVolume<dim, PropertiesIndex>::insert(
           ++current_inserting_particle_type);
     }
 
-  // Check to see if the remaining un-inserted particles are equal to zero or
+  // Check to see if the remaining uninserted particles are equal to zero or
   // not
   if (particles_of_each_type_remaining != 0)
     {
@@ -86,17 +86,17 @@ InsertionVolume<dim, PropertiesIndex>::insert(
         Utilities::MPI::all_gather(communicator, my_bounding_box);
 
       // Distributing particles between processors
-      this->inserted_this_step_this_proc = static_cast<unsigned int>(
+      unsigned int inserted_this_step_this_proc = static_cast<unsigned int>(
         floor(this->inserted_this_step / n_mpi_process));
       if (this_mpi_process == (n_mpi_process - 1))
-        this->inserted_this_step_this_proc = static_cast<unsigned int>(
+        inserted_this_step_this_proc = static_cast<unsigned int>(
           this->inserted_this_step -
           (n_mpi_process - 1) *
             floor(this->inserted_this_step / n_mpi_process));
 
-      // Call random number generator
+      // Call the random number generator
       std::vector<double> random_number_vector;
-      random_number_vector.reserve(this->inserted_this_step_this_proc);
+      random_number_vector.reserve(inserted_this_step_this_proc);
       create_random_number_container(
         random_number_vector,
         this->inserted_this_step,
@@ -105,7 +105,7 @@ InsertionVolume<dim, PropertiesIndex>::insert(
 
       Point<dim>              insertion_location;
       std::vector<Point<dim>> insertion_points_on_proc;
-      insertion_points_on_proc.reserve(this->inserted_this_step_this_proc);
+      insertion_points_on_proc.reserve(inserted_this_step_this_proc);
 
       // Find the first and the last particle id for each process
       // The number of particles on the last process is different
@@ -113,9 +113,8 @@ InsertionVolume<dim, PropertiesIndex>::insert(
       unsigned int last_id;
       if (this_mpi_process == (n_mpi_process - 1))
         {
-          first_id =
-            this->inserted_this_step - this->inserted_this_step_this_proc;
-          last_id = this->inserted_this_step;
+          first_id = this->inserted_this_step - inserted_this_step_this_proc;
+          last_id  = this->inserted_this_step;
         }
       // For the processes 1 : n-1
       else
@@ -136,6 +135,7 @@ InsertionVolume<dim, PropertiesIndex>::insert(
             random_number_vector[this->inserted_this_step - particle_counter -
                                  1],
             dem_parameters.insertion_info);
+
           insertion_points_on_proc.push_back(insertion_location);
         }
 
@@ -144,7 +144,7 @@ InsertionVolume<dim, PropertiesIndex>::insert(
       // Assigning inserted particles properties using
       // assign_particle_properties function
       this->assign_particle_properties(dem_parameters,
-                                       this->inserted_this_step_this_proc,
+                                       inserted_this_step_this_proc,
                                        current_inserting_particle_type,
                                        insertion_points_on_proc,
                                        particle_properties);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

A std::vector<double> was kept in the distribution class, which could take a lot of ram when the number of particle inserted in a single time-step was large big. This is was it wasn't notice before. 

I also took the time to correct typos in the code and stuff.

### Solution

Store the particles in a std::vector that is passed by reference to the assign_properties function.

### Testing

Tests are still good. 

### Documentation

Nothing

### Miscellaneous (will be removed when merged)

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] An entry describing the origin of the bug as well as its fix has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [] There are at least 2 reviewers (or 1 if small feature)
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR