### PR TITLE
Dem contact container

### DIFF
--- a/include/dem/contact_info.h
+++ b/include/dem/contact_info.h
@@ -17,8 +17,8 @@ using namespace dealii;
  * information that has to be preserved over multiple iterations of a contact,
  * namely everything related to tangential displacements.
  *
- * The iterator to particle one is not stored here. Since all the contacts of a
- * given particle one share the same iterator, it is stored only once in the
+ * The iterator to "particle one" is not stored here. Since all the contacts of
+ * a given particle one share the same iterator, it is stored only once in the
  * enclosing adjacency container (see data_containers.h) instead of being
  * duplicated in every contact.
  */

--- a/include/dem/contact_info.h
+++ b/include/dem/contact_info.h
@@ -16,11 +16,15 @@ using namespace dealii;
  * particle-particle contact force. Notably it is responsible for storing
  * information that has to be preserved over multiple iterations of a contact,
  * namely everything related to tangential displacements.
+ *
+ * The iterator to particle one is not stored here. Since all the contacts of a
+ * given particle one share the same iterator, it is stored only once in the
+ * enclosing adjacency container (see data_containers.h) instead of being
+ * duplicated in every contact.
  */
 template <int dim>
 struct particle_particle_contact_info
 {
-  Particles::ParticleIterator<dim> particle_one;
   Particles::ParticleIterator<dim> particle_two;
   Tensor<1, 3>                     tangential_displacement;
   Tensor<1, 3>                     rolling_resistance_spring_torque;

--- a/include/dem/data_containers.h
+++ b/include/dem/data_containers.h
@@ -111,14 +111,35 @@ namespace DEM
       map<types::particle_index, periodic_particle_particle_contact_info<dim>>
         periodic_particle_contact_info;
 
-    // <particle id, <particle id, particle-particle info>>
+    // Value stored per "particle one" in the adjacency containers below. The
+    // iterator to particle one is shared by all its contacts, so it is stored
+    // once here instead of being duplicated in every particle-particle contact
+    // info. second_particles maps each particle two id to the contact info.
+    // (particle one iterator, <particle id, particle-particle info>)
+    struct adjacent_particle_pairs_value
+    {
+      Particles::ParticleIterator<dim> particle_one;
+      particle_contact_info            second_particles;
+    };
+
+    // Periodic counterpart of adjacent_particle_pairs_value.
+    // (particle one iterator, <particle id, periodic particle-particle info>)
+    struct periodic_adjacent_particle_pairs_value
+    {
+      Particles::ParticleIterator<dim> particle_one;
+      periodic_particle_contact_info   second_particles;
+    };
+
+    // <particle id, (particle one iterator, <particle id, particle-particle
+    // info>)>
     typedef ankerl::unordered_dense::map<types::particle_index,
-                                         particle_contact_info>
+                                         adjacent_particle_pairs_value>
       adjacent_particle_pairs;
 
-    // <particle id, <particle id, periodic particle-particle info>>
+    // <particle id, (particle one iterator, <particle id, periodic
+    // particle-particle info>)>
     typedef ankerl::unordered_dense::map<types::particle_index,
-                                         periodic_particle_contact_info>
+                                         periodic_adjacent_particle_pairs_value>
       periodic_adjacent_particle_pairs;
 
     // <cell iterator, <particle id, particle iterator>>

--- a/include/dem/data_containers.h
+++ b/include/dem/data_containers.h
@@ -114,7 +114,8 @@ namespace DEM
     // Value stored per "particle one" in the adjacency containers below. The
     // iterator to particle one is shared by all its contacts, so it is stored
     // once here instead of being duplicated in every particle-particle contact
-    // info. second_particles maps each particle two id to the contact info.
+    // info. second_particles maps uses each particle two id (key)
+    // to access the contact info (value) between particle one and two.
     // (particle one iterator, <particle id, particle-particle info>)
     struct adjacent_particle_pairs_value
     {

--- a/include/dem/force_chains_visualization.h
+++ b/include/dem/force_chains_visualization.h
@@ -198,7 +198,7 @@ private:
                               std::vector<double>   &normal_forces_vector)
   {
     // No contact calculation if no adjacent particles
-    if (adjacent_particles_list.empty())
+    if (adjacent_particles_list.second_particles.empty())
       return;
 
     const double force_calculation_threshold_distance =
@@ -214,16 +214,17 @@ private:
     double       normal_relative_velocity_value;
     Tensor<1, 3> tangential_relative_velocity;
 
-    // Gather information about particle 1 and set it up.
-    auto first_contact_info      = adjacent_particles_list.begin();
-    auto particle_one            = first_contact_info->second.particle_one;
+    // Gather information about particle 1 and set it up. The iterator to
+    // particle 1 is shared by all its contacts and stored once in the adjacency
+    // value.
+    auto particle_one            = adjacent_particles_list.particle_one;
     auto particle_one_properties = particle_one->get_properties();
 
     // Fix particle one location for 2d and 3d
     Point<3> particle_one_location = this->get_location(particle_one);
 
     for (auto &&contact_info :
-         adjacent_particles_list | boost::adaptors::map_values)
+         adjacent_particles_list.second_particles | boost::adaptors::map_values)
       {
         // Getting information (location and properties) of particle 2 in
         // contact with particle 1

--- a/include/dem/particle_particle_contact_force.h
+++ b/include/dem/particle_particle_contact_force.h
@@ -1731,7 +1731,7 @@ private:
     ParticleInteractionOutcomes<PropertiesIndex> &contact_outcome)
   {
     // No contact calculation if no adjacent particles
-    if (adjacent_particles_list.empty())
+    if (adjacent_particles_list.second_particles.empty())
       return;
 
     // Define local variables which will be used within the contact calculation
@@ -1744,9 +1744,10 @@ private:
     double       normal_relative_velocity_value;
     Tensor<1, 3> tangential_relative_velocity;
 
-    // Gather information about particle 1 and set it up.
-    auto first_contact_info      = adjacent_particles_list.begin();
-    auto particle_one            = first_contact_info->second.particle_one;
+    // Gather information about particle 1 and set it up. The iterator to
+    // particle 1 is shared by all its contacts and stored once in the adjacency
+    // value.
+    auto particle_one            = adjacent_particles_list.particle_one;
     auto particle_one_properties = particle_one->get_properties();
 
     types::particle_index particle_one_id = particle_one->get_local_index();
@@ -1757,7 +1758,7 @@ private:
     Point<3> particle_one_location = get_location(particle_one);
 
     for (auto &&contact_info :
-         adjacent_particles_list | boost::adaptors::map_values)
+         adjacent_particles_list.second_particles | boost::adaptors::map_values)
       {
         // Getting information (location and properties) of particle 2 in
         // contact with particle 1

--- a/release_notes/current/2026_07_02_Blais.md
+++ b/release_notes/current/2026_07_02_Blais.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/07/02
+
+### Changed
+
+- MINOR This PR refactors the DEM particle-particle contact container. The iterator to the first particle was previously duplicated in every contact of the inner map. It is now stored only once per particle in the adjacency value alongside its map of contacts (`second_particles`). This removes data duplication and also some confusion, because all containers contained the same first particle iterator, which was confusing. It has no impact on simulation results and absolutely no test results are changed. [#2053](https://github.com/chaos-polymtl/lethe/pull/2053)

--- a/release_notes/current/2026_07_02_Blais.md
+++ b/release_notes/current/2026_07_02_Blais.md
@@ -2,4 +2,4 @@
 
 ### Changed
 
-- MINOR This PR refactors the DEM particle-particle contact container. The iterator to the first particle was previously duplicated in every contact of the inner map. It is now stored only once per particle in the adjacency value alongside its map of contacts (`second_particles`). This removes data duplication and also some confusion, because all containers contained the same first particle iterator, which was confusing. It has no impact on simulation results and absolutely no test results are changed. [#2053](https://github.com/chaos-polymtl/lethe/pull/2053)
+- MAJOR This PR refactors the DEM particle-particle contact container. The iterator to the first particle was previously duplicated in every contact of the inner map. It is now stored only once per particle in the adjacency value alongside its map of contacts (`second_particles`). This removes data duplication and also some confusion, because all containers contained the same first particle iterator, which was confusing. It has no impact on simulation results and absolutely no test results are changed. [#2053](https://github.com/chaos-polymtl/lethe/pull/2053)

--- a/source/dem/particle_particle_fine_search.cc
+++ b/source/dem/particle_particle_fine_search.cc
@@ -31,11 +31,14 @@ particle_particle_fine_search(
   for (auto &&adjacent_particles_list :
        adjacent_particles | boost::adaptors::map_values)
     {
-      if (adjacent_particles_list.empty())
+      auto &second_particles = adjacent_particles_list.second_particles;
+
+      if (second_particles.empty())
         continue;
 
-      // Gather information about particle 1
-      auto &particle_one = adjacent_particles_list.begin()->second.particle_one;
+      // Gather information about particle 1. The iterator to particle 1 is
+      // shared by all its contacts and stored once in the adjacency value.
+      auto              &particle_one = adjacent_particles_list.particle_one;
       Point<dim, double> particle_one_location = particle_one->get_location();
 
       // For non-periodic contacts
@@ -43,10 +46,8 @@ particle_particle_fine_search(
                     contact_type == ghost_particle_particle)
         {
           // Iterating over each map which contains the contact information
-          for (auto adjacent_particles_list_iterator =
-                 adjacent_particles_list.begin();
-               adjacent_particles_list_iterator !=
-               adjacent_particles_list.end();)
+          for (auto adjacent_particles_list_iterator = second_particles.begin();
+               adjacent_particles_list_iterator != second_particles.end();)
             {
               // Getting contact information and particle 2 as local variables
               auto &adjacent_pair_information =
@@ -62,8 +63,7 @@ particle_particle_fine_search(
               if (square_distance > neighborhood_threshold)
                 {
                   adjacent_particles_list_iterator =
-                    adjacent_particles_list.erase(
-                      adjacent_particles_list_iterator);
+                    second_particles.erase(adjacent_particles_list_iterator);
                 }
               else
                 {
@@ -78,10 +78,8 @@ particle_particle_fine_search(
                     contact_type == ghost_local_periodic_particle_particle)
         {
           // Iterating over each map which contains the contact information
-          for (auto adjacent_particles_list_iterator =
-                 adjacent_particles_list.begin();
-               adjacent_particles_list_iterator !=
-               adjacent_particles_list.end();)
+          for (auto adjacent_particles_list_iterator = second_particles.begin();
+               adjacent_particles_list_iterator != second_particles.end();)
             {
               // Getting contact information and particle 2 as local variables
               auto &adjacent_pair_information =
@@ -121,8 +119,7 @@ particle_particle_fine_search(
               if (min_square_distance > neighborhood_threshold)
                 {
                   adjacent_particles_list_iterator =
-                    adjacent_particles_list.erase(
-                      adjacent_particles_list_iterator);
+                    second_particles.erase(adjacent_particles_list_iterator);
                 }
               else
                 {
@@ -170,11 +167,11 @@ particle_particle_fine_search(
                 {
                   auto &particle_one_contact_list =
                     adjacent_particles[particle_one_id];
+                  particle_one_contact_list.particle_one = particle_one;
 
-                  particle_one_contact_list.emplace(
+                  particle_one_contact_list.second_particles.emplace(
                     particle_two_id,
-                    particle_particle_contact_info<dim>{particle_one,
-                                                        particle_two,
+                    particle_particle_contact_info<dim>{particle_two,
                                                         Tensor<1, 3>(),
                                                         Tensor<1, 3>()});
                 }
@@ -221,14 +218,12 @@ particle_particle_fine_search(
 
                   auto &particle_one_contact_list =
                     adjacent_particles[particle_one_id];
+                  particle_one_contact_list.particle_one = particle_one;
 
-                  particle_one_contact_list.emplace(
+                  particle_one_contact_list.second_particles.emplace(
                     particle_two_id,
                     periodic_particle_particle_contact_info<dim>{
-                      {particle_one,
-                       particle_two,
-                       Tensor<1, 3>(),
-                       Tensor<1, 3>()},
+                      {particle_two, Tensor<1, 3>(), Tensor<1, 3>()},
                       offset_3d});
                 }
             }

--- a/source/dem/update_fine_search_candidates.cc
+++ b/source/dem/update_fine_search_candidates.cc
@@ -28,9 +28,28 @@ update_fine_search_candidates(pairs_structure      &pairs_in_contact,
       // particle (from the fine search history)
       auto adjacent_pairs_content = &pairs_in_contact_iterator->second;
 
+      // For particle-particle contacts, the map of objects in contact is held
+      // in second_particles (the iterator to particle one is stored alongside
+      // it in the adjacency value). For the other contact types,
+      // adjacent_pairs_content is directly the map of objects in contact.
+      // Select the map to loop over accordingly.
+      auto &second_objects = [&]() -> auto & {
+        if constexpr (contact_type == ContactType::local_particle_particle ||
+                      contact_type == ContactType::ghost_particle_particle ||
+                      contact_type ==
+                        ContactType::local_periodic_particle_particle ||
+                      contact_type ==
+                        ContactType::ghost_periodic_particle_particle ||
+                      contact_type ==
+                        ContactType::ghost_local_periodic_particle_particle)
+          return adjacent_pairs_content->second_particles;
+        else
+          return *adjacent_pairs_content;
+      }();
+
       // Loop over all the adjacent objects
-      for (auto adjacent_map_iterator = adjacent_pairs_content->begin();
-           adjacent_map_iterator != adjacent_pairs_content->end();)
+      for (auto adjacent_map_iterator = second_objects.begin();
+           adjacent_map_iterator != second_objects.end();)
         {
           // Get the object (2nd particle/wall/face) id in the history list
           auto object_id = adjacent_map_iterator->first;
@@ -127,8 +146,8 @@ update_fine_search_candidates(pairs_structure      &pairs_in_contact,
                           // history in the fine search list particle-particle
                           // contact candidates list but kept in new broad
                           // search list
-                          adjacent_map_iterator = adjacent_pairs_content->erase(
-                            adjacent_map_iterator);
+                          adjacent_map_iterator =
+                            second_objects.erase(adjacent_map_iterator);
                           continue;
                         }
                     }
@@ -138,7 +157,7 @@ update_fine_search_candidates(pairs_structure      &pairs_in_contact,
               // The particle is then removed as a candidate for fine
               // search contact candidates list
               adjacent_map_iterator =
-                adjacent_pairs_content->erase(adjacent_map_iterator);
+                second_objects.erase(adjacent_map_iterator);
             }
 
           if constexpr (contact_type == ContactType::particle_wall ||
@@ -174,13 +193,13 @@ update_fine_search_candidates(pairs_structure      &pairs_in_contact,
               // removed as a candidate for fine search contact candidates
               // list
               adjacent_map_iterator =
-                adjacent_pairs_content->erase(adjacent_map_iterator);
+                second_objects.erase(adjacent_map_iterator);
             }
         }
 
       // If there are still particle/wall/face in the adjacent_pairs_content
       // then the pairs_in_contact_iterator remains in memory
-      if (adjacent_pairs_content->size() > 0)
+      if (second_objects.size() > 0)
         ++pairs_in_contact_iterator;
 
       // Otherwise it is deleted. This is necessary to prevent memory inflation.

--- a/source/dem/update_local_particle_containers.cc
+++ b/source/dem/update_local_particle_containers.cc
@@ -82,9 +82,44 @@ update_contact_container_iterators(
               continue;
             }
 
+          // For particle-particle contacts, the iterator to particle one is
+          // shared by all its contacts and stored once in the adjacency value,
+          // while its map of contacts is held in second_particles. For the
+          // other contact types, adjacent_pairs_content is directly the map of
+          // objects in contact. Select the map to loop over accordingly.
+          auto &second_objects = [&]() -> auto & {
+            if constexpr (contact_type ==
+                            ContactType::local_particle_particle ||
+                          contact_type ==
+                            ContactType::ghost_particle_particle ||
+                          contact_type ==
+                            ContactType::local_periodic_particle_particle ||
+                          contact_type ==
+                            ContactType::ghost_periodic_particle_particle ||
+                          contact_type ==
+                            ContactType::ghost_local_periodic_particle_particle)
+              return adjacent_pairs_content->second_particles;
+            else
+              return *adjacent_pairs_content;
+          }();
+
+          // Update the shared iterator to particle one once for the whole list
+          if constexpr (contact_type == ContactType::local_particle_particle ||
+                        contact_type == ContactType::ghost_particle_particle ||
+                        contact_type ==
+                          ContactType::local_periodic_particle_particle ||
+                        contact_type ==
+                          ContactType::ghost_periodic_particle_particle ||
+                        contact_type ==
+                          ContactType::ghost_local_periodic_particle_particle)
+            {
+              adjacent_pairs_content->particle_one =
+                particle_one_container->second;
+            }
+
           // Loop over all the other objects of contact_type in contact
-          for (auto adjacent_map_iterator = adjacent_pairs_content->begin();
-               adjacent_map_iterator != adjacent_pairs_content->end();)
+          for (auto adjacent_map_iterator = second_objects.begin();
+               adjacent_map_iterator != second_objects.end();)
             {
               if constexpr (contact_type ==
                               ContactType::local_particle_particle ||
@@ -109,14 +144,12 @@ update_contact_container_iterators(
                   if (particle_two_container == particle_container.end())
                     {
                       adjacent_map_iterator =
-                        adjacent_pairs_content->erase(adjacent_map_iterator);
+                        second_objects.erase(adjacent_map_iterator);
                       continue;
                     }
 
-                  // Both particles are still on this process, update their
-                  // iterators
-                  adjacent_map_iterator->second.particle_one =
-                    particle_one_container->second;
+                  // Both particles are still on this process, update the
+                  // iterator to particle two
                   adjacent_map_iterator->second.particle_two =
                     particle_two_container->second;
 

--- a/source/dem/update_local_particle_containers.cc
+++ b/source/dem/update_local_particle_containers.cc
@@ -83,7 +83,8 @@ update_contact_container_iterators(
             }
 
           // For particle-particle contacts, the iterator to particle one is
-          // shared by all its contacts and stored once in the adjacency value,
+          // shared by all its contact candidates (potential contacts)
+          // and stored once in the adjacency value,
           // while its map of contacts is held in second_particles. For the
           // other contact types, adjacent_pairs_content is directly the map of
           // objects in contact. Select the map to loop over accordingly.

--- a/source/fem-dem/fluid_dynamics_sharp.cc
+++ b/source/fem-dem/fluid_dynamics_sharp.cc
@@ -3211,7 +3211,6 @@ FluidDynamicsSharp<dim>::build_contact_containers(
             continue;
 
           particle_particle_contact_info<dim> dem_contact_info;
-          dem_contact_info.particle_one = particle_one_it->second;
           dem_contact_info.particle_two = particle_two_it->second;
           dem_contact_info.tangential_displacement =
             contact_info.tangential_displacement;
@@ -3220,14 +3219,22 @@ FluidDynamicsSharp<dim>::build_contact_containers(
 
           // Keep the same convention as for DEM, contacts between two owned
           // particles stay in the local container, while contacts involving a
-          // ghost neighbor go in the ghost container.
+          // ghost neighbor go in the ghost container. The iterator to particle
+          // one is shared by all its contacts and stored once in the adjacency
+          // value.
           if (local_particle_ids.find(particle_two_id) !=
               local_particle_ids.end())
-            local_adjacent_particles[particle_id][particle_two_id] =
-              dem_contact_info;
+            {
+              auto &adjacency        = local_adjacent_particles[particle_id];
+              adjacency.particle_one = particle_one_it->second;
+              adjacency.second_particles[particle_two_id] = dem_contact_info;
+            }
           else
-            ghost_adjacent_particles[particle_id][particle_two_id] =
-              dem_contact_info;
+            {
+              auto &adjacency        = ghost_adjacent_particles[particle_id];
+              adjacency.particle_one = particle_one_it->second;
+              adjacency.second_particles[particle_two_id] = dem_contact_info;
+            }
         }
     }
 

--- a/tests/dem/particle_particle_fine_search.cc
+++ b/tests/dem/particle_particle_fine_search.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 /**
@@ -117,14 +117,16 @@ test()
        adjacent_particles_iterator != local_adjacent_particles.end();
        ++adjacent_particles_iterator)
     {
-      auto information_iterator =
-        (&adjacent_particles_iterator->second)->begin();
-      while (information_iterator !=
-             (&adjacent_particles_iterator->second)->end())
+      // The iterator to particle one is shared by all its contacts and stored
+      // once in the adjacency value, alongside the second_particles map.
+      auto &particle_one = adjacent_particles_iterator->second.particle_one;
+      auto &second_particles =
+        adjacent_particles_iterator->second.second_particles;
+      auto information_iterator = second_particles.begin();
+      while (information_iterator != second_particles.end())
         {
           deallog << "The particle pair in contact are particles: "
-                  << information_iterator->second.particle_one->get_id()
-                  << " and "
+                  << particle_one->get_id() << " and "
                   << information_iterator->second.particle_two->get_id()
                   << std::endl;
           deallog << "Tangential displacement at the beginning of contact is: "


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

 This PR refactors the DEM particle-particle contact container. The iterator to the first particle was previously duplicated in every contact of the inner map. It is now stored only once per particle in the adjacency value alongside its map of contacts (`second_particles`). This removes data duplication and also some confusion, because all containers contained the same first particle iterator, which was confusing and difficult to follow.

### Testing

It has no impact on simulation results and absolutely no test results are changed.

### Documentation

Nothing to document.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Copyright headers are present and up to date
- [ ] Lethe documentation is up to date
- [ ] The branch is rebased onto master
- [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [ ] If parameters are modified, the tests and the documentation of examples are up to date
- [ ] An entry describing the change has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`

Pull request related list:
- [ ] No other PR is open related to this refactoring
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature)
- [ ] If any future work is planned, an issue is opened
- [ ] The PR description is clean and is ready to be used as the commit message when merging the PR