### PR TITLE
Fix compilation with dealii current master version due to renamed solution transfer files

### DIFF
--- a/include/solvers/cahn_hilliard.h
+++ b/include/solvers/cahn_hilliard.h
@@ -30,7 +30,6 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/timer.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria_base.h>
 
 #include <deal.II/fe/fe_q.h>
@@ -43,6 +42,8 @@
 #include <deal.II/lac/trilinos_precondition.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/lac/trilinos_vector.h>
+
+#include <deal.II/numerics/solution_transfer.h>
 
 DeclException1(
   CahnHilliardBoundaryConditionMissing,

--- a/include/solvers/cls.h
+++ b/include/solvers/cls.h
@@ -22,7 +22,6 @@
 #include <deal.II/base/table_handler.h>
 #include <deal.II/base/timer.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria_base.h>
 
 #include <deal.II/grid/grid_tools.h>
@@ -30,6 +29,8 @@
 #include <deal.II/lac/trilinos_precondition.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/lac/trilinos_vector.h>
+
+#include <deal.II/numerics/solution_transfer.h>
 
 
 DeclException1(

--- a/include/solvers/heat_transfer.h
+++ b/include/solvers/heat_transfer.h
@@ -19,7 +19,6 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/timer.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria_base.h>
 
 #include <deal.II/fe/fe_q.h>
@@ -35,6 +34,8 @@
 
 #include <deal.II/non_matching/fe_values.h>
 #include <deal.II/non_matching/mesh_classifier.h>
+
+#include <deal.II/numerics/solution_transfer.h>
 
 DeclException1(
   HeatTransferBoundaryConditionMissing,

--- a/include/solvers/postprocessing_scalar.h
+++ b/include/solvers/postprocessing_scalar.h
@@ -6,7 +6,7 @@
 
 #include <core/parameters.h>
 
-#include <deal.II/distributed/solution_transfer.h>
+#include <deal.II/numerics/solution_transfer.h>
 
 using namespace dealii;
 

--- a/include/solvers/postprocessing_velocities.h
+++ b/include/solvers/postprocessing_velocities.h
@@ -6,7 +6,7 @@
 
 #include <core/parameters.h>
 
-#include <deal.II/distributed/solution_transfer.h>
+#include <deal.II/numerics/solution_transfer.h>
 
 using namespace dealii;
 

--- a/include/solvers/time_harmonic_maxwell.h
+++ b/include/solvers/time_harmonic_maxwell.h
@@ -19,7 +19,6 @@
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/timer.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria_base.h>
 
 #include <deal.II/fe/fe_dgq.h>
@@ -37,6 +36,7 @@
 
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/error_estimator.h>
+#include <deal.II/numerics/solution_transfer.h>
 
 #include <memory.h>
 

--- a/include/solvers/tracer.h
+++ b/include/solvers/tracer.h
@@ -18,7 +18,6 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/timer.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria_base.h>
 
 #include <deal.II/fe/fe_q.h>
@@ -31,6 +30,8 @@
 #include <deal.II/lac/trilinos_precondition.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/lac/trilinos_vector.h>
+
+#include <deal.II/numerics/solution_transfer.h>
 
 #include <map>
 

--- a/prototypes/vof_advection/vof_advection.cc
+++ b/prototypes/vof_advection/vof_advection.cc
@@ -12,7 +12,6 @@
 #include <deal.II/base/work_stream.h>
 
 #include <deal.II/distributed/grid_refinement.h>
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>

--- a/release_notes/current/2026_08_23_Blais.md
+++ b/release_notes/current/2026_08_23_Blais.md
@@ -1,0 +1,6 @@
+## [Master] - 2026/08/23
+
+### Fixed
+
+- MINOR Restore compilation against deal.II master, which removed the code deprecated in 9.8: include `deal.II/numerics/solution_transfer.h` instead of the deleted `deal.II/distributed/solution_transfer.h`, derive the mortar test operators from `EnableObserverPointer` instead of the removed `Subscriptor`, and use `Triangulation::get_mpi_communicator()` instead of the removed `get_communicator()`. [#2100](https://github.com/chaos-polymtl/lethe/pull/2100)
+- MINOR Add the missing `<numbers>` include in `grid_cube_merged.cc`, which used `std::numbers::pi` through a transitive deal.II include that no longer exists on deal.II master. [#2100](https://github.com/chaos-polymtl/lethe/pull/2100)

--- a/source/core/grid_cube_merged.cc
+++ b/source/core/grid_cube_merged.cc
@@ -8,6 +8,8 @@
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/manifold_lib.h>
 
+#include <numbers>
+
 template <int dim, int spacedim>
 GridCubeMerged<dim, spacedim>::GridCubeMerged(const std::string &grid_arguments)
 {

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -8,7 +8,6 @@
 #include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/distributed/fully_distributed_tria.h>
-#include <deal.II/distributed/solution_transfer.h>
 
 #include <deal.II/dofs/dof_tools.h>
 
@@ -22,6 +21,7 @@
 #include <deal.II/grid/grid_in.h>
 #include <deal.II/grid/grid_tools.h>
 
+#include <deal.II/numerics/solution_transfer.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include <deal.II/particles/data_out.h>

--- a/tests/dem/particle_particle_contact_on_two_processors.cc
+++ b/tests/dem/particle_particle_contact_on_two_processors.cc
@@ -97,7 +97,7 @@ test()
     nonlinear_force_object(dem_parameters);
   VelocityVerletIntegrator<dim, PropertiesIndex> integrator_object;
 
-  MPI_Comm communicator     = triangulation.get_communicator();
+  MPI_Comm communicator     = triangulation.get_mpi_communicator();
   auto     this_mpi_process = Utilities::MPI::this_mpi_process(communicator);
 
   // Inserting two particles in contact

--- a/tests/dem/two_particles_multiple_contacts_parallel.cc
+++ b/tests/dem/two_particles_multiple_contacts_parallel.cc
@@ -89,7 +89,7 @@ test()
     nonlinear_force_object(dem_parameters);
   VelocityVerletIntegrator<dim, PropertiesIndex> integrator_object;
 
-  MPI_Comm communicator     = triangulation.get_communicator();
+  MPI_Comm communicator     = triangulation.get_mpi_communicator();
   auto     this_mpi_process = Utilities::MPI::this_mpi_process(communicator);
 
   // Inserting two particles in contact

--- a/tests/mortar/tests.h
+++ b/tests/mortar/tests.h
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2021-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
+#include <deal.II/base/enable_observer_pointer.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/manifold_lib.h>
@@ -460,7 +462,7 @@ template <int dim,
           int n_components,
           typename Number,
           typename VectorizedArrayType = VectorizedArray<Number>>
-class OperatorBase : public Subscriptor
+class OperatorBase : public EnableObserverPointer
 {
 public:
   using FECellIntegrator =
@@ -814,7 +816,7 @@ private:
 template <int dim,
           typename Number,
           typename VectorizedArrayType = VectorizedArray<Number>>
-class GeneralStokesOperator : public Subscriptor
+class GeneralStokesOperator : public EnableObserverPointer
 {
 public:
   using FECellIntegratorU =
@@ -1224,7 +1226,7 @@ template <int dim,
           int n_components,
           typename Number,
           typename VectorizedArrayType = VectorizedArray<Number>>
-class PoissonOperatorDG : public Subscriptor
+class PoissonOperatorDG : public EnableObserverPointer
 {
 public:
   using FECellIntegrator =
@@ -1643,7 +1645,7 @@ protected:
 template <int dim,
           typename Number,
           typename VectorizedArrayType = VectorizedArray<Number>>
-class GeneralStokesOperatorDG : public Subscriptor
+class GeneralStokesOperatorDG : public EnableObserverPointer
 {
 public:
   using FECellIntegratorU =


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

- The include file for solution_transfer has moved to deal.II/numerics
- There was a missing include (numbers) in the grid_cube_merged
- Some tests did not call the right API to get the MPI communicator from the triangulation

### Solution

- Used the right include in the solvers
- Added the missing numbers incluide
- Used the modern API version

### Testing

No test results change, but compilation and everything is fine on both 9.7 and current master.

### Documentation

Nothing to document.

### Use of LLMs (Large Language Models)

No LLM were used here.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests.
         Any comments or highlights for the reviewers. -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] Fix has unit test(s) (preferred) or application test(s), and restart files are in the generator folder
- [x] The branch is rebased onto master
- [x] An entry describing the origin of the bug as well as its fix has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If the fix is temporary, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR