### PR TITLE
Turbulent cylinder

### DIFF
--- a/doc/source/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/3d-turbulent-flow-around-cylinder.rst
+++ b/doc/source/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/3d-turbulent-flow-around-cylinder.rst
@@ -50,22 +50,24 @@ Parameter File
 Mesh
 ~~~~
 
-The ``mesh`` subsection specifies the computational grid. We use a custom mesh generated using the functionality ``uniform_channel_with_cylinder``  of the deal.II library's `GridGenerator <https://www.dealii.org/current/doxygen/deal.II/namespaceGridGenerator.html>`_ to discretize the domain using high-order elements. The mesh is also refined once in the vicinity of the cylinder to capture the boundary layer and wake region more accurately. This is achieved by setting ``initial boundary refinement = 1`` and ``boundaries refined = 2``. 
+The ``mesh`` subsection specifies the computational grid. We use a mesh generated with the ``uniform_channel_with_cylinder`` function of the deal.II library's `GridGenerator <https://www.dealii.org/current/doxygen/deal.II/namespaceGridGenerator.html>`_ to discretize the domain using high-order elements. The mesh is also refined once in the vicinity of the cylinder to capture the boundary layer and wake region more accurately. This is achieved by setting ``initial boundary refinement = 1`` and ``boundaries refined = 2``. 
 
 .. code-block:: text
   
   subsection mesh
     set type                        = dealii
     set grid type                   = uniform_channel_with_cylinder
-    set grid arguments              = 25 : 8 : 52 : 4.71238898038 : 4 : 0.75 : 5 : 1:  false : true
+    set grid arguments              = 8, 52, 25, 25 : 4.71238898038 : 4 : 0.75 : 5 : 1:  false: true
     set initial boundary refinement = 1 
     set boundaries refined          = 2
   end
 
 
+The ``grid arguments`` are those of the deal.II generator. The first field is the list of the four distances (expressed in cylinder diameters) between the center of the cylinder and, respectively, the inlet, the outlet, the bottom and the top of the channel. The following fields are the depth of the channel (:math:`1.5 \pi D`), the number of cells used to discretize it in the :math:`z` direction, the radius of the region of shells around the cylinder, the number of shells, the skewness of the shells, whether a transfinite manifold is used in the region between the shells and the channel, and whether the boundaries are colorized.
+
 .. warning::
 
-  This ``uniform_channel_with_cylinder`` grid generator is only present in the 9.7 version of the deal.II library.
+  This ``uniform_channel_with_cylinder`` grid generator requires deal.II 9.7 or a more recent version. In earlier development versions of deal.II, this generator was named ``custom_channel_with_cylinder``.
 
 Box refinement
 ~~~~~~~~~~~~~~~~

--- a/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/turbulent-cylinder.prm
+++ b/examples/incompressible-flow/3d-turbulent-flow-around-cylinder/turbulent-cylinder.prm
@@ -74,7 +74,7 @@ end
 
 subsection mesh
   set type                        = dealii
-  set grid type                   = custom_channel_with_cylinder
+  set grid type                   = uniform_channel_with_cylinder
   set grid arguments              = 8, 52, 25, 25 : 4.71238898038 : 4 : 0.75 : 5 : 1:  false: true
   set initial boundary refinement = 1
   set boundaries refined          = 2

--- a/release_notes/current/2026_08_18_Blais.md
+++ b/release_notes/current/2026_08_18_Blais.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/08/18
+
+### Fixed
+
+- MINOR Fixed the mesh of the `3d-turbulent-flow-around-cylinder` example, which could not be generated anymore. The `grid type` of the example was `custom_channel_with_cylinder`, a name the deal.II grid generator only carried during its development. It was renamed to `uniform_channel_with_cylinder` before the 9.7 release, and the example parameter file was never updated. The `grid arguments` shown in the documentation of the example were also inconsistent with those of the parameter file and are now identical to them, and the arguments of the generator are documented. [#2094](https://github.com/chaos-polymtl/lethe/pull/2094)


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

The name of the grid generator used to generate the 3d-turbulent-flow-around-cylinder was not correct. It was based on an old deal.II nomenclature that was changed.

### Solution

The real grid name is uniform_channel_with_cylinder

### Testing

Reran the example

### Documentation

Updated the documentation.


### Use of LLMs (Large Language Models)

I found the bug and fixed the issue myself. I used Claude Opus 5.0 to update the documentation with my changes.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] An entry describing the origin of the bug as well as its fix has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR