### PR TITLE
Template Parameters::Mesh with dim

### DIFF
--- a/doc/source/parameters/cfd/mesh.rst
+++ b/doc/source/parameters/cfd/mesh.rst
@@ -110,13 +110,10 @@ This subsection provides information of the simulation geometry and its mesh. Th
 
 * The ``initial translation`` parameter provides a way to move the mesh in space prior to simulating the problem. It can be useful when space-dependent functions are used, but that generating a translated mesh is inconvenient or impossible.
 
-  .. attention::
-    Regardless of the dimension of the problem, 3 components (:math:`x`, :math:`y`, and :math:`z`) must be specified for the ``initial translation``. If the mesh is defined in a 2D space, the third component of ``initial translation`` (:math:`z`-component) is ignored and the mesh translates in :math:`x` and :math:`y` only.
-
 * The ``initial rotation axis`` and ``initial rotation angle`` parameters provide another way to move the mesh prior to simulating the problem.
 
   .. attention::
-    If the mesh is defined in a 2D space, ``initial rotation axis`` is ignored and the mesh rotates counter-clockwise around the origin of the coordinate system.
+    If the mesh is defined in a 2D space, ``initial rotation axis`` is ignored and the mesh rotates counter-clockwise around the origin of the coordinate system according to ``initial rotation angle``.
 
 * The ``scale`` parameter is used to scale the mesh. This is useful when the mesh is made in a different set of unit than what is desired by the simulation.
 

--- a/include/core/grids.h
+++ b/include/core/grids.h
@@ -22,8 +22,9 @@ using namespace dealii;
  */
 template <int dim, int spacedim = dim>
 void
-attach_grid_to_triangulation(Triangulation<dim, spacedim> &triangulation,
-                             const Parameters::Mesh       &mesh_parameters);
+attach_grid_to_triangulation(
+  Triangulation<dim, spacedim>          &triangulation,
+  const Parameters::Mesh<dim, spacedim> &mesh_parameters);
 
 /**
  * @brief Modifies the triangulation to set up its periodic boundary conditions
@@ -67,7 +68,7 @@ template <int dim, int spacedim = dim>
 void
 read_mesh_and_manifolds(
   parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
-  const Parameters::Mesh                                &mesh_parameters,
+  const Parameters::Mesh<dim, spacedim>                 &mesh_parameters,
   const Parameters::Manifolds                           &manifolds_parameters,
   bool                                                   restart,
   const Parameters::PeriodicBoundaries                  &periodic_boundaries);
@@ -98,7 +99,7 @@ template <int dim, int spacedim = dim>
 void
 read_mesh_and_manifolds_for_stator_and_rotor(
   parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
-  const Parameters::Mesh                                &mesh_parameters,
+  const Parameters::Mesh<dim, spacedim>                 &mesh_parameters,
   const Parameters::Manifolds                           &manifolds_parameters,
   bool                                                   restart,
   const Parameters::PeriodicBoundaries                  &periodic_boundaries,
@@ -185,7 +186,8 @@ build_refinement_box_triangulation(
  */
 template <int dim, int spacedim = dim>
 void
-apply_mesh_transformation(const Parameters::Mesh       &mesh_parameters,
-                          Triangulation<dim, spacedim> &triangulation);
+apply_mesh_transformation(
+  const Parameters::Mesh<dim, spacedim> &mesh_parameters,
+  Triangulation<dim, spacedim>          &triangulation);
 
 #endif

--- a/include/core/grids.h
+++ b/include/core/grids.h
@@ -169,8 +169,8 @@ refine_triangulation_at_boundaries(
 template <int dim, int spacedim = dim>
 void
 build_refinement_box_triangulation(
-  const Parameters::Mesh       &box_mesh_parameters,
-  Triangulation<dim, spacedim> &box_triangulation);
+  const Parameters::Mesh<dim, spacedim> &box_mesh_parameters,
+  Triangulation<dim, spacedim>          &box_triangulation);
 
 /**
  * @brief Apply scaling, rotation and translation to the mesh in the listed

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1722,6 +1722,7 @@ namespace Parameters
   /**
    * @brief Mesh - Parameters that control mesh reading and mesh generation.
    */
+  template <int dim, int spacedim = dim>
   struct Mesh
   {
     // GMSH or dealii
@@ -1773,11 +1774,11 @@ namespace Parameters
     bool expand_particle_wall_contact_search;
 
     // Grid displacement at initiation
-    Tensor<1, 3> translation;
+    Tensor<1, spacedim> translation;
 
     // Grid rotation at initiation
-    Tensor<1, 3> rotation_axis;
-    double       rotation_angle;
+    Tensor<1, spacedim> rotation_axis;
+    double              rotation_angle;
 
     /// Rescale the grid by the scale factor
     double scale;
@@ -1871,6 +1872,7 @@ namespace Parameters
    * Container of the parameters for box refinements. The regions to refine can
    * be described by either a GMSH or a deal.II mesh.
    */
+  template <int dim, int spacedim = dim>
   struct MeshBoxRefinement
   {
     /// Number of boxes delimiting refinement regions
@@ -1888,8 +1890,9 @@ namespace Parameters
      * Shared pointer of a vector of GMSH and deal.II meshes representing
      * refinement areas.
      */
-    std::shared_ptr<std::vector<Mesh>> refinement_boxes_meshes =
-      std::make_shared<std::vector<Mesh>>(max_number_of_refinement_boxes);
+    std::shared_ptr<std::vector<Mesh<dim, spacedim>>> refinement_boxes_meshes =
+      std::make_shared<std::vector<Mesh<dim, spacedim>>>(
+        max_number_of_refinement_boxes);
 
     /// Vector of additional refinement values of the different boxes
     std::vector<unsigned int> box_additional_refinements =
@@ -2207,7 +2210,7 @@ namespace Parameters
       linear
     } interface_type;
     /// Mesh parameters for the rotor part
-    std::shared_ptr<Mesh> rotor_mesh;
+    std::shared_ptr<Mesh<dim>> rotor_mesh;
     /// Boundary ID # of the rotor at the rotor-stator interface
     unsigned int rotor_boundary_id;
     /// Boundary ID # of the stator at the rotor-stator interface

--- a/include/core/parameters.h
+++ b/include/core/parameters.h
@@ -1723,8 +1723,9 @@ namespace Parameters
    * @brief Mesh - Parameters that control mesh reading and mesh generation.
    */
   template <int dim, int spacedim = dim>
-  struct Mesh
+  class Mesh
   {
+  public:
     // GMSH or dealii
     enum class Type : std::int8_t
     {

--- a/include/core/parameters_lagrangian.h
+++ b/include/core/parameters_lagrangian.h
@@ -967,7 +967,7 @@ namespace Parameters
     {
     public:
       /// Mesh parameters for the floating grid.
-      Parameters::Mesh mesh;
+      Parameters::Mesh<dim> mesh;
 
       /// Motion parameters for the floating grid.
       Parameters::Lagrangian::GridMotion<dim> motion;

--- a/include/core/serial_solid.h
+++ b/include/core/serial_solid.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_serial_solid_h
@@ -36,8 +36,9 @@ template <int dim, int spacedim = dim>
 class SerialSolid
 {
 public:
-  SerialSolid(std::shared_ptr<Parameters::RigidSolidObject<spacedim>> &param,
-              unsigned int                                             id);
+  SerialSolid(
+    std::shared_ptr<Parameters::RigidSolidObject<dim, spacedim>> &param,
+    unsigned int                                                  id);
 
   /**
    * @brief Maps the solid object in the background triangulation
@@ -289,7 +290,8 @@ private:
    *
    */
   void
-  rotate_grid(const double angle, [[maybe_unused]] const Tensor<1, 3> &axis);
+  rotate_grid(const double                                angle,
+              [[maybe_unused]] const Tensor<1, spacedim> &axis);
 
   /**
    * @brief Translate the grid. In spacedim=2, the third component is ignored
@@ -297,7 +299,7 @@ private:
    * @param translate The vector with which the solid is translated.
    */
   void
-  translate_grid(const Tensor<1, 3> &translate);
+  translate_grid(const Tensor<1, spacedim> &translate);
 
   // Member variables
 
@@ -307,7 +309,7 @@ private:
   const unsigned int this_mpi_process;
 
   // Parameters
-  std::shared_ptr<Parameters::RigidSolidObject<spacedim>> &param;
+  std::shared_ptr<Parameters::RigidSolidObject<dim, spacedim>> &param;
 
   // Identifier of the solid
   unsigned int id;

--- a/include/core/solid_base.h
+++ b/include/core/solid_base.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #ifndef lethe_solid_base_h
@@ -179,7 +179,7 @@ public:
    *
    */
   void
-  rotate_grid(const double angle, const Tensor<1, 3> &axis);
+  rotate_grid(const double angle, const Tensor<1, spacedim> &axis);
 
   /**
    * @brief Translate the grid. In spacedim=2, the third component is ignore
@@ -187,7 +187,7 @@ public:
    * @param translate The vector with which the solid is translated.
    */
   void
-  translate_grid(const Tensor<1, 3> &translate);
+  translate_grid(const Tensor<1, spacedim> &translate);
 
   /**
    * @brief Updates the time in the function used to describe the solid temperature

--- a/include/core/solid_objects_parameters.h
+++ b/include/core/solid_objects_parameters.h
@@ -50,12 +50,12 @@ namespace Parameters
    *
    * @tparam dim Number of spatial dimensions.
    */
-  template <int dim>
+  template <int dim, int spacedim = dim>
   class NitscheObject
   {
   public:
     NitscheObject()
-      : solid_velocity(dim)
+      : solid_velocity(spacedim)
     {}
 
     /**
@@ -77,16 +77,16 @@ namespace Parameters
     parse_parameters(ParameterHandler &prm, unsigned int id);
 
     /// Mesh parameters for the solid object.
-    Parameters::Mesh solid_mesh;
+    Parameters::Mesh<dim, spacedim> solid_mesh;
 
     /// Number of quadrature points per 1D cell used to represent the solid.
     unsigned int number_quadrature_points;
 
     /// Velocity function imposed on the solid.
-    Functions::ParsedFunction<dim> solid_velocity;
+    Functions::ParsedFunction<spacedim> solid_velocity;
 
     /// Temperature function imposed on the solid boundary.
-    Functions::ParsedFunction<dim> solid_temperature;
+    Functions::ParsedFunction<spacedim> solid_temperature;
 
     /// Enable the motion of Nitsche particles.
     bool enable_particles_motion;
@@ -107,7 +107,7 @@ namespace Parameters
     bool stop_particles_lost;
 
     /// Center of rotation used for torque calculation.
-    Point<dim> center_of_rotation;
+    Point<spacedim> center_of_rotation;
 
     /// Enable calculation of forces on the solid.
     bool calculate_force_on_solid;
@@ -116,7 +116,7 @@ namespace Parameters
     bool calculate_torque_on_solid;
 
     /// Center of rotation used for torque calculation.
-    Point<dim> cor;
+    Point<spacedim> cor;
 
     /// File name prefix for the force output.
     std::string force_output_name;
@@ -125,9 +125,10 @@ namespace Parameters
     std::string torque_output_name;
   };
 
-  template <int dim>
+  template <int dim, int spacedim>
   void
-  NitscheObject<dim>::declare_parameters(ParameterHandler &prm, unsigned int id)
+  NitscheObject<dim, spacedim>::declare_parameters(ParameterHandler &prm,
+                                                   unsigned int      id)
   {
     prm.enter_subsection("nitsche solid " + Utilities::int_to_string(id, 1));
     {
@@ -184,14 +185,14 @@ namespace Parameters
         "inserted points will be higher for higher dimensions. Increasing this"
         "number will lead to a higher points density inside the solid.");
 
-      if constexpr (dim == 2)
+      if constexpr (spacedim == 2)
         {
           prm.declare_entry("center of rotation",
                             "0., 0.",
                             Patterns::List(Patterns::Double()),
                             "Solid object center of rotation");
         }
-      if constexpr (dim == 3)
+      if constexpr (spacedim == 3)
         {
           prm.declare_entry("center of rotation",
                             "0., 0., 0.",
@@ -219,9 +220,10 @@ namespace Parameters
     prm.leave_subsection();
   }
 
-  template <int dim>
+  template <int dim, int spacedim>
   void
-  NitscheObject<dim>::parse_parameters(ParameterHandler &prm, unsigned int id)
+  NitscheObject<dim, spacedim>::parse_parameters(ParameterHandler &prm,
+                                                 unsigned int      id)
   {
     prm.enter_subsection("nitsche solid " + Utilities::int_to_string(id, 1));
     {
@@ -245,12 +247,12 @@ namespace Parameters
       const std::vector<double> temp =
         convert_string_to_vector<double>(prm, "center of rotation");
 
-      AssertThrow(temp.size() == dim,
+      AssertThrow(temp.size() == spacedim,
                   ExcMessage("Invalid center of rotation. This should be a " +
-                             Utilities::int_to_string(dim) +
+                             Utilities::int_to_string(spacedim) +
                              " dimensional point."));
 
-      for (unsigned int i = 0; i < dim; ++i)
+      for (unsigned int i = 0; i < spacedim; ++i)
         {
           center_of_rotation[i] = temp.at(i);
         }
@@ -370,7 +372,7 @@ namespace Parameters
    *
    * @tparam dim Number of spatial dimensions.
    */
-  template <int dim>
+  template <int dim, int spacedim = dim>
   class RigidSolidObject
   {
   public:
@@ -396,64 +398,64 @@ namespace Parameters
     parse_parameters(ParameterHandler &prm, unsigned int id);
 
     /// Mesh parameters for the solid object.
-    Parameters::Mesh solid_mesh;
+    Parameters::Mesh<dim, spacedim> solid_mesh;
 
     /// Controls the generation of output files for this solid.
     bool output_bool;
 
     /// Translational velocity function of the solid object.
-    std::shared_ptr<Function<dim>> translational_velocity;
+    std::shared_ptr<Function<spacedim>> translational_velocity;
 
     /// Angular velocity function of the solid object.
-    std::shared_ptr<Function<dim>> angular_velocity;
+    std::shared_ptr<Function<spacedim>> angular_velocity;
 
     /// Center of rotation used to locate and rotate the solid object.
-    Point<dim> center_of_rotation;
+    Point<spacedim> center_of_rotation;
 
     /// Temperature function for the solid object boundary.
-    std::shared_ptr<Function<dim>> solid_temperature;
+    std::shared_ptr<Function<spacedim>> solid_temperature;
 
     /// Type of thermal boundary condition applied on the solid surface.
     ThermalBoundaryType thermal_boundary_type;
   };
 
 
-  template <int dim>
+  template <int dim, int spacedim>
   void
-  RigidSolidObject<dim>::declare_parameters(ParameterHandler &prm,
-                                            unsigned int      id)
+  RigidSolidObject<dim, spacedim>::declare_parameters(ParameterHandler &prm,
+                                                      unsigned int      id)
   {
     // Use ParsedFunction<dim> during parameter declaration. We need to do this
     // to use the declare_parameters function, which is not possible with
     // std::make_shared<Function<dim>> type. Please refer to the comment before
     // the translational_velocity and angular_velocity attributes declaration.
     auto translational_velocity_parsed =
-      std::make_shared<Functions::ParsedFunction<dim>>(dim);
+      std::make_shared<Functions::ParsedFunction<spacedim>>(spacedim);
     auto angular_velocity_parsed =
-      std::make_shared<Functions::ParsedFunction<dim>>(3);
+      std::make_shared<Functions::ParsedFunction<spacedim>>(spacedim);
     auto solid_temperature_parsed =
-      std::make_shared<Functions::ParsedFunction<dim>>(1);
+      std::make_shared<Functions::ParsedFunction<spacedim>>(1);
 
     prm.enter_subsection("solid object " + Utilities::int_to_string(id, 1));
     {
       solid_mesh.declare_parameters(prm);
 
       prm.enter_subsection("translational velocity");
-      translational_velocity_parsed->declare_parameters(prm, dim);
+      translational_velocity_parsed->declare_parameters(prm, spacedim);
       prm.leave_subsection();
 
       prm.enter_subsection("angular velocity");
       angular_velocity_parsed->declare_parameters(prm, 3);
       prm.leave_subsection();
 
-      if constexpr (dim == 2)
+      if constexpr (spacedim == 2)
         {
           prm.declare_entry("center of rotation",
                             "0., 0.",
                             Patterns::List(Patterns::Double()),
                             "Solid object center of rotation");
         }
-      if constexpr (dim == 3)
+      if constexpr (spacedim == 3)
         {
           prm.declare_entry("center of rotation",
                             "0., 0., 0.",
@@ -485,21 +487,21 @@ namespace Parameters
     solid_temperature      = solid_temperature_parsed;
   }
 
-  template <int dim>
+  template <int dim, int spacedim>
   void
-  RigidSolidObject<dim>::parse_parameters(ParameterHandler &prm,
-                                          unsigned int      id)
+  RigidSolidObject<dim, spacedim>::parse_parameters(ParameterHandler &prm,
+                                                    unsigned int      id)
   {
     // Use ParsedFunction<dim> during parameter declaration. We need to do this
     // to use the parse_parameters function, which is not possible with
     // std::make_shared<Function<dim>> type. Please refer to the comment before
     // the translational_velocity and angular_velocity attributes declaration.
     auto translational_velocity_parsed =
-      std::make_shared<Functions::ParsedFunction<dim>>(dim);
+      std::make_shared<Functions::ParsedFunction<spacedim>>(spacedim);
     auto angular_velocity_parsed =
-      std::make_shared<Functions::ParsedFunction<dim>>(3);
+      std::make_shared<Functions::ParsedFunction<spacedim>>(spacedim);
     auto solid_temperature_parsed =
-      std::make_shared<Functions::ParsedFunction<dim>>(1);
+      std::make_shared<Functions::ParsedFunction<spacedim>>(1);
 
     prm.enter_subsection("solid object " + Utilities::int_to_string(id, 1));
     {
@@ -515,12 +517,12 @@ namespace Parameters
       const std::vector<double> temp =
         convert_string_to_vector<double>(prm, "center of rotation");
 
-      AssertThrow(temp.size() == dim,
+      AssertThrow(temp.size() == spacedim,
                   ExcMessage("Invalid center of rotation. This should be a " +
-                             Utilities::int_to_string(dim) +
+                             Utilities::int_to_string(spacedim) +
                              " dimensional point."));
 
-      for (unsigned int i = 0; i < dim; ++i)
+      for (unsigned int i = 0; i < spacedim; ++i)
         {
           center_of_rotation[i] = temp.at(i);
         }
@@ -586,10 +588,10 @@ namespace Parameters
     Verbosity verbosity;
 
     /// Collection of rigid solid surface objects.
-    std::vector<std::shared_ptr<RigidSolidObject<dim>>> solid_surfaces;
+    std::vector<std::shared_ptr<RigidSolidObject<dim - 1, dim>>> solid_surfaces;
 
     /// Collection of rigid solid volume objects.
-    std::vector<std::shared_ptr<RigidSolidObject<dim>>> solid_volumes;
+    std::vector<std::shared_ptr<RigidSolidObject<dim, dim>>> solid_volumes;
 
     /// Number of active solid surface objects.
     unsigned int number_solid_surfaces;
@@ -622,7 +624,8 @@ namespace Parameters
         for (unsigned int i_solid = 0; i_solid < max_number_of_solids;
              ++i_solid)
           {
-            solid_surfaces[i_solid] = std::make_shared<RigidSolidObject<dim>>();
+            solid_surfaces[i_solid] =
+              std::make_shared<RigidSolidObject<dim - 1, dim>>();
             solid_surfaces[i_solid]->declare_parameters(prm, i_solid);
           }
       }
@@ -638,7 +641,8 @@ namespace Parameters
         for (unsigned int i_solid = 0; i_solid < max_number_of_solids;
              ++i_solid)
           {
-            solid_volumes[i_solid] = std::make_shared<RigidSolidObject<dim>>();
+            solid_volumes[i_solid] =
+              std::make_shared<RigidSolidObject<dim, dim>>();
             solid_volumes[i_solid]->declare_parameters(prm, i_solid);
           }
       }

--- a/include/core/solid_objects_parameters.h
+++ b/include/core/solid_objects_parameters.h
@@ -115,9 +115,6 @@ namespace Parameters
     /// Enable calculation of torques on the solid.
     bool calculate_torque_on_solid;
 
-    /// Center of rotation used for torque calculation.
-    Point<spacedim> cor;
-
     /// File name prefix for the force output.
     std::string force_output_name;
 

--- a/include/core/solid_objects_parameters.h
+++ b/include/core/solid_objects_parameters.h
@@ -182,20 +182,12 @@ namespace Parameters
         "inserted points will be higher for higher dimensions. Increasing this"
         "number will lead to a higher points density inside the solid.");
 
-      if constexpr (spacedim == 2)
-        {
-          prm.declare_entry("center of rotation",
-                            "0., 0.",
-                            Patterns::List(Patterns::Double()),
-                            "Solid object center of rotation");
-        }
-      if constexpr (spacedim == 3)
-        {
-          prm.declare_entry("center of rotation",
-                            "0., 0., 0.",
-                            Patterns::List(Patterns::Double()),
-                            "Solid object center of rotation");
-        }
+      std::string default_rotation = (spacedim == 2) ? "0., 0." : "0., 0., 0.";
+      prm.declare_entry("center of rotation",
+                        default_rotation,
+                        Patterns::List(Patterns::Double()),
+                        "Solid object center of rotation");
+
 
       prm.declare_entry("calculate force on solid",
                         "false",
@@ -445,20 +437,11 @@ namespace Parameters
       angular_velocity_parsed->declare_parameters(prm, 3);
       prm.leave_subsection();
 
-      if constexpr (spacedim == 2)
-        {
-          prm.declare_entry("center of rotation",
-                            "0., 0.",
-                            Patterns::List(Patterns::Double()),
-                            "Solid object center of rotation");
-        }
-      if constexpr (spacedim == 3)
-        {
-          prm.declare_entry("center of rotation",
-                            "0., 0., 0.",
-                            Patterns::List(Patterns::Double()),
-                            "Solid object center of rotation");
-        }
+      std::string default_rotation = (spacedim == 2) ? "0., 0." : "0., 0., 0.";
+      prm.declare_entry("center of rotation",
+                        default_rotation,
+                        Patterns::List(Patterns::Double()),
+                        "Solid object center of rotation");
 
       prm.declare_entry("thermal boundary type",
                         "adiabatic",

--- a/include/dem/dem_solver_parameters.h
+++ b/include/dem/dem_solver_parameters.h
@@ -16,13 +16,13 @@ template <int dim>
 class DEMSolverParameters
 {
 public:
-  Parameters::Mesh<dim>                          mesh;
-  Parameters::Manifolds                          manifolds_parameters;
-  std::shared_ptr<Parameters::MeshBoxRefinement> mesh_box_refinement;
-  Parameters::Testing                            test;
-  Parameters::Restart                            restart;
-  Parameters::Timer                              timer;
-  Parameters::SimulationControl                  simulation_control;
+  Parameters::Mesh<dim>                               mesh;
+  Parameters::Manifolds                               manifolds_parameters;
+  std::shared_ptr<Parameters::MeshBoxRefinement<dim>> mesh_box_refinement;
+  Parameters::Testing                                 test;
+  Parameters::Restart                                 restart;
+  Parameters::Timer                                   timer;
+  Parameters::SimulationControl                       simulation_control;
   Parameters::Lagrangian::LagrangianPhysicalProperties
                                                  lagrangian_physical_properties;
   Parameters::Lagrangian::InsertionInfo<dim>     insertion_info;
@@ -68,7 +68,8 @@ public:
     simulation_control.declare_parameters(prm);
     mesh.declare_parameters(prm);
     manifolds_parameters.declare_parameters(prm, size_of_subsections.manifolds);
-    mesh_box_refinement = std::make_shared<Parameters::MeshBoxRefinement>();
+    mesh_box_refinement =
+      std::make_shared<Parameters::MeshBoxRefinement<dim>>();
     mesh_box_refinement->declare_parameters(prm);
     restart.declare_parameters(prm);
     timer.declare_parameters(prm);

--- a/include/dem/dem_solver_parameters.h
+++ b/include/dem/dem_solver_parameters.h
@@ -16,7 +16,7 @@ template <int dim>
 class DEMSolverParameters
 {
 public:
-  Parameters::Mesh                               mesh;
+  Parameters::Mesh<dim>                          mesh;
   Parameters::Manifolds                          manifolds_parameters;
   std::shared_ptr<Parameters::MeshBoxRefinement> mesh_box_refinement;
   Parameters::Testing                            test;

--- a/include/dem/ray_tracing_solver_parameters.h
+++ b/include/dem/ray_tracing_solver_parameters.h
@@ -16,7 +16,7 @@ template <int dim>
 class RayTracingSolverParameters
 {
 public:
-  Parameters::Mesh                                mesh;
+  Parameters::Mesh<dim>                           mesh;
   Parameters::Manifolds                           manifolds_parameters;
   Parameters::Testing                             test;
   Parameters::Timer                               timer;
@@ -55,7 +55,7 @@ public:
       Patterns::Anything(),
       "Print a comment at the beginning of the console output.");
 
-    Parameters::Mesh::declare_parameters(prm);
+    Parameters::Mesh<dim>::declare_parameters(prm);
     manifolds_parameters.declare_parameters(prm, size_of_subsections.manifolds);
     Parameters::Testing::declare_parameters(prm);
     Parameters::Timer::declare_parameters(prm);

--- a/include/solvers/simulation_parameters.h
+++ b/include/solvers/simulation_parameters.h
@@ -31,20 +31,20 @@ public:
   std::map<CLSSubequationsID, Parameters::NonLinearSolver>
                              cls_subequations_non_linear_solvers;
   Parameters::MeshAdaptation mesh_adaptation;
-  Parameters::Mesh           mesh;
+  Parameters::Mesh<dim>      mesh;
   Parameters::Dimensionality dimensionality;
-  std::shared_ptr<Parameters::MeshBoxRefinement>    mesh_box_refinement;
-  std::shared_ptr<Parameters::Nitsche<dim>>         nitsche;
-  Parameters::SimulationControl                     simulation_control;
-  Parameters::Timer                                 timer;
-  Parameters::FEM                                   fem_parameters;
-  Parameters::Forces                                forces_parameters;
-  std::shared_ptr<Parameters::Laser<dim>>           laser_parameters;
-  Parameters::PostProcessing<dim>                   post_processing;
-  Parameters::Restart                               restart_parameters;
-  Parameters::Manifolds                             manifolds_parameters;
-  BoundaryConditions::NSBoundaryConditions<dim>     boundary_conditions;
-  BoundaryConditions::HTBoundaryConditions<dim>     boundary_conditions_ht;
+  std::shared_ptr<Parameters::MeshBoxRefinement<dim>> mesh_box_refinement;
+  std::shared_ptr<Parameters::Nitsche<dim>>           nitsche;
+  Parameters::SimulationControl                       simulation_control;
+  Parameters::Timer                                   timer;
+  Parameters::FEM                                     fem_parameters;
+  Parameters::Forces                                  forces_parameters;
+  std::shared_ptr<Parameters::Laser<dim>>             laser_parameters;
+  Parameters::PostProcessing<dim>                     post_processing;
+  Parameters::Restart                                 restart_parameters;
+  Parameters::Manifolds                               manifolds_parameters;
+  BoundaryConditions::NSBoundaryConditions<dim>       boundary_conditions;
+  BoundaryConditions::HTBoundaryConditions<dim>       boundary_conditions_ht;
   BoundaryConditions::TracerBoundaryConditions<dim> boundary_conditions_tracer;
   BoundaryConditions::CLSBoundaryConditions<dim>    boundary_conditions_cls;
   BoundaryConditions::CahnHilliardBoundaryConditions<dim>
@@ -92,7 +92,7 @@ public:
     dimensionality.declare_parameters(prm);
     Parameters::SimulationControl::declare_parameters(prm);
     physical_properties.declare_parameters(prm);
-    Parameters::Mesh::declare_parameters(prm);
+    Parameters::Mesh<dim>::declare_parameters(prm);
     nitsche = std::make_shared<Parameters::Nitsche<dim>>();
     nitsche->declare_parameters(prm);
     Parameters::Restart::declare_parameters(prm);
@@ -118,7 +118,8 @@ public:
     laser_parameters = std::make_shared<Parameters::Laser<dim>>();
     laser_parameters->declare_parameters(prm);
     Parameters::MeshAdaptation::declare_parameters(prm);
-    mesh_box_refinement = std::make_shared<Parameters::MeshBoxRefinement>();
+    mesh_box_refinement =
+      std::make_shared<Parameters::MeshBoxRefinement<dim>>();
     mesh_box_refinement->declare_parameters(prm);
     for (auto physics_name : nonlinear_physics_names)
       {

--- a/release_notes/current/2026_09_10_Campos.md
+++ b/release_notes/current/2026_09_10_Campos.md
@@ -1,0 +1,4 @@
+## [Master] - 2026/09/10
+
+### Changed
+- MINOR Addressing issue #2043, this PR templates `Parameters::Mesh` with `dim` so that the `translation` and `rotation` parameters are initialized with the correct dimension. [#2118](https://github.com/chaos-polymtl/lethe/pull/2118)

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -53,8 +53,8 @@
 template <int dim, int spacedim>
 static void
 warn_if_scaling_curved_manifolds(
-  const Parameters::Mesh<dim, spacedim>             &mesh_parameters,
-  const Triangulation<dim, spacedim> &triangulation)
+  const Parameters::Mesh<dim, spacedim> &mesh_parameters,
+  const Triangulation<dim, spacedim>    &triangulation)
 {
   if (mesh_parameters.scale == 1.0 ||
       mesh_parameters.type == Parameters::Mesh<dim, spacedim>::Type::gmsh)
@@ -79,8 +79,9 @@ warn_if_scaling_curved_manifolds(
   pcout
     << "WARNING: a mesh 'scale' factor of " << mesh_parameters.scale
     << " is being applied to a '"
-    << (mesh_parameters.type == Parameters::Mesh<dim, spacedim>::Type::dealii ? "dealii" :
-                                                                 "lethe")
+    << (mesh_parameters.type == Parameters::Mesh<dim, spacedim>::Type::dealii ?
+          "dealii" :
+          "lethe")
     << "' grid. \nScaling moves the mesh vertices but not the curved "
        "manifolds attached to the triangulation, which can distort the "
        "geometry under refinement. \nVerify the resulting mesh, or dimension "
@@ -90,8 +91,9 @@ warn_if_scaling_curved_manifolds(
 
 template <int dim, int spacedim>
 void
-attach_grid_to_triangulation(Triangulation<dim, spacedim> &triangulation,
-                             const Parameters::Mesh<dim, spacedim>       &mesh_parameters)
+attach_grid_to_triangulation(
+  Triangulation<dim, spacedim>          &triangulation,
+  const Parameters::Mesh<dim, spacedim> &mesh_parameters)
 
 {
   // GMSH input
@@ -381,7 +383,7 @@ setup_periodic_boundary_conditions(
 template <int dim, int spacedim>
 static void
 apply_initial_refinement(
-  const Parameters::Mesh                                &mesh_parameters,
+  const Parameters::Mesh<dim, spacedim>                 &mesh_parameters,
   const bool                                             restart,
   parallel::DistributedTriangulationBase<dim, spacedim> &triangulation)
 {
@@ -684,8 +686,8 @@ read_mesh_and_manifolds_for_stator_and_rotor(
 template <int dim, int spacedim>
 void
 build_refinement_box_triangulation(
-  const Parameters::Mesh       &box_mesh_parameters,
-  Triangulation<dim, spacedim> &box_triangulation)
+  const Parameters::Mesh<dim, spacedim> &box_mesh_parameters,
+  Triangulation<dim, spacedim>          &box_triangulation)
 {
   attach_grid_to_triangulation(box_triangulation, box_mesh_parameters);
 
@@ -806,14 +808,17 @@ read_mesh_and_manifolds_for_stator_and_rotor(
   const Parameters::Mortar<3>               &mortar_parameters);
 
 template void
-build_refinement_box_triangulation(const Parameters::Mesh<2> &box_mesh_parameters,
-                                   Triangulation<2, 2>    &box_triangulation);
+build_refinement_box_triangulation(
+  const Parameters::Mesh<2> &box_mesh_parameters,
+  Triangulation<2, 2>       &box_triangulation);
 template void
-build_refinement_box_triangulation(const Parameters::Mesh<2, 3> &box_mesh_parameters,
-                                   Triangulation<2, 3>    &box_triangulation);
+build_refinement_box_triangulation(
+  const Parameters::Mesh<2, 3> &box_mesh_parameters,
+  Triangulation<2, 3>          &box_triangulation);
 template void
-build_refinement_box_triangulation(const Parameters::Mesh<3> &box_mesh_parameters,
-                                   Triangulation<3, 3>    &box_triangulation);
+build_refinement_box_triangulation(
+  const Parameters::Mesh<3> &box_mesh_parameters,
+  Triangulation<3, 3>       &box_triangulation);
 
 template void
 apply_mesh_transformation(const Parameters::Mesh<2> &mesh_parameters,

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -707,31 +707,15 @@ apply_mesh_transformation(
 {
   // Mesh scaling
   GridTools::scale(mesh_parameters.scale, triangulation);
-  if constexpr (dim == 2 && spacedim == 2)
+  if constexpr (spacedim == 2)
     {
       // Box mesh rotation around the origin of the system coordinates
       GridTools::rotate(mesh_parameters.rotation_angle, triangulation);
 
       // Box mesh translation
-      Tensor<1, 2> translation_vector;
-      translation_vector[0] = mesh_parameters.translation[0];
-      translation_vector[1] = mesh_parameters.translation[1];
-      GridTools::shift(translation_vector, triangulation);
-    }
-  else if constexpr (dim == 2 && spacedim == 3)
-    {
-      // Box mesh rotation
-      GridTools::rotate(mesh_parameters.rotation_axis,
-                        mesh_parameters.rotation_angle,
-                        triangulation);
-
-      // Tensor<1, 3> translation_vector;
-      // translation_vector[0] = mesh_parameters.translation[0];
-      // translation_vector[1] = mesh_parameters.translation[1];
-      // Box mesh translation
       GridTools::shift(mesh_parameters.translation, triangulation);
     }
-  else if constexpr (dim == 3)
+  else if constexpr (spacedim == 3)
     {
       // Box mesh rotation
       GridTools::rotate(mesh_parameters.rotation_axis,

--- a/source/core/grids.cc
+++ b/source/core/grids.cc
@@ -53,11 +53,11 @@
 template <int dim, int spacedim>
 static void
 warn_if_scaling_curved_manifolds(
-  const Parameters::Mesh             &mesh_parameters,
+  const Parameters::Mesh<dim, spacedim>             &mesh_parameters,
   const Triangulation<dim, spacedim> &triangulation)
 {
   if (mesh_parameters.scale == 1.0 ||
-      mesh_parameters.type == Parameters::Mesh::Type::gmsh)
+      mesh_parameters.type == Parameters::Mesh<dim, spacedim>::Type::gmsh)
     return;
 
   const std::vector<types::manifold_id> &manifold_ids =
@@ -79,7 +79,7 @@ warn_if_scaling_curved_manifolds(
   pcout
     << "WARNING: a mesh 'scale' factor of " << mesh_parameters.scale
     << " is being applied to a '"
-    << (mesh_parameters.type == Parameters::Mesh::Type::dealii ? "dealii" :
+    << (mesh_parameters.type == Parameters::Mesh<dim, spacedim>::Type::dealii ? "dealii" :
                                                                  "lethe")
     << "' grid. \nScaling moves the mesh vertices but not the curved "
        "manifolds attached to the triangulation, which can distort the "
@@ -91,11 +91,11 @@ warn_if_scaling_curved_manifolds(
 template <int dim, int spacedim>
 void
 attach_grid_to_triangulation(Triangulation<dim, spacedim> &triangulation,
-                             const Parameters::Mesh       &mesh_parameters)
+                             const Parameters::Mesh<dim, spacedim>       &mesh_parameters)
 
 {
   // GMSH input
-  if (mesh_parameters.type == Parameters::Mesh::Type::gmsh)
+  if (mesh_parameters.type == Parameters::Mesh<dim, spacedim>::Type::gmsh)
     {
       if (mesh_parameters.simplex)
         {
@@ -148,7 +148,8 @@ attach_grid_to_triangulation(Triangulation<dim, spacedim> &triangulation,
         }
     }
   // Dealii grids
-  else if (mesh_parameters.type == Parameters::Mesh::Type::dealii)
+  else if (mesh_parameters.type ==
+           Parameters::Mesh<dim, spacedim>::Type::dealii)
     {
       if (mesh_parameters.simplex)
         {
@@ -214,7 +215,7 @@ attach_grid_to_triangulation(Triangulation<dim, spacedim> &triangulation,
         cell->set_material_id(0);
     }
 
-  else if (mesh_parameters.type == Parameters::Mesh::Type::lethe)
+  else if (mesh_parameters.type == Parameters::Mesh<dim, spacedim>::Type::lethe)
     {
       std::string grid_type = mesh_parameters.grid_type;
 
@@ -419,7 +420,7 @@ template <int dim, int spacedim>
 void
 read_mesh_and_manifolds(
   parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
-  const Parameters::Mesh                                &mesh_parameters,
+  const Parameters::Mesh<dim, spacedim>                 &mesh_parameters,
   const Parameters::Manifolds                           &manifolds_parameters,
   const bool                                             restart,
   const Parameters::PeriodicBoundaries                  &periodic_boundaries)
@@ -433,7 +434,7 @@ read_mesh_and_manifolds(
   // ID, otherwise, we will be unable to use external manifold.
   // This is done manually by looping through all faces and giving them a
   // manifold id if there is a manifold associated with this number.
-  if (mesh_parameters.type == Parameters::Mesh::Type::gmsh)
+  if (mesh_parameters.type == Parameters::Mesh<dim, spacedim>::Type::gmsh)
     {
       // Gather all the manifold ids within a set
       std::set<int> manifold_ids;
@@ -473,7 +474,7 @@ template <int dim, int spacedim>
 void
 read_mesh_and_manifolds_for_stator_and_rotor(
   parallel::DistributedTriangulationBase<dim, spacedim> &triangulation,
-  const Parameters::Mesh                                &mesh_parameters,
+  const Parameters::Mesh<dim, spacedim>                 &mesh_parameters,
   const Parameters::Manifolds                           &manifolds_parameters,
   const bool                                             restart,
   const Parameters::PeriodicBoundaries                  &periodic_boundaries,
@@ -514,7 +515,7 @@ read_mesh_and_manifolds_for_stator_and_rotor(
   for (const auto &cell : stator_temp_tria.active_cell_iterators())
     cell->set_material_id(0);
 
-  if (mesh_parameters.type == Parameters::Mesh::Type::dealii)
+  if (mesh_parameters.type == Parameters::Mesh<dim, spacedim>::Type::dealii)
     {
       // Get stator manifold ids without flat id
       unsigned int stator_ids_no_flat = 0;
@@ -605,7 +606,7 @@ read_mesh_and_manifolds_for_stator_and_rotor(
           n++;
         }
     }
-  else if (mesh_parameters.type == Parameters::Mesh::Type::gmsh)
+  else if (mesh_parameters.type == Parameters::Mesh<dim, spacedim>::Type::gmsh)
     {
       // Merge triangulations
       GridGenerator::merge_triangulations(
@@ -698,8 +699,9 @@ build_refinement_box_triangulation(
 
 template <int dim, int spacedim>
 void
-apply_mesh_transformation(const Parameters::Mesh       &mesh_parameters,
-                          Triangulation<dim, spacedim> &triangulation)
+apply_mesh_transformation(
+  const Parameters::Mesh<dim, spacedim> &mesh_parameters,
+  Triangulation<dim, spacedim>          &triangulation)
 {
   // Mesh scaling
   GridTools::scale(mesh_parameters.scale, triangulation);
@@ -721,6 +723,9 @@ apply_mesh_transformation(const Parameters::Mesh       &mesh_parameters,
                         mesh_parameters.rotation_angle,
                         triangulation);
 
+      // Tensor<1, 3> translation_vector;
+      // translation_vector[0] = mesh_parameters.translation[0];
+      // translation_vector[1] = mesh_parameters.translation[1];
       // Box mesh translation
       GridTools::shift(mesh_parameters.translation, triangulation);
     }
@@ -738,14 +743,14 @@ apply_mesh_transformation(const Parameters::Mesh       &mesh_parameters,
 
 
 template void
-attach_grid_to_triangulation(Triangulation<2>       &triangulation,
-                             const Parameters::Mesh &mesh_parameters);
+attach_grid_to_triangulation(Triangulation<2>          &triangulation,
+                             const Parameters::Mesh<2> &mesh_parameters);
 template void
-attach_grid_to_triangulation(Triangulation<3>       &triangulation,
-                             const Parameters::Mesh &mesh_parameters);
+attach_grid_to_triangulation(Triangulation<3>          &triangulation,
+                             const Parameters::Mesh<3> &mesh_parameters);
 template void
-attach_grid_to_triangulation(Triangulation<2, 3>    &triangulation,
-                             const Parameters::Mesh &mesh_parameters);
+attach_grid_to_triangulation(Triangulation<2, 3>          &triangulation,
+                             const Parameters::Mesh<2, 3> &mesh_parameters);
 
 
 template void
@@ -764,21 +769,21 @@ setup_periodic_boundary_conditions(
 template void
 read_mesh_and_manifolds(
   parallel::DistributedTriangulationBase<2> &triangulation,
-  const Parameters::Mesh                    &mesh_parameters,
+  const Parameters::Mesh<2>                 &mesh_parameters,
   const Parameters::Manifolds               &manifolds_parameters,
   const bool                                 restart,
   const Parameters::PeriodicBoundaries      &periodic_boundaries);
 template void
 read_mesh_and_manifolds(
   parallel::DistributedTriangulationBase<3> &triangulation,
-  const Parameters::Mesh                    &mesh_parameters,
+  const Parameters::Mesh<3>                 &mesh_parameters,
   const Parameters::Manifolds               &manifolds_parameters,
   const bool                                 restart,
   const Parameters::PeriodicBoundaries      &periodic_boundaries);
 template void
 read_mesh_and_manifolds(
   parallel::DistributedTriangulationBase<2, 3> &triangulation,
-  const Parameters::Mesh                       &mesh_parameters,
+  const Parameters::Mesh<2, 3>                 &mesh_parameters,
   const Parameters::Manifolds                  &manifolds_parameters,
   const bool                                    restart,
   const Parameters::PeriodicBoundaries         &periodic_boundaries);
@@ -786,7 +791,7 @@ read_mesh_and_manifolds(
 template void
 read_mesh_and_manifolds_for_stator_and_rotor(
   parallel::DistributedTriangulationBase<2> &triangulation,
-  const Parameters::Mesh                    &mesh_parameters,
+  const Parameters::Mesh<2>                 &mesh_parameters,
   const Parameters::Manifolds               &manifolds_parameters,
   const bool                                 restart,
   const Parameters::PeriodicBoundaries      &periodic_boundaries,
@@ -794,28 +799,28 @@ read_mesh_and_manifolds_for_stator_and_rotor(
 template void
 read_mesh_and_manifolds_for_stator_and_rotor(
   parallel::DistributedTriangulationBase<3> &triangulation,
-  const Parameters::Mesh                    &mesh_parameters,
+  const Parameters::Mesh<3>                 &mesh_parameters,
   const Parameters::Manifolds               &manifolds_parameters,
   const bool                                 restart,
   const Parameters::PeriodicBoundaries      &periodic_boundaries,
   const Parameters::Mortar<3>               &mortar_parameters);
 
 template void
-build_refinement_box_triangulation(const Parameters::Mesh &box_mesh_parameters,
+build_refinement_box_triangulation(const Parameters::Mesh<2> &box_mesh_parameters,
                                    Triangulation<2, 2>    &box_triangulation);
 template void
-build_refinement_box_triangulation(const Parameters::Mesh &box_mesh_parameters,
+build_refinement_box_triangulation(const Parameters::Mesh<2, 3> &box_mesh_parameters,
                                    Triangulation<2, 3>    &box_triangulation);
 template void
-build_refinement_box_triangulation(const Parameters::Mesh &box_mesh_parameters,
+build_refinement_box_triangulation(const Parameters::Mesh<3> &box_mesh_parameters,
                                    Triangulation<3, 3>    &box_triangulation);
 
 template void
-apply_mesh_transformation(const Parameters::Mesh &mesh_parameters,
-                          Triangulation<2, 2>    &triangulation);
+apply_mesh_transformation(const Parameters::Mesh<2> &mesh_parameters,
+                          Triangulation<2, 2>       &triangulation);
 template void
-apply_mesh_transformation(const Parameters::Mesh &mesh_parameters,
-                          Triangulation<2, 3>    &triangulation);
+apply_mesh_transformation(const Parameters::Mesh<2, 3> &mesh_parameters,
+                          Triangulation<2, 3>          &triangulation);
 template void
-apply_mesh_transformation(const Parameters::Mesh &mesh_parameters,
-                          Triangulation<3, 3>    &triangulation);
+apply_mesh_transformation(const Parameters::Mesh<3> &mesh_parameters,
+                          Triangulation<3, 3>       &triangulation);

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3124,8 +3124,10 @@ namespace Parameters
     }
     prm.leave_subsection();
   }
+
+  template <int dim, int spacedim>
   void
-  Mesh::declare_parameters(ParameterHandler &prm)
+  Mesh<dim, spacedim>::declare_parameters(ParameterHandler &prm)
   {
     prm.enter_subsection("mesh");
     {
@@ -3193,12 +3195,14 @@ namespace Parameters
       prm.declare_entry("grid type", "hyper_cube");
       prm.declare_entry("grid arguments", "-1 : 1 : false");
 
+      std::string default_translation =
+        (spacedim == 2) ? "0., 0." : "0., 0., 0.";
       prm.declare_entry(
         "initial translation",
         "0, 0, 0",
+        // default_translation,
         Patterns::List(Patterns::Double()),
-        "Component of the desired translation of the mesh at initialization. \n"
-        "In 2D, the third value (z-component) is ignored.");
+        "Component of the desired translation of the mesh at initialization.");
 
       prm.declare_entry(
         "initial rotation axis",
@@ -3222,8 +3226,9 @@ namespace Parameters
     prm.leave_subsection();
   }
 
+  template <int dim, int spacedim>
   void
-  Mesh::parse_parameters(ParameterHandler &prm)
+  Mesh<dim, spacedim>::parse_parameters(ParameterHandler &prm)
   {
     prm.enter_subsection("mesh");
     {
@@ -3268,11 +3273,12 @@ namespace Parameters
       target_size = prm.get_double("target size");
 
       // Initial translation
-      translation = value_string_to_tensor<3>(prm.get("initial translation"));
+      translation =
+        value_string_to_tensor<spacedim>(prm.get("initial translation"));
 
       // Initial rotation axis and angle
       rotation_axis =
-        value_string_to_tensor<3>(prm.get("initial rotation axis"));
+        value_string_to_tensor<spacedim>(prm.get("initial rotation axis"));
       rotation_angle = prm.get_double("initial rotation angle");
 
       // Scaling factor
@@ -3281,8 +3287,9 @@ namespace Parameters
     prm.leave_subsection();
   }
 
+  template <int dim, int spacedim>
   void
-  MeshBoxRefinement::declare_parameters(ParameterHandler &prm)
+  MeshBoxRefinement<dim, spacedim>::declare_parameters(ParameterHandler &prm)
   {
     prm.enter_subsection("box refinement");
     {
@@ -3311,8 +3318,9 @@ namespace Parameters
     prm.leave_subsection();
   }
 
+  template <int dim, int spacedim>
   void
-  MeshBoxRefinement::parse_parameters(ParameterHandler &prm)
+  MeshBoxRefinement<dim, spacedim>::parse_parameters(ParameterHandler &prm)
   {
     prm.enter_subsection("box refinement");
     {
@@ -5188,7 +5196,7 @@ namespace Parameters
                         Patterns::Selection("circular|linear"),
                         "Type of mortar interface"
                         "Choices are <circular|linear>.");
-      rotor_mesh = std::make_shared<Mesh>();
+      rotor_mesh = std::make_shared<Mesh<dim>>();
       rotor_mesh->declare_parameters(prm);
       prm.declare_entry("rotor boundary id",
                         "1",
@@ -5306,6 +5314,13 @@ namespace Parameters
   template class PostProcessing<3>;
   template class IBParticles<2>;
   template class IBParticles<3>;
+  template struct Mesh<1>;
+  template struct Mesh<1, 2>;
+  template struct Mesh<2>;
+  template struct Mesh<2, 3>;
+  template struct Mesh<3>;
+  template struct MeshBoxRefinement<2>;
+  template struct MeshBoxRefinement<3>;
   template struct ConstrainSolidDomain<2>;
   template struct ConstrainSolidDomain<3>;
   template struct Mortar<2>;

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3199,14 +3199,14 @@ namespace Parameters
         (spacedim == 2) ? "0., 0." : "0., 0., 0.";
       prm.declare_entry(
         "initial translation",
-        "0, 0, 0",
-        // default_translation,
+        default_translation,
         Patterns::List(Patterns::Double()),
         "Component of the desired translation of the mesh at initialization.");
 
+      std::string default_rotation = (spacedim == 2) ? "0., 0." : "1., 0., 0.";
       prm.declare_entry(
         "initial rotation axis",
-        "1, 0, 0",
+        default_rotation,
         Patterns::List(Patterns::Double()),
         "Component of the desired rotation of the mesh at initialization.\n"
         "In 2D, this has no effect, only a counter-clockwise rotation around the origin \n "

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -5314,11 +5314,11 @@ namespace Parameters
   template class PostProcessing<3>;
   template class IBParticles<2>;
   template class IBParticles<3>;
-  template struct Mesh<1>;
-  template struct Mesh<1, 2>;
-  template struct Mesh<2>;
-  template struct Mesh<2, 3>;
-  template struct Mesh<3>;
+  template class Mesh<1>;
+  template class Mesh<1, 2>;
+  template class Mesh<2>;
+  template class Mesh<2, 3>;
+  template class Mesh<3>;
   template struct MeshBoxRefinement<2>;
   template struct MeshBoxRefinement<3>;
   template struct ConstrainSolidDomain<2>;

--- a/source/core/parameters.cc
+++ b/source/core/parameters.cc
@@ -3209,8 +3209,8 @@ namespace Parameters
         default_rotation,
         Patterns::List(Patterns::Double()),
         "Component of the desired rotation of the mesh at initialization.\n"
-        "In 2D, this has no effect, only a counter-clockwise rotation around the origin \n "
-        "of the coordinate system is applied.");
+        "In 2D, this parameter is not used, and a counter-clockwise rotation around the origin \n "
+        "of the coordinate system is applied according to the prescribed rotation angle.");
 
       prm.declare_entry(
         "initial rotation angle",

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -21,8 +21,8 @@
 
 template <int dim, int spacedim>
 SerialSolid<dim, spacedim>::SerialSolid(
-  std::shared_ptr<Parameters::RigidSolidObject<spacedim>> &param,
-  const unsigned int                                       id)
+  std::shared_ptr<Parameters::RigidSolidObject<dim, spacedim>> &param,
+  const unsigned int                                            id)
   : mpi_communicator(MPI_COMM_WORLD)
   , n_mpi_processes(Utilities::MPI::n_mpi_processes(mpi_communicator))
   , this_mpi_process(Utilities::MPI::this_mpi_process(mpi_communicator))
@@ -162,7 +162,7 @@ template <int dim, int spacedim>
 void
 SerialSolid<dim, spacedim>::setup_triangulation(const bool restart)
 {
-  if (param->solid_mesh.type == Parameters::Mesh::Type::gmsh)
+  if (param->solid_mesh.type == Parameters::Mesh<dim, spacedim>::Type::gmsh)
     {
       // Grid creation
       GridIn<dim, spacedim> grid_in;
@@ -173,7 +173,8 @@ SerialSolid<dim, spacedim>::setup_triangulation(const bool restart)
 
       grid_in.read_msh(input_file);
     }
-  else if (param->solid_mesh.type == Parameters::Mesh::Type::dealii)
+  else if (param->solid_mesh.type ==
+           Parameters::Mesh<dim, spacedim>::Type::dealii)
     {
       if (param->solid_mesh.simplex)
         {
@@ -260,62 +261,84 @@ SerialSolid<dim, spacedim>::get_triangulation()
   return solid_tria;
 }
 
-template <>
+template <int dim, int spacedim>
 void
-SerialSolid<1, 2>::rotate_grid(const double                         angle,
-                               [[maybe_unused]] const Tensor<1, 3> &axis)
+SerialSolid<dim, spacedim>::rotate_grid(
+  const double                                angle,
+  [[maybe_unused]] const Tensor<1, spacedim> &axis)
 {
-  GridTools::rotate(angle, *solid_tria);
+  if constexpr (spacedim == 2)
+    GridTools::rotate(angle, *solid_tria);
+  else
+    GridTools::rotate(axis, angle, *solid_tria);
 }
 
-template <>
-void
-SerialSolid<2, 2>::rotate_grid(const double                         angle,
-                               [[maybe_unused]] const Tensor<1, 3> &axis)
-{
-  GridTools::rotate(angle, *solid_tria);
-}
+// template <>
+// void
+// SerialSolid<1, 2>::rotate_grid(const double                         angle,
+//                                [[maybe_unused]] const Tensor<1, 3> &axis)
+// {
+//   GridTools::rotate(angle, *solid_tria);
+// }
 
-template <>
-void
-SerialSolid<2, 3>::rotate_grid(const double angle, const Tensor<1, 3> &axis)
-{
-  GridTools::rotate(axis, angle, *solid_tria);
-}
-template <>
-void
-SerialSolid<3, 3>::rotate_grid(const double angle, const Tensor<1, 3> &axis)
-{
-  GridTools::rotate(axis, angle, *solid_tria);
-}
+// template <>
+// void
+// SerialSolid<2, 2>::rotate_grid(const double                         angle,
+//                                [[maybe_unused]] const Tensor<1, 3> &axis)
+// {
+//   GridTools::rotate(angle, *solid_tria);
+// }
 
-template <>
-void
-SerialSolid<1, 2>::translate_grid(const Tensor<1, 3> &translation)
-{
-  GridTools::shift(Tensor<1, 2>({translation[0], translation[1]}), *solid_tria);
-}
+// template <>
+// void
+// SerialSolid<2, 3>::rotate_grid(const double angle, const Tensor<1, 3> &axis)
+// {
+//   GridTools::rotate(axis, angle, *solid_tria);
+// }
+// template <>
+// void
+// SerialSolid<3, 3>::rotate_grid(const double angle, const Tensor<1, 3> &axis)
+// {
+//   GridTools::rotate(axis, angle, *solid_tria);
+// }
 
-template <>
+template <int dim, int spacedim>
 void
-SerialSolid<2, 2>::translate_grid(const Tensor<1, 3> &translation)
-{
-  GridTools::shift(Tensor<1, 2>({translation[0], translation[1]}), *solid_tria);
-}
-
-template <>
-void
-SerialSolid<2, 3>::translate_grid(const Tensor<1, 3> &translation)
+SerialSolid<dim, spacedim>::translate_grid(
+  const Tensor<1, spacedim> &translation)
 {
   GridTools::shift(translation, *solid_tria);
 }
 
-template <>
-void
-SerialSolid<3, 3>::translate_grid(const Tensor<1, 3> &translation)
-{
-  GridTools::shift(translation, *solid_tria);
-}
+// template <>
+// void
+// SerialSolid<1, 2>::translate_grid(const Tensor<1, 3> &translation)
+// {
+//   GridTools::shift(Tensor<1, 2>({translation[0], translation[1]}),
+//   *solid_tria);
+// }
+
+// template <>
+// void
+// SerialSolid<2, 2>::translate_grid(const Tensor<1, 3> &translation)
+// {
+//   GridTools::shift(Tensor<1, 2>({translation[0], translation[1]}),
+//   *solid_tria);
+// }
+
+// template <>
+// void
+// SerialSolid<2, 3>::translate_grid(const Tensor<1, 3> &translation)
+// {
+//   GridTools::shift(translation, *solid_tria);
+// }
+
+// template <>
+// void
+// SerialSolid<3, 3>::translate_grid(const Tensor<1, 3> &translation)
+// {
+//   GridTools::shift(translation, *solid_tria);
+// }
 
 template <int dim, int spacedim>
 void

--- a/source/core/serial_solid.cc
+++ b/source/core/serial_solid.cc
@@ -273,35 +273,6 @@ SerialSolid<dim, spacedim>::rotate_grid(
     GridTools::rotate(axis, angle, *solid_tria);
 }
 
-// template <>
-// void
-// SerialSolid<1, 2>::rotate_grid(const double                         angle,
-//                                [[maybe_unused]] const Tensor<1, 3> &axis)
-// {
-//   GridTools::rotate(angle, *solid_tria);
-// }
-
-// template <>
-// void
-// SerialSolid<2, 2>::rotate_grid(const double                         angle,
-//                                [[maybe_unused]] const Tensor<1, 3> &axis)
-// {
-//   GridTools::rotate(angle, *solid_tria);
-// }
-
-// template <>
-// void
-// SerialSolid<2, 3>::rotate_grid(const double angle, const Tensor<1, 3> &axis)
-// {
-//   GridTools::rotate(axis, angle, *solid_tria);
-// }
-// template <>
-// void
-// SerialSolid<3, 3>::rotate_grid(const double angle, const Tensor<1, 3> &axis)
-// {
-//   GridTools::rotate(axis, angle, *solid_tria);
-// }
-
 template <int dim, int spacedim>
 void
 SerialSolid<dim, spacedim>::translate_grid(
@@ -309,36 +280,6 @@ SerialSolid<dim, spacedim>::translate_grid(
 {
   GridTools::shift(translation, *solid_tria);
 }
-
-// template <>
-// void
-// SerialSolid<1, 2>::translate_grid(const Tensor<1, 3> &translation)
-// {
-//   GridTools::shift(Tensor<1, 2>({translation[0], translation[1]}),
-//   *solid_tria);
-// }
-
-// template <>
-// void
-// SerialSolid<2, 2>::translate_grid(const Tensor<1, 3> &translation)
-// {
-//   GridTools::shift(Tensor<1, 2>({translation[0], translation[1]}),
-//   *solid_tria);
-// }
-
-// template <>
-// void
-// SerialSolid<2, 3>::translate_grid(const Tensor<1, 3> &translation)
-// {
-//   GridTools::shift(translation, *solid_tria);
-// }
-
-// template <>
-// void
-// SerialSolid<3, 3>::translate_grid(const Tensor<1, 3> &translation)
-// {
-//   GridTools::shift(translation, *solid_tria);
-// }
 
 template <int dim, int spacedim>
 void

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -232,56 +232,12 @@ SolidBase<dim, spacedim>::rotate_grid(
     GridTools::rotate(axis, angle, *solid_tria);
 }
 
-// template <>
-// void
-// SolidBase<2, 2>::rotate_grid(const double angle,
-//                              const Tensor<1, 3> /*axis*/
-//                                &)
-// {
-//   GridTools::rotate(angle, *solid_tria);
-// }
-// template <>
-// void
-// SolidBase<2, 3>::rotate_grid(const double angle, const Tensor<1, 3> &axis)
-// {
-//   GridTools::rotate(axis, angle, *solid_tria);
-// }
-// template <>
-// void
-// SolidBase<3, 3>::rotate_grid(const double angle, const Tensor<1, 3> &axis)
-// {
-//   GridTools::rotate(axis, angle, *solid_tria);
-// }
-
 template <int dim, int spacedim>
 void
 SolidBase<dim, spacedim>::translate_grid(const Tensor<1, spacedim> &translation)
 {
   GridTools::shift(translation, *solid_tria);
 }
-
-// template <>
-// void
-// SolidBase<2, 2>::translate_grid(const Tensor<1, 3> &translation)
-// {
-//   GridTools::shift(Tensor<1, 2>({translation[0], translation[1]}),
-//   *solid_tria);
-// }
-
-// template <>
-// void
-// SolidBase<2, 3>::translate_grid(const Tensor<1, 3> &translation)
-// {
-//   GridTools::shift(translation, *solid_tria);
-// }
-
-// template <>
-// void
-// SolidBase<3, 3>::translate_grid(const Tensor<1, 3> &translation)
-// {
-//   GridTools::shift(translation, *solid_tria);
-// }
-
 
 template <int dim, int spacedim>
 void
@@ -375,8 +331,6 @@ SolidBase<dim, spacedim>::setup_particles()
 
   // Compute fluid bounding box
   std::vector<std::vector<BoundingBox<spacedim>>> global_fluid_bounding_boxes;
-
-
 
   // Use the more general boost rtree bounding boxes
   std::vector<BoundingBox<spacedim>> all_boxes;

--- a/source/core/solid_base.cc
+++ b/source/core/solid_base.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 #include <core/solid_base.h>
@@ -108,7 +108,7 @@ template <int dim, int spacedim>
 void
 SolidBase<dim, spacedim>::setup_triangulation(const bool restart)
 {
-  if (param->solid_mesh.type == Parameters::Mesh::Type::gmsh)
+  if (param->solid_mesh.type == Parameters::Mesh<spacedim>::Type::gmsh)
     {
       if (param->solid_mesh.simplex)
         {
@@ -146,7 +146,7 @@ SolidBase<dim, spacedim>::setup_triangulation(const bool restart)
           grid_in.read_msh(input_file);
         }
     }
-  else if (param->solid_mesh.type == Parameters::Mesh::Type::dealii)
+  else if (param->solid_mesh.type == Parameters::Mesh<spacedim>::Type::dealii)
     {
       if (param->solid_mesh.simplex)
         { // TODO Using dealii generated meshes with simplices in Nitsche solver
@@ -220,47 +220,67 @@ SolidBase<dim, spacedim>::setup_triangulation(const bool restart)
     }
 }
 
-template <>
+template <int dim, int spacedim>
 void
-SolidBase<2, 2>::rotate_grid(const double angle,
-                             const Tensor<1, 3> /*axis*/
-                               &)
+SolidBase<dim, spacedim>::rotate_grid(
+  const double                                angle,
+  [[maybe_unused]] const Tensor<1, spacedim> &axis)
 {
-  GridTools::rotate(angle, *solid_tria);
-}
-template <>
-void
-SolidBase<2, 3>::rotate_grid(const double angle, const Tensor<1, 3> &axis)
-{
-  GridTools::rotate(axis, angle, *solid_tria);
-}
-template <>
-void
-SolidBase<3, 3>::rotate_grid(const double angle, const Tensor<1, 3> &axis)
-{
-  GridTools::rotate(axis, angle, *solid_tria);
+  if constexpr (spacedim == 2)
+    GridTools::rotate(angle, *solid_tria);
+  else
+    GridTools::rotate(axis, angle, *solid_tria);
 }
 
-template <>
-void
-SolidBase<2, 2>::translate_grid(const Tensor<1, 3> &translation)
-{
-  GridTools::shift(Tensor<1, 2>({translation[0], translation[1]}), *solid_tria);
-}
+// template <>
+// void
+// SolidBase<2, 2>::rotate_grid(const double angle,
+//                              const Tensor<1, 3> /*axis*/
+//                                &)
+// {
+//   GridTools::rotate(angle, *solid_tria);
+// }
+// template <>
+// void
+// SolidBase<2, 3>::rotate_grid(const double angle, const Tensor<1, 3> &axis)
+// {
+//   GridTools::rotate(axis, angle, *solid_tria);
+// }
+// template <>
+// void
+// SolidBase<3, 3>::rotate_grid(const double angle, const Tensor<1, 3> &axis)
+// {
+//   GridTools::rotate(axis, angle, *solid_tria);
+// }
 
-template <>
+template <int dim, int spacedim>
 void
-SolidBase<2, 3>::translate_grid(const Tensor<1, 3> &translation)
+SolidBase<dim, spacedim>::translate_grid(const Tensor<1, spacedim> &translation)
 {
   GridTools::shift(translation, *solid_tria);
 }
 
-template <>
-void
-SolidBase<3, 3>::translate_grid(const Tensor<1, 3> &translation)
-{
-  GridTools::shift(translation, *solid_tria);
-}
+// template <>
+// void
+// SolidBase<2, 2>::translate_grid(const Tensor<1, 3> &translation)
+// {
+//   GridTools::shift(Tensor<1, 2>({translation[0], translation[1]}),
+//   *solid_tria);
+// }
+
+// template <>
+// void
+// SolidBase<2, 3>::translate_grid(const Tensor<1, 3> &translation)
+// {
+//   GridTools::shift(translation, *solid_tria);
+// }
+
+// template <>
+// void
+// SolidBase<3, 3>::translate_grid(const Tensor<1, 3> &translation)
+// {
+//   GridTools::shift(translation, *solid_tria);
+// }
 
 
 template <int dim, int spacedim>

--- a/source/dem/dem.cc
+++ b/source/dem/dem.cc
@@ -297,7 +297,7 @@ DEMSolver<dim, PropertiesIndex>::box_refine_mesh(const bool restart)
   if (restart)
     return;
 
-  const Parameters::MeshBoxRefinement &box_refinement =
+  const Parameters::MeshBoxRefinement<dim> &box_refinement =
     *parameters.mesh_box_refinement;
 
   for (unsigned int i_box = 0;

--- a/source/solvers/fluid_dynamics_nitsche.cc
+++ b/source/solvers/fluid_dynamics_nitsche.cc
@@ -412,7 +412,7 @@ FluidDynamicsNitsche<dim, spacedim>::calculate_torque_on_solid(
 
   // Todo center of rotation should be parameter passed.
   Point<spacedim> center_of_rotation =
-    this->simulation_parameters.nitsche->nitsche_solids[i_solid]->cor;
+    this->simulation_parameters.nitsche->nitsche_solids[i_solid]->center_of_rotation;
 
   // Loop over all local particles
   auto particle = solid_ph->begin();

--- a/source/solvers/fluid_dynamics_nitsche.cc
+++ b/source/solvers/fluid_dynamics_nitsche.cc
@@ -412,7 +412,8 @@ FluidDynamicsNitsche<dim, spacedim>::calculate_torque_on_solid(
 
   // Todo center of rotation should be parameter passed.
   Point<spacedim> center_of_rotation =
-    this->simulation_parameters.nitsche->nitsche_solids[i_solid]->center_of_rotation;
+    this->simulation_parameters.nitsche->nitsche_solids[i_solid]
+      ->center_of_rotation;
 
   // Loop over all local particles
   auto particle = solid_ph->begin();

--- a/tests/core/mesh_transformation_01.cc
+++ b/tests/core/mesh_transformation_01.cc
@@ -37,11 +37,11 @@
  *
  * @param[in] simplex Whether the mesh is converted to a simplex mesh
  */
-Parameters::Mesh
+Parameters::Mesh<2>
 transformed_unit_square_mesh_parameters(const bool simplex)
 {
-  Parameters::Mesh mesh_parameters;
-  mesh_parameters.type           = Parameters::Mesh::Type::dealii;
+  Parameters::Mesh<2> mesh_parameters;
+  mesh_parameters.type           = Parameters::Mesh<2>::Type::dealii;
   mesh_parameters.grid_type      = "hyper_cube";
   mesh_parameters.grid_arguments = "0 : 1 : true";
 
@@ -54,8 +54,8 @@ transformed_unit_square_mesh_parameters(const bool simplex)
   mesh_parameters.check_for_diamond_cells             = false;
   mesh_parameters.expand_particle_wall_contact_search = false;
 
-  mesh_parameters.translation    = Tensor<1, 3>({1., 0., 0.});
-  mesh_parameters.rotation_axis  = Tensor<1, 3>({0., 0., 1.});
+  mesh_parameters.translation    = Tensor<1, 2>({1., 0.});
+  mesh_parameters.rotation_axis  = Tensor<1, 2>({0., 0.});
   mesh_parameters.rotation_angle = std::numbers::pi / 2.;
   mesh_parameters.scale          = 2.;
 
@@ -95,7 +95,7 @@ report_bounding_box(const std::string      &case_name,
 void
 test_quad_mesh_transformation()
 {
-  const Parameters::Mesh mesh_parameters =
+  const Parameters::Mesh<2> mesh_parameters =
     transformed_unit_square_mesh_parameters(false);
 
   Triangulation<2> triangulation;
@@ -108,7 +108,7 @@ test_quad_mesh_transformation()
 void
 test_simplex_mesh_transformation()
 {
-  const Parameters::Mesh mesh_parameters =
+  const Parameters::Mesh<2> mesh_parameters =
     transformed_unit_square_mesh_parameters(true);
 
   // A simplex mesh is stored in a fully distributed triangulation, since it is
@@ -124,7 +124,7 @@ test_simplex_mesh_transformation()
 void
 test_refinement_box_transformation()
 {
-  const Parameters::Mesh box_mesh_parameters =
+  const Parameters::Mesh<2> box_mesh_parameters =
     transformed_unit_square_mesh_parameters(false);
 
   Triangulation<2> box_triangulation;

--- a/tests/core/read_mesh_and_manifolds_01.cc
+++ b/tests/core/read_mesh_and_manifolds_01.cc
@@ -33,11 +33,11 @@
  * @brief Build the mesh parameters of a unit square discretized by a single
  * deal.II hyper_cube cell.
  */
-Parameters::Mesh
+Parameters::Mesh<2>
 unit_square_mesh_parameters()
 {
-  Parameters::Mesh mesh_parameters;
-  mesh_parameters.type           = Parameters::Mesh::Type::dealii;
+  Parameters::Mesh<2> mesh_parameters;
+  mesh_parameters.type           = Parameters::Mesh<2>::Type::dealii;
   mesh_parameters.grid_type      = "hyper_cube";
   mesh_parameters.grid_arguments = "0 : 1 : true";
 
@@ -50,8 +50,8 @@ unit_square_mesh_parameters()
   mesh_parameters.check_for_diamond_cells             = false;
   mesh_parameters.expand_particle_wall_contact_search = false;
 
-  mesh_parameters.translation    = Tensor<1, 3>();
-  mesh_parameters.rotation_axis  = Tensor<1, 3>({1., 0., 0.});
+  mesh_parameters.translation    = Tensor<1, 2>();
+  mesh_parameters.rotation_axis  = Tensor<1, 2>({1., 0.});
   mesh_parameters.rotation_angle = 0.;
   mesh_parameters.scale          = 1.;
 
@@ -65,7 +65,7 @@ unit_square_mesh_parameters()
 void
 report_number_of_cells(
   const std::string           &case_name,
-  const Parameters::Mesh      &mesh_parameters,
+  const Parameters::Mesh<2>   &mesh_parameters,
   const bool                   restart,
   const Parameters::Manifolds &manifolds_parameters = Parameters::Manifolds())
 {
@@ -90,8 +90,8 @@ test_initial_refinement()
 {
   deallog << "--- Initial refinement ---" << std::endl;
 
-  Parameters::Mesh mesh_parameters   = unit_square_mesh_parameters();
-  mesh_parameters.initial_refinement = 2;
+  Parameters::Mesh<2> mesh_parameters = unit_square_mesh_parameters();
+  mesh_parameters.initial_refinement  = 2;
 
   // Without restart, the mesh is refined twice: 4^2 = 16 cells
   report_number_of_cells("initial refinement, no restart",
@@ -108,7 +108,7 @@ test_refinement_until_target_size()
 {
   deallog << "--- Refinement until target size ---" << std::endl;
 
-  Parameters::Mesh mesh_parameters         = unit_square_mesh_parameters();
+  Parameters::Mesh<2> mesh_parameters      = unit_square_mesh_parameters();
   mesh_parameters.refine_until_target_size = true;
 
   // The minimal cell diameter of the single-cell unit square is its diagonal,
@@ -129,8 +129,8 @@ test_refinement_at_boundaries()
 {
   deallog << "--- Refinement at boundaries ---" << std::endl;
 
-  Parameters::Mesh mesh_parameters   = unit_square_mesh_parameters();
-  mesh_parameters.initial_refinement = 2;
+  Parameters::Mesh<2> mesh_parameters = unit_square_mesh_parameters();
+  mesh_parameters.initial_refinement  = 2;
 
   // The hyper_cube is colorized: boundary id 0 is the x = 0 face. Refining it
   // once more adds 3 cells for each of the 4 cells touching that boundary.
@@ -158,7 +158,7 @@ test_manifold_attachment()
 {
   deallog << "--- Manifold attachment ---" << std::endl;
 
-  const Parameters::Mesh mesh_parameters = unit_square_mesh_parameters();
+  const Parameters::Mesh<2> mesh_parameters = unit_square_mesh_parameters();
 
   // Declare a spherical manifold centered at the origin and attach it to
   // manifold id 1

--- a/tests/core/serial_solid_intersection_01.cc
+++ b/tests/core/serial_solid_intersection_01.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2023-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2023-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 /*
@@ -42,8 +42,8 @@ test()
   // Generate the serial solid
 
   // Parameters for the Serial solid object
-  auto param             = std::make_shared<Parameters::RigidSolidObject<3>>();
-  param->solid_mesh.type = Parameters::Mesh::Type::dealii;
+  auto param = std::make_shared<Parameters::RigidSolidObject<2, 3>>();
+  param->solid_mesh.type               = Parameters::Mesh<2, 3>::Type::dealii;
   param->solid_mesh.grid_type          = "hyper_rectangle";
   param->solid_mesh.grid_arguments     = "-2, -1 : 2, 1 : false";
   param->solid_mesh.initial_refinement = 3;

--- a/tests/core/solid_base_22.cc
+++ b/tests/core/solid_base_22.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 // Deal.II includes
@@ -40,14 +40,14 @@ test()
         Triangulation<2>::smoothing_on_coarsening));
 
   // Mesh of the solid
-  param->solid_mesh.type               = Parameters::Mesh::Type::dealii;
+  param->solid_mesh.type               = Parameters::Mesh<2>::Type::dealii;
   param->solid_mesh.grid_type          = "hyper_cube";
   param->solid_mesh.grid_arguments     = "-0.5 : 0.5 : false";
   param->solid_mesh.initial_refinement = 4;
   param->solid_mesh.simplex            = false;
   param->number_quadrature_points      = 2;
-  param->solid_mesh.translation        = Tensor<1, 3>({0., 0., 0.});
-  param->solid_mesh.rotation_axis      = Tensor<1, 3>({1., 0., 0.});
+  param->solid_mesh.translation        = Tensor<1, 2>({0., 0.});
+  param->solid_mesh.rotation_axis      = Tensor<1, 2>({1., 0.});
   param->solid_mesh.rotation_angle     = 0.;
 
   // Mesh of the fluid

--- a/tests/core/solid_base_23.cc
+++ b/tests/core/solid_base_23.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 // Deal.II includes
@@ -39,7 +39,7 @@ test()
         Triangulation<2, 3>::smoothing_on_coarsening));
 
   // Mesh of the solid
-  param->solid_mesh.type               = Parameters::Mesh::Type::dealii;
+  param->solid_mesh.type               = Parameters::Mesh<3>::Type::dealii;
   param->solid_mesh.grid_type          = "hyper_sphere";
   param->solid_mesh.grid_arguments     = "0 , 0 , 0 : 0.75";
   param->solid_mesh.initial_refinement = 1;

--- a/tests/core/solid_base_33.cc
+++ b/tests/core/solid_base_33.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 // Deal.II includes
@@ -39,7 +39,7 @@ test()
         Triangulation<3>::smoothing_on_coarsening));
 
   // Mesh of the solid
-  param->solid_mesh.type               = Parameters::Mesh::Type::dealii;
+  param->solid_mesh.type               = Parameters::Mesh<3>::Type::dealii;
   param->solid_mesh.grid_type          = "hyper_ball";
   param->solid_mesh.grid_arguments     = "0 , 0 , 0 : 0.75 : false";
   param->solid_mesh.initial_refinement = 1;

--- a/tests/core/solid_base_33_moving_particles.cc
+++ b/tests/core/solid_base_33_moving_particles.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 // Deal.II includes
@@ -51,7 +51,7 @@ test()
         Triangulation<3, 3>::smoothing_on_coarsening));
 
   // Mesh of the solid
-  param->solid_mesh.type               = Parameters::Mesh::Type::dealii;
+  param->solid_mesh.type               = Parameters::Mesh<3>::Type::dealii;
   param->solid_mesh.grid_type          = "hyper_cube";
   param->solid_mesh.grid_arguments     = "-0.5 : 0.5 : false";
   param->solid_mesh.initial_refinement = 3;

--- a/tests/core/solid_base_33_moving_triangulation.cc
+++ b/tests/core/solid_base_33_moving_triangulation.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2020-2024 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2020-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 // Deal.II includes
@@ -43,7 +43,7 @@ test()
         Triangulation<3, 3>::smoothing_on_coarsening));
 
   // Mesh of the solid
-  param->solid_mesh.type               = Parameters::Mesh::Type::dealii;
+  param->solid_mesh.type               = Parameters::Mesh<3>::Type::dealii;
   param->solid_mesh.grid_type          = "hyper_cube";
   param->solid_mesh.grid_arguments     = "-0.5 : 0.5 : false";
   param->solid_mesh.initial_refinement = 3;

--- a/tests/dem/volume_solid_object_displacement.cc
+++ b/tests/dem/volume_solid_object_displacement.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 The Lethe Authors
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 The Lethe Authors
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
 
 /**
@@ -26,19 +26,19 @@ void
 test()
 {
   // RigidSolidObject
-  auto param = std::make_shared<Parameters::RigidSolidObject<spacedim>>();
+  auto param = std::make_shared<Parameters::RigidSolidObject<dim, spacedim>>();
 
   // Mesh of the solid
-  param->solid_mesh.type               = Parameters::Mesh::Type::dealii;
-  param->output_bool                   = false;
-  param->solid_mesh.grid_type          = "hyper_cube";
+  param->solid_mesh.type      = Parameters::Mesh<dim, spacedim>::Type::dealii;
+  param->output_bool          = false;
+  param->solid_mesh.grid_type = "hyper_cube";
   param->solid_mesh.grid_arguments     = "-0.5 : 0.5 : false";
   param->solid_mesh.initial_refinement = 0;
   param->solid_mesh.simplex            = false;
-  param->solid_mesh.translation        = Tensor<1, 3>({0.5, 0.5, 0.5});
-  param->solid_mesh.rotation_axis      = Tensor<1, 3>({1., 0., 0.});
+  param->solid_mesh.translation        = Tensor<1, spacedim>({0.5, 0.5, 0.5});
+  param->solid_mesh.rotation_axis      = Tensor<1, spacedim>({1., 0., 0.});
   param->solid_mesh.rotation_angle     = 0;
-  param->center_of_rotation            = Point<3>({0., -0.5, 0.25});
+  param->center_of_rotation            = Point<spacedim>({0., -0.5, 0.25});
 
   param->output_bool = false;
 

--- a/tests/mortar/read_mortar_data_01.cc
+++ b/tests/mortar/read_mortar_data_01.cc
@@ -46,28 +46,28 @@ test()
   const unsigned int dim            = 2;
   const unsigned int mapping_degree = 3;
 
-  Parameters::Mesh        mesh_parameters;
+  Parameters::Mesh<dim>   mesh_parameters;
   Parameters::Mortar<dim> mortar_parameters;
   Parameters::Manifolds   manifolds_parameters;
   // No periodic boundary is set up in this test
   const Parameters::PeriodicBoundaries periodic_boundaries;
 
   // Stator mesh parameters
-  mesh_parameters.type                     = Parameters::Mesh::Type::dealii;
-  mesh_parameters.grid_type                = "hyper_shell";
-  mesh_parameters.grid_arguments           = "0, 0 : 0.5 : 1.0 : 6 : true";
-  mesh_parameters.scale                    = 1;
-  mesh_parameters.simplex                  = false;
-  mesh_parameters.initial_refinement       = 2;
-  mesh_parameters.refine_until_target_size = false;
-  mesh_parameters.boundaries_to_refine     = std::vector<int>();
+  mesh_parameters.type               = Parameters::Mesh<dim>::Type::dealii;
+  mesh_parameters.grid_type          = "hyper_shell";
+  mesh_parameters.grid_arguments     = "0, 0 : 0.5 : 1.0 : 6 : true";
+  mesh_parameters.scale              = 1;
+  mesh_parameters.simplex            = false;
+  mesh_parameters.initial_refinement = 2;
+  mesh_parameters.refine_until_target_size         = false;
+  mesh_parameters.boundaries_to_refine             = std::vector<int>();
   mesh_parameters.initial_refinement_at_boundaries = 0;
 
   // Rotor mesh parameters
-  mortar_parameters.enable           = "true";
-  mortar_parameters.rotor_mesh       = std::make_shared<Parameters::Mesh>();
-  mortar_parameters.rotor_mesh->type = Parameters::Mesh::Type::dealii;
-  mortar_parameters.rotor_mesh->grid_type      = "hyper_shell";
+  mortar_parameters.enable     = "true";
+  mortar_parameters.rotor_mesh = std::make_shared<Parameters::Mesh<dim>>();
+  mortar_parameters.rotor_mesh->type      = Parameters::Mesh<dim>::Type::dealii;
+  mortar_parameters.rotor_mesh->grid_type = "hyper_shell";
   mortar_parameters.rotor_mesh->grid_arguments = "0, 0 : 0.25 : 0.5 : 6 : true";
   mortar_parameters.rotor_mesh->scale          = 1;
   mortar_parameters.rotor_mesh->simplex        = false;

--- a/tests/mortar/read_mortar_data_03.cc
+++ b/tests/mortar/read_mortar_data_03.cc
@@ -43,30 +43,30 @@ test()
 
   const unsigned int dim = 3;
 
-  Parameters::Mesh        mesh_parameters;
+  Parameters::Mesh<dim>   mesh_parameters;
   Parameters::Mortar<dim> mortar_parameters;
   Parameters::Manifolds   manifolds_parameters;
   // No periodic boundary is set up in this test
   const Parameters::PeriodicBoundaries periodic_boundaries;
 
   // Stator mesh parameters
-  mesh_parameters.type                     = Parameters::Mesh::Type::dealii;
-  mesh_parameters.grid_type                = "cylinder_shell";
-  mesh_parameters.grid_arguments           = "2.0 : 0.5 : 1.0 : 4 : 4 : true";
-  mesh_parameters.scale                    = 1;
-  mesh_parameters.simplex                  = false;
-  mesh_parameters.initial_refinement       = 2;
-  mesh_parameters.refine_until_target_size = false;
-  mesh_parameters.boundaries_to_refine     = std::vector<int>();
+  mesh_parameters.type               = Parameters::Mesh<dim>::Type::dealii;
+  mesh_parameters.grid_type          = "cylinder_shell";
+  mesh_parameters.grid_arguments     = "2.0 : 0.5 : 1.0 : 4 : 4 : true";
+  mesh_parameters.scale              = 1;
+  mesh_parameters.simplex            = false;
+  mesh_parameters.initial_refinement = 2;
+  mesh_parameters.refine_until_target_size         = false;
+  mesh_parameters.boundaries_to_refine             = std::vector<int>();
   mesh_parameters.initial_refinement_at_boundaries = 0;
   mesh_parameters.translation                      = Tensor<1, dim>({0, 0, 0});
   mesh_parameters.rotation_axis                    = Tensor<1, dim>({0, 0, 1});
   mesh_parameters.rotation_angle                   = 0.0;
 
   // Rotor mesh parameters
-  mortar_parameters.enable           = "true";
-  mortar_parameters.rotor_mesh       = std::make_shared<Parameters::Mesh>();
-  mortar_parameters.rotor_mesh->type = Parameters::Mesh::Type::dealii;
+  mortar_parameters.enable     = "true";
+  mortar_parameters.rotor_mesh = std::make_shared<Parameters::Mesh<dim>>();
+  mortar_parameters.rotor_mesh->type      = Parameters::Mesh<dim>::Type::dealii;
   mortar_parameters.rotor_mesh->grid_type = "cylinder_shell";
   mortar_parameters.rotor_mesh->grid_arguments =
     "2.0 : 0.25 : 0.5 : 4 : 4 : true";

--- a/tests/mortar/rotate_mapping.cc
+++ b/tests/mortar/rotate_mapping.cc
@@ -46,28 +46,28 @@ test()
   const unsigned int mapping_degree = 3;
   const unsigned int fe_degree      = 3;
 
-  Parameters::Mesh        mesh_parameters;
+  Parameters::Mesh<dim>   mesh_parameters;
   Parameters::Mortar<dim> mortar_parameters;
   Parameters::Manifolds   manifolds_parameters;
   // No periodic boundary is set up in this test
   const Parameters::PeriodicBoundaries periodic_boundaries;
 
   // Stator mesh parameters
-  mesh_parameters.type                     = Parameters::Mesh::Type::dealii;
-  mesh_parameters.grid_type                = "hyper_cube_with_cylindrical_hole";
-  mesh_parameters.grid_arguments           = "1.0 : 2.0 : 5.0 : 1 : true";
-  mesh_parameters.scale                    = 1;
-  mesh_parameters.simplex                  = false;
-  mesh_parameters.initial_refinement       = 2;
-  mesh_parameters.refine_until_target_size = false;
-  mesh_parameters.boundaries_to_refine     = std::vector<int>();
+  mesh_parameters.type               = Parameters::Mesh<dim>::Type::dealii;
+  mesh_parameters.grid_type          = "hyper_cube_with_cylindrical_hole";
+  mesh_parameters.grid_arguments     = "1.0 : 2.0 : 5.0 : 1 : true";
+  mesh_parameters.scale              = 1;
+  mesh_parameters.simplex            = false;
+  mesh_parameters.initial_refinement = 2;
+  mesh_parameters.refine_until_target_size         = false;
+  mesh_parameters.boundaries_to_refine             = std::vector<int>();
   mesh_parameters.initial_refinement_at_boundaries = 0;
 
   // Rotor mesh parameters
-  mortar_parameters.enable           = "true";
-  mortar_parameters.rotor_mesh       = std::make_shared<Parameters::Mesh>();
-  mortar_parameters.rotor_mesh->type = Parameters::Mesh::Type::dealii;
-  mortar_parameters.rotor_mesh->grid_type      = "hyper_ball_balanced";
+  mortar_parameters.enable     = "true";
+  mortar_parameters.rotor_mesh = std::make_shared<Parameters::Mesh<dim>>();
+  mortar_parameters.rotor_mesh->type      = Parameters::Mesh<dim>::Type::dealii;
+  mortar_parameters.rotor_mesh->grid_type = "hyper_ball_balanced";
   mortar_parameters.rotor_mesh->grid_arguments = "0, 0 : 1.0";
   mortar_parameters.rotor_mesh->rotation_angle = 3.0;
   mortar_parameters.rotor_mesh->scale          = 1;

--- a/tests/mortar/rotate_mapping_3d.cc
+++ b/tests/mortar/rotate_mapping_3d.cc
@@ -46,30 +46,30 @@ test()
   const unsigned int mapping_degree = 3;
   const unsigned int fe_degree      = 3;
 
-  Parameters::Mesh        mesh_parameters;
+  Parameters::Mesh<dim>   mesh_parameters;
   Parameters::Mortar<dim> mortar_parameters;
   Parameters::Manifolds   manifolds_parameters;
   // No periodic boundary is set up in this test
   const Parameters::PeriodicBoundaries periodic_boundaries;
 
   // Stator mesh parameters
-  mesh_parameters.type                     = Parameters::Mesh::Type::dealii;
-  mesh_parameters.grid_type                = "cylinder_shell";
-  mesh_parameters.grid_arguments           = "2.0 : 0.5 : 1.0 : 4 : 6 : true";
-  mesh_parameters.scale                    = 1;
-  mesh_parameters.simplex                  = false;
-  mesh_parameters.initial_refinement       = 1;
-  mesh_parameters.refine_until_target_size = false;
-  mesh_parameters.boundaries_to_refine     = std::vector<int>();
+  mesh_parameters.type               = Parameters::Mesh<dim>::Type::dealii;
+  mesh_parameters.grid_type          = "cylinder_shell";
+  mesh_parameters.grid_arguments     = "2.0 : 0.5 : 1.0 : 4 : 6 : true";
+  mesh_parameters.scale              = 1;
+  mesh_parameters.simplex            = false;
+  mesh_parameters.initial_refinement = 1;
+  mesh_parameters.refine_until_target_size         = false;
+  mesh_parameters.boundaries_to_refine             = std::vector<int>();
   mesh_parameters.initial_refinement_at_boundaries = 0;
   mesh_parameters.translation                      = Tensor<1, dim>({0, 0, 0});
   mesh_parameters.rotation_axis                    = Tensor<1, dim>({0, 0, 1});
   mesh_parameters.rotation_angle                   = 0.0;
 
   // Rotor mesh parameters
-  mortar_parameters.enable           = "true";
-  mortar_parameters.rotor_mesh       = std::make_shared<Parameters::Mesh>();
-  mortar_parameters.rotor_mesh->type = Parameters::Mesh::Type::dealii;
+  mortar_parameters.enable     = "true";
+  mortar_parameters.rotor_mesh = std::make_shared<Parameters::Mesh<dim>>();
+  mortar_parameters.rotor_mesh->type      = Parameters::Mesh<dim>::Type::dealii;
   mortar_parameters.rotor_mesh->grid_type = "cylinder_shell";
   mortar_parameters.rotor_mesh->grid_arguments =
     "2.0 : 0.25 : 0.5 : 4 : 6 : true";


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

### Description

<!-- Explain the aim of this refactoring.
       What are the motivations? 
       How is it integrated to the current code? -->

Addressing issue #2043, this PR templates `Parameters::Mesh` with `dim` so that the `translation` and `rotation` parameters are initialized with the correct dimension.

### Testing

<!-- Does this refactoring include new tests?
       What are the new test(s) and what feature(s)/parameter(s) does it test? 
       Are there changes and/or impacts on current tests, why? -->

No new tests have been included, and nothing should change.

### Documentation

<!-- Does this refactor modify or have new simulation parameters? If so, describe them. -->

Documentation has been updated.

### Use of LLMs  (Large Language Models)

<!-- LLM-assisted contributions are welcome, but they must be declared.
       If an LLM (e.g. GitHub Copilot, ChatGPT, Claude, Cursor) generated a substantial portion
       of this pull request (e.g. more than a small fraction of the source code, or algorithms
       that are crucial for the functionality), describe here which parts were generated and
       what the LLM was used for.
       Write "None" if no LLM was used.
       By submitting this pull request, you confirm that you have reviewed and verified all
       LLM-generated content, and that you understand and accept responsibility for the
       proposed changes. -->

I did everything myself, and then used Copilot to verify the implementation.

### Miscellaneous (will be removed when merged)

<!-- Anything that you would like to add that does not fit into any of the categories above.
       Note that any critical information should be in the categories above.
       Examples:
         Future changes or features that will be added in subsequent pull requests
         Any comments or highlights for the reviewers -->

### Checklist (will be removed when merged)
See [this page](https://chaos-polymtl.github.io/lethe/documentation/contributing/pull-requests.html) for more information about the pull request process.

Code related list:
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Copyright headers are present and up to date
- [x] Lethe documentation is up to date
- [x] The branch is rebased onto master
- [x] Code is indented with indent-all and .prm files (examples and tests) with prm-indent
- [x] If parameters are modified, the tests and the documentation of examples are up to date
- [x] An entry describing the change has been added in `/release_notes/current/` following the instructions of `/release_notes/template.md`

Pull request related list:
- [x] No other PR is open related to this refactoring
- [ ] Labels are applied
- [ ] There are at least 2 reviewers (or 1 if small feature)
- [x] If any future work is planned, an issue is opened
- [x] The PR description is clean and is ready to be used as the commit message when merging the PR