### PR TITLE
Use FEPointEvaluation for void fraction and CLS at particle locations

### DIFF
--- a/include/solvers/navier_stokes_scratch_data.h
+++ b/include/solvers/navier_stokes_scratch_data.h
@@ -23,6 +23,8 @@
 
 #include <deal.II/fe/fe_system.h>
 
+#include <deal.II/matrix_free/fe_point_evaluation.h>
+
 #include <deal.II/particles/particle_handler.h>
 
 using namespace dealii;
@@ -882,19 +884,25 @@ public:
       ExcMessage(
         "gather_void_fraction has been set to false, yet you are trying to gather the void fraction at the location of the particles. The scratch data is currently unaware of the finite element interpolation for the void fraction and the simulation will abort."));
 
-    FEValues<dim> fe_values_particles_void_fraction(
-      this->fe_values_void_fraction->get_fe(),
-      q_particles_location,
-      update_values);
-
     Assert(
       cell_void_fraction.size() == q_particles_location.size(),
       ExcMessage(
         "The vector for the void fraction at the particle location does not have the same size as the quadrature used to evaluate it."));
-    fe_values_particles_void_fraction.reinit(void_fraction_cell);
 
-    fe_values_particles_void_fraction.get_function_values(
-      void_fraction_solution, cell_void_fraction);
+    Vector<double> local_void_fraction_dof_values(
+      void_fraction_cell->get_fe().n_dofs_per_cell());
+    void_fraction_cell->get_dof_values(void_fraction_solution,
+                                       local_void_fraction_dof_values);
+
+    point_evaluator_void_fraction->reinit(
+      void_fraction_cell, make_array_view(q_particles_location.get_points()));
+    point_evaluator_void_fraction->evaluate(
+      make_array_view(local_void_fraction_dof_values), EvaluationFlags::values);
+
+    for (unsigned int i_particle = 0; i_particle < q_particles_location.size();
+         ++i_particle)
+      cell_void_fraction[i_particle] =
+        point_evaluator_void_fraction->get_value(i_particle);
   }
 
   /**
@@ -1026,19 +1034,23 @@ public:
       ExcMessage(
         "gather_cls has been set to false, yet you are trying to gather the CLS at the location of the particles. The scratch data is currently unaware of the finite element interpolation for CLS and the simulation will abort."));
 
-
-    FEValues<dim> fe_values_cls_local_particles((*this->fe_values_cls).get_fe(),
-                                                q_particles_location,
-                                                update_values |
-                                                  update_quadrature_points |
-                                                  update_JxW_values);
-
     filtered_phase_values_at_particle_location.resize(number_of_particles);
 
-    fe_values_cls_local_particles.reinit(phase_cell);
+    Vector<double> local_filtered_phase_dof_values(
+      phase_cell->get_fe().n_dofs_per_cell());
+    phase_cell->get_dof_values(current_filtered_solution,
+                               local_filtered_phase_dof_values);
 
-    fe_values_cls_local_particles.get_function_values(
-      current_filtered_solution, filtered_phase_values_at_particle_location);
+    point_evaluator_cls->reinit(
+      phase_cell, make_array_view(q_particles_location.get_points()));
+    point_evaluator_cls->evaluate(make_array_view(
+                                    local_filtered_phase_dof_values),
+                                  EvaluationFlags::values);
+
+    for (unsigned int i_particle = 0; i_particle < number_of_particles;
+         ++i_particle)
+      filtered_phase_values_at_particle_location[i_particle] =
+        point_evaluator_cls->get_value(i_particle);
   }
 
   /**
@@ -1586,6 +1598,10 @@ public:
   std::vector<Tensor<1, dim>>      phase_gradient_values;
   // This is stored as a shared_ptr because it is only instantiated when needed
   std::shared_ptr<FEValues<dim>> fe_values_cls;
+  // Used to evaluate the filtered CLS solution at particle locations
+  // (arbitrary points within the cell); stored as a shared_ptr because it is
+  // only instantiated when needed
+  std::shared_ptr<FEPointEvaluation<1, dim>> point_evaluator_cls;
   std::shared_ptr<ConservativeLevelSetFilterBase>
     filter; // Phase indicator filter
 
@@ -1606,6 +1622,10 @@ public:
   std::vector<Tensor<1, dim>>      void_fraction_gradient_values;
   // This is stored as a shared_ptr because it is only instantiated when needed
   std::shared_ptr<FEValues<dim>> fe_values_void_fraction;
+  // Used to evaluate the void fraction at particle locations (arbitrary
+  // points within the cell); stored as a shared_ptr because it is only
+  // instantiated when needed
+  std::shared_ptr<FEPointEvaluation<1, dim>> point_evaluator_void_fraction;
 
   /**
    * Scratch component for the particle fluid interaction auxiliary physics

--- a/release_notes/current/2026_08_11_Mohit.md
+++ b/release_notes/current/2026_08_11_Mohit.md
@@ -1,0 +1,12 @@
+## [Master] - 2026/08/11
+
+### Changed
+
+- MINOR Replaces `FEValues` with `FEPointEvaluation` to interpolate the void
+  fraction and the filtered CLS solution at particle locations in
+  `NavierStokesScratchData`, and promotes both evaluators to persistent
+  scratch members built once in `enable_void_fraction`/`enable_cls` instead of
+  being reallocated on every cell. The velocity/pressure particle-location
+  evaluation is left unchanged because it requires the velocity Laplacian,
+  which needs Hessians that `FEPointEvaluation` does not yet support upstream.
+  [#PR](link)

--- a/release_notes/current/2026_08_11_Mohit.md
+++ b/release_notes/current/2026_08_11_Mohit.md
@@ -9,4 +9,4 @@
   being reallocated on every cell. The velocity/pressure particle-location
   evaluation is left unchanged because it requires the velocity Laplacian,
   which needs Hessians that `FEPointEvaluation` does not yet support upstream.
-  [#PR](link)
+  [#2087](https://github.com/chaos-polymtl/lethe/pull/2087)

--- a/source/solvers/navier_stokes_scratch_data.cc
+++ b/source/solvers/navier_stokes_scratch_data.cc
@@ -105,6 +105,8 @@ NavierStokesScratchData<dim>::enable_cls(
   gather_cls    = true;
   fe_values_cls = std::make_shared<FEValues<dim>>(
     mapping, fe, quadrature, update_values | update_gradients);
+  point_evaluator_cls =
+    std::make_shared<FEPointEvaluation<1, dim>>(mapping, fe, update_values);
 
   // Allocate CLS values
   phase_values          = std::vector<double>(this->n_q_points);
@@ -146,6 +148,8 @@ NavierStokesScratchData<dim>::enable_cls(
   gather_cls    = true;
   fe_values_cls = std::make_shared<FEValues<dim>>(
     mapping, fe, quadrature, update_values | update_gradients);
+  point_evaluator_cls =
+    std::make_shared<FEPointEvaluation<1, dim>>(mapping, fe, update_values);
 
   // Allocate CLS values
   phase_values          = std::vector<double>(this->n_q_points);
@@ -329,6 +333,8 @@ NavierStokesScratchData<dim>::enable_void_fraction(
                                     quadrature,
                                     update_values | update_gradients |
                                       update_JxW_values);
+  point_evaluator_void_fraction =
+    std::make_shared<FEPointEvaluation<1, dim>>(mapping, fe, update_values);
 
   // Void Fraction
   void_fraction_values = std::vector<double>(this->n_q_points);


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

Addresses #1581. `NavierStokesScratchData` builds three `FEValues` objects
from a per-cell particle-location `Quadrature` (i.e. arbitrary in-cell
points, not a fixed quadrature rule) to interpolate fields at particle
locations for CFD-DEM coupling:

- `calculate_fluid_fields_at_particle_location` (velocity/pressure, incl.
  `update_hessians` for the velocity Laplacian)
- `calculate_void_fraction_at_particle_location` (`update_values` only)
- `calculate_cls_at_particle_location` (`update_values` only)

The latter two are value-only evaluations on a scalar FE (void fraction and
CLS are each their own scalar `FE_Q<dim>` DoFHandler), a direct fit for
`FEPointEvaluation`. This PR swaps those two to `FEPointEvaluation`, and
additionally promotes them from per-call local objects (rebuilt from scratch,
including their internal shape function tables, on every single cell/call)
to persistent scratch members built once in `enable_void_fraction`/
`enable_cls`, mirroring how `fe_values_cls`/`fe_values_void_fraction` already
work. That reuse is where most of the actual efficiency win comes from, not
just the type swap.

The velocity/pressure instance (`calculate_fluid_fields_at_particle_location`)
is intentionally left unchanged: it needs the velocity Laplacian, and I
confirmed directly in deal.II's `fe_point_evaluation.h` that every
`evaluate()`/`integrate()` path currently asserts
`!(flags & EvaluationFlags::hessians)` — Hessians aren't implemented
upstream yet. Swapping that instance would drop the Laplacian, so it's out
of scope for now (happy to revisit if/when upstream support lands).

### Testing

No new tests: this is a value-preserving internal refactor with no change to
simulation results, and the existing golden-output tests that exercise these
code paths (`lethe-fluid-vans*`, `lethe-fluid-particles*`, the CFD-DEM
`particle_projector` tests) already cover it end-to-end via `numdiff` against
reference output, so they'd catch any numerical regression.

I built Debug (`dealii/dealii:v9.7.1-noble`) and ran the
`lethe-fluid-particles`, `lethe-fluid-vans`, `lethe-fluid-vans-matrix-free`,
`lethe-fluid-particles-matrix-free`, `fem-dem`, and `solvers` ctest
categories (84 tests) both before and after this change: **identical
results** (61/84 passed, the same 23 pre-existing failures both times). I
root-caused all 23: they're artifacts of running on aarch64 rather than the
x86-64 CI runners (a CGAL FPU-rounding-mode self-check that doesn't hold on
ARM, one pre-existing floating-point drift in a golden-value diff, and one
MPI test timing out under my local container's resource limits) — none are
Lethe bugs, and none are affected by this change. Happy to paste the full
before/after logs if useful for review.

### Documentation

No simulation parameters are added, changed, or removed.

### Use of LLMs (Large Language Models)

Yes. I used Claude (Anthropic) as a coding assistant for most of this PR,
under my direction: it located the relevant `FEValues` usages, read
deal.II's `fe_point_evaluation.h` source to determine the Hessian limitation
described above, wrote the code change, and ran the build/test verification
described above (Docker build, baseline vs. post-change ctest comparison). I
reviewed the resulting diff and the test-comparison output before opening
this PR and take responsibility for the change as submitted.

### Miscellaneous (will be removed when merged)

None.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] An entry describing the change has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`

Pull request related list:
- [x] No other PR is open related to this refactoring
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature)
- [x] If any future work is planned, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR
