### PR TITLE
Allow list of boundary IDs in manifolds subsection

### DIFF
--- a/applications_tests/lethe-fluid/mortar_asymmetric_height.prm
+++ b/applications_tests/lethe-fluid/mortar_asymmetric_height.prm
@@ -43,15 +43,9 @@ end
 #---------------------------------------------------
 
 subsection manifolds
-  set number = 2
+  set number = 1
   subsection manifold 0
-    set id                = 4
-    set type              = cylindrical
-    set point coordinates = 0, 0, 0
-    set direction vector  = 0, 0, 1
-  end
-  subsection manifold 1
-    set id                = 7
+    set id                = 4, 7
     set type              = cylindrical
     set point coordinates = 0, 0, 0
     set direction vector  = 0, 0, 1

--- a/applications_tests/lethe-fluid/mortar_mms3d.prm
+++ b/applications_tests/lethe-fluid/mortar_mms3d.prm
@@ -43,15 +43,9 @@ end
 #---------------------------------------------------
 
 subsection manifolds
-  set number = 2
+  set number = 1
   subsection manifold 0
-    set id                = 4
-    set type              = cylindrical
-    set point coordinates = 0, 0, 0
-    set direction vector  = 0, 0, 1
-  end
-  subsection manifold 1
-    set id                = 7
+    set id                = 4, 7
     set type              = cylindrical
     set point coordinates = 0, 0, 0
     set direction vector  = 0, 0, 1

--- a/applications_tests/lethe-fluid/mortar_mms_gmsh.prm
+++ b/applications_tests/lethe-fluid/mortar_mms_gmsh.prm
@@ -43,14 +43,9 @@ end
 #---------------------------------------------------
 
 subsection manifolds
-  set number = 2
+  set number = 1
   subsection manifold 0
-    set id                = 1
-    set type              = spherical
-    set point coordinates = 1, 1
-  end
-  subsection manifold 1
-    set id                = 2
+    set id                = 1, 2
     set type              = spherical
     set point coordinates = 1, 1
   end

--- a/applications_tests/lethe-fluid/taylorcouette-unstructured_gls.prm
+++ b/applications_tests/lethe-fluid/taylorcouette-unstructured_gls.prm
@@ -100,14 +100,9 @@ end
 #---------------------------------------------------
 
 subsection manifolds
-  set number = 2
+  set number = 1
   subsection manifold 0
-    set id                = 0
-    set type              = spherical
-    set point coordinates = 0,0
-  end
-  subsection manifold 1
-    set id                = 1
+    set id                = 0, 1
     set type              = spherical
     set point coordinates = 0,0
   end

--- a/doc/source/parameters/cfd/manifolds.rst
+++ b/doc/source/parameters/cfd/manifolds.rst
@@ -30,6 +30,11 @@ Linking parts of the mesh to manifolds is an interesting way to factor the real 
 
 First the number of manifolds is specified by the ``set number`` command. Then a subsection for each of the manifolds is created starting with the ``manifold 0``. The boundary ``id`` is in this case set to ``0`` corresponding to the mesh boundary to which the manifold will be applied. Then the ``type`` of the manifold is specified.
 
+
+.. warning::
+    The manifold id will always be the same as the prescribed boundary ``id``. Similar to :doc:`../cfd/boundary_conditions_cfd`, The parameter ``id`` can also take a list of boundary ids.
+    Hence, ``set number`` refers to the number of ``manifold`` subsections, and not the total number of manifolds in the mesh.
+
 * Lethe supports three types of manifolds:
 
   * ``spherical`` manifold: The former can be used to describe any sphere, circle, hypesphere or hyperdisc in two or three dimensions and requires the center of the geometry to set the manifold.

--- a/include/core/manifolds.h
+++ b/include/core/manifolds.h
@@ -47,8 +47,12 @@ namespace Parameters
     // File names for cad manifolds
     std::vector<std::string> cad_files;
 
-    // Number of manifolds
-    unsigned int number_of_manifolds;
+    // Number of manifolds subsections. Each manifold description (i.e., type
+    // and geometric characteristics) can be associated to more than one
+    // boundary ID. Hence, the total number of individual manifolds should be
+    // accessed through the size of the manifold description vectors (e.g.,
+    // `ids`).
+    unsigned int number_of_manifolds_subsections;
 
     void
     parse_boundary(const ParameterHandler &prm);

--- a/include/core/manifolds.h
+++ b/include/core/manifolds.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_manifolds_h

--- a/include/core/manifolds.h
+++ b/include/core/manifolds.h
@@ -32,8 +32,9 @@ namespace Parameters
       iges
     };
 
-    // ID of boundaries to which the manifold will be applied
-    std::vector<unsigned int> boundary_ids;
+    // ID of boundaries to which the manifold will be applied. Each manifold
+    // will be stored with its corresponding boundary ID
+    std::vector<unsigned int> ids;
 
     // List of boundary type for each number
     std::vector<ManifoldType> types;
@@ -48,7 +49,6 @@ namespace Parameters
 
     // Number of manifold types
     unsigned int number_of_manifolds;
-    unsigned int max_size;
 
     void
     parse_boundary(const ParameterHandler &prm);

--- a/include/core/manifolds.h
+++ b/include/core/manifolds.h
@@ -32,8 +32,11 @@ namespace Parameters
       iges
     };
 
-    // ID of boundary condition
-    std::vector<unsigned int> id;
+    // Manifold ID
+    std::vector<unsigned int> manifold_ids;
+
+    // ID of boundaries to which the manifold will be applied
+    std::vector<unsigned int> boundary_ids;
 
     // List of boundary type for each number
     std::vector<ManifoldType> types;
@@ -51,7 +54,7 @@ namespace Parameters
     unsigned int max_size;
 
     void
-    parse_boundary(const ParameterHandler &prm, unsigned int i_bc);
+    parse_boundary(const ParameterHandler &prm, const unsigned int manifold_id);
 
     static void
     declareDefaultEntry(ParameterHandler &prm, unsigned int i_bc);

--- a/include/core/manifolds.h
+++ b/include/core/manifolds.h
@@ -32,9 +32,6 @@ namespace Parameters
       iges
     };
 
-    // Manifold ID
-    std::vector<unsigned int> manifold_ids;
-
     // ID of boundaries to which the manifold will be applied
     std::vector<unsigned int> boundary_ids;
 
@@ -49,12 +46,12 @@ namespace Parameters
     // File names for cad manifolds
     std::vector<std::string> cad_files;
 
-    // Number of boundary conditions
-    unsigned int size;
+    // Number of manifold types
+    unsigned int number_of_manifolds;
     unsigned int max_size;
 
     void
-    parse_boundary(const ParameterHandler &prm, const unsigned int manifold_id);
+    parse_boundary(const ParameterHandler &prm);
 
     static void
     declareDefaultEntry(ParameterHandler &prm, unsigned int i_bc);

--- a/include/core/manifolds.h
+++ b/include/core/manifolds.h
@@ -32,7 +32,7 @@ namespace Parameters
       iges
     };
 
-    // ID of boundaries to which the manifold will be applied. Each manifold
+    // IDs of boundaries to which the manifold will be applied. Each manifold
     // will be stored with its corresponding boundary ID
     std::vector<unsigned int> ids;
 
@@ -47,7 +47,7 @@ namespace Parameters
     // File names for cad manifolds
     std::vector<std::string> cad_files;
 
-    // Number of manifold types
+    // Number of manifolds
     unsigned int number_of_manifolds;
 
     void
@@ -55,6 +55,7 @@ namespace Parameters
 
     static void
     declareDefaultEntry(ParameterHandler &prm, unsigned int i_bc);
+
     void
     declare_parameters(ParameterHandler &prm, unsigned int subsection_max_size);
 

--- a/include/core/utilities.h
+++ b/include/core/utilities.h
@@ -632,13 +632,12 @@ get_dimension(const std::string &file_name);
  * and the number of manifolds from the file. This value is linked to the
  * "number" string defined in the simulation parameter file.
  * It provides an estimate for the amount of parameters or manifolds and is
-* used to determine the size of the vectors that will store boundary conditions
-* and manifold data. This feature will need to be monitored extensively in the
-* future.
-*
+ * used to determine the size of the vectors that will store boundary conditions
+ * and manifold data. This feature will need to be monitored extensively in the
+ * future.
+ *
  * @param[in] file_name The file name from which the number of boundary
-conditions
- * is read
+ * conditions is read
  *
  * @return The maximum number of boundary conditions or manifolds.
  */

--- a/release_notes/current/2026_08_25_Campos.md
+++ b/release_notes/current/2026_08_25_Campos.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/08/25
+
+### Changed
+
+- MINOR This PR allow the user to prescribe a list of boundary IDs to a specific manifold type, addressing issue #2066. [#2104](https://github.com/chaos-polymtl/lethe/pull/2104)

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -344,8 +344,8 @@ read_mesh_and_manifolds(
     {
       // Gather all the manifold ids within a set
       std::set<int> manifold_ids;
-      for (unsigned int i = 0; i < manifolds_parameters.ids.size(); ++i)
-        manifold_ids.insert(manifolds_parameters.ids[i]);
+      for (const unsigned int id : manifolds_parameters.ids)
+        manifold_ids.insert(id);
 
       // Reset all the manifolds manually and force them to zero
       triangulation.reset_all_manifolds();
@@ -544,8 +544,8 @@ read_mesh_and_manifolds_for_stator_and_rotor(
 
       // Gather all the manifold ids within a set
       std::set<int> manifold_ids;
-      for (unsigned int i = 0; i < manifolds_parameters.ids.size(); ++i)
-        manifold_ids.insert(manifolds_parameters.ids[i]);
+      for (const unsigned int id : manifolds_parameters.ids)
+        manifold_ids.insert(id);
 
       // Reset all the manifolds manually and force them to zero
       triangulation.reset_all_manifolds();

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -344,8 +344,7 @@ read_mesh_and_manifolds(
     {
       // Gather all the manifold ids within a set
       std::set<int> manifold_ids;
-      for (unsigned int i = 0; i < manifolds_parameters.number_of_manifolds;
-           ++i)
+      for (unsigned int i = 0; i < manifolds_parameters.ids.size(); ++i)
         manifold_ids.insert(manifolds_parameters.ids[i]);
 
       // Reset all the manifolds manually and force them to zero
@@ -358,7 +357,7 @@ read_mesh_and_manifolds(
       // this face manually to be that of the boundary id. In the past, this
       // was done by default for every face, but since 2023-12 this throws
       // (rightfully) an error in deal.II
-      if (manifolds_parameters.number_of_manifolds > 0)
+      if (manifolds_parameters.ids.size() > 0)
         {
           for (const auto &face : triangulation.active_face_iterators())
             {
@@ -545,15 +544,14 @@ read_mesh_and_manifolds_for_stator_and_rotor(
 
       // Gather all the manifold ids within a set
       std::set<int> manifold_ids;
-      for (unsigned int i = 0; i < manifolds_parameters.number_of_manifolds;
-           ++i)
+      for (unsigned int i = 0; i < manifolds_parameters.ids.size(); ++i)
         manifold_ids.insert(manifolds_parameters.ids[i]);
 
       // Reset all the manifolds manually and force them to zero
       triangulation.reset_all_manifolds();
 
       // Set manifolds
-      if (manifolds_parameters.number_of_manifolds > 0)
+      if (manifolds_parameters.ids.size() > 0)
         {
           for (const auto &face : triangulation.active_face_iterators())
             {

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -344,8 +344,8 @@ read_mesh_and_manifolds(
     {
       // Gather all the manifold ids within a set
       std::set<int> manifold_ids;
-      for (unsigned int i = 0; i < manifolds_parameters.size; ++i)
-        manifold_ids.insert(manifolds_parameters.boundary_id[i]);
+      for (unsigned int i = 0; i < manifolds_parameters.number_of_manifolds; ++i)
+        manifold_ids.insert(manifolds_parameters.boundary_ids[i]);
 
       // Reset all the manifolds manually and force them to zero
       triangulation.reset_all_manifolds();
@@ -357,7 +357,7 @@ read_mesh_and_manifolds(
       // this face manually to be that of the boundary id. In the past, this
       // was done by default for every face, but since 2023-12 this throws
       // (rightfully) an error in deal.II
-      if (manifolds_parameters.size > 0)
+      if (manifolds_parameters.number_of_manifolds > 0)
         {
           for (const auto &face : triangulation.active_face_iterators())
             {
@@ -544,14 +544,14 @@ read_mesh_and_manifolds_for_stator_and_rotor(
 
       // Gather all the manifold ids within a set
       std::set<int> manifold_ids;
-      for (unsigned int i = 0; i < manifolds_parameters.size; ++i)
-        manifold_ids.insert(manifolds_parameters.boundary_id[i]);
+      for (unsigned int i = 0; i < manifolds_parameters.number_of_manifolds; ++i)
+        manifold_ids.insert(manifolds_parameters.boundary_ids[i]);
 
       // Reset all the manifolds manually and force them to zero
       triangulation.reset_all_manifolds();
 
       // Set manifolds
-      if (manifolds_parameters.size > 0)
+      if (manifolds_parameters.number_of_manifolds > 0)
         {
           for (const auto &face : triangulation.active_face_iterators())
             {

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -345,7 +345,7 @@ read_mesh_and_manifolds(
       // Gather all the manifold ids within a set
       std::set<int> manifold_ids;
       for (unsigned int i = 0; i < manifolds_parameters.size; ++i)
-        manifold_ids.insert(manifolds_parameters.id[i]);
+        manifold_ids.insert(manifolds_parameters.boundary_id[i]);
 
       // Reset all the manifolds manually and force them to zero
       triangulation.reset_all_manifolds();
@@ -545,7 +545,7 @@ read_mesh_and_manifolds_for_stator_and_rotor(
       // Gather all the manifold ids within a set
       std::set<int> manifold_ids;
       for (unsigned int i = 0; i < manifolds_parameters.size; ++i)
-        manifold_ids.insert(manifolds_parameters.id[i]);
+        manifold_ids.insert(manifolds_parameters.boundary_id[i]);
 
       // Reset all the manifolds manually and force them to zero
       triangulation.reset_all_manifolds();

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -344,8 +344,9 @@ read_mesh_and_manifolds(
     {
       // Gather all the manifold ids within a set
       std::set<int> manifold_ids;
-      for (unsigned int i = 0; i < manifolds_parameters.number_of_manifolds; ++i)
-        manifold_ids.insert(manifolds_parameters.boundary_ids[i]);
+      for (unsigned int i = 0; i < manifolds_parameters.number_of_manifolds;
+           ++i)
+        manifold_ids.insert(manifolds_parameters.ids[i]);
 
       // Reset all the manifolds manually and force them to zero
       triangulation.reset_all_manifolds();
@@ -544,8 +545,9 @@ read_mesh_and_manifolds_for_stator_and_rotor(
 
       // Gather all the manifold ids within a set
       std::set<int> manifold_ids;
-      for (unsigned int i = 0; i < manifolds_parameters.number_of_manifolds; ++i)
-        manifold_ids.insert(manifolds_parameters.boundary_ids[i]);
+      for (unsigned int i = 0; i < manifolds_parameters.number_of_manifolds;
+           ++i)
+        manifold_ids.insert(manifolds_parameters.ids[i]);
 
       // Reset all the manifolds manually and force them to zero
       triangulation.reset_all_manifolds();

--- a/source/core/manifolds.cc
+++ b/source/core/manifolds.cc
@@ -21,10 +21,10 @@ namespace Parameters
                       "Type of manifold description"
                       "Choices are <none|spherical|cylindrical|iges>.");
 
-    prm.declare_entry("id",
+    prm.declare_entry("boundary id",
                       Utilities::int_to_string(i_bc, 2),
-                      Patterns::Integer(),
-                      "Mesh id for boundary conditions");
+                      Patterns::List(Patterns::Integer()),
+                      "ID of boundary to which the manifold will be applied");
 
     prm.declare_entry("cad file",
                       "none",
@@ -42,23 +42,31 @@ namespace Parameters
   }
 
   void
-  Manifolds::parse_boundary(const ParameterHandler &prm,
-                            const unsigned int      i_bc)
+  Manifolds::parse_boundary(const ParameterHandler &prm, const unsigned int manifold_id)
   {
-    const std::string op = prm.get("type");
-    if (op == "none")
-      types[i_bc] = ManifoldType::none;
-    else if (op == "spherical")
-      types[i_bc] = ManifoldType::spherical;
-    else if (op == "cylindrical")
-      types[i_bc] = ManifoldType::cylindrical;
-    else if (op == "iges")
-      types[i_bc] = ManifoldType::iges;
+    // Parse the list of boundary IDs
+    std::vector<unsigned int> boundary_ids =
+      convert_string_to_vector<unsigned int>(prm, "boundary id");
 
-    id[i_bc]                 = prm.get_integer("id");
-    manifold_point[i_bc]     = prm.get("point coordinates");
-    manifold_direction[i_bc] = prm.get("direction vector");
-    cad_files[i_bc]          = prm.get("cad file");
+    for (const unsigned int boundary_id : boundary_ids)
+    {
+      std::cout << "Boundary ID: " << boundary_id << std::endl;
+
+      const std::string op = prm.get("type");
+      if (op == "none")
+        types[manifold_id] = ManifoldType::none;
+      else if (op == "spherical")
+        types[manifold_id] = ManifoldType::spherical;
+      else if (op == "cylindrical")
+        types[manifold_id] = ManifoldType::cylindrical;
+      else if (op == "iges")
+        types[manifold_id] = ManifoldType::iges;
+
+      manifold_point[manifold_id]     = prm.get("point coordinates");
+      manifold_direction[manifold_id] = prm.get("direction vector");
+      cad_files[manifold_id]          = prm.get("cad file");
+    }
+    
   }
 
   void
@@ -75,7 +83,7 @@ namespace Parameters
                         "0",
                         Patterns::Integer(),
                         "Number of boundary conditions");
-      id.resize(subsection_max_size);
+      manifold_id.resize(subsection_max_size);
       types.resize(subsection_max_size);
       for (unsigned int i = 0; i < subsection_max_size; i++)
         {
@@ -94,9 +102,15 @@ namespace Parameters
     {
       size = prm.get_integer("number");
       types.resize(size);
-      id.resize(size);
+      manifold_ids.resize(size);
+      std::cout << "Manifold IDs: ";
+      for (unsigned int k = 0; k < manifold_ids.size(); ++k)
+        std::cout << manifold_ids[k] << "  ";
+
+      std::cout << std::endl;  
       for (unsigned int i = 0; i < size; i++)
         {
+          manifold_ids[i] = i;
           prm.enter_subsection("manifold " + Utilities::int_to_string(i));
           parse_boundary(prm, i);
           prm.leave_subsection();
@@ -121,7 +135,7 @@ attach_manifolds_to_triangulation(
             value_string_to_tensor<spacedim>(manifolds.manifold_point[i]));
 
           SphericalManifold<dim, spacedim> manifold_description(circle_center);
-          triangulation.set_manifold(manifolds.id[i], manifold_description);
+          triangulation.set_manifold(manifolds.boundary_id[i], manifold_description);
         }
       else if (manifolds.types[i] ==
                Parameters::Manifolds::ManifoldType::cylindrical)
@@ -140,7 +154,7 @@ attach_manifolds_to_triangulation(
 
               CylindricalManifold<dim, spacedim> manifold_description(
                 cylinder_axis, point_on_axis);
-              triangulation.set_manifold(manifolds.id[i], manifold_description);
+              triangulation.set_manifold(manifolds.boundary_id[i], manifold_description);
             }
           else
             throw std::runtime_error(
@@ -150,7 +164,7 @@ attach_manifolds_to_triangulation(
         {
           attach_cad_to_manifold(triangulation,
                                  manifolds.cad_files[i],
-                                 manifolds.id[i]);
+                                 manifolds.boundary_id[i]);
         }
       else if (manifolds.types[i] == Parameters::Manifolds::ManifoldType::none)
         {

--- a/source/core/manifolds.cc
+++ b/source/core/manifolds.cc
@@ -24,7 +24,7 @@ namespace Parameters
     prm.declare_entry("boundary id",
                       Utilities::int_to_string(i_bc, 2),
                       Patterns::List(Patterns::Integer()),
-                      "ID of boundary to which the manifold will be applied");
+                      "IDs of boundaries to which the manifold will be applied");
 
     prm.declare_entry("cad file",
                       "none",
@@ -42,7 +42,7 @@ namespace Parameters
   }
 
   void
-  Manifolds::parse_boundary(const ParameterHandler &prm, const unsigned int manifold_id)
+  Manifolds::parse_boundary(const ParameterHandler &prm)
   {
     // Parse the list of boundary IDs
     std::vector<unsigned int> boundary_ids =
@@ -54,17 +54,17 @@ namespace Parameters
 
       const std::string op = prm.get("type");
       if (op == "none")
-        types[manifold_id] = ManifoldType::none;
+        types[boundary_id] = ManifoldType::none;
       else if (op == "spherical")
-        types[manifold_id] = ManifoldType::spherical;
+        types[boundary_id] = ManifoldType::spherical;
       else if (op == "cylindrical")
-        types[manifold_id] = ManifoldType::cylindrical;
+        types[boundary_id] = ManifoldType::cylindrical;
       else if (op == "iges")
-        types[manifold_id] = ManifoldType::iges;
+        types[boundary_id] = ManifoldType::iges;
 
-      manifold_point[manifold_id]     = prm.get("point coordinates");
-      manifold_direction[manifold_id] = prm.get("direction vector");
-      cad_files[manifold_id]          = prm.get("cad file");
+      manifold_point[boundary_id]     = prm.get("point coordinates");
+      manifold_direction[boundary_id] = prm.get("direction vector");
+      cad_files[boundary_id]          = prm.get("cad file");
     }
     
   }
@@ -83,7 +83,6 @@ namespace Parameters
                         "0",
                         Patterns::Integer(),
                         "Number of boundary conditions");
-      manifold_id.resize(subsection_max_size);
       types.resize(subsection_max_size);
       for (unsigned int i = 0; i < subsection_max_size; i++)
         {
@@ -100,19 +99,13 @@ namespace Parameters
   {
     prm.enter_subsection("manifolds");
     {
-      size = prm.get_integer("number");
-      types.resize(size);
-      manifold_ids.resize(size);
-      std::cout << "Manifold IDs: ";
-      for (unsigned int k = 0; k < manifold_ids.size(); ++k)
-        std::cout << manifold_ids[k] << "  ";
+      number_of_manifolds = prm.get_integer("number");
+      types.resize(number_of_manifolds);
 
-      std::cout << std::endl;  
-      for (unsigned int i = 0; i < size; i++)
+      for (unsigned int i = 0; i < number_of_manifolds; i++)
         {
-          manifold_ids[i] = i;
           prm.enter_subsection("manifold " + Utilities::int_to_string(i));
-          parse_boundary(prm, i);
+          parse_boundary(prm);
           prm.leave_subsection();
         }
     }
@@ -135,7 +128,7 @@ attach_manifolds_to_triangulation(
             value_string_to_tensor<spacedim>(manifolds.manifold_point[i]));
 
           SphericalManifold<dim, spacedim> manifold_description(circle_center);
-          triangulation.set_manifold(manifolds.boundary_id[i], manifold_description);
+          triangulation.set_manifold(manifolds.boundary_ids[i], manifold_description);
         }
       else if (manifolds.types[i] ==
                Parameters::Manifolds::ManifoldType::cylindrical)
@@ -154,7 +147,7 @@ attach_manifolds_to_triangulation(
 
               CylindricalManifold<dim, spacedim> manifold_description(
                 cylinder_axis, point_on_axis);
-              triangulation.set_manifold(manifolds.boundary_id[i], manifold_description);
+              triangulation.set_manifold(manifolds.boundary_ids[i], manifold_description);
             }
           else
             throw std::runtime_error(
@@ -164,7 +157,7 @@ attach_manifolds_to_triangulation(
         {
           attach_cad_to_manifold(triangulation,
                                  manifolds.cad_files[i],
-                                 manifolds.boundary_id[i]);
+                                 manifolds.boundary_ids[i]);
         }
       else if (manifolds.types[i] == Parameters::Manifolds::ManifoldType::none)
         {

--- a/source/core/manifolds.cc
+++ b/source/core/manifolds.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2019-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/manifolds.h>

--- a/source/core/manifolds.cc
+++ b/source/core/manifolds.cc
@@ -22,7 +22,7 @@ namespace Parameters
                       "Choices are <none|spherical|cylindrical|iges>.");
 
     prm.declare_entry(
-      "boundary id",
+      "id",
       Utilities::int_to_string(i_bc, 2),
       Patterns::List(Patterns::Integer()),
       "IDs of boundaries to which the manifold will be applied");
@@ -47,7 +47,7 @@ namespace Parameters
   {
     // Parse the list of boundary IDs for the current manifold type
     std::vector<unsigned int> ids_current =
-      convert_string_to_vector<unsigned int>(prm, "boundary id");
+      convert_string_to_vector<unsigned int>(prm, "id");
 
     for (unsigned int i = 0; i < ids_current.size(); ++i)
       {
@@ -77,8 +77,7 @@ namespace Parameters
       prm.declare_entry("number",
                         "0",
                         Patterns::Integer(),
-                        "Number of boundary conditions");
-      types.resize(subsection_max_size);
+                        "Number of manifolds");
       for (unsigned int i = 0; i < subsection_max_size; i++)
         {
           prm.enter_subsection("manifold " + Utilities::int_to_string(i));
@@ -94,8 +93,7 @@ namespace Parameters
   {
     prm.enter_subsection("manifolds");
     {
-      number_of_manifolds = prm.get_integer("number");
-      types.resize(number_of_manifolds);
+      this->number_of_manifolds = prm.get_integer("number");
 
       for (unsigned int i = 0; i < this->number_of_manifolds; i++)
         {

--- a/source/core/manifolds.cc
+++ b/source/core/manifolds.cc
@@ -21,10 +21,11 @@ namespace Parameters
                       "Type of manifold description"
                       "Choices are <none|spherical|cylindrical|iges>.");
 
-    prm.declare_entry("boundary id",
-                      Utilities::int_to_string(i_bc, 2),
-                      Patterns::List(Patterns::Integer()),
-                      "IDs of boundaries to which the manifold will be applied");
+    prm.declare_entry(
+      "boundary id",
+      Utilities::int_to_string(i_bc, 2),
+      Patterns::List(Patterns::Integer()),
+      "IDs of boundaries to which the manifold will be applied");
 
     prm.declare_entry("cad file",
                       "none",
@@ -44,39 +45,33 @@ namespace Parameters
   void
   Manifolds::parse_boundary(const ParameterHandler &prm)
   {
-    // Parse the list of boundary IDs
-    std::vector<unsigned int> boundary_ids =
+    // Parse the list of boundary IDs for the current manifold type
+    std::vector<unsigned int> ids_current =
       convert_string_to_vector<unsigned int>(prm, "boundary id");
 
-    for (const unsigned int boundary_id : boundary_ids)
-    {
-      std::cout << "Boundary ID: " << boundary_id << std::endl;
+    for (unsigned int i = 0; i < ids_current.size(); ++i)
+      {
+        const std::string op = prm.get("type");
+        if (op == "none")
+          this->types.emplace_back(ManifoldType::none);
+        else if (op == "spherical")
+          this->types.emplace_back(ManifoldType::spherical);
+        else if (op == "cylindrical")
+          this->types.emplace_back(ManifoldType::cylindrical);
+        else if (op == "iges")
+          this->types.emplace_back(ManifoldType::iges);
 
-      const std::string op = prm.get("type");
-      if (op == "none")
-        types[boundary_id] = ManifoldType::none;
-      else if (op == "spherical")
-        types[boundary_id] = ManifoldType::spherical;
-      else if (op == "cylindrical")
-        types[boundary_id] = ManifoldType::cylindrical;
-      else if (op == "iges")
-        types[boundary_id] = ManifoldType::iges;
-
-      manifold_point[boundary_id]     = prm.get("point coordinates");
-      manifold_direction[boundary_id] = prm.get("direction vector");
-      cad_files[boundary_id]          = prm.get("cad file");
-    }
-    
+        this->ids.emplace_back(ids_current[i]);
+        this->manifold_point.emplace_back(prm.get("point coordinates"));
+        this->manifold_direction.emplace_back(prm.get("direction vector"));
+        this->cad_files.emplace_back(prm.get("cad file"));
+      }
   }
 
   void
   Manifolds::declare_parameters(ParameterHandler &prm,
                                 unsigned int      subsection_max_size)
   {
-    manifold_point.resize(subsection_max_size);
-    manifold_direction.resize(subsection_max_size);
-    cad_files.resize(subsection_max_size);
-
     prm.enter_subsection("manifolds");
     {
       prm.declare_entry("number",
@@ -102,7 +97,7 @@ namespace Parameters
       number_of_manifolds = prm.get_integer("number");
       types.resize(number_of_manifolds);
 
-      for (unsigned int i = 0; i < number_of_manifolds; i++)
+      for (unsigned int i = 0; i < this->number_of_manifolds; i++)
         {
           prm.enter_subsection("manifold " + Utilities::int_to_string(i));
           parse_boundary(prm);
@@ -128,7 +123,7 @@ attach_manifolds_to_triangulation(
             value_string_to_tensor<spacedim>(manifolds.manifold_point[i]));
 
           SphericalManifold<dim, spacedim> manifold_description(circle_center);
-          triangulation.set_manifold(manifolds.boundary_ids[i], manifold_description);
+          triangulation.set_manifold(manifolds.ids[i], manifold_description);
         }
       else if (manifolds.types[i] ==
                Parameters::Manifolds::ManifoldType::cylindrical)
@@ -147,7 +142,8 @@ attach_manifolds_to_triangulation(
 
               CylindricalManifold<dim, spacedim> manifold_description(
                 cylinder_axis, point_on_axis);
-              triangulation.set_manifold(manifolds.boundary_ids[i], manifold_description);
+              triangulation.set_manifold(manifolds.ids[i],
+                                         manifold_description);
             }
           else
             throw std::runtime_error(
@@ -157,7 +153,7 @@ attach_manifolds_to_triangulation(
         {
           attach_cad_to_manifold(triangulation,
                                  manifolds.cad_files[i],
-                                 manifolds.boundary_ids[i]);
+                                 manifolds.ids[i]);
         }
       else if (manifolds.types[i] == Parameters::Manifolds::ManifoldType::none)
         {

--- a/source/core/manifolds.cc
+++ b/source/core/manifolds.cc
@@ -93,9 +93,9 @@ namespace Parameters
   {
     prm.enter_subsection("manifolds");
     {
-      this->number_of_manifolds = prm.get_integer("number");
+      this->number_of_manifolds_subsections = prm.get_integer("number");
 
-      for (unsigned int i = 0; i < this->number_of_manifolds; i++)
+      for (unsigned int i = 0; i < this->number_of_manifolds_subsections; i++)
         {
           prm.enter_subsection("manifold " + Utilities::int_to_string(i));
           parse_boundary(prm);

--- a/source/core/manifolds.cc
+++ b/source/core/manifolds.cc
@@ -49,7 +49,7 @@ namespace Parameters
     std::vector<unsigned int> ids_current =
       convert_string_to_vector<unsigned int>(prm, "id");
 
-    for (unsigned int i = 0; i < ids_current.size(); ++i)
+    for (const unsigned int id : ids_current)
       {
         const std::string op = prm.get("type");
         if (op == "none")
@@ -61,7 +61,7 @@ namespace Parameters
         else if (op == "iges")
           this->types.emplace_back(ManifoldType::iges);
 
-        this->ids.emplace_back(ids_current[i]);
+        this->ids.emplace_back(id);
         this->manifold_point.emplace_back(prm.get("point coordinates"));
         this->manifold_direction.emplace_back(prm.get("direction vector"));
         this->cad_files.emplace_back(prm.get("cad file"));


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

This PR allow the user to prescribe a list of boundary IDs to a specific manifold type, addressing issue #2066. 

### Testing

<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

No changes in test results, but tests `mortar_mms_gmsh` and `mortar_asymmetric_height` had its `manifolds` subsections modified to test the new feature.

### Documentation

<!-- Does this refactor modify or have new simulation parameters? If so, describe them. -->

The Manifolds parameters subsection was updated to mention the new option.

### Use of LLMs  (Large Language Models)

<!-- LLM-assisted contributions are welcome, but they must be declared.
       If an LLM (e.g. GitHub Copilot, ChatGPT, Claude, Cursor) generated a substantial portion
       of this pull request (e.g. more than a small fraction of the source code, or algorithms
       that are crucial for the functionality), describe here which parts were generated and
       what the LLM was used for.
       Write "None" if no LLM was used.
       By submitting this pull request, you confirm that you have reviewed and verified all
       LLM-generated content, and that you understand and accept responsibility for the
       proposed changes. -->

None

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] An entry describing the change has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`

Pull request related list:
- [x] No other PR is open related to this refactoring
- [ ] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If any future work is planned, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR