### PR TITLE
Fix fichera oven

### DIFF
--- a/examples/multiphysics/fichera_oven/fichera_oven.prm
+++ b/examples/multiphysics/fichera_oven/fichera_oven.prm
@@ -142,6 +142,7 @@ subsection linear solver
     set verbosity         = verbose
     set relative residual = 1e-8
     set minimum residual  = 1e-12
+    set preconditioner    = none
   end
 end
 

--- a/release_notes/current/2026_06_30_Blais_3.md
+++ b/release_notes/current/2026_06_30_Blais_3.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/06/30
+
+### Fixed
+
+- MINOR This PR fixes the `fichera_oven` example by setting `preconditioner = none` in the linear solver subsection, which was missing from the parameter file. [#2049](https://github.com/chaos-polymtl/lethe/pull/2049)


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

I had not updated the preconditioner parameter in the linear solver of the fichera oven when doing #2037. This PR fixes this.


### Miscellaneous (will be removed when merged)

Mistakes happen.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] Lethe documentation is up to date
- [x] Copyright headers are present and up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] Links are added to parent .rst files
- [x] The example is following the [standard format](https://chaos-polymtl.github.io/lethe/documentation/contributing/documentation.html#general-rules-and-format)
- [x] An entry describing the addition of the example has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If any future work is planned, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR