### PR TITLE
Mortar: Change rotation_axis to rotation_axis_direction

### DIFF
--- a/applications_tests/lethe-fluid/mortar_taylorcouette3d_x_rotation.prm
+++ b/applications_tests/lethe-fluid/mortar_taylorcouette3d_x_rotation.prm
@@ -69,10 +69,10 @@ subsection mortar
     set initial rotation axis  = 0, 1, 0
     set initial rotation angle = 1.57079632679
   end
-  set rotor boundary id  = 5
-  set stator boundary id = 0
-  set rotation axis      = 1, 0, 0
-  set penalty factor     = 1
+  set rotor boundary id       = 5
+  set stator boundary id      = 0
+  set rotation axis direction = 0
+  set penalty factor          = 1
 end
 
 #---------------------------------------------------

--- a/doc/source/parameters/cfd/mortar.rst
+++ b/doc/source/parameters/cfd/mortar.rst
@@ -15,10 +15,10 @@ The mortar section is used when simulating rotor-stator geometries, in which the
       set grid arguments         = 1,1,1 : -1,-1,-1 : 1,1,1 : true
       set initial refinement     = 0
     end
-    set rotor boundary id   = 4
-    set stator boundary id  = 2
-    set center of rotation  = 0, 0
-    set rotation axis       = 0, 0, 1
+    set rotor boundary id         = 4
+    set stator boundary id        = 2
+    set center of rotation        = 0, 0
+    set rotation axis direction   = 2
     subsection rotor rotation angle
       set Function expression = 0
     end
@@ -50,7 +50,7 @@ The mortar section is used when simulating rotor-stator geometries, in which the
 
 * The ``center of rotation`` is the reference point for the prescribed rotation at the rotor domain.
 
-* The ``rotation axis`` is the unit vector that defines the rotor axis of rotation.
+* The ``rotation axis direction`` is the direction of the rotation axis given by 0, 1, or 2 corresponding to the x, y, or z axis respectively.
 
 * The ``rotor rotation angle`` subsection allows the imposition of a constant or time-dependent rotation angle for the rotor.
 

--- a/doc/source/parameters/cfd/mortar.rst
+++ b/doc/source/parameters/cfd/mortar.rst
@@ -50,7 +50,7 @@ The mortar section is used when simulating rotor-stator geometries, in which the
 
 * The ``center of rotation`` is the reference point for the prescribed rotation at the rotor domain.
 
-* The ``rotation axis direction`` is the direction of the rotation axis given by 0, 1, or 2 corresponding to the x, y, or z axis respectively.
+* The ``rotation axis direction`` is the direction of the rotation axis given by 0, 1, or 2, corresponding to the x, y, or z axis respectively. In 2D, this parameter is ignored and the rotation is always about the z axis.
 
 * The ``rotor rotation angle`` subsection allows the imposition of a constant or time-dependent rotation angle for the rotor.
 

--- a/include/core/lethe_grid_tools.h
+++ b/include/core/lethe_grid_tools.h
@@ -417,7 +417,7 @@ namespace LetheGridTools
   inline Tensor<1, dim>
   angular_to_linear_velocity(const double          omega,
                              const Tensor<1, dim> &point,
-                             const unsigned int   &rotation_axis_direction = 2)
+                             const unsigned int    rotation_axis_direction = 2)
   {
     Tensor<1, dim> result;
 
@@ -456,9 +456,9 @@ namespace LetheGridTools
   rotate_mapping(const DoFHandler<dim> &dof_handler,
                  MappingQCache<dim>    &mapping_cache,
                  const Mapping<dim>    &mapping,
-                 const double          &rotation_angle,
+                 const double           rotation_angle,
                  const Point<dim>      &center_of_rotation      = Point<dim>(),
-                 const unsigned int    &rotation_axis_direction = 2);
+                 const unsigned int     rotation_axis_direction = 2);
 
   /**
    * @brief

--- a/include/core/lethe_grid_tools.h
+++ b/include/core/lethe_grid_tools.h
@@ -408,18 +408,16 @@ namespace LetheGridTools
    * @param[in] omega Angular velocity value
    * @param[in] point Coordinates of the point at which the linear velocity is
    * being calculated
-   * @param[in] rotation_axis Rotation axis used in 3D cases, so that the
-   * angular velocity vector is given by omega_vec = omega * rotation_axis. In
-   * 2D, we apply a rotation around the z-axis.
+   * @param[in] rotation_axis_direction Direction of the rotation axis. In 2D,
+   * we apply a rotation around the z-axis.
    *
    * @return Linear velocity at @p point
    */
   template <int dim>
   inline Tensor<1, dim>
-  angular_to_linear_velocity(
-    const double          omega,
-    const Tensor<1, dim> &point,
-    const Tensor<1, dim> &rotation_axis = Tensor<1, dim>())
+  angular_to_linear_velocity(const double          omega,
+                             const Tensor<1, dim> &point,
+                             const unsigned int   &rotation_axis_direction = 2)
   {
     Tensor<1, dim> result;
 
@@ -433,7 +431,8 @@ namespace LetheGridTools
       {
         // Store angular velocity according to unit vector that defines the
         // rotation axis
-        const auto omega_vec = omega * rotation_axis;
+        Tensor<1, dim> omega_vec;
+        omega_vec[rotation_axis_direction] = omega;
         // Compute cross product
         result = cross_product_3d(omega_vec, point);
       }
@@ -450,7 +449,7 @@ namespace LetheGridTools
    * @param[in] rotation_angle Rotation angle of the rotor domain
    * @param[in] center_of_rotation Center of rotation of the rotor domain.
    * Default is the origin
-   * @param[in] rotation_axis Rotation axis of the rotor domain for 3D case
+   * @param[in] rotation_axis_direction Direction of the rotation axis
    */
   template <int dim>
   void
@@ -458,8 +457,8 @@ namespace LetheGridTools
                  MappingQCache<dim>    &mapping_cache,
                  const Mapping<dim>    &mapping,
                  const double          &rotation_angle,
-                 const Point<dim>      &center_of_rotation = Point<dim>(),
-                 const Tensor<1, dim>  &rotation_axis      = Tensor<1, dim>());
+                 const Point<dim>      &center_of_rotation      = Point<dim>(),
+                 const unsigned int    &rotation_axis_direction = 2);
 
   /**
    * @brief

--- a/include/core/mortar_coupling_manager.h
+++ b/include/core/mortar_coupling_manager.h
@@ -295,18 +295,6 @@ construct_quadrature(const Quadrature<dim>         &quadrature,
                      const Parameters::Mortar<dim> &mortar_parameters);
 
 /**
- * @brief Return the rotation axis direction for the mortar interface
- *
- * @param[in] mortar_parameters The information about the mortar method
- * control, including the rotor mesh parameters
- *
- * @return Direction of the rotation axis (x=0, y=1, z=2)
- */
-template <int dim>
-unsigned int
-get_rotation_axis_direction(const Parameters::Mortar<dim> &mortar_parameters);
-
-/**
  * @brief Compute the stage heights in the direction of the
  * rotation axis at the mortar interface. Stages are defined as planes
  * perpendicular to the rotation axis containing vertices of the same
@@ -570,7 +558,7 @@ MortarManagerCircle<dim>::MortarManagerCircle(
                                               mortar_parameters)),
       construct_quadrature(quadrature, mortar_parameters),
       mortar_parameters.rotor_rotation_angle->value(Point<dim>()),
-      get_rotation_axis_direction(mortar_parameters),
+      mortar_parameters.rotation_axis_direction,
       compute_stage_heights(dof_handler.get_triangulation(), mortar_parameters),
       mortar_parameters.center_of_rotation,
       std::get<1>(

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -2064,8 +2064,8 @@ namespace Parameters
     unsigned int stator_boundary_id;
     /// Center of rotation of the rotor domain
     Point<dim> center_of_rotation;
-    /// Rotation axis of the rotor domain
-    Tensor<1, dim> rotation_axis;
+    /// Rotation axis direction
+    unsigned int rotation_axis_direction;
     /// Rotation angle of the rotor domain in radians
     std::shared_ptr<Functions::ParsedFunction<dim>> rotor_rotation_angle;
     /// Angular velocity of the rotor domain

--- a/include/solvers/fluid_dynamics_matrix_free_operators.h
+++ b/include/solvers/fluid_dynamics_matrix_free_operators.h
@@ -452,14 +452,14 @@ public:
    *
    * @param[in] mapping Describes the transformations from unit to real cell.
    * @param[in] center_of_rotation Center of rotation of the rotor domain.
-   * @param[in] rotation_axis Rotation axis of the rotor domain for 3D case.
+   * @param[in] rotation_axis_direction Direction of the rotation axis.
    * @param[in] rotor_angular_velocity  Angular velocity of the rotor domain.
    */
   void
   evaluate_velocity_ale(
     const Mapping<dim>                             &mapping,
     const Point<dim>                                center_of_rotation,
-    const Tensor<1, dim>                            rotation_axis,
+    const unsigned int                              rotation_axis_direction,
     std::shared_ptr<Functions::ParsedFunction<dim>> rotor_angular_velocity);
 
   /**

--- a/include/solvers/tracer_scratch_data.h
+++ b/include/solvers/tracer_scratch_data.h
@@ -534,7 +534,7 @@ public:
         // Compute terms of u_ale
         rotor_linear_velocity_values[q] =
           LetheGridTools::angular_to_linear_velocity(
-            omega, p, mortar_parameters.rotation_axis);
+            omega, p, mortar_parameters.rotation_axis_direction);
 
         // Subtract u_ale from the advective velocity
         velocity_values[q] -= rotor_linear_velocity_values[q];

--- a/release_notes/current/2026_08_04_Campos.md
+++ b/release_notes/current/2026_08_04_Campos.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/08/04
+
+### Changed
+
+- MINOR This PR changes the `rotation axis` parameter in the Mortar subsection to a `rotation axis direction` instead. Since the rotation axis is always going to be either x, y or z directions, it is more adequate to prescribe the rotation axis direction instead of a unit vector. This simplifies the code implementation. [#2083](https://github.com/chaos-polymtl/lethe/pull/2083)

--- a/release_notes/current/2026_08_04_Campos.md
+++ b/release_notes/current/2026_08_04_Campos.md
@@ -2,4 +2,4 @@
 
 ### Changed
 
-- MINOR This PR changes the `rotation axis` parameter in the Mortar subsection to a `rotation axis direction` instead. Since the rotation axis is always going to be either x, y or z directions, it is more adequate to prescribe the rotation axis direction instead of a unit vector. This simplifies the code implementation. [#2083](https://github.com/chaos-polymtl/lethe/pull/2083)
+- MAJOR This PR changes the `rotation axis` parameter in the Mortar subsection to a `rotation axis direction` instead. Since the rotation axis is always going to be either x, y or z directions, it is more adequate to prescribe the rotation axis direction instead of a unit vector. This simplifies the code implementation. [#2083](https://github.com/chaos-polymtl/lethe/pull/2083)

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -1809,9 +1809,9 @@ void
 LetheGridTools::rotate_mapping(const DoFHandler<dim> &dof_handler,
                                MappingQCache<dim>    &mapping_cache,
                                const Mapping<dim>    &mapping,
-                               const double          &rotation_angle,
+                               const double           rotation_angle,
                                const Point<dim>      &center_of_rotation,
-                               const unsigned int    &rotation_axis_direction)
+                               const unsigned int     rotation_axis_direction)
 {
   if constexpr (dim == 2)
     {
@@ -1866,17 +1866,17 @@ template void
 LetheGridTools::rotate_mapping(const DoFHandler<2> &dof_handler,
                                MappingQCache<2>    &mapping_cache,
                                const Mapping<2>    &mapping,
-                               const double        &rotation_angle,
+                               const double         rotation_angle,
                                const Point<2>      &center_of_rotation,
-                               const unsigned int  &rotation_axis_direction);
+                               const unsigned int   rotation_axis_direction);
 
 template void
 LetheGridTools::rotate_mapping(const DoFHandler<3> &dof_handler,
                                MappingQCache<3>    &mapping_cache,
                                const Mapping<3>    &mapping,
-                               const double        &rotation_angle,
+                               const double         rotation_angle,
                                const Point<3>      &center_of_rotation,
-                               const unsigned int  &rotation_axis_direction);
+                               const unsigned int   rotation_axis_direction);
 
 template <int dim, int spacedim>
 void

--- a/source/core/lethe_grid_tools.cc
+++ b/source/core/lethe_grid_tools.cc
@@ -1811,7 +1811,7 @@ LetheGridTools::rotate_mapping(const DoFHandler<dim> &dof_handler,
                                const Mapping<dim>    &mapping,
                                const double          &rotation_angle,
                                const Point<dim>      &center_of_rotation,
-                               const Tensor<1, dim>  &rotation_axis)
+                               const unsigned int    &rotation_axis_direction)
 {
   if constexpr (dim == 2)
     {
@@ -1847,6 +1847,9 @@ LetheGridTools::rotate_mapping(const DoFHandler<dim> &dof_handler,
 
           // Shift point by the center of rotation
           const auto shift_point = point - center_of_rotation;
+          // Rotation axis tensor
+          Tensor<1, 3> rotation_axis;
+          rotation_axis[rotation_axis_direction] = 1.0;
           // Rotate
           const auto rotate_point =
             Physics::Transformations::Rotations::rotation_matrix_3d(
@@ -1865,7 +1868,7 @@ LetheGridTools::rotate_mapping(const DoFHandler<2> &dof_handler,
                                const Mapping<2>    &mapping,
                                const double        &rotation_angle,
                                const Point<2>      &center_of_rotation,
-                               const Tensor<1, 2>  &rotation_axis);
+                               const unsigned int  &rotation_axis_direction);
 
 template void
 LetheGridTools::rotate_mapping(const DoFHandler<3> &dof_handler,
@@ -1873,7 +1876,7 @@ LetheGridTools::rotate_mapping(const DoFHandler<3> &dof_handler,
                                const Mapping<3>    &mapping,
                                const double        &rotation_angle,
                                const Point<3>      &center_of_rotation,
-                               const Tensor<1, 3>  &rotation_axis);
+                               const unsigned int  &rotation_axis_direction);
 
 template <int dim, int spacedim>
 void

--- a/source/core/mortar_coupling_manager.cc
+++ b/source/core/mortar_coupling_manager.cc
@@ -563,13 +563,13 @@ compute_interface_dimensions_circular(
   // Direction of the rotation axis
   const unsigned int rotation_axis_direction =
     mortar_parameters.rotation_axis_direction;
-  // Create rotation axis vector for distance computation in 3D case
+  // Create rotation axis vector for distance computation in 3D cases
   Tensor<1, dim> rotation_axis;
   if constexpr (dim == 3)
     rotation_axis[rotation_axis_direction] = 1.0;
 
   // Min and max vertex coordinates for length computation in the axial
-  // direction. Used in 3D case
+  // direction. Used in 3D cases
   double vertex_min = std::numeric_limits<double>::max();
   double vertex_max = std::numeric_limits<double>::lowest();
 

--- a/source/core/mortar_coupling_manager.cc
+++ b/source/core/mortar_coupling_manager.cc
@@ -463,7 +463,7 @@ compute_number_interface_cells(const Triangulation<dim>      &triangulation,
   const double radius_tolerance = mortar_parameters.radius_tolerance;
   // Direction of the rotation axis
   const unsigned int rotation_axis_direction =
-    get_rotation_axis_direction(mortar_parameters);
+    mortar_parameters.rotation_axis_direction;
 
   // Coordinate of the reference cell for computation of the number of
   // subdivisions in the radial direction. Used in 3D case
@@ -562,7 +562,10 @@ compute_interface_dimensions_circular(
 
   // Direction of the rotation axis
   const unsigned int rotation_axis_direction =
-    get_rotation_axis_direction(mortar_parameters);
+    mortar_parameters.rotation_axis_direction;
+  Tensor<1, dim> rotation_axis;
+  rotation_axis[rotation_axis_direction] = 1.0;
+
   // Min and max vertex coordinates for length computation in the axial
   // direction. Used in 3D case
   double vertex_min = std::numeric_limits<double>::max();
@@ -606,7 +609,7 @@ compute_interface_dimensions_circular(
                               radius_current =
                                 LetheGridTools::find_point_line_distance(
                                   mortar_parameters.center_of_rotation,
-                                  mortar_parameters.rotation_axis,
+                                  rotation_axis,
                                   v);
                             }
 
@@ -736,39 +739,6 @@ construct_quadrature(const Quadrature<dim>         &quadrature,
 }
 
 template <int dim>
-unsigned int
-get_rotation_axis_direction(const Parameters::Mortar<dim> &mortar_parameters)
-{
-  if constexpr (dim == 3)
-    {
-      // First check if the vector has a unit norm, with a small margin for
-      // error
-      bool is_unit_axis =
-        std::abs(mortar_parameters.rotation_axis.norm() - 1) < 1e-8;
-
-      // Now check if the vector represents the x, y, or z directions
-      // specifically (we assume those are the only options for now)
-      for (int i = 0; i < dim; i++)
-        if (mortar_parameters.rotation_axis[i] != 0. &&
-            mortar_parameters.rotation_axis[i] != 1.)
-          is_unit_axis = false;
-
-      AssertThrow(
-        is_unit_axis,
-        ExcMessage(
-          "The rotation axis must be a unit vector in the positive x, y, or z direction."));
-
-      // Find the direction of the rotation axis
-      for (int d = 0; d < dim; d++)
-        if (mortar_parameters.rotation_axis[d] != 0.0)
-          return d;
-    }
-  // In 2D, the rotation_axis_direction is not used, but we return 2 to indicate
-  // that the rotation axis is perpendicular to the plane
-  return 2;
-}
-
-template <int dim>
 std::vector<double>
 compute_stage_heights(const Triangulation<dim>      &triangulation,
                       const Parameters::Mortar<dim> &mortar_parameters)
@@ -777,7 +747,7 @@ compute_stage_heights(const Triangulation<dim>      &triangulation,
     {
       // Direction of the rotation axis
       const unsigned int rotation_axis_direction =
-        get_rotation_axis_direction(mortar_parameters);
+        mortar_parameters.rotation_axis_direction;
       // Container storing all vertex coordinates in the rotation axis direction
       // for the local cells at the mortar boundary
       std::vector<double> stage_heights_local;
@@ -2179,12 +2149,6 @@ construct_quadrature(const Quadrature<2>         &quadrature,
 template Quadrature<3>
 construct_quadrature(const Quadrature<3>         &quadrature,
                      const Parameters::Mortar<3> &mortar_parameters);
-
-template unsigned int
-get_rotation_axis_direction(const Parameters::Mortar<2> &mortar_parameters);
-
-template unsigned int
-get_rotation_axis_direction(const Parameters::Mortar<3> &mortar_parameters);
 
 template std::vector<double>
 compute_stage_heights<2>(const Triangulation<2>      &triangulation,

--- a/source/core/mortar_coupling_manager.cc
+++ b/source/core/mortar_coupling_manager.cc
@@ -563,8 +563,10 @@ compute_interface_dimensions_circular(
   // Direction of the rotation axis
   const unsigned int rotation_axis_direction =
     mortar_parameters.rotation_axis_direction;
+  // Create rotation axis vector for distance computation in 3D case
   Tensor<1, dim> rotation_axis;
-  rotation_axis[rotation_axis_direction] = 1.0;
+  if constexpr (dim == 3)
+    rotation_axis[rotation_axis_direction] = 1.0;
 
   // Min and max vertex coordinates for length computation in the axial
   // direction. Used in 3D case

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -4918,11 +4918,11 @@ namespace Parameters
                         Patterns::List(Patterns::Double()),
                         "Center of rotation coordinates of rotor domain");
 
-      prm.declare_entry("rotation axis",
-                        "0.0, 0.0, 1.0",
-                        Patterns::List(Patterns::Double()),
-                        "Unit vector representing the rotor rotation axis."
-                        "Choices are <1, 0, 0 | 0, 1, 0 | 0, 0, 1>.");
+      prm.declare_entry("rotation axis direction",
+                        "2",
+                        Patterns::Integer(),
+                        "Direction of the rotation axis."
+                        "Choices are <0|1|2>.");
 
       prm.enter_subsection("rotor rotation angle");
       rotor_rotation_angle = std::make_shared<Functions::ParsedFunction<dim>>();
@@ -4985,7 +4985,7 @@ namespace Parameters
       stator_boundary_id = prm.get_integer("stator boundary id");
       center_of_rotation =
         value_string_to_tensor<dim>(prm.get("center of rotation"));
-      rotation_axis = value_string_to_tensor<dim>(prm.get("rotation axis"));
+      rotation_axis_direction = prm.get_integer("rotation axis direction");
       prm.enter_subsection("rotor rotation angle");
       rotor_rotation_angle->parse_parameters(prm);
       rotor_rotation_angle->set_time(0);

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -4920,9 +4920,8 @@ namespace Parameters
 
       prm.declare_entry("rotation axis direction",
                         "2",
-                        Patterns::Integer(),
-                        "Direction of the rotation axis."
-                        "Choices are <0|1|2>.");
+                        Patterns::Integer(0, 2),
+                        "Direction of the rotation axis. Choices are <0|1|2>.");
 
       prm.enter_subsection("rotor rotation angle");
       rotor_rotation_angle = std::make_shared<Functions::ParsedFunction<dim>>();

--- a/source/solvers/fluid_dynamics_matrix_free.cc
+++ b/source/solvers/fluid_dynamics_matrix_free.cc
@@ -1548,7 +1548,8 @@ MFNavierStokesPreconditionGMGBase<dim>::reinit(
                     .rotor_rotation_angle->value(Point<dim>()),
                   this->simulation_parameters.mortar_parameters
                     .center_of_rotation,
-                  this->simulation_parameters.mortar_parameters.rotation_axis);
+                  this->simulation_parameters.mortar_parameters
+                    .rotation_axis_direction);
               else if (this->simulation_parameters.mortar_parameters
                          .interface_type ==
                        Parameters::Mortar<dim>::InterfaceType::linear)
@@ -2681,7 +2682,7 @@ MFNavierStokesPreconditionGMG<dim>::initialize(
              .get_mapping_info()
              .mapping,
           this->simulation_parameters.mortar_parameters.center_of_rotation,
-          this->simulation_parameters.mortar_parameters.rotation_axis,
+          this->simulation_parameters.mortar_parameters.rotation_axis_direction,
           this->simulation_parameters.mortar_parameters.rotor_angular_velocity);
 
       this->mg_operators[level]->evaluate_non_linear_term_and_calculate_tau(
@@ -3413,7 +3414,7 @@ FluidDynamicsMatrixFree<dim>::assemble_system_rhs()
     this->system_operator->evaluate_velocity_ale(
       *this->get_mapping(),
       this->simulation_parameters.mortar_parameters.center_of_rotation,
-      this->simulation_parameters.mortar_parameters.rotation_axis,
+      this->simulation_parameters.mortar_parameters.rotation_axis_direction,
       this->simulation_parameters.mortar_parameters.rotor_angular_velocity);
 
   this->system_operator->evaluate_non_linear_term_and_calculate_tau(
@@ -3749,7 +3750,7 @@ FluidDynamicsMatrixFree<dim>::setup_preconditioner()
     this->system_operator->evaluate_velocity_ale(
       *this->get_mapping(),
       this->simulation_parameters.mortar_parameters.center_of_rotation,
-      this->simulation_parameters.mortar_parameters.rotation_axis,
+      this->simulation_parameters.mortar_parameters.rotation_axis_direction,
       this->simulation_parameters.mortar_parameters.rotor_angular_velocity);
 
   this->computing_timer.enter_subsection("Evaluate non linear term and tau");

--- a/source/solvers/fluid_dynamics_matrix_free_operators.cc
+++ b/source/solvers/fluid_dynamics_matrix_free_operators.cc
@@ -1263,7 +1263,7 @@ void
 NavierStokesOperatorBase<dim, number>::evaluate_velocity_ale(
   const Mapping<dim>                             &mapping,
   const Point<dim>                                center_of_rotation,
-  const Tensor<1, dim>                            rotation_axis,
+  const unsigned int                              rotation_axis_direction,
   std::shared_ptr<Functions::ParsedFunction<dim>> rotor_angular_velocity)
 {
   this->timer.enter_subsection("operator::evaluate_velocity_ale");
@@ -1316,10 +1316,8 @@ NavierStokesOperatorBase<dim, number>::evaluate_velocity_ale(
                        center_of_rotation[i];
 
               // Compute terms of u_ale
-              const auto product =
-                LetheGridTools::angular_to_linear_velocity(omega,
-                                                           p,
-                                                           rotation_axis);
+              const auto product = LetheGridTools::angular_to_linear_velocity(
+                omega, p, rotation_axis_direction);
 
               for (int i = 0; i < dim; i++)
                 this->velocity_ale[cell][q][i][lane] = product[i];

--- a/source/solvers/navier_stokes_base.cc
+++ b/source/solvers/navier_stokes_base.cc
@@ -2224,7 +2224,7 @@ NavierStokesBase<dim, VectorType, DofsType>::rotate_rotor_mapping(
       *this->mapping,
       rotation_angle,
       this->simulation_parameters.mortar_parameters.center_of_rotation,
-      this->simulation_parameters.mortar_parameters.rotation_axis);
+      this->simulation_parameters.mortar_parameters.rotation_axis_direction);
   else if (this->simulation_parameters.mortar_parameters.interface_type ==
            Parameters::Mortar<dim>::InterfaceType::linear)
     this->mapping_cache->initialize(*this->mapping,

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -471,7 +471,7 @@ NavierStokesScratchData<dim>::reinit_mortar(
       // Compute terms of u_ale
       rotor_linear_velocity_values[q] =
         LetheGridTools::angular_to_linear_velocity(
-          omega, p, mortar_parameters.rotation_axis);
+          omega, p, mortar_parameters.rotation_axis_direction);
 
       // Subtract u_ale from the advective velocity
       this->advective_velocity[q] -= rotor_linear_velocity_values[q];

--- a/source/solvers/tracer.cc
+++ b/source/solvers/tracer.cc
@@ -1792,7 +1792,7 @@ Tracer<dim>::rotate_rotor_mapping()
       *this->mapping,
       rotation_angle,
       this->simulation_parameters.mortar_parameters.center_of_rotation,
-      this->simulation_parameters.mortar_parameters.rotation_axis);
+      this->simulation_parameters.mortar_parameters.rotation_axis_direction);
   else if (this->simulation_parameters.mortar_parameters.interface_type ==
            Parameters::Mortar<dim>::InterfaceType::linear)
     this->mapping_cache->initialize(*this->mapping,

--- a/tests/mortar/rotate_mapping.cc
+++ b/tests/mortar/rotate_mapping.cc
@@ -74,7 +74,7 @@ test()
   mortar_parameters.rotor_mesh->simplex        = false;
   mortar_parameters.stator_boundary_id         = 4;
   mortar_parameters.rotor_boundary_id          = 5; // after shifting
-  mortar_parameters.rotation_axis              = Tensor<1, dim>({0, 0});
+  mortar_parameters.rotation_axis_direction    = 2;
   mortar_parameters.radius_tolerance           = 1e-8;
   const double rotation_angle =
     2 * numbers::PI * mortar_parameters.rotor_mesh->rotation_angle / 360.0;

--- a/tests/mortar/rotate_mapping_3d.cc
+++ b/tests/mortar/rotate_mapping_3d.cc
@@ -80,7 +80,7 @@ test()
   mortar_parameters.rotor_mesh->rotation_angle = 0.0;
   mortar_parameters.stator_boundary_id         = 0;
   mortar_parameters.rotor_boundary_id          = 5; // after shifting
-  mortar_parameters.rotation_axis              = Tensor<1, dim>({0, 0, 1});
+  mortar_parameters.rotation_axis_direction    = 2;
   mortar_parameters.center_of_rotation         = Point<dim>();
   mortar_parameters.radius_tolerance           = 1e-8;
   const double rotation_angle                  = 0.1;
@@ -120,7 +120,7 @@ test()
                                  mapping,
                                  rotation_angle,
                                  mortar_parameters.center_of_rotation,
-                                 mortar_parameters.rotation_axis);
+                                 mortar_parameters.rotation_axis_direction);
 
   // Print information
   if (Utilities::MPI::this_mpi_process(comm) == 0)


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

This PR changes the `rotation axis` parameter in the `Mortar` subsection to a `rotation axis direction` instead. Since the rotation axis is always going to be either x, y or z directions, it is more adequate to prescribe the rotation axis direction instead of a unit vector. This simplifies the code implementation.

### Testing

<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

No new tests were added, but the test `mortar_taylorcouette3d_x_rotation` was updated to read a `rotation axis direction`.

### Documentation

<!-- Does this refactor modify or have new simulation parameters? If so, describe them. -->

The `rotation axis direction` parameter has been updated in the documentation.

### Use of LLMs  (Large Language Models)

<!-- LLM-assisted contributions are welcome, but they must be declared.
       If an LLM (e.g. GitHub Copilot, ChatGPT, Claude, Cursor) generated a substantial portion
       of this pull request (e.g. more than a small fraction of the source code, or algorithms
       that are crucial for the functionality), describe here which parts were generated and
       what the LLM was used for.
       Write "None" if no LLM was used.
       By submitting this pull request, you confirm that you have reviewed and verified all
       LLM-generated content, and that you understand and accept responsibility for the
       proposed changes. -->

None

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] An entry describing the change has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If any future work is planned, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR