### PR TITLE
Fix pull request documentation link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ request.
     the source of the bug should be explained and the way it was identified should be briefly described. 
     A unit test or application test that reproduces the bug should be added.
 
-See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing.html#pull-requests) for more information about the pull request process.
+See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.
 
 
 # Good practices

--- a/release_notes/current/2026_08_11_Alphonius_2.md
+++ b/release_notes/current/2026_08_11_Alphonius_2.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/08/11
+
+### Fixed
+
+- MINOR In Lethe's contributing Markdown page (``CONTRIBUTING.md``) the pull request documentation page link was out of date. It is now up to date. [#2092](https://github.com/chaos-polymtl/lethe/pull/2092)


### PR DESCRIPTION
### Description

In Lethe's contributing markdown page (``CONTRIBUTING.md``) the pull request documentation page link was out of date.

### Solution

This PR simply updates this link.

### Use of LLMs (Large Language Models)

None

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Copyright headers are present and up to date
- [ ] Lethe documentation is up to date
- [ ] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [ ] The branch is rebased onto master
- [ ] An entry describing the origin of the bug as well as its fix has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`
- [ ] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature)
- [ ] If the fix is temporary, an issue is opened
- [ ] The PR description is clean and is ready to be used as the commit message when merging the PR