### PR TITLE
Fix some warnings on clang

### DIFF
--- a/include/solvers/navier_stokes_cls_assemblers.h
+++ b/include/solvers/navier_stokes_cls_assemblers.h
@@ -513,7 +513,7 @@ public:
   /**
    * @brief Calculates an approximation of the gradient of the viscosity
    * @param velocity_gradient The velocity gradient tensor on the quadrature point
-     @param velocity_hessians The velocity hessian tensor on the quadrture point
+     @param velocity_hessians The velocity hessian tensor on the quadrature point
      @param non_newtonian_viscosity The viscosity at which the gradient is calculated
      @param d_gamma_dot Th difference in the shear rate magnitude to approximate the
      viscosity variation with a slight change in the shear_rate magnitude

--- a/include/solvers/navier_stokes_cls_assemblers.h
+++ b/include/solvers/navier_stokes_cls_assemblers.h
@@ -491,14 +491,14 @@ private:
 
 /**
  * @brief Assembles the core of the Navier-Stokes equation
-   * using a Rheological model to predict non-Newtonian behaviors
-   *
-   * @tparam dim An integer that denotes the number of spatial dimensions
-   *
-   * @ingroup assemblers
-   */
-  template <int dim>
-  class GLSNavierStokesCLSAssemblerNonNewtonianCore
+ * using a Rheological model to predict non-Newtonian behaviors
+ *
+ * @tparam dim An integer that denotes the number of spatial dimensions
+ *
+ * @ingroup assemblers
+ */
+template <int dim>
+class GLSNavierStokesCLSAssemblerNonNewtonianCore
   : public NavierStokesAssemblerBase<dim>
 {
 public:

--- a/include/solvers/navier_stokes_cls_assemblers.h
+++ b/include/solvers/navier_stokes_cls_assemblers.h
@@ -301,7 +301,7 @@ private:
   static std::vector<bool>
   indentify_fluid_with_phase_change(
     const Parameters::FluidIndicator fluid_with_phase_change,
-    const double                     n_fluids)
+    const unsigned int               n_fluids)
   {
     std::vector<bool> enable_phase_change_vector(n_fluids, false);
 

--- a/include/solvers/navier_stokes_cls_assemblers.h
+++ b/include/solvers/navier_stokes_cls_assemblers.h
@@ -490,16 +490,16 @@ private:
 };
 e
 
-/**
- * @brief Assembles the core of the Navier-Stokes equation
- * using a Rheological model to predict non-Newtonian behaviors
- *
- * @tparam dim An integer that denotes the number of spatial dimensions
- *
- * @ingroup assemblers
- */
-template <int dim>
-class GLSNavierStokesCLSAssemblerNonNewtonianCore
+  /**
+   * @brief Assembles the core of the Navier-Stokes equation
+   * using a Rheological model to predict non-Newtonian behaviors
+   *
+   * @tparam dim An integer that denotes the number of spatial dimensions
+   *
+   * @ingroup assemblers
+   */
+  template <int dim>
+  class GLSNavierStokesCLSAssemblerNonNewtonianCore
   : public NavierStokesAssemblerBase<dim>
 {
 public:

--- a/include/solvers/navier_stokes_cls_assemblers.h
+++ b/include/solvers/navier_stokes_cls_assemblers.h
@@ -292,9 +292,9 @@ private:
    * boolean indicating if each fluid has phase change (@p true) or not
    * (@p false). The indices of the vector correspond to the fluid ID.
    *
-   * @paramp[in] fluid_with_phase_change Indicates which fluid(s) has/have phase
+   * @param[in] fluid_with_phase_change Indicates which fluid(s) has/have phase
    * change.
-   * @paramp[in] n_fluids Number of fluids.
+   * @param[in] n_fluids Number of fluids.
    *
    * @return Vector of boolean indicating which fluid(s) has/have phase change.
    */
@@ -488,7 +488,7 @@ private:
   // Evaporation model
   std::shared_ptr<EvaporationModel> evaporation_model;
 };
-
+e
 
 /**
  * @brief Assembles the core of the Navier-Stokes equation

--- a/include/solvers/navier_stokes_cls_assemblers.h
+++ b/include/solvers/navier_stokes_cls_assemblers.h
@@ -488,10 +488,9 @@ private:
   // Evaporation model
   std::shared_ptr<EvaporationModel> evaporation_model;
 };
-e
 
-  /**
-   * @brief Assembles the core of the Navier-Stokes equation
+/**
+ * @brief Assembles the core of the Navier-Stokes equation
    * using a Rheological model to predict non-Newtonian behaviors
    *
    * @tparam dim An integer that denotes the number of spatial dimensions

--- a/release_notes/current/2026_06_30_Blais.md
+++ b/release_notes/current/2026_06_30_Blais.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/06/30
+
+### Fixed
+
+- MINOR Fixed several implicit floating-point to integer conversion warnings (`-Wfloat-conversion`) reported by Apple Clang. In the DEM insertion classes, the particle density is now looked up using the integer particle type index instead of a `double`, and the `n_fluids` argument of `indentify_fluid_with_phase_change` in the Carman-Kozeny CLS assembler is now an `unsigned int` instead of a `double`. These changes have no impact on simulation results. [#](https://github.com/chaos-polymtl/lethe/pull/)

--- a/release_notes/current/2026_06_30_Blais.md
+++ b/release_notes/current/2026_06_30_Blais.md
@@ -2,4 +2,4 @@
 
 ### Fixed
 
-- MINOR Fixed several implicit floating-point to integer conversion warnings (`-Wfloat-conversion`) reported by Apple Clang. In the DEM insertion classes, the particle density is now looked up using the integer particle type index instead of a `double`, and the `n_fluids` argument of `indentify_fluid_with_phase_change` in the Carman-Kozeny CLS assembler is now an `unsigned int` instead of a `double`. These changes have no impact on simulation results. [#](https://github.com/chaos-polymtl/lethe/pull/)
+- MINOR Fixed several implicit floating-point to integer conversion warnings (`-Wfloat-conversion`) reported by Apple Clang. In the DEM insertion classes, the particle density is now looked up using the integer particle type index instead of a `double`, and the `n_fluids` argument of `indentify_fluid_with_phase_change` in the Carman-Kozeny CLS assembler is now an `unsigned int` instead of a `double`. These changes have no impact on simulation results. [#2047](https://github.com/chaos-polymtl/lethe/pull/2047)

--- a/source/dem/insertion.cc
+++ b/source/dem/insertion.cc
@@ -88,14 +88,15 @@ Insertion<dim, PropertiesIndex>::assign_particle_properties(
       double type = current_inserting_particle_type;
       // We make sure that the diameter is positive
       double diameter = std::abs(particle_sizes[particle_counter]);
-      double density  = physical_properties.density_particle[type];
-      double vel_x    = dem_parameters.insertion_info.initial_vel[0];
-      double vel_y    = dem_parameters.insertion_info.initial_vel[1];
-      double vel_z    = dem_parameters.insertion_info.initial_vel[2];
-      double omega_x  = dem_parameters.insertion_info.initial_omega[0];
-      double omega_y  = dem_parameters.insertion_info.initial_omega[1];
-      double omega_z  = dem_parameters.insertion_info.initial_omega[2];
-      double mass     = density * 4. / 3. * M_PI *
+      double density =
+        physical_properties.density_particle[current_inserting_particle_type];
+      double vel_x   = dem_parameters.insertion_info.initial_vel[0];
+      double vel_y   = dem_parameters.insertion_info.initial_vel[1];
+      double vel_z   = dem_parameters.insertion_info.initial_vel[2];
+      double omega_x = dem_parameters.insertion_info.initial_omega[0];
+      double omega_y = dem_parameters.insertion_info.initial_omega[1];
+      double omega_z = dem_parameters.insertion_info.initial_omega[2];
+      double mass    = density * 4. / 3. * M_PI *
                     Utilities::fixed_power<3, double>(diameter * 0.5);
 
       std::vector<double> properties_of_one_particle{

--- a/source/dem/insertion_list.cc
+++ b/source/dem/insertion_list.cc
@@ -193,14 +193,15 @@ InsertionList<dim, PropertiesIndex>::
     {
       const double type     = current_inserting_particle_type;
       const double diameter = this->diameters[particle_counter];
-      const double density  = physical_properties.density_particle[type];
-      const double vel_x    = this->velocities[particle_counter][0];
-      const double vel_y    = this->velocities[particle_counter][1];
-      const double vel_z    = this->velocities[particle_counter][2];
-      const double omega_x  = this->angular_velocities[particle_counter][0];
-      const double omega_y  = this->angular_velocities[particle_counter][1];
-      const double omega_z  = this->angular_velocities[particle_counter][2];
-      const double mass     = density * 4. / 3. * M_PI *
+      const double density =
+        physical_properties.density_particle[current_inserting_particle_type];
+      const double vel_x   = this->velocities[particle_counter][0];
+      const double vel_y   = this->velocities[particle_counter][1];
+      const double vel_z   = this->velocities[particle_counter][2];
+      const double omega_x = this->angular_velocities[particle_counter][0];
+      const double omega_y = this->angular_velocities[particle_counter][1];
+      const double omega_z = this->angular_velocities[particle_counter][2];
+      const double mass    = density * 4. / 3. * M_PI *
                           Utilities::fixed_power<3, double>(diameter * 0.5);
 
       std::vector<double> properties_of_one_particle{


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

There were some odd compilation warning regarding double usages as index on Clang. 

### Solution

Fixed them.

### Testing

All test results are unchanged. 

### Documentation

Nothing to document

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] An entry describing the origin of the bug as well as its fix has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR