### PR TITLE
Justify user documentation text

### DIFF
--- a/doc/source/_static/style.css
+++ b/doc/source/_static/style.css
@@ -1,0 +1,10 @@
+/*
+  SPDX-FileCopyrightText: Copyright (c) 2026 The Lethe Authors
+  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+*/
+
+.content p,
+.content li,
+.content dd {
+    text-align: justify;
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -62,6 +62,7 @@ html_theme = 'furo'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+html_css_files = ['style.css']
 
 # Set favicon
 html_favicon = '_static/lethe_favicon.ico'

--- a/release_notes/current/2026_08_25_Alphonius.md
+++ b/release_notes/current/2026_08_25_Alphonius.md
@@ -1,0 +1,5 @@
+## [Master] - 2026/08/24
+
+### Changed
+
+- MINOR Formats the text in the user documentation for it to be justified. [#2106](https://github.com/chaos-polymtl/lethe/pull/2106)


### PR DESCRIPTION
### Description

This PR justifies the text of the user documentation by adding a CSS file.

### Use of LLMs (Large Language Models)

ChatGPT was used.

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent

Pull request related list:
- [x] Labels are applied
- [x] There are at least 2 reviewers (or 1 if small feature)
- [x] If any future work is planned, an issue is opened
- [ ] The PR description is clean and is ready to be used as the commit message when merging the PR