### PR TITLE
Fix CLang TIDY CI to prevent linking challenges

### DIFF
--- a/contrib/utilities/run_clang_tidy.sh
+++ b/contrib/utilities/run_clang_tidy.sh
@@ -54,7 +54,13 @@ fi
 
 CC=clang CXX=clang++ cmake "${ARGS[@]}" "$SRC" || (echo "cmake failed!"; false) || exit 2
 
-CXXFLAGS="-Wno-unknown-warning-option";  cmake --build . -j 12 
+# Build only the static libraries. Linking the applications and the tests is
+# unnecessary for static analysis, and it fails whenever deal.II was built with
+# a compiler other than clang: GCC and clang mangle deal.II's enable_if-based
+# template signatures (e.g. TrilinosWrappers::SparseMatrix::vmult) differently,
+# so the explicit instantiations shipped in libdeal_II cannot be resolved.
+CXXFLAGS="-Wno-unknown-warning-option";  cmake --build . -j 12 \
+  --target lethe-core lethe-dem lethe-solvers lethe-fem-dem
 
 # generate allheaders.h
 #(cd include; find . -name '*.h'; cd $SRC/include/; find . -name '*.h') | grep -v allheaders.h | grep -v undefine_macros.h | sed 's|^./|#include <|' | sed 's|$|>|' >include/deal.II/allheaders.h

--- a/release_notes/current/2026_08_09_Blais.md
+++ b/release_notes/current/2026_08_09_Blais.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/08/09
+
+### Changed
+
+- MINOR Restricts the build carried out by `run_clang_tidy.sh` to the Lethe libraries instead of building the full project. Linking the applications and the tests is unnecessary for static analysis and fails when deal.II was built with a compiler other than Clang, since GCC and Clang mangle deal.II's `enable_if`-based template signatures (e.g. `TrilinosWrappers::SparseMatrix::vmult`) differently. This also shortens the runtime of the clang-tidy CI job. [#XXXX](https://github.com/chaos-polymtl/lethe/pull/XXXX)

--- a/release_notes/current/2026_08_09_Blais.md
+++ b/release_notes/current/2026_08_09_Blais.md
@@ -2,4 +2,4 @@
 
 ### Changed
 
-- MINOR Restricts the build carried out by `run_clang_tidy.sh` to the Lethe libraries instead of building the full project. Linking the applications and the tests is unnecessary for static analysis and fails when deal.II was built with a compiler other than Clang, since GCC and Clang mangle deal.II's `enable_if`-based template signatures (e.g. `TrilinosWrappers::SparseMatrix::vmult`) differently. This also shortens the runtime of the clang-tidy CI job. [#XXXX](https://github.com/chaos-polymtl/lethe/pull/XXXX)
+- MINOR Restricts the build carried out by `run_clang_tidy.sh` to the Lethe libraries instead of building the full project. Linking the applications and the tests is unnecessary for static analysis and fails when deal.II was built with a compiler other than Clang, since GCC and Clang mangle deal.II's `enable_if`-based template signatures (e.g. `TrilinosWrappers::SparseMatrix::vmult`) differently. This also shortens the runtime of the clang-tidy CI job. [#2085](https://github.com/chaos-polymtl/lethe/pull/2085)


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The Clang TIDY CI would often yield an error message not taken into account. This was caused by the fact that Trilinos in the Ubuntu image is compiled using GCC but we compile Lethe with CLang in the CLang TIDY CI. This PR fixes this by just compiling the libraries themselves and not the executables.


### Testing

Nothing to test here, the outcome of the CI will be sufficient to check.

### Documentation

Nothing to document

### Use of LLMs  (Large Language Models)

I had the idea myself, but then I used Claude (Opus 5.0) to find a simple solution which ended up specifying the targets manually in the cmake command used in the CI.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] An entry describing the change has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`

Pull request related list:
- [x] No other PR is open related to this refactoring
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If any future work is planned, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR