### PR TITLE
Fix minimum cell size / maximum diameter ratio calculation for restarts

### DIFF
--- a/applications_tests/lethe-particles/restart_cell_weight_function.with_dealii.geq.9.7.mpirun=2.output
+++ b/applications_tests/lethe-particles/restart_cell_weight_function.with_dealii.geq.9.7.mpirun=2.output
@@ -7,8 +7,8 @@ DEM time step is 3.69227% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation
-Minimum vertex distance between cell vertices: 0.4
-Minimum cell size to maximum particle diameter ratio: 40
+Minimum vertex distance between cell vertices: 0.025
+Minimum cell size to maximum particle diameter ratio: 2.5
 Warning: expansion of particle-wall contact list is disabled. 
 This feature is useful in geometries with convex boundaries. 
 -->Repartitioning triangulation

--- a/applications_tests/lethe-particles/restart_circle.mpirun=1.output
+++ b/applications_tests/lethe-particles/restart_circle.mpirun=1.output
@@ -7,8 +7,8 @@ DEM time step is 2.58386% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation
-Minimum vertex distance between cell vertices: 0.0585786
-Minimum cell size to maximum particle diameter ratio: 11.7157
+Minimum vertex distance between cell vertices: 0.00699653
+Minimum cell size to maximum particle diameter ratio: 1.39931
 Warning: expansion of particle-wall contact list is enabled. 
 This feature should be used only in geometries with convex boundaries. (For example, particles flowing inside a cylinder or sphere). For geometries with concave boundaries, this feature MUST NOT be activated.
 **********************************************************************

--- a/applications_tests/lethe-particles/restart_file_insertion.mpirun=1.output
+++ b/applications_tests/lethe-particles/restart_file_insertion.mpirun=1.output
@@ -7,8 +7,8 @@ DEM time step is 11.5554% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation
-Minimum vertex distance between cell vertices: 1
-Minimum cell size to maximum particle diameter ratio: 1000
+Minimum vertex distance between cell vertices: 0.125
+Minimum cell size to maximum particle diameter ratio: 125
 Warning: expansion of particle-wall contact list is disabled. 
 This feature is useful in geometries with convex boundaries. 
 *********************************************************************

--- a/applications_tests/lethe-particles/restart_sliding.mpirun=1.output
+++ b/applications_tests/lethe-particles/restart_sliding.mpirun=1.output
@@ -7,8 +7,8 @@ DEM time step is 1.63418% of Rayleigh time step
 Reading triangulation
 
 Finished reading triangulation
-Minimum vertex distance between cell vertices: 0.14
-Minimum cell size to maximum particle diameter ratio: 28
+Minimum vertex distance between cell vertices: 0.0175
+Minimum cell size to maximum particle diameter ratio: 3.5
 Warning: expansion of particle-wall contact list is disabled. 
 This feature is useful in geometries with convex boundaries. 
 id, type, dp, x, y, z 

--- a/release_notes/current/2026_07_27_Gaboriault.md
+++ b/release_notes/current/2026_07_27_Gaboriault.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/07/27
+
+### Fixed
+
+- MINOR The ``Minimum cell size to maximum particle diameter ratio`` was not properly displayed at the beginning of a restart DEM simulation. The ``report_cell_size_to_particle_diameter_ratio`` was called before setting the ``triangulation`` for a restart in ``read_checkpoint``, thus the minimum cell size used in the report function was a default value instead of the real one. [#2070](https://github.com/chaos-polymtl/lethe/pull/2070)

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -851,11 +851,6 @@ DEMSolver<dim, PropertiesIndex>::solve()
             triangulation,
             parameters.boundary_conditions);
 
-  report_cell_size_to_particle_diameter_ratio(triangulation,
-                                              maximum_particle_diameter,
-                                              pcout,
-                                              mpi_communicator);
-
   // Set up functions and pointers according to parameters
   setup_functions_and_pointers();
 
@@ -870,6 +865,11 @@ DEMSolver<dim, PropertiesIndex>::solve()
                   insertion_object,
                   solid_surfaces,
                   checkpoint_controller);
+
+  report_cell_size_to_particle_diameter_ratio(triangulation,
+                                             maximum_particle_diameter,
+                                             pcout,
+                                             mpi_communicator);
 
   // Set up the various parameters that need the triangulation
   setup_triangulation_dependent_parameters();

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -867,9 +867,9 @@ DEMSolver<dim, PropertiesIndex>::solve()
                   checkpoint_controller);
 
   report_cell_size_to_particle_diameter_ratio(triangulation,
-                                             maximum_particle_diameter,
-                                             pcout,
-                                             mpi_communicator);
+                                              maximum_particle_diameter,
+                                              pcout,
+                                              mpi_communicator);
 
   // Set up the various parameters that need the triangulation
   setup_triangulation_dependent_parameters();


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The minimum cell size to maximum diameter size ratio was incorrect when restarting a simulation. The report was called before setting the triangulation the in restart function, thus the cell size used in the report was faulty.

### Solution
Move the ``report_cell_size_to_particle_diameter_ratio`` function after the ``read_checkpoint`` function. 

### Testing

The only changes are the ratio output at the start in the ``restart`` application tests.  

### Documentation

N/A


### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [X] All in-code documentation related to this PR is up to date (Doxygen format)
- [X] Copyright headers are present and up to date
- [X] Lethe documentation is up to date
- [X] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [X] The branch is rebased onto master
- [X] An entry describing the origin of the bug as well as its fix has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`
- [X] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [X] Labels are applied
- [X] There are at least 2 reviewers (or 1 if small feature)
- [X] If the fix is temporary, an issue is opened
- [X] The PR description is clean and is ready to be used as the commit message when merging the PR