### PR TITLE
Allow pure DEM simulations within the CFD-DEM solver by disabling fluid dynamics

### DIFF
--- a/include/solvers/navier_stokes_base.h
+++ b/include/solvers/navier_stokes_base.h
@@ -403,6 +403,18 @@ protected:
   update_multi_stage_solution(double time_step);
 
   /**
+   * @brief Specify the fluid dynamics solution instead of solving for it.
+   *
+   * When the fluid dynamics is disabled (fluid dynamics = false in the
+   * multiphysics subsection), the velocity and the pressure fields are not
+   * solved for, but rather imposed. They are either taken from the average
+   * velocity profile or re-established from the initial condition, which may
+   * be time-dependent.
+   */
+  virtual void
+  set_specified_fluid_dynamics_solution();
+
+  /**
    * @brief Do a regular CFD iteration
    */
   virtual void

--- a/release_notes/current/2026_07_27_Blais_2.md
+++ b/release_notes/current/2026_07_27_Blais_2.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/07/27
+
+### Fixed
+
+- MINOR The `fluid dynamics = false` parameter of the `multiphysics` subsection was ignored by the `lethe-fluid-vans` and `lethe-fluid-particles` applications. Both applications rely on `FluidDynamicsVANS::iterate()`, which overrides `NavierStokesBase::iterate()` (the only place where this parameter is taken into account) and solved the VANS equations unconditionally. The velocity and the pressure fields are now specified from the initial condition (or from the average velocity profile) instead of being solved for, which mimics the behavior of the `lethe-fluid` application. The imposition of the specified fluid dynamics solution was gathered in the new `NavierStokesBase::set_specified_fluid_dynamics_solution()` member function, which is shared by both `iterate()` implementations. [#2072](https://github.com/chaos-polymtl/lethe/pull/2072)

--- a/source/fem-dem/fluid_dynamics_vans.cc
+++ b/source/fem-dem/fluid_dynamics_vans.cc
@@ -191,10 +191,20 @@ void
 FluidDynamicsVANS<dim>::iterate()
 {
   announce_string(this->pcout, "Volume-Averaged Fluid Dynamics");
-  this->forcing_function->set_time(
-    this->simulation_control->get_current_time());
 
-  PhysicsSolver<GlobalVectorType>::solve_governing_system();
+  if (this->simulation_parameters.multiphysics.fluid_dynamics)
+    {
+      this->forcing_function->set_time(
+        this->simulation_control->get_current_time());
+
+      PhysicsSolver<GlobalVectorType>::solve_governing_system();
+    }
+  else
+    {
+      // The fluid dynamics is not to be solved, but rather specified. Update
+      // the velocity and the pressure fields and move on.
+      this->set_specified_fluid_dynamics_solution();
+    }
 }
 
 template <int dim>

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -617,6 +617,29 @@ void
 NavierStokesBase<dim, VectorType, DofsType>::update_multi_stage_solution(double)
 {}
 
+template <int dim, typename VectorType, typename DofsType>
+void
+NavierStokesBase<dim, VectorType, DofsType>::
+  set_specified_fluid_dynamics_solution()
+{
+  if (this->simulation_parameters.initial_condition->type ==
+      Parameters::FluidDynamicsInitialConditionType::average_velocity_profile)
+    {
+      // We get the solution via the average solution
+      this->local_evaluation_point =
+        *this->average_velocities->get_average_velocities();
+      *this->present_solution = this->local_evaluation_point;
+    }
+  else
+    {
+      // We get the solution via an initial condition
+      this->simulation_parameters.initial_condition->uvwp.set_time(
+        this->simulation_control->get_current_time());
+      set_initial_condition_fd(
+        this->simulation_parameters.initial_condition->type);
+    }
+}
+
 // Do an iteration with the NavierStokes Solver
 // Handles the fact that we may or may not be at a first
 // iteration with the solver and sets the initial condition
@@ -630,8 +653,6 @@ NavierStokesBase<dim, VectorType, DofsType>::iterate()
   const auto         method = this->simulation_control->get_assembly_method();
   const auto         time_step = this->simulation_control->get_time_step();
   const unsigned int n_stages = SimulationControl::get_number_of_stages(method);
-
-  auto &present_solution = *this->present_solution;
 
   // For a multi-stages method, at each time iteration, we reset the value of
   // sum_bi_ki
@@ -700,23 +721,7 @@ NavierStokesBase<dim, VectorType, DofsType>::iterate()
                               simulation_parameters.simulation_control.method);
           multiphysics->percolate_time_vectors(false);
 
-          if (this->simulation_parameters.initial_condition->type ==
-              Parameters::FluidDynamicsInitialConditionType::
-                average_velocity_profile)
-            {
-              // We get the solution via the average solution
-              this->local_evaluation_point =
-                *this->average_velocities->get_average_velocities();
-              present_solution = this->local_evaluation_point;
-            }
-          else
-            {
-              // We get the solution via an initial condition
-              this->simulation_parameters.initial_condition->uvwp.set_time(
-                this->simulation_control->get_current_time());
-              set_initial_condition_fd(
-                this->simulation_parameters.initial_condition->type);
-            }
+          this->set_specified_fluid_dynamics_solution();
 
           // Solve and percolate the auxiliary physics that should be treated
           // AFTER the fluid dynamics


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The CFD-DEM solver could not be used with fluid dynamics = false. It is still an interesting behaviour to be able to do these FEM-DEM simulation without fluid dynamics (e.g. for coupling with microwave). This PR adds this option.

### Testing

Testing on an eexample and it works just fine. I don,t think this requires it's own application test, since this is a simple if.

### Documentation

Nothing to document here that parameter is already documented, it is just efficiently generalized now.


### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] New feature has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] An entry describing the new feature has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR