### PR TITLE
Fix preconditioner waveguide example

### DIFF
--- a/examples/multiphysics/waveguide/waveguide.prm
+++ b/examples/multiphysics/waveguide/waveguide.prm
@@ -174,6 +174,7 @@ subsection linear solver
     set verbosity         = verbose
     set relative residual = 1e-8
     set minimum residual  = 1e-12
+    set preconditioner    = none
   end
 end
 

--- a/release_notes/current/2026_07_24_Blais.md
+++ b/release_notes/current/2026_07_24_Blais.md
@@ -2,4 +2,4 @@
 
 ### Fixed
 
-- MINOR The `waveguide` multiphysics example now explicitly sets `set preconditioner = none` in its `electromagnetics` linear solver subsection. The time-harmonic Maxwell physics does not support a preconditioner and throws when one is set, but the default preconditioner is `ilu`, so the example previously failed at runtime. [#XXXX](https://github.com/chaos-polymtl/lethe/pull/XXXX)
+- MINOR The `waveguide` multiphysics example now explicitly sets `set preconditioner = none` in its `electromagnetics` linear solver subsection. The time-harmonic Maxwell physics does not support a preconditioner and throws when one is set, but the default preconditioner is `ilu`, so the example previously failed at runtime. [#2068](https://github.com/chaos-polymtl/lethe/pull/2068)

--- a/release_notes/current/2026_07_24_Blais.md
+++ b/release_notes/current/2026_07_24_Blais.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/07/24
+
+### Fixed
+
+- MINOR The `waveguide` multiphysics example now explicitly sets `set preconditioner = none` in its `electromagnetics` linear solver subsection. The time-harmonic Maxwell physics does not support a preconditioner and throws when one is set, but the default preconditioner is `ilu`, so the example previously failed at runtime. [#XXXX](https://github.com/chaos-polymtl/lethe/pull/XXXX)


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The Maxwell solver requires specifying that the linear solver preconditioner be none to avoid confusion. This was not present in the waveguide example

### Solution

Added the correct preconditioner

### Testing

Nothing else changes

### Documentation

Nothing to document here the prm is clear.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] An entry describing the origin of the bug as well as its fix has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR